### PR TITLE
feature/digital-ocean-1-click-installer

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -8,7 +8,7 @@ spec:
     dockerfile_path: Dockerfile
     http_port: 8000
     git:
-      branch: feature-digital-ocean-1-click-installer # todo: move to main
+      branch: main
       repo_clone_url: https://github.com/flagsmith/flagsmith.git
     envs:
       - key: DATABASE_URL

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -8,7 +8,7 @@ spec:
     dockerfile_path: Dockerfile
     http_port: 8000
     git:
-      branch: main
+      branch: feature-digital-ocean-1-click-installer # todo: move to main
       repo_clone_url: https://github.com/flagsmith/flagsmith.git
     envs:
       - key: DATABASE_URL

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,15 @@
+spec:
+  name: flagsmith
+  services:
+  - name: flagsmith-server
+    image:
+      registry_type: DOCKER_HUB
+      registry: flagsmith
+      repository: flagsmith
+      tag: latest
+    envs:
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        value: ${flagsmith-db.DATABASE_URL}
+  databases:
+  - name: flagsmith-db

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -14,5 +14,8 @@ spec:
       - key: DATABASE_URL
         scope: RUN_TIME
         value: ${flagsmith-db.DATABASE_URL}
+      - key: DJANGO_ALLOWED_HOSTS
+        scope: RUN_TIME
+        value: '*'
   databases:
   - name: flagsmith-db

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -2,11 +2,10 @@ spec:
   name: flagsmith
   services:
   - name: flagsmith-server
-    image:
-      registry_type: DOCKER_HUB
-      registry: flagsmith
-      repository: flagsmith
-      tag: latest
+    dockerfile_path: Dockerfile
+    git:
+      branch: main
+      repo_clone_url: https://github.com/flagsmith/flagsmith.git
     envs:
       - key: DATABASE_URL
         scope: RUN_TIME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,8 +1,12 @@
+# This file describes the deployment for a Digital Ocean One Click app install
+# It builds the unified dockerfile, creates a DB connects the Flagsmith server to the DB
+
 spec:
   name: flagsmith
   services:
   - name: flagsmith-server
     dockerfile_path: Dockerfile
+    http_port: 8000
     git:
       branch: main
       repo_clone_url: https://github.com/flagsmith/flagsmith.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ ENV DJANGO_SETTINGS_MODULE=app.settings.production
 
 EXPOSE 8000
 
-#USER nobody
+USER nobody
 
 CMD ["./scripts/run-docker.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ ENV DJANGO_SETTINGS_MODULE=app.settings.production
 
 EXPOSE 8000
 
-USER nobody
+#USER nobody
 
 CMD ["./scripts/run-docker.sh"]

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -2,4 +2,5 @@
 set -e
 
 python manage.py migrate
-gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir /dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi
+mkdir gunicorn-worker-tmp-dir
+gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir=gunicorn-worker-tmp-dir --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -2,4 +2,4 @@
 set -e
 
 python manage.py migrate
-gunicorn --bind 0.0.0.0:8000 --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} app.wsgi --access-logfile $ACCESS_LOG_LOCATION
+gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir /dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} app.wsgi --access-logfile $ACCESS_LOG_LOCATION

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -2,4 +2,4 @@
 set -e
 
 python manage.py migrate
-gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir /dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} app.wsgi --access-logfile $ACCESS_LOG_LOCATION
+gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir /dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -2,5 +2,4 @@
 set -e
 
 python manage.py migrate
-mkdir gunicorn-worker-tmp-dir
-gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir=/dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi
+gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir /dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -3,4 +3,4 @@ set -e
 
 python manage.py migrate
 mkdir gunicorn-worker-tmp-dir
-gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir=gunicorn-worker-tmp-dir --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi
+gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir=/dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi


### PR DESCRIPTION
App Spec to deploy to digital ocean

Also updates docker to run gunicorn without touching `/tmp` as it can sometimes be read only

one click URL is 
https://cloud.digitalocean.com/apps/new?repo=https://github.com/flagsmith/flagsmith/tree/main