### PR TITLE
improvement/Precommit to ignore django migrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        args: [--config=./api/pyproject.toml]
+        exclude: migrations
   - repo: https://github.com/pycqa/flake8
     rev: '4.0.1'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
+        args: [--config=./api/pyproject.toml]
   - repo: https://github.com/pycqa/flake8
     rev: '4.0.1'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.3
+    rev: v2.2.0
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.9.3
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 21.10b0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
The pre-commit hook for `black` was not honouring `pyproject.toml` exclusions (as  descrbied https://github.com/psf/black/issues/438) this fixes that