### PR TITLE
prevent frontend breaking when no GA defined

### DIFF
--- a/src/analytics/query.py
+++ b/src/analytics/query.py
@@ -20,18 +20,20 @@ def get_service():
     return build(GA_API_NAME, GA_API_VERSION, credentials=credentials)
 
 
-def get_events_for_organisation(organisation):
+def get_events_for_organisation(organisation):    
     """
     Get number of tracked events for last 30 days for an organisation
 
     :return: number of events as integer
     """
-    ga_response = get_service().data().ga().get(
-        ids=settings.GA_TABLE_ID,
-        start_date='30daysAgo',
-        end_date='today',
-        metrics='ga:totalEvents',
-        dimensions='ga:date',
-        filters=f'ga:eventCategory=={organisation.get_unique_slug()}').execute()
-
-    return int(ga_response['totalsForAllResults']['ga:totalEvents'])
+    try:
+        ga_response = get_service().data().ga().get(
+            ids=settings.GA_TABLE_ID,
+            start_date='30daysAgo',
+            end_date='today',
+            metrics='ga:totalEvents',
+            dimensions='ga:date',
+            filters=f'ga:eventCategory=={organisation.get_unique_slug()}').execute()
+        return int(ga_response['totalsForAllResults']['ga:totalEvents'])
+    except:
+        return 0


### PR DESCRIPTION
simple fix to prevent front end completely breaking if no GA account is defined.