### PR TITLE
Better equality check for remote config

### DIFF
--- a/frontend/common/stores/identity-store.js
+++ b/frontend/common/stores/identity-store.js
@@ -72,7 +72,7 @@ const controller = {
             }))
             : data.post(`${Project.api}environments/${environmentId}/identities/${identity}/featurestates/`, {
                 feature: projectFlag.id,
-                enabled: environmentFlag.enabled,
+                enabled: identityFlag.enabled,
                 multivariate_feature_state_values:identityFlag.multivariate_options,
                 feature_state_value: identityFlag.feature_state_value,
             });

--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -185,9 +185,9 @@ const UserPage = class extends Component {
 
                                                       const actualEnabled = (actualFlags && !!actualFlags && actualFlags[name] && actualFlags[name].enabled) || false;
                                                       const actualValue = !!actualFlags && actualFlags[name] && actualFlags[name].feature_state_value;
-                                                      const flagEnabledDifferent = type === 'FLAG' && (hasUserOverride ? false
+                                                      const flagEnabledDifferent = (hasUserOverride ? false
                                                           : actualEnabled !== flagEnabled);
-                                                      const flagValueDifferent = type !== 'FLAG' && (hasUserOverride ? false : !valuesEqual(actualValue, flagValue));
+                                                      const flagValueDifferent = (hasUserOverride ? false : !valuesEqual(actualValue, flagValue));
                                                       const projectFlag = projectFlags && projectFlags.find(p => p.id === (environmentFlag && environmentFlag.feature));
                                                       const isMultiVariateOverride = flagValueDifferent && projectFlag && projectFlag.multivariate_options && projectFlag.multivariate_options.find((v) => {
                                                           const value = Utils.featureStateToValue(v);

--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -12,6 +12,14 @@ const returnIfDefined = (value, value2) => {
     }
     return value;
 };
+const valuesEqual = (actualValue, flagValue) => {
+    const nullFalseyA = actualValue == null || actualValue === '' || typeof actualValue === 'undefined';
+    const nullFalseyB = flagValue == null || flagValue === '' || typeof flagValue === 'undefined';
+    if (nullFalseyA && nullFalseyB) {
+        return true;
+    }
+    return actualValue == flagValue;
+};
 const UserPage = class extends Component {
     static displayName = 'UserPage'
 
@@ -179,7 +187,7 @@ const UserPage = class extends Component {
                                                       const actualValue = !!actualFlags && actualFlags[name] && actualFlags[name].feature_state_value;
                                                       const flagEnabledDifferent = type === 'FLAG' && (hasUserOverride ? false
                                                           : actualEnabled !== flagEnabled);
-                                                      const flagValueDifferent = type !== 'FLAG' && (hasUserOverride ? false : actualValue !== flagValue);
+                                                      const flagValueDifferent = type !== 'FLAG' && (hasUserOverride ? false : !valuesEqual(actualValue, flagValue));
                                                       const projectFlag = projectFlags && projectFlags.find(p => p.id === (environmentFlag && environmentFlag.feature));
                                                       const isMultiVariateOverride = flagValueDifferent && projectFlag && projectFlag.multivariate_options && projectFlag.multivariate_options.find((v) => {
                                                           const value = Utils.featureStateToValue(v);

--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -200,7 +200,7 @@ const UserPage = class extends Component {
                                                             data-test={`user-feature-${i}`}
                                                           >
                                                               <div
-                                                                onClick={() => this.editFlag(_.find(projectFlags, { id }), environmentFlags[id], identityFlag)}
+                                                                onClick={() => this.editFlag(_.find(projectFlags, { id }), environmentFlags[id], actualFlags[name])}
                                                                 className="flex flex-1"
                                                               >
                                                                   <Row>


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/8608314/130652571-56951e02-d7af-4a98-9825-e2fc75293e17.png)


After:

![image](https://user-images.githubusercontent.com/8608314/130654616-ce674aad-8428-45fd-ae40-4fad198509a9.png)

This treats null and empty strings as the same when comparing remote config from the environment level to user level.


Also fixes https://github.com/Flagsmith/flagsmith/issues/277