### PR TITLE
Batch influxDB writes

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -56,6 +56,11 @@ INFLUXDB_TOKEN = env.str("INFLUXDB_TOKEN", default="")
 INFLUXDB_BUCKET = env.str("INFLUXDB_BUCKET", default="")
 INFLUXDB_URL = env.str("INFLUXDB_URL", default="")
 INFLUXDB_ORG = env.str("INFLUXDB_ORG", default="")
+INFLUXDB_BATCH_SIZE = env.int("INFLUXDB_BATCH_SIZE", default=100)
+INFLUXDB_FLUSH_INTERVAL = env.int("INFLUXDB_FLUSH_INTERVAL", default=2000) # this is ms
+INFLUXDB_RETRY_INTERVAL = env.int("INFLUXDB_RETRY_INTERVAL", default=2000) # also ms
+INFLUXDB_RETRY_MAX = env.int("INFLUXDB_RETRY_MAX", default=5) # Maximum number of retries
+
 
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=[])
 CSRF_TRUSTED_ORIGINS = env.list("DJANGO_CSRF_TRUSTED_ORIGINS", default=[])

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -3,7 +3,7 @@ import typing
 from collections import defaultdict
 
 from django.conf import settings
-from influxdb_client import InfluxDBClient, Point
+from influxdb_client import InfluxDBClient, Point, WriteOptions
 from influxdb_client.client.write_api import SYNCHRONOUS
 from sentry_sdk import capture_exception
 from urllib3 import Retry
@@ -31,7 +31,15 @@ class InfluxDBWrapper:
     def __init__(self, name):
         self.name = name
         self.records = []
-        self.write_api = influxdb_client.write_api(write_options=SYNCHRONOUS)
+        #self.write_api = influxdb_client.write_api(write_options=SYNCHRONOUS)
+        self.write_api = influxdb_client.write_api(
+            write_options = WriteOptions(
+                    batch_size=10,
+                    flush_interval=1200_000, # For testing purposes, want to ensure we don't hit a time based flush
+                    retry_interval=20_000,
+                    max_retries=5
+                )
+            )
 
     def add_data_point(self, field_name, field_value, tags=None):
         point = Point(self.name)

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from influxdb_client import InfluxDBClient, Point, WriteOptions
 from influxdb_client.client.write_api import SYNCHRONOUS
 from sentry_sdk import capture_exception
-from urllib3 import Retry
 from urllib3.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)
@@ -23,8 +22,8 @@ range_bucket_mappings = {
     "7d": settings.INFLUXDB_BUCKET + "_downsampled_15m",
     "30d": settings.INFLUXDB_BUCKET + "_downsampled_1h",
 }
-retries = Retry(connect=3, read=3, redirect=3)
-influxdb_client = InfluxDBClient(url=url, token=token, org=influx_org, retries=retries)
+
+influxdb_client = InfluxDBClient(url=url, token=token, org=influx_org)
 
 
 class InfluxDBWrapper:

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -31,13 +31,12 @@ class InfluxDBWrapper:
     def __init__(self, name):
         self.name = name
         self.records = []
-        #self.write_api = influxdb_client.write_api(write_options=SYNCHRONOUS)
         self.write_api = influxdb_client.write_api(
             write_options = WriteOptions(
-                    batch_size=10,
-                    flush_interval=1200_000, # For testing purposes, want to ensure we don't hit a time based flush
-                    retry_interval=20_000,
-                    max_retries=5
+                    batch_size=settings.INFLUXDB_BATCH_SIZE,
+                    flush_interval=settings.INFLUXDB_FLUSH_INTERVAL,
+                    retry_interval=settings.INFLUXDB_RETRY_INTERVAL,
+                    max_retries=settings.INFLUXDB_RETRY_MAX
                 )
             )
 

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -41,6 +41,14 @@ class InfluxDBWrapper:
                 )
             )
 
+    def __del__(self):
+        # Ensure any queued writes get flushed
+        #
+        # Check the attribute exists - we don't want to pollute any early start
+        # failures with misleading messages
+        if hasattr(self, "write_api") and self.write_api:
+            self.write_api.close()
+
     def add_data_point(self, field_name, field_value, tags=None):
         point = Point(self.name)
         point.field(field_name, field_value)

--- a/api/app_analytics/middleware.py
+++ b/api/app_analytics/middleware.py
@@ -1,6 +1,7 @@
 from .track import (
     track_request_googleanalytics_async,
     track_request_influxdb_async,
+    get_influxdb_wrapper
 )
 
 
@@ -20,10 +21,11 @@ class GoogleAnalyticsMiddleware:
 class InfluxDBMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
+        self.InfluxDB = get_influxdb_wrapper()
 
     def __call__(self, request):
         # for each API request, trigger a call to InfluxDB to track the request
-        track_request_influxdb_async(request)
+        track_request_influxdb_async(request, self.InfluxDB)
 
         response = self.get_response(request)
 

--- a/api/app_analytics/track.py
+++ b/api/app_analytics/track.py
@@ -33,8 +33,11 @@ def track_request_googleanalytics_async(request):
 
 
 @postpone
-def track_request_influxdb_async(request):
-    return track_request_influxdb(request)
+def track_request_influxdb_async(request, influxdb):
+    return track_request_influxdb(request, influxdb)
+
+def get_influxdb_wrapper():
+    return InfluxDBWrapper("api_call")
 
 
 def get_resource_from_uri(request_uri):
@@ -92,7 +95,7 @@ def track_event(category, action, label="", value=""):
     requests.post(GOOGLE_ANALYTICS_COLLECT_URL, data=data)
 
 
-def track_request_influxdb(request):
+def track_request_influxdb(request, influxdb):
     """
     Sends API event data to InfluxDB
 
@@ -115,7 +118,7 @@ def track_request_influxdb(request):
             "project_id": environment.project_id,
         }
 
-        influxdb = InfluxDBWrapper("api_call")
+        #influxdb = InfluxDBWrapper("api_call")
         influxdb.add_data_point("request_count", 1, tags=tags)
         influxdb.write()
 


### PR DESCRIPTION
This PR shuffles things around a little to allow InfluxDB writes to be batched.

### Changes

4 Settings are added:

* `INFLUXDB_BATCH_SIZE` : How many entries should we try to reach before writing (default 100)
* `INFLUXDB_FLUSH_INTERVAL` : If the above isn't reached, how often should we flush (default 2000ms)
* `INFLUXDB_RETRY_INTERVAL`: If a write fails, how long do we wait to retry (default 2000ms)
* `INFLUXDB_RETRY_MAX`: How many retries should there be

I've not added these to the `docker-compose` files, but they _can_ be added there to override the defaults.


Because records are now queued, a timestamp needed to be added to them (without this, InfluxDB will use the time it received them, so you'd see rushes of activity periodically when graphing behaviour out).

To tie this all together, `InfluxDBWrapper` needs to persist between requests rather than be reinstantiated each time. As `track.py` doesn't contain a class, I added a property to `InfluxDBMiddleware` - it's not the cleanest solution, but seemed better to keep changes small than to try and refactor.

A destructor has also been added to try and ensure that any pending records get flushed when the system is being shutdown (though this is obviously subject to the very limited guarantee's Python gives for `__del__()`)


### Verification

I tested this against an InfluxDB account at cloud2.influxdata.com. In order to view the writes and verify, I adjusted the compose slightly to include a man-in-the-middle (changes marked with `<HERE>`:

```
version: '3'
services:
    api:
        image: buildtest
        environment:
            DJANGO_ALLOWED_HOSTS: '*' # Change this in production
            DATABASE_URL: postgresql://postgres:password@db:5432/flagsmith
            INFLUXDB_URL: http://mitm  # <HERE>
            INFLUXDB_BUCKET: [my bucket]
            INFLUXDB_ORG: [my org]
            INFLUXDB_TOKEN: [my token]
        ports:
            - '8000:8000'
        depends_on:
            - db
        links:
            - db:db
            - mitm:mitm # <HERE>
            # - influxdb:influxdb
        container_name: flagsmith_api

    frontend:
        image: flagsmith/flagsmith-frontend:latest
        environment:
            # You might need to change the 2 host names below depending on your docker dns setup
            FLAGSMITH_API_URL: http://localhost:8000/api/v1/
            STATIC_ASSET_CDN_URL: http://localhost:8080/
            ENABLE_INFLUXDB_FEATURES: 'true' # set to true to enable InfluxDB
            FLAGSMITH_ON_FLAGSMITH_API_KEY: 4vfqhypYjcPoGGu8ByrBaj # This is the production Flagsmith API key
        ports:
            - '8080:8080'
        links:
            - api:api
        container_name: flagsmith_frontend

    db:
        image: postgres:11.12-alpine
        environment:
            POSTGRES_PASSWORD: password
            POSTGRES_DB: flagsmith
        container_name: flagsmith_postgres

    mitm: # <HERE>
        image: bentasker12/nginx_simple_mitm # <HERE>
        environment: # <HERE>
            SERVER_NAME: _ # <HERE>
            DEST: https://us-east-1-1.aws.cloud2.influxdata.com # <HERE>
        container_name: mitm

```
Where `DEST` in the `mitm` is the URL you'd normally use to reach the cloud service.

By exec'ing into `mitm` and running a capture whilst calling the Flagsmith API, we can confirm that writes are indeed being batched:
```
POST /api/v2/write?org=[redacted]&bucket=[redacted]&precision=ns HTTP/1.1
Host: mitm
Accept-Encoding: identity
Content-Length: 2739
Content-Encoding: identity
Content-Type: text/plain
Accept: application/json
Authorization: Token [redacted]
User-Agent: influxdb-client-python/1.11.0

api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817431322000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817578957000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817760628000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817771196000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817802033000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817813284000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817824639000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817845716000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817878201000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099817888232000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099826854786000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099826898798000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099826962182000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099826986282000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099826998235000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099827022665000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099827034332000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099827047225000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099827058720000
api_call,organisation=1-Test\ org,organisation_id=1,project=My\ project,project_id=1,resource=flags request_count=1i 1633099828357113000HTTP/1.1 204 No Content
Server: nginx/1.21.1
Date: Fri, 01 Oct 2021 14:50:28 GMT
Connection: keep-alive
trace-id: cd04e455453df13a
trace-sampled: false
Strict-Transport-Security: max-age=15724800; includeSubDomains
X-Influxdb-Build: Cloud
```

I also killed the `mitm` container to verify that upstream write failures wouldn't disrupt the API's JSON response - there's no change to the response, and in the error logs you'll get warnings like

```
    flagsmith_api | urllib3.connectionpool WARNING  Retrying (WritesRetry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff940600190>: Failed to establish a new connection: [Errno -2] Name or service not known')': /api/v2/write?org=[my org]&bucket=[my bucket]&precision=ns

    flagsmith_api | urllib3.connectionpool WARNING  Retrying (WritesRetry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff94059a6a0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /api/v2/write?org=[my org]&bucket=[my bucket]&precision=ns
    flagsmith_api | urllib3.connectionpool WARNING  Retrying (WritesRetry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7ff9405995e0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /api/v2/write?org=[my org]&bucket=[my bucket]&precision=ns

```


### Summary 

This PR makes adjustments so that writes to an upstream InfluxDB are batched in order to minimise the overheads of repeated writes.

With the default config established in this PR, the Analytics modules will write to InfluxDB

- Every 100 datapoints, or
- Every 2 seconds

In the event of a write failure, there will be up to 5 retries 2 seconds apart. It's not implemented in the PR, but you could also adjust to [make the delay exponential](https://github.com/influxdata/influxdb-client-python#batching)