### PR TITLE
Allow sentry-trace header in CORS restrictions

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -271,7 +271,7 @@ STATIC_ROOT = os.path.join(PROJECT_ROOT, "../../static/")
 # CORS settings
 
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_ALLOW_HEADERS = default_headers + ("X-Environment-Key", "X-E2E-Test-Auth-Token")
+CORS_ALLOW_HEADERS = default_headers + ("X-Environment-Key", "X-E2E-Test-Auth-Token", "sentry-trace")
 
 DEFAULT_FROM_EMAIL = env("SENDER_EMAIL", default="noreply@flagsmith.com")
 EMAIL_CONFIGURATION = {


### PR DESCRIPTION
The way Sentry works in the browser is that it injects itself into the XMLHttpRequest function and adds a sentry-trace header there. This ends up causing calls to the Flagsmith api to fail. I think the proper way to do it is just allow the sentry flags to pass through

Optionally just allow ALL headers. I am not sure why there are header restrictions in the first place.