### PR TITLE
Allow the ability to turn off the admin initiation URL

### DIFF
--- a/src/app/settings/common.py
+++ b/src/app/settings/common.py
@@ -175,6 +175,7 @@ DEFAULT_FROM_EMAIL = "noreply@bullet-train.io"
 
 
 # Used on init to create admin user for the site, update accordingly before hitting /auth/init
+ALLOW_ADMIN_INITIATION_VIA_URL = True
 ADMIN_EMAIL = "admin@example.com"
 ADMIN_INITIAL_PASSWORD = "password"
 

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import url, include
 from rest_framework import routers
 
@@ -7,8 +8,8 @@ app_name = "users"
 router = routers.DefaultRouter()
 router.register(r'', FFAdminUserViewSet, base_name="user")
 
-
 urlpatterns = [
-    url(r'init/', AdminInitView.as_view()),
-    url(r'^', include(router.urls))
+    url(r'^', include(router.urls)),
 ]
+if settings.ALLOW_ADMIN_INITIATION_VIA_URL:
+    urlpatterns.insert(0, url(r'init/', AdminInitView.as_view()))


### PR DESCRIPTION
This effectively allows racing to be the first admin for a system. This
is not always desired as we can just use the `createsuperuser` command
on the system and bypass the ability for someone to beat us there.