### PR TITLE
improvement/conn max age setting

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -141,7 +141,8 @@ if GOOGLE_ANALYTICS_KEY or INFLUXDB_TOKEN:
 
 SITE_ID = 1
 
-DJANGO_DB_CONN_MAX_AGE = env.int("DJANGO_DB_CONN_MAX_AGE", 60)
+db_conn_max_age = env.int("DJANGO_DB_CONN_MAX_AGE", 60)
+DJANGO_DB_CONN_MAX_AGE = None if db_conn_max_age == -1 else db_conn_max_age
 
 # Allows collectstatic to run without a database, mainly for Docker builds to collectstatic at build time
 if "DATABASE_URL" in os.environ:

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -141,9 +141,19 @@ if GOOGLE_ANALYTICS_KEY or INFLUXDB_TOKEN:
 
 SITE_ID = 1
 
+DJANGO_DB_CONN_MAX_AGE = 60
+try:
+    DJANGO_DB_CONN_MAX_AGE = env.int("DJANGO_DB_CONN_MAX_AGE")
+except ValueError:
+    DJANGO_DB_CONN_MAX_AGE = None
+
 # Allows collectstatic to run without a database, mainly for Docker builds to collectstatic at build time
 if "DATABASE_URL" in os.environ:
-    DATABASES = {"default": dj_database_url.parse(env("DATABASE_URL"), conn_max_age=60)}
+    DATABASES = {
+        "default": dj_database_url.parse(
+            env("DATABASE_URL"), conn_max_age=DJANGO_DB_CONN_MAX_AGE
+        )
+    }
 elif "DJANGO_DB_NAME" in os.environ:
     # If there is no DATABASE_URL configured, check for old style DB config parameters
     DATABASES = {

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -141,11 +141,7 @@ if GOOGLE_ANALYTICS_KEY or INFLUXDB_TOKEN:
 
 SITE_ID = 1
 
-DJANGO_DB_CONN_MAX_AGE = 60
-try:
-    DJANGO_DB_CONN_MAX_AGE = env.int("DJANGO_DB_CONN_MAX_AGE")
-except ValueError:
-    DJANGO_DB_CONN_MAX_AGE = None
+DJANGO_DB_CONN_MAX_AGE = env.int("DJANGO_DB_CONN_MAX_AGE", 60)
 
 # Allows collectstatic to run without a database, mainly for Docker builds to collectstatic at build time
 if "DATABASE_URL" in os.environ:
@@ -164,10 +160,9 @@ elif "DJANGO_DB_NAME" in os.environ:
             "PASSWORD": os.environ["DJANGO_DB_PASSWORD"],
             "HOST": os.environ["DJANGO_DB_HOST"],
             "PORT": os.environ["DJANGO_DB_PORT"],
-            "CONN_MAX_AGE": 60,
+            "CONN_MAX_AGE": DJANGO_DB_CONN_MAX_AGE,
         },
     }
-
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_AUTHENTICATION_CLASSES": (


### PR DESCRIPTION
- Added optional max_age

Not sure if there's a better way of doing:

```
try:
    DJANGO_DB_CONN_MAX_AGE = env.int("DJANGO_DB_CONN_MAX_AGE")
except ValueError:
    DJANGO_DB_CONN_MAX_AGE = None
```

The value can either be missing, an int or None...
