### PR TITLE
feat(mailer_lite): add new subscribers to a given group

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -520,6 +520,7 @@ MAILERLITE_BASE_URL = env.str(
     "MAILERLITE_BASE_URL", default="https://api.mailerlite.com/api/v2/"
 )
 MAILERLITE_API_KEY = env.str("MAILERLITE_API_KEY", None)
+MAILERLITE_NEW_USER_GROUP_ID = env.int("MAILERLITE_NEW_USER_GROUP_ID", None)
 
 # Additional functionality for using SAML in Flagsmith SaaS
 SAML_MODULE_PATH = env("SAML_MODULE_PATH", os.path.join(BASE_DIR, "saml"))

--- a/api/users/tests/utils/test_mailer_lite.py
+++ b/api/users/tests/utils/test_mailer_lite.py
@@ -17,8 +17,7 @@ def test_mailer_lite_subscribe_calls_post_with_correct_arguments(mocker, setting
     mocked_requests = mocker.patch("users.utils.mailer_lite.requests")
     base_url = "http//localhost/mailer/test/"
     settings.MAILERLITE_BASE_URL = base_url
-    resource = "subscribers"
-
+    resource = "/test"
     user = FFAdminUser.objects.create(
         email="test_user",
         first_name="test",
@@ -26,6 +25,8 @@ def test_mailer_lite_subscribe_calls_post_with_correct_arguments(mocker, setting
         marketing_consent_given=True,
     )
     mailer_lite = MailerLite()
+
+    mocker.patch("users.utils.mailer_lite.MailerLite.resource", resource)
     mocked_headers = mocker.patch(
         "users.utils.mailer_lite.MailerLiteBaseClient.request_headers",
     )

--- a/api/users/utils/mailer_lite.py
+++ b/api/users/utils/mailer_lite.py
@@ -27,7 +27,7 @@ class MailerLiteBaseClient:
 
 
 class MailerLite(MailerLiteBaseClient):
-    resource = "subscribers"
+    resource = f"groups/{settings.MAILERLITE_NEW_USER_GROUP_ID}/subscribers"
 
     @postpone
     def subscribe(self, user: "models.FFAdminUser"):


### PR DESCRIPTION
Adds `MAILERLITE_NEW_USER_GROUP_ID` environment variable to set mailer lite group ID for new user. 

Implements #666 