### PR TITLE
Increase page size to fix frontend bug

### DIFF
--- a/src/app/settings/master-docker.py
+++ b/src/app/settings/master-docker.py
@@ -45,3 +45,5 @@ LOGGING = {
         }
     }
 }
+
+REST_FRAMEWORK['PAGE_SIZE'] = 999


### PR DESCRIPTION
The Bullet Train frontend does not have UI to handle pagination, so the page size must be increased to accommodate.