### PR TITLE
Add identity to segment logic, missed in previous PR

### DIFF
--- a/api/integrations/segment/segment.py
+++ b/api/integrations/segment/segment.py
@@ -25,7 +25,7 @@ class SegmentWrapper(AbstractBaseIdentityIntegrationWrapper):
         feature_properties = {}
 
         for feature_state in feature_states:
-            value = feature_state.get_feature_state_value()
+            value = feature_state.get_feature_state_value(identity=identity)
             feature_properties[feature_state.feature.name] = (
                 value if (feature_state.enabled and value) else feature_state.enabled
             )


### PR DESCRIPTION
Somehow managed to miss adding the identity to the `get_feature_state_value` call in the segment wrapper only. This PR corrects that. 