### PR TITLE
fix proxy url env name after renaming

### DIFF
--- a/frontend/server/index.js
+++ b/frontend/server/index.js
@@ -83,9 +83,9 @@ app.get('/api/project-overrides', (req, res) => {
 });
 
 // Optionally proxy the API to get around CSRF issues, exposing the API to the world
-// PROXY_API_URL should end with the hostname and not /api/v1/
-// e.g. PROXY_API_URL=http://api.flagsmith.com/
-if (process.env.PROXY_API_URL) {
+// FLAGSMITH_PROXY_API_URL should end with the hostname and not /api/v1/
+// e.g. FLAGSMITH_PROXY_API_URL=http://api.flagsmith.com/
+if (process.env.FLAGSMITH_PROXY_API_URL) {
     const { createProxyMiddleware } = require('http-proxy-middleware');
     app.use('/api/v1/', createProxyMiddleware({ target: process.env.FLAGSMITH_PROXY_API_URL, changeOrigin: true }));
 }


### PR DESCRIPTION
fix rename of `PROXY_API_URL` in this commit https://github.com/Flagsmith/flagsmith/commit/ab79fbd521dee59d6e1d7c63361ba1d7034685da 