### PR TITLE
Add segment information to FeatureStateSerializerFull

### DIFF
--- a/src/features/serializers.py
+++ b/src/features/serializers.py
@@ -77,6 +77,7 @@ class FeatureSerializer(serializers.ModelSerializer):
 
 class FeatureStateSerializerFull(serializers.ModelSerializer):
     feature = CreateFeatureSerializer()
+    feature_segment = FeatureSegmentCreateSerializer()
     feature_state_value = serializers.SerializerMethodField()
 
     class Meta:


### PR DESCRIPTION
This grabs the full information for the `feature_segment` part of `FeatureState` when serializing. This is mostly useful for the webhooks; currently webhooks only include the `feature_segment` ID, and (as far as I could tell) there is no simple way to map this ID back to the segment information (such as the segment name, description, ...).

Context for why this would be useful: we are using webhooks to provide Slack notifications of flags changing, and knowing that the flag was changed for only a single segment (and which segment it was) would be very useful.