### PR TITLE
Remove decode from identifier for retrieving flags

### DIFF
--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -46,7 +46,7 @@ const UserPage = class extends Component {
 
 
     getActualFlags = () => {
-        const url = `${Project.api}identities/?identifier=${decodeURIComponent(this.props.match.params.identity)}`;
+        const url = `${Project.api}identities/?identifier=${this.props.match.params.identity}`;
         fetch(url, {
             headers: { 'X-Environment-Key': this.props.match.params.environmentId },
         }).then(res => res.json()).then((res) => {


### PR DESCRIPTION
In #192 I'd added decode everywhere that was previously using the identifier directly. This works fine for most of the use cases but not for this one where the identity is again used in a URL. As such, we just need to remove the decode from it here. 