### PR TITLE
chore/Add retries to InfluxDB API writes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ multi_line_output=3
 include_trailing_comma=true
 line_length=79
 known_first_party=analytics,app,custom_auth,environments,integrations,organisations,projects,segments,users,webhooks,api,audit,e2etests,features,permissions,util
-known_third_party=apiclient,app_analytics,axes,chargebee,core,coreapi,corsheaders,dateutil,dj_database_url,django,django_lifecycle,djoser,drf_writable_nested,drf_yasg2,environs,google,influxdb_client,ordered_model,pyotp,pytest,pytz,requests,responses,rest_framework,rest_framework_nested,rest_framework_recursive,sentry_sdk,shortuuid,simple_history,six,telemetry,tests,trench,whitenoise
+known_third_party=apiclient,app_analytics,axes,chargebee,core,coreapi,corsheaders,dateutil,dj_database_url,django,django_lifecycle,djoser,drf_writable_nested,drf_yasg2,environs,google,influxdb_client,ordered_model,pyotp,pytest,pytz,requests,responses,rest_framework,rest_framework_nested,rest_framework_recursive,sentry_sdk,shortuuid,simple_history,six,telemetry,tests,trench,urllib3,whitenoise

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from django.conf import settings
 from influxdb_client import InfluxDBClient, Point
 from influxdb_client.client.write_api import SYNCHRONOUS
+from urllib3 import Retry
 
 url = settings.INFLUXDB_URL
 token = settings.INFLUXDB_TOKEN
@@ -15,7 +16,8 @@ range_bucket_mappings = {
     "7d": settings.INFLUXDB_BUCKET + "_downsampled_15m",
     "30d": settings.INFLUXDB_BUCKET + "_downsampled_1h",
 }
-influxdb_client = InfluxDBClient(url=url, token=token, org=influx_org)
+retries = Retry(connect=3, read=3, redirect=3)
+influxdb_client = InfluxDBClient(url=url, token=token, org=influx_org, retries=retries)
 
 
 class InfluxDBWrapper:


### PR DESCRIPTION
Recommended to do https://github.com/influxdata/influxdb-client-python#http-retry-strategy based on https://community.influxdata.com/t/write-to-influxdb-cloud-fails-with-apiexception-503-reason-service-unavailable-upstream-connect-error-or-disconnect-reset-before-headers-reset-reason-connection-failure/21501/21