### PR TITLE
Adding missing environment variable DJANGO_DB_HOST

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       DJANGO_DB_PASSWORD: password
       DJANGO_DB_PORT: 5432
       DJANGO_ALLOWED_HOSTS: localhost
+      DJANGO_DB_HOST: db
     ports:
      - "8000:8000"
     depends_on:


### PR DESCRIPTION
"docker-compose up" command had the below mistake:

api_1  | Traceback (most recent call last):
api_1  |   File "manage.py", line 11, in <module>
api_1  |     execute_from_command_line(sys.argv)
api_1  |   File "/root/.local/share/virtualenvs/src-NCIGkioc/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
api_1  |     utility.execute()
api_1  |   File "/root/.local/share/virtualenvs/src-NCIGkioc/lib/python3.7/site-packages/django/core/management/__init__.py", line 325, in execute
api_1  |     settings.INSTALLED_APPS
api_1  |   File "/root/.local/share/virtualenvs/src-NCIGkioc/lib/python3.7/site-packages/django/conf/__init__.py", line 79, in __getattr__
api_1  |     self._setup(name)
api_1  |   File "/root/.local/share/virtualenvs/src-NCIGkioc/lib/python3.7/site-packages/django/conf/__init__.py", line 66, in _setup
api_1  |     self._wrapped = Settings(settings_module)
api_1  |   File "/root/.local/share/virtualenvs/src-NCIGkioc/lib/python3.7/site-packages/django/conf/__init__.py", line 157, in __init__
api_1  |     mod = importlib.import_module(self.SETTINGS_MODULE)
api_1  |   File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
api_1  |     return _bootstrap._gcd_import(name[level:], package, level)
api_1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
api_1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
api_1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
api_1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
api_1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
api_1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
api_1  |   File "/usr/src/app/settings/master-docker.py", line 12, in <module>
api_1  |     'HOST': os.environ['DJANGO_DB_HOST'],
api_1  |   File "/usr/local/lib/python3.7/os.py", line 681, in __getitem__
api_1  |     raise KeyError(key) from None
api_1  | KeyError: 'DJANGO_DB_HOST'