### PR TITLE
Audit log api search

### DIFF
--- a/frontend/common/dispatcher/app-actions.js
+++ b/frontend/common/dispatcher/app-actions.js
@@ -419,10 +419,11 @@ const AppActions = Object.assign({}, require('./base/_app-actions'), {
             pageSize,
         });
     },
-    getAuditLog(projectId) {
+    getAuditLog(projectId, search) {
         Dispatcher.handleViewAction({
             actionType: Actions.GET_AUDIT_LOG,
             projectId,
+            search
         });
     },
     getAuditLogPage(projectId, page) {

--- a/frontend/common/project.js
+++ b/frontend/common/project.js
@@ -1,31 +1,18 @@
-// Dev is unused
-// module.exports = global.Project = {
-//     api: 'https://api-dev.flagsmith.com/api/v1/',
-//     flagsmithClientAPI: 'https://api.flagsmith.com/api/v1/',
-//     flagsmith: '8KzETdDeMY7xkqkSkY3Gsg', // This is our Bullet Train API key - Bullet Train runs on Bullet Train!
-//     debug: false,
-//     env: 'dev', // This is used for Sentry tracking
-//     maintenance: false, // trigger maintenance mode
-//     demoAccount: {
-//         email: 'kyle+bullet-train@solidstategroup.com',
-//         password: 'demo_account',
-//     },
-//     chargebee: {
-//         site: 'flagsmith-test',
-//     },
-// };
-
 module.exports = global.Project = {
-    api: 'https://api-staging.flagsmith.com/api/v1/',
+    api: 'https://api.flagsmith.com/api/v1/',
     flagsmithClientAPI: 'https://api.flagsmith.com/api/v1/',
-    flagsmith: 'ENktaJnfLVbLifybz34JmX', // This is our Bullet Train API key - Bullet Train runs on Bullet Train!
-    env: 'staging', // This is used for Sentry tracking
+    flagsmith: '4vfqhypYjcPoGGu8ByrBaj', // This is our Bullet Train API key - Bullet Train runs on Bullet Train!
+    env: 'prod', // This is used for Sentry tracking
+    sentry: 'https://2f6eb58a3987406aaeee38d5f0c38005@o486744.ingest.sentry.io/5666694',
     maintenance: false, // trigger maintenance mode
+    cookieDomain: '.flagsmith.com',
+    excludeAnalytics: 'nightwatch@solidstategroup.com',
     demoAccount: {
         email: 'kyle+bullet-train@solidstategroup.com',
         password: 'demo_account',
     },
     chargebee: {
-        site: 'flagsmith-test',
+        site: 'flagsmith',
     },
+    assetUrl: 'https://cdn.flagsmith.com', // Location of the static files from build/, should contain a directory called static/
 };

--- a/frontend/common/stores/audit-log-store.js
+++ b/frontend/common/stores/audit-log-store.js
@@ -1,12 +1,14 @@
 const BaseStore = require('./base/_store');
 const data = require('../data/base/_data');
 
-const PAGE_SIZE = 999;
 
 const controller = {
     getAuditLog: (page, projectId) => {
+        const PAGE_SIZE = flagsmith.hasFeature("audit_api_search")? flagsmith.getValue("audit_api_search")||999 :999;
+
         store.loading();
-        const endpoint = ((page && `${page}${store.search ? `&q=${store.search}&project=${projectId}` : `&project=${projectId}`}`) || `${Project.api}audit/${store.search ? `?q=${store.search}&project=${projectId}` : `?project=${projectId}`}`);
+        let endpoint = ((page && `${page}${store.search ? `&search=${store.search}&project=${projectId}` : `&project=${projectId}`}`) || `${Project.api}audit/${store.search ? `?search=${store.search}&project=${projectId}` : `?project=${projectId}`}`);
+        endpoint = endpoint + `&page_size=${PAGE_SIZE}`
         data.get(endpoint)
             .then((res) => {
                 store.model = res && res.results;
@@ -27,10 +29,12 @@ const controller = {
 const store = Object.assign({}, BaseStore, {
     id: 'identitylist',
     paging: {
-        pageSize: PAGE_SIZE,
     },
     getPaging() {
-        return store.paging;
+        return {
+            ...store.paging,
+            pageSize: flagsmith.hasFeature("audit_api_search")?flagsmith.getValue("audit_api_search")||999 :999
+        };
     },
 });
 
@@ -40,7 +44,7 @@ store.dispatcherIndex = Dispatcher.register(store, (payload) => {
 
     switch (action.actionType) {
         case Actions.GET_AUDIT_LOG:
-            store.search = '';
+            store.search = action.search || '';
             controller.getAuditLog(null, action.projectId);
             break;
         case Actions.GET_AUDIT_LOG_PAGE:


### PR DESCRIPTION
This moves the searching of audit log entries to the API. when audit_api_search is enabled, the remote config determines the page size