### PR TITLE
Remove username from django admin

### DIFF
--- a/api/users/admin.py
+++ b/api/users/admin.py
@@ -3,6 +3,7 @@ from django.contrib.auth.admin import UserAdmin
 
 from organisations.models import UserOrganisation
 
+from .forms import CustomUserAdminForm
 from .models import FFAdminUser
 
 
@@ -17,6 +18,7 @@ class UserOrganisationInline(admin.TabularInline):
 @admin.register(FFAdminUser)
 class CustomUserAdmin(UserAdmin):
     model = FFAdminUser
+    form = CustomUserAdminForm
 
     add_fieldsets = (
         (
@@ -59,3 +61,5 @@ class CustomUserAdmin(UserAdmin):
     )
 
     inlines = [UserOrganisationInline]
+
+    # exclude = ["username"]

--- a/api/users/admin.py
+++ b/api/users/admin.py
@@ -61,5 +61,3 @@ class CustomUserAdmin(UserAdmin):
     )
 
     inlines = [UserOrganisationInline]
-
-    # exclude = ["username"]

--- a/api/users/forms.py
+++ b/api/users/forms.py
@@ -1,0 +1,6 @@
+from django.contrib.auth.forms import UserChangeForm
+from django.forms import HiddenInput, fields
+
+
+class CustomUserAdminForm(UserChangeForm):
+    username = fields.CharField(required=False, widget=HiddenInput)


### PR DESCRIPTION
Fixes an issue where saving a user with an empty username throws a 500 error. 