### PR TITLE
Preselect tags on load

### DIFF
--- a/frontend/web/components/pages/FeaturesPage.js
+++ b/frontend/web/components/pages/FeaturesPage.js
@@ -8,6 +8,7 @@ import TagSelect from '../TagSelect';
 import HistoryIcon from '../HistoryIcon';
 import TagValues from '../TagValues';
 import withAuditWebhooks from '../../../common/providers/withAuditWebhooks';
+import TagStore from '../../../common/stores/tags-store';
 
 const FeaturesPage = class extends Component {
     static displayName = 'FeaturesPage';
@@ -21,6 +22,14 @@ const FeaturesPage = class extends Component {
         this.state = {
             tags: [],
         };
+        ES6Component(this);
+        this.listenTo(TagStore, 'loaded', () => {
+            const tags = TagStore.model && TagStore.model[parseInt(this.props.match.params.projectId)];
+            if (this.state.tags.length === 0 && tags && tags.length > 0) {
+                this.setState({ tags: tags.map(v => v.id) });
+            }
+        });
+        this.getTags(this.props.match.params.projectId);
         AppActions.getFeatures(this.props.match.params.projectId, this.props.match.params.environmentId);
     }
 


### PR DESCRIPTION
With this change, tags will all be preselected once they load.

This allows an easier way to quickly deselect tags, which was raised here https://github.com/Flagsmith/flagsmith/issues/112.



![image](https://user-images.githubusercontent.com/8608314/121785294-ea44eb80-cbb0-11eb-8bc0-0adbdb2134e9.png)
