### PR TITLE
Move project overrides

### DIFF
--- a/frontend/server/index.js
+++ b/frontend/server/index.js
@@ -25,7 +25,7 @@ const linkedin = process.env.LINKEDIN;
 const app = express();
 const port = process.env.PORT || 8080;
 
-app.get('/static/project-overrides.js', (req, res) => {
+app.get('/api/project-overrides', (req, res) => {
     const getVariable = ({ name, value }) => {
         if (!value) {
             if (typeof value === 'boolean') {

--- a/frontend/web/index.handlebars
+++ b/frontend/web/index.handlebars
@@ -14,7 +14,7 @@
     <script src="/javascript/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB"
             crossorigin="anonymous"></script>
     <!--Project.js overrides-->
-    <script src="/static/project-overrides.js"></script>
+    <script src="/api/project-overrides"></script>
     <style>
         @font-face {
             font-family: 'OpenSans';

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -23,7 +23,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB"
         crossorigin="anonymous"></script>
     <!--Project.js overrides-->
-    <script src="/static/project-overrides.js"></script>
+    <script src="/api/project-overrides"></script>
     <style>
         @font-face {
             font-family: 'OpenSans';


### PR DESCRIPTION
App Engine was caching the static project-overrides file, this uses the api approach that the docker builds use.