### PR TITLE
Add str / unicode compatability

### DIFF
--- a/src/environments/models.py
+++ b/src/environments/models.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 from django.db import models
 
 from app.utils import create_hash
+from django.utils.encoding import python_2_unicode_compatible
 from features.models import FeatureState
 from projects.models import Project
 
 
+@python_2_unicode_compatible
 class Environment(models.Model):
     name = models.CharField(max_length=2000)
     created_date = models.DateTimeField('DateCreated', auto_now_add=True)
@@ -32,10 +34,8 @@ class Environment(models.Model):
     def __str__(self):
         return "Project %s - Environment %s" % (self.project.name, self.name)
 
-    def __unicode__(self):
-        return "Project %s - Environment %s" % (self.project.name, self.name)
 
-
+@python_2_unicode_compatible
 class Identity(models.Model):
     identifier = models.CharField(max_length=2000)
     created_date = models.DateTimeField('DateCreated', auto_now_add=True)
@@ -60,7 +60,4 @@ class Identity(models.Model):
         return identity_flags, environment_flags
 
     def __str__(self):
-        return "Account %s" % self.identifier
-
-    def __unicode__(self):
         return "Account %s" % self.identifier

--- a/src/features/models.py
+++ b/src/features/models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError, NON_FIELD_ERRORS
 from django.db import models, IntegrityError
+from django.utils.encoding import python_2_unicode_compatible
 
 from projects.models import Project
 
@@ -17,6 +18,7 @@ STRING = "unicode"
 BOOLEAN = "bool"
 
 
+@python_2_unicode_compatible
 class Feature(models.Model):
     FEATURE_TYPES = (
         (FLAG, 'Feature Flag'),
@@ -69,6 +71,7 @@ class Feature(models.Model):
         return "Project %s - Feature %s" % (self.project.name, self.name)
 
 
+@python_2_unicode_compatible
 class FeatureState(models.Model):
     feature = models.ForeignKey(Feature, related_name='feature_states')
     environment = models.ForeignKey('environments.Environment', related_name='feature_states',

--- a/src/organisations/models.py
+++ b/src/organisations/models.py
@@ -2,8 +2,10 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class Organisation(models.Model):
     name = models.CharField(max_length=2000)
 
@@ -11,7 +13,4 @@ class Organisation(models.Model):
         ordering = ['id']
 
     def __str__(self):
-        return "Org %s" % self.name
-
-    def __unicode__(self):
         return "Org %s" % self.name

--- a/src/projects/models.py
+++ b/src/projects/models.py
@@ -2,10 +2,12 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 from organisations.models import Organisation
 
 
+@python_2_unicode_compatible
 class Project(models.Model):
     name = models.CharField(max_length=2000)
     created_date = models.DateTimeField('DateCreated', auto_now_add=True)
@@ -15,7 +17,4 @@ class Project(models.Model):
         ordering = ['id']
 
     def __str__(self):
-        return "Project %s" % self.name
-
-    def __unicode__(self):
         return "Project %s" % self.name

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.template.loader import get_template
 
 from app.utils import create_hash
+from django.utils.encoding import python_2_unicode_compatible
 from organisations.models import Organisation
 
 
@@ -42,6 +43,7 @@ class UserManager(BaseUserManager):
         return self._create_user(email, password, **extra_fields)
 
 
+@python_2_unicode_compatible
 class FFAdminUser(AbstractUser):
     organisations = models.ManyToManyField(Organisation, related_name="users", blank=True)
     email = models.EmailField(unique=True, null=False)
@@ -68,6 +70,7 @@ class FFAdminUser(AbstractUser):
         return "%s %s" % (self.first_name, self.last_name)
 
 
+@python_2_unicode_compatible
 class Invite(models.Model):
     email = models.EmailField()
     hash = models.CharField(max_length=100, default=create_hash, unique=True)


### PR DESCRIPTION
By using `python_2_unicode_compatible` we don't need to explicitly set
both the `__str__` and the `__unicode__` methods. After providing one it
will add a reference for the other function.