### PR TITLE
Fix conditional logic in project overrides endpoint

### DIFF
--- a/api/app/views.py
+++ b/api/app/views.py
@@ -51,12 +51,11 @@ def project_overrides(request):
         "amplitude": "AMPLITUDE_API_KEY",
     }
 
-    override_data = {}
-
-    for key, value in config_mapping_dict.items():
-        settings_value = getattr(settings, value, None)
-        if settings_value:
-            override_data[key] = settings_value
+    override_data = {
+        key: getattr(settings, value)
+        for key, value in config_mapping_dict.items()
+        if getattr(settings, value, None) is not None
+    }
 
     return HttpResponse(
         content="window.projectOverrides = " + json.dumps(override_data),


### PR DESCRIPTION
Previously, if a value was explicitly set to False in the project overrides, it wouldn't appear in the response from this view.

It's probable that this change will maintain the current behaviour as I imagine that the FE is evaluating any missing values to false anyway, however, I think it's better to be explicit like this so that in the future, we can better understand what is being set. 