### PR TITLE
Handle subscriptions without subscription ids

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -64,7 +64,10 @@ class Organisation(models.Model):
         return self.users.count()
 
     def has_subscription(self):
-        return hasattr(self, "subscription")
+        return (
+            hasattr(self, "subscription")
+            and self.subscription.subscription_id is not None
+        )
 
     def over_plan_seats_limit(self):
         if self.has_subscription():

--- a/api/organisations/tests/test_models.py
+++ b/api/organisations/tests/test_models.py
@@ -16,6 +16,31 @@ class OrganisationTestCase(TestCase):
         self.assertTrue(organisation_1.name)
         self.assertTrue(organisation_2.name)
 
+    def test_has_subscription_true(self):
+        # Given
+        organisation = Organisation.objects.create(name="Test org")
+        Subscription.objects.create(
+            organisation=organisation, subscription_id="subscription_id"
+        )
+
+        # Then
+        assert organisation.has_subscription()
+
+    def test_has_subscription_missing_subscription(self):
+        # Given
+        organisation = Organisation.objects.create(name="Test org")
+
+        # Then
+        assert not organisation.has_subscription()
+
+    def test_has_subscription_missing_subscription_id(self):
+        # Given
+        organisation = Organisation.objects.create(name="Test org")
+        Subscription.objects.create(organisation=organisation)
+
+        # Then
+        assert not organisation.has_subscription()
+
 
 class SubscriptionTestCase(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Handles the case raised [here](https://github.com/Flagsmith/flagsmith/issues/312#issuecomment-986043706) by throwing a more appropriate error. 