### PR TITLE
Allow prevent user creation via oauth

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,4 +15,6 @@ ENV ACCESS_LOG_LOCATION=${ACCESS_LOG_LOCATION}
 ENV DJANGO_SETTINGS_MODULE=app.settings.production
 EXPOSE 8000
 
+USER nobody
+
 CMD ["./bin/docker"]

--- a/docker/Dockerfile.redhat-ubi
+++ b/docker/Dockerfile.redhat-ubi
@@ -1,0 +1,30 @@
+FROM registry.redhat.io/ubi8/python-38 as application
+
+MAINTAINER Ben Rometsch <support@flagsmith.com>
+
+LABEL name="flagsmith-api" \
+      vendor="Flagsmith" \
+      maintainer="support@flagsmith.com" \
+      version="0.0.1" \
+      summary="Feature Flags and Remote Config API" \
+      description="Feature Flags and Remote Config API"
+COPY License /licenses/License
+
+USER root
+RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
+USER 1001
+
+ADD --chown=1001:0 requirements.txt .
+RUN pip install -r requirements.txt
+ADD --chown=1001:0 docker/bin/ bin/
+ADD --chown=1001:0 src/ src/
+
+RUN python src/manage.py collectstatic --no-input
+
+ARG ACCESS_LOG_LOCATION="/dev/null"
+ENV ACCESS_LOG_LOCATION=${ACCESS_LOG_LOCATION}
+ENV DJANGO_SETTINGS_MODULE=app.settings.production
+
+EXPOSE 8000
+
+CMD ["./bin/docker"]

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ django-ses==1.0.3
 django-axes==5.8.0
 django-admin-sso==3.0.0
 drf-yasg2==1.19.3
-django-debug-toolbar==3.1.1
+django-debug-toolbar==3.2.1
 sentry-sdk==0.19.4
 environs==9.2.0
 analytics-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ django-axes==5.8.0
     # via -r requirements.in
 django-cors-headers==3.5.0
     # via -r requirements.in
-django-debug-toolbar==3.1.1
+django-debug-toolbar==3.2.1
     # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in


### PR DESCRIPTION
Allows maintainers to prevent registration via OAuth by adding a new setting called `ALLOW_OAUTH_REGISTRATION`. 