### PR TITLE
feat(audit-logs/search): Add filter using log and environments

### DIFF
--- a/api/audit/serializers.py
+++ b/api/audit/serializers.py
@@ -22,3 +22,11 @@ class AuditLogSerializer(serializers.ModelSerializer):
             "related_object_id",
             "related_object_type",
         )
+
+
+class AuditLogsQueryParamSerializer(serializers.Serializer):
+    project = serializers.IntegerField(required=False)
+    environments = serializers.ListField(
+        child=serializers.IntegerField(min_value=0), required=False
+    )
+    search = serializers.CharField(max_length=256, required=False)

--- a/api/audit/tests/test_views.py
+++ b/api/audit/tests/test_views.py
@@ -3,6 +3,7 @@ from rest_framework import status
 
 from audit.models import AuditLog
 from environments.models import Environment
+from projects.models import Project
 
 
 def test_audit_log_can_be_filtered_by_environments(admin_client, project, environment):
@@ -25,9 +26,7 @@ def test_audit_log_can_be_filtered_by_environments(admin_client, project, enviro
     assert response.json()["results"][1]["environment"] is None
 
 
-def test_audit_log_can_be_filtered_by_related_object_type(
-    admin_client, project, environment
-):
+def test_audit_log_can_be_filtered_by_log_text(admin_client, project, environment):
     # Given
     flag_state_updated_log = "Flag state updated"
     flag_state_deleted_log = "flag state deleted"
@@ -46,3 +45,26 @@ def test_audit_log_can_be_filtered_by_related_object_type(
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["results"][0]["log"] == flag_state_deleted_log
     assert response.json()["results"][1]["log"] == flag_state_updated_log
+
+
+def test_audit_log_can_be_filtered_by_project(
+    admin_client, project, environment, organisation
+):
+    # Given
+    another_project = Project.objects.create(
+        name="another_project", organisation=organisation
+    )
+    AuditLog.objects.create(project=project)
+    AuditLog.objects.create(project=project, environment=environment)
+    AuditLog.objects.create(project=another_project, environment=environment)
+
+    url = reverse("api-v1:audit-list")
+
+    # When
+    response = admin_client.get(url, {"project": project.id})
+
+    # Then
+    assert response.json()["count"] == 2
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["results"][0]["project"]["id"] == project.id
+    assert response.json()["results"][1]["project"]["id"] == project.id

--- a/api/audit/tests/test_views.py
+++ b/api/audit/tests/test_views.py
@@ -1,0 +1,48 @@
+from django.urls import reverse
+from rest_framework import status
+
+from audit.models import AuditLog
+from environments.models import Environment
+
+
+def test_audit_log_can_be_filtered_by_environments(admin_client, project, environment):
+    # Given
+    audit_env = Environment.objects.create(name="env_n", project=project)
+
+    AuditLog.objects.create(project=project)
+    AuditLog.objects.create(project=project, environment=environment)
+    AuditLog.objects.create(project=project, environment=audit_env)
+
+    url = reverse("api-v1:audit-list")
+    # When
+    response = admin_client.get(
+        url, {"project": project.id, "environments": [audit_env.id]}
+    )
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["count"] == 2
+    assert response.json()["results"][0]["environment"]["id"] == audit_env.id
+    assert response.json()["results"][1]["environment"] is None
+
+
+def test_audit_log_can_be_filtered_by_related_object_type(
+    admin_client, project, environment
+):
+    # Given
+    flag_state_updated_log = "Flag state updated"
+    flag_state_deleted_log = "flag state deleted"
+
+    AuditLog.objects.create(project=project, log="New flag created")
+    AuditLog.objects.create(project=project, log=flag_state_updated_log)
+    AuditLog.objects.create(project=project, log=flag_state_deleted_log)
+    AuditLog.objects.create(project=project, log="New Environment Created")
+
+    url = reverse("api-v1:audit-list")
+
+    # When
+    response = admin_client.get(url, {"project": project.id, "search": "flag state"})
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["results"][0]["log"] == flag_state_deleted_log
+    assert response.json()["results"][1]["log"] == flag_state_updated_log

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from rest_framework.test import APIClient
 
 from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
@@ -9,8 +10,17 @@ from projects.models import Project
 
 
 @pytest.fixture()
-def organisation(db):
-    return Organisation.objects.create(name="Test Org")
+def admin_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture()
+def organisation(db, admin_user):
+    org = Organisation.objects.create(name="Test Org")
+    admin_user.add_organisation(org)
+    return org
 
 
 @pytest.fixture()


### PR DESCRIPTION
Accepts `search` as query parms to perform search on `log`.

Since the audit log table is huge, I think we should run the SQL on prod database to see the performance once before rolling it out to production. 
Generated sql looks like this:
```
 SELECT          "audit_auditlog"."id",
                "audit_auditlog"."created_date",
                "audit_auditlog"."project_id",
                "audit_auditlog"."environment_id",
                "audit_auditlog"."log",
                "audit_auditlog"."author_id",
                "audit_auditlog"."related_object_id",
                "audit_auditlog"."related_object_type",
                "projects_project"."id",
                "projects_project"."name",
                "projects_project"."created_date",
                "projects_project"."organisation_id",
                "projects_project"."hide_disabled_flags",
                "projects_project"."enable_dynamo_db",
                "environments_environment"."id",
                "environments_environment"."name",
                "environments_environment"."created_date",
                "environments_environment"."project_id",
                "environments_environment"."api_key",
                "environments_environment"."webhooks_enabled",
                "environments_environment"."webhook_url",
                "users_ffadminuser"."id",
                "users_ffadminuser"."password",
                "users_ffadminuser"."last_login",
                "users_ffadminuser"."is_superuser",
                "users_ffadminuser"."is_staff",
                "users_ffadminuser"."is_active",
                "users_ffadminuser"."date_joined",
                "users_ffadminuser"."email",
                "users_ffadminuser"."username",
                "users_ffadminuser"."first_name",
                "users_ffadminuser"."last_name",
                "users_ffadminuser"."google_user_id",
                "users_ffadminuser"."github_user_id"
FROM            "audit_auditlog"
INNER JOIN      "projects_project"
ON              (
                                "audit_auditlog"."project_id" = "projects_project"."id")
LEFT OUTER JOIN "environments_environment"
ON              (
                                "audit_auditlog"."environment_id" = "environments_environment"."id")
LEFT OUTER JOIN "users_ffadminuser"
ON              (
                                "audit_auditlog"."author_id" = "users_ffadminuser"."id")
WHERE           (
                                "projects_project"."organisation_id" IN
                                (
                                           SELECT     u0."id"
                                           FROM       "organisations_organisation" U0
                                           INNER JOIN "organisations_userorganisation" U1
                                           ON         (
                                                                 u0."id" = u1."organisation_id")
                                           WHERE      u1."user_id" = <user_id>)
                AND             Upper("audit_auditlog"."log"::text) LIKE Upper('%Segment%'))
ORDER BY        "audit_auditlog"."created_date" DESC limit 10


```
Full text search approach:
I think full text search approach seems kinda overkill right now because of multiple reasons:
1. The length of the log column is limited(less than 100 in most cases)
2. Django does not have support for full text search(out of the box) for all the databases that we support.


Ref: https://github.com/Flagsmith/flagsmith/issues/408