### PR TITLE
Increase login throttle rate

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -171,7 +171,7 @@ REST_FRAMEWORK = {
     "UNICODE_JSON": False,
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "DEFAULT_THROTTLE_RATES": {
-        "login": "20/min",
+        "login": "120/min",
         "mfa_code": "5/min",
         "invite": "10/min",
     },

--- a/frontend/nightwatch.conf.js
+++ b/frontend/nightwatch.conf.js
@@ -45,6 +45,8 @@ module.exports = {
     test_settings: {
         default: {
             globals: {
+                end_session_on_fail: true,
+                skip_testcases_on_fail: true,
                 'waitForConditionPollInterval': 500, // sometimes internet is slow so wait.
                 'waitForConditionTimeout': 20000, // sometimes internet is slow so wait.
                 'asyncHookTimeout': 60000,
@@ -79,7 +81,7 @@ module.exports = {
                             });
                             browser.source((result) => {
                                 // Source will be stored in result.value
-                                console.log(result && result.value)
+                                console.log(result && result.value);
                                 done();
                             });
                         });

--- a/frontend/nightwatch.conf.js
+++ b/frontend/nightwatch.conf.js
@@ -75,13 +75,11 @@ module.exports = {
                     ) {
                         browser.getLog('browser', (logEntries) => {
                             logEntries.forEach((log) => {
-                                if (log.level === 'SEVERE') {
-                                    console.log(`[${log.level}] ${log.message}`);
-                                }
+                                console.log(`[${log.level}] ${log.message}`);
                             });
                             browser.source((result) => {
                                 // Source will be stored in result.value
-                                // console.log(result && result.value)
+                                console.log(result && result.value)
                                 done();
                             });
                         });


### PR DESCRIPTION
@kyle-ssg and I think this will fix the current failures we are seeing with the E2E tests. I can't quite see why our throttle on an unauthenticated endpoint like this would need to be so low, especially now that we have axes running too. 