### PR TITLE
Add an API endpoint to support cloning of environment 

### DIFF
--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -23,18 +23,20 @@ class EnvironmentKeyPermissions(BasePermission):
 class EnvironmentPermissions(BasePermission):
     def has_permission(self, request, view):
         try:
+            if view.action not in ["clone", "create"]:
+                # return true as all users can list and specific object permissions will be handled later
+                return True
+
             if view.action == "clone":
                 api_key = request.path_info.split("/")[-3]
                 project = Project.objects.get(environments__api_key=api_key)
 
-            if view.action == "create":
+            elif view.action == "create":
                 project_id = request.data.get("project")
                 project = Project.objects.get(id=project_id)
 
             return request.user.has_project_permission("CREATE_ENVIRONMENT", project)
 
-            # return true as all users can list and specific object permissions will be handled later
-            return True
         except Project.DoesNotExist:
             return False
 

--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -48,6 +48,10 @@ class EnvironmentPermissions(BasePermission):
 
         if view.action == "user_permissions":
             return True
+        if view.action == "clone":
+            return request.user.has_project_permission(
+                "CREATE_ENVIRONMENT", obj.project
+            )
 
         return False
 

--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -23,16 +23,18 @@ class EnvironmentKeyPermissions(BasePermission):
 class EnvironmentPermissions(BasePermission):
     def has_permission(self, request, view):
         try:
+            if view.action == "clone":
+                api_key = request.path_info.split("/")[-3]
+                project = Project.objects.get(environments__api_key=api_key)
+
             if view.action == "create":
                 project_id = request.data.get("project")
                 project = Project.objects.get(id=project_id)
-                return request.user.has_project_permission(
-                    "CREATE_ENVIRONMENT", project
-                )
+
+            return request.user.has_project_permission("CREATE_ENVIRONMENT", project)
 
             # return true as all users can list and specific object permissions will be handled later
             return True
-
         except Project.DoesNotExist:
             return False
 
@@ -48,11 +50,6 @@ class EnvironmentPermissions(BasePermission):
 
         if view.action == "user_permissions":
             return True
-        if view.action == "clone":
-            return request.user.has_project_permission(
-                "CREATE_ENVIRONMENT", obj.project
-            )
-
         return False
 
 

--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -52,10 +52,19 @@ class EnvironmentSerializerLight(serializers.ModelSerializer):
         )
 
 
-class CloneEnvironmentInputSerializer(serializers.ModelSerializer):
+class CloneEnvironmentSerializer(EnvironmentSerializerLight):
     class Meta:
         model = Environment
-        fields = ("name",)
+        fields = ("id", "name", "api_key", "project")
+        read_only_fields = ("id", "api_key", "project")
+
+    def create(self, validated_data):
+        name = validated_data.get("name")
+        source_env = validated_data.get("source_env")
+        clone = source_env.clone(name)
+        clone.save()
+        self._create_audit_log(clone, True)
+        return clone
 
 
 class WebhookSerializer(serializers.ModelSerializer):

--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -52,6 +52,10 @@ class EnvironmentSerializerLight(serializers.ModelSerializer):
         )
 
 
+class CloneEnvironmentInputSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=2000)
+
+
 class WebhookSerializer(serializers.ModelSerializer):
     class Meta:
         model = Webhook

--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -52,8 +52,10 @@ class EnvironmentSerializerLight(serializers.ModelSerializer):
         )
 
 
-class CloneEnvironmentInputSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=2000)
+class CloneEnvironmentInputSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Environment
+        fields = ("name",)
 
 
 class WebhookSerializer(serializers.ModelSerializer):

--- a/api/environments/tests/test_models.py
+++ b/api/environments/tests/test_models.py
@@ -79,6 +79,23 @@ class EnvironmentTestCase(TestCase):
         feature_states = FeatureState.objects.filter(environment=clone)
         assert feature_states.count() == 1
 
+    def test_clone_does_not_modify_source_feature_state(self):
+        # Given
+        self.environment.save()
+        source_feature_state_before_clone = FeatureState.objects.filter(
+            environment=self.environment
+        ).first()
+
+        # When
+        clone = self.environment.clone(name="Cloned env")
+        clone.save()
+        source_feature_state_after_clone = FeatureState.objects.filter(
+            environment=self.environment
+        ).first()
+
+        # Then
+        assert source_feature_state_before_clone == source_feature_state_after_clone
+
     @mock.patch("environments.models.environment_cache")
     def test_get_from_cache_stores_environment_in_cache_on_success(self, mock_cache):
         # Given

--- a/api/environments/tests/test_models.py
+++ b/api/environments/tests/test_models.py
@@ -55,6 +55,30 @@ class EnvironmentTestCase(TestCase):
         self.environment.save()
         self.assertFalse(FeatureState.objects.get().enabled)
 
+    def test_clone_does_not_modify_the_original_instance(self):
+        # Given
+        self.environment.save()
+
+        # When
+        clone = self.environment.clone(name="Cloned env")
+        clone.save()
+
+        # Then
+        self.assertNotEqual(clone.name, self.environment.name)
+        self.assertNotEqual(clone.api_key, self.environment.api_key)
+
+    def test_clone_save_creates_feature_states(self):
+        # Given
+        self.environment.save()
+
+        # When
+        clone = self.environment.clone(name="Cloned env")
+        clone.save()
+
+        # Then
+        feature_states = FeatureState.objects.filter(environment=clone)
+        assert feature_states.count() == 1
+
     @mock.patch("environments.models.environment_cache")
     def test_get_from_cache_stores_environment_in_cache_on_success(self, mock_cache):
         # Given

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -110,7 +110,7 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
             )
 
     @action(detail=True, methods=["POST"])
-    def clone_env(self, request, *args, **kwargs):
+    def clone(self, request, *args, **kwargs):
         input_serializer = CloneEnvironmentInputSerializer(data=request.data)
         if not input_serializer.is_valid():
             return Response(input_serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -109,6 +109,10 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+    @swagger_auto_schema(
+        request_body=CloneEnvironmentInputSerializer,
+        responses={200: EnvironmentSerializerLight()},
+    )
     @action(detail=True, methods=["POST"])
     def clone(self, request, *args, **kwargs):
         input_serializer = CloneEnvironmentInputSerializer(data=request.data)

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -41,15 +41,21 @@ def environment_api_key():
 
 
 @pytest.fixture()
-def environment(admin_client, project, environment_api_key):
+def environment_dict(admin_client, project, environment_api_key):
     environment_data = {
         "name": "Test Environment",
         "api_key": environment_api_key,
         "project": project,
     }
     url = reverse("api-v1:environments:environment-list")
+
     response = admin_client.post(url, data=environment_data)
-    return response.json()["id"]
+    return response.json()
+
+
+@pytest.fixture()
+def environment(environment_dict) -> int:
+    return environment_dict["id"]
 
 
 @pytest.fixture()

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def environment_api_key():
 
 
 @pytest.fixture()
-def environment_dict(admin_client, project, environment_api_key):
+def environment(admin_client, project, environment_api_key) -> int:
     environment_data = {
         "name": "Test Environment",
         "api_key": environment_api_key,
@@ -50,12 +50,7 @@ def environment_dict(admin_client, project, environment_api_key):
     url = reverse("api-v1:environments:environment-list")
 
     response = admin_client.post(url, data=environment_data)
-    return response.json()
-
-
-@pytest.fixture()
-def environment(environment_dict) -> int:
-    return environment_dict["id"]
+    return response.json()["id"]
 
 
 @pytest.fixture()

--- a/api/tests/integration/environments/test_environments.py
+++ b/api/tests/integration/environments/test_environments.py
@@ -6,10 +6,11 @@ def test_clone_environment_returns_200(
     admin_client, project, environment, environment_api_key
 ):
     # Given
+    env_name = "Cloned env"
     url = reverse("api-v1:environments:environment-clone", args=[environment_api_key])
     # When
-    res = admin_client.post(url, {"name": "clone-env"})
+    res = admin_client.post(url, {"name": env_name})
 
     # Then
     assert res.status_code == status.HTTP_200_OK
-    assert res.json()["name"] == "clone-env"
+    assert res.json()["name"] == env_name

--- a/api/tests/integration/environments/test_environments.py
+++ b/api/tests/integration/environments/test_environments.py
@@ -1,0 +1,12 @@
+from django.urls import reverse
+from rest_framework import status
+
+
+def test_clone_environment_returns_200(admin_client, environment_dict):
+    url = reverse(
+        "api-v1:environments:environment-clone", args=[environment_dict["api_key"]]
+    )
+
+    res = admin_client.post(url, {"name": "clone-env"})
+    assert res.status_code == status.HTTP_200_OK
+    assert res.json()["name"] == "clone-env"

--- a/api/tests/integration/environments/test_environments.py
+++ b/api/tests/integration/environments/test_environments.py
@@ -2,11 +2,14 @@ from django.urls import reverse
 from rest_framework import status
 
 
-def test_clone_environment_returns_200(admin_client, environment_dict):
-    url = reverse(
-        "api-v1:environments:environment-clone", args=[environment_dict["api_key"]]
-    )
-
+def test_clone_environment_returns_200(
+    admin_client, project, environment, environment_api_key
+):
+    # Given
+    url = reverse("api-v1:environments:environment-clone", args=[environment_api_key])
+    # When
     res = admin_client.post(url, {"name": "clone-env"})
+
+    # Then
     assert res.status_code == status.HTTP_200_OK
     assert res.json()["name"] == "clone-env"


### PR DESCRIPTION
Creates an endpoint that clones the environment and returns the new environment. 
ref: https://github.com/Flagsmith/flagsmith/issues/172