### PR TITLE
Making iOS Install help consistent with the documentation

### DIFF
--- a/frontend/common/code-help/create-user/create-user-ios.js
+++ b/frontend/common/code-help/create-user/create-user-ios.js
@@ -1,23 +1,23 @@
 import Utils from '../../utils/utils';
 
-module.exports = (envId, { FEATURE_NAME,USER_ID, FEATURE_FUNCTION, FEATURE_NAME_ALT }) => `import BulletTrainClient
+module.exports = (envId, { FEATURE_NAME,USER_ID, FEATURE_FUNCTION, FEATURE_NAME_ALT }) => `import FlagsmithClient
 
 func application(_ application: UIApplication,
  didFinishLaunchingWithOptions launchOptions:
   [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-  BulletTrain.shared.apiKey = "${envId}"
-  
+  Flagsmith.shared.apiKey = "${envId}"
+
   // This will create a user in the dashboard if they don't already exist
-  
+
   // Check for a feature
-  BulletTrain.shared
+  Flagsmith.shared
   .hasFeatureFlag(withID: "${FEATURE_NAME}", forIdentity: "${USER_ID}") { (result) in
       print(result)
   }
 
   // Or, use the value of a feature
-  BulletTrain.shared
+  Flagsmith.shared
   .getFeatureValue(withID: "${FEATURE_NAME_ALT}", forIdentity: "${USER_ID}") { (result) in
       switch result {
       case .success(let value):

--- a/frontend/common/code-help/init/init-ios.js
+++ b/frontend/common/code-help/init/init-ios.js
@@ -1,19 +1,19 @@
 import Utils from '../../utils/utils';
 
-module.exports = (envId, { FEATURE_NAME, FEATURE_FUNCTION, FEATURE_NAME_ALT }) => `import BulletTrainClient
+module.exports = (envId, { FEATURE_NAME, FEATURE_FUNCTION, FEATURE_NAME_ALT }) => `import FlagsmithClient
 
 func application(_ application: UIApplication,
  didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-  BulletTrain.shared.apiKey = "${envId}"
+  Flagsmith.shared.apiKey = "${envId}"
   // Check for a feature
-  BulletTrain.shared
+  Flagsmith.shared
   .hasFeatureFlag(withID: "${FEATURE_NAME}", forIdentity: nil) { (result) in
       print(result)
   }
 
   // Or, use the value of a feature
-  BulletTrain.shared
+  Flagsmith.shared
   .getFeatureValue(withID: "${FEATURE_NAME_ALT}", forIdentity: nil) { (result) in
       switch result {
       case .success(let value):

--- a/frontend/common/code-help/install/install-ios.js
+++ b/frontend/common/code-help/install/install-ios.js
@@ -1,3 +1,3 @@
 module.exports = ({ NPM_RN_CLIENT }) => `// cocoapods
-pod 'BulletTrainClient', '~> 1.0.1'
+pod 'FlagsmithClient', '~> 1.0.1'
 `;


### PR DESCRIPTION
I think "BulletTrainClient" is the old name? The docs mention "FlagsmithClient," so I changed it accordingly.