### PR TITLE
Show message when segment_operators is not set

### DIFF
--- a/frontend/web/components/pages/SegmentsPage.js
+++ b/frontend/web/components/pages/SegmentsPage.js
@@ -104,6 +104,7 @@ const SegmentsPage = class extends Component {
 
     render() {
         const { projectId, environmentId } = this.props.match.params;
+        const hasNoOperators = !this.props.getValue('segment_operators');
         return (
             <div data-test="segments-page" id="segments-page" className="app-container container">
                 <Permission level="project" permission="ADMIN" id={projectId}>
@@ -129,6 +130,7 @@ const SegmentsPage = class extends Component {
                                                         <div className="text-right">
                                                             {permission ? (
                                                                 <Button
+                                                                  disabled={hasNoOperators}
                                                                   className="btn-lg btn-primary"
                                                                   id="show-create-segment-btn"
                                                                   data-test="show-create-segment-btn"
@@ -155,6 +157,13 @@ const SegmentsPage = class extends Component {
                                                         </div>
                                                     </FormGroup>
                                                 </Row>
+                                                {hasNoOperators && (
+                                                    <div className="mt-2">
+                                                        <p className="alert alert-info">
+                                                            In order to use segments, please set the segment_operators remote config value. <a target="_blank" href="https://docs.flagsmith.com/deployment/overview#running-flagsmith-on-flagsmith">Learn about self hosting</a>.
+                                                        </p>
+                                                    </div>
+                                                )}
 
                                                 <FormGroup>
                                                     <PanelSearch
@@ -268,4 +277,4 @@ const SegmentsPage = class extends Component {
 
 SegmentsPage.propTypes = {};
 
-module.exports = SegmentsPage;
+module.exports = ConfigProvider(SegmentsPage);

--- a/frontend/web/styles/project/_alert.scss
+++ b/frontend/web/styles/project/_alert.scss
@@ -22,3 +22,13 @@
         }
     }
 }
+
+.dark {
+    .alert {
+        &.alert-info {
+            background: $dark-bg-10;
+            border-color: $dark-bg-10;
+            color: $header-color-dark;
+        }
+    }
+}


### PR DESCRIPTION
The following will now show for self hosted without a remote config value for segment_operators.

Mentioned in https://github.com/Flagsmith/flagsmith/issues/139.

![image](https://user-images.githubusercontent.com/8608314/122646024-275f2f80-d115-11eb-9374-b8e7a53c9439.png)
![image](https://user-images.githubusercontent.com/8608314/122646108-7dcc6e00-d115-11eb-8017-4757987da45f.png)
