### PR TITLE
Adds support to control user creation permissions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ The application relies on the following environment variables to run:
 * `AWS_STORAGE_BUCKET_NAME`: bucket name to store static files. Required if `USE_S3_STORAGE' is true.
 * `AWS_S3_REGION_NAME`: region name of the static files bucket. Defaults to eu-west-2.
 * `ALLOWED_ADMIN_IP_ADDRESSES`: restrict access to the django admin console to a comma separated list of IP addresses (e.g. `127.0.0.1,127.0.0.2`) 
+* `USER_CREATE_PERMISSIONS`: set the permissions for creating new users, using a comma separated list of djoser or rest_framework permissions. Use this to turn off public user creation for self hosting. e.g. `'djoser.permissions.CurrentUserOrAdmin'` Defaults to `'rest_framework.permissions.AllowAny'`.
 
 ### Creating a secret key
 It is important to also set an environment variable on whatever platform you are using for 

--- a/src/app/settings/common.py
+++ b/src/app/settings/common.py
@@ -355,6 +355,8 @@ TRENCH_AUTH = {
     },
 }
 
+USER_CREATE_PERMISSIONS = env.list('USER_CREATE_PERMISSIONS', default=['rest_framework.permissions.AllowAny'])
+
 DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': 'password-reset/confirm/{uid}/{token}',
     'SEND_ACTIVATION_EMAIL': False,
@@ -369,6 +371,7 @@ DJOSER = {
     'PERMISSIONS': {
         'user': ['custom_auth.permissions.CurrentUser'],
         'user_list': ['custom_auth.permissions.CurrentUser'],
+        'user_create': USER_CREATE_PERMISSIONS,
     }
 }
 


### PR DESCRIPTION
Adds an ENV Variable to allow configuration for the create_users djoser permissions

When trying to create a self hosted solution, we discovered that the api still allowed for anyone to create a user account, by posting to the `/api/v1/auth/user` endpoint. 

This adds the ability to change the permissions, through djoser settings, on that endpoint. I've updated the README to include a quick explanation for the ENV var, but please let me know if there is a better solution to securing that endpoint.