### PR TITLE
improvement/fix-render-builds

### DIFF
--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -2,4 +2,10 @@
 set -e
 
 python manage.py migrate
-gunicorn --bind 0.0.0.0:8000 --worker-tmp-dir /dev/shm --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --access-logfile $ACCESS_LOG_LOCATION app.wsgi
+gunicorn --bind 0.0.0.0:8000 \
+         --worker-tmp-dir /dev/shm \
+         --timeout ${GUNICORN_TIMEOUT:-30} \
+         --workers ${GUNICORN_WORKERS:-3} \
+         --threads ${GUNICORN_THREADS:-2} \
+         --access-logfile $ACCESS_LOG_LOCATION \
+         app.wsgi

--- a/render.yaml
+++ b/render.yaml
@@ -6,16 +6,19 @@ services:
     - type: web
       name: flagsmith
       env: docker
-      repo: https://github.com/flagsmith/flagsmith.git
       healthCheckPath: /health
       envVars:
+          - key: PORT
+            value: 8000
           - key: DATABASE_URL
             fromDatabase:
                 name: flagsmith-db
                 property: connectionString
           - key: DJANGO_ALLOWED_HOSTS
             value: "*"
-
+          - key: GUNICORN_TIMEOUT
+            value: 300
+          
 databases:
     # The Flagsmith Postgres Database
     - name: flagsmith-db


### PR DESCRIPTION
Render.com deployments break without this timeout. It's useful to be able to control this regardless. 