### PR TITLE
fix(github-179): Force the API to only render json

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -11,6 +11,7 @@ from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView, get_object_or_404
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.schemas import AutoSchema
 
@@ -334,6 +335,7 @@ class SDKFeatureStates(GenericAPIView):
     serializer_class = FeatureStateSerializerFull
     permission_classes = (EnvironmentKeyPermissions,)
     authentication_classes = (EnvironmentKeyAuthentication,)
+    renderer_classes = [JSONRenderer]
 
     schema = AutoSchema(
         manual_fields=[


### PR DESCRIPTION
The issue was cause by the accept header from client being set to html
which fails because don't have queryset/get_queryset defined on the class

fixes: https://github.com/Flagsmith/flagsmith/issues/179