### PR TITLE
Add ability to force sentry trace

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -485,6 +485,8 @@ if ENABLE_AXES:
 # Sentry tracking
 SENTRY_SDK_DSN = env("SENTRY_SDK_DSN", default=None)
 SENTRY_TRACE_SAMPLE_RATE = env.float("SENTRY_TRACE_SAMPLE_RATE", default=1.0)
+if SENTRY_SDK_DSN:
+    MIDDLEWARE.append("integrations.sentry.middleware.ForceSentryTraceMiddleware")
 
 # allow users to access the admin console
 ENABLE_ADMIN_ACCESS_USER_PASS = env.bool("ENABLE_ADMIN_ACCESS_USER_PASS", default=None)

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -485,6 +485,7 @@ if ENABLE_AXES:
 # Sentry tracking
 SENTRY_SDK_DSN = env("SENTRY_SDK_DSN", default=None)
 SENTRY_TRACE_SAMPLE_RATE = env.float("SENTRY_TRACE_SAMPLE_RATE", default=1.0)
+FORCE_SENTRY_TRACE_AUTH_KEY = env("FORCE_SENTRY_TRACE_AUTH_KEY", default=None)
 if SENTRY_SDK_DSN:
     MIDDLEWARE.append("integrations.sentry.middleware.ForceSentryTraceMiddleware")
 

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -485,8 +485,8 @@ if ENABLE_AXES:
 # Sentry tracking
 SENTRY_SDK_DSN = env("SENTRY_SDK_DSN", default=None)
 SENTRY_TRACE_SAMPLE_RATE = env.float("SENTRY_TRACE_SAMPLE_RATE", default=1.0)
-FORCE_SENTRY_TRACE_AUTH_KEY = env("FORCE_SENTRY_TRACE_AUTH_KEY", default=None)
-if SENTRY_SDK_DSN:
+FORCE_SENTRY_TRACE_KEY = env("FORCE_SENTRY_TRACE_KEY", default=None)
+if FORCE_SENTRY_TRACE_KEY:
     MIDDLEWARE.append("integrations.sentry.middleware.ForceSentryTraceMiddleware")
 
 # allow users to access the admin console

--- a/api/integrations/sentry/middleware.py
+++ b/api/integrations/sentry/middleware.py
@@ -2,7 +2,6 @@ import logging
 
 import sentry_sdk
 from django.conf import settings
-from rest_framework.exceptions import AuthenticationFailed
 
 logger = logging.getLogger(__name__)
 
@@ -12,31 +11,20 @@ class ForceSentryTraceMiddleware:
     Middleware class to allow us to force Sentry traces on given requests.
 
     To use the middleware the application must be running in an environment with the
-    FORCE_SENTRY_TRACE_AUTH_KEY environment variable set. Assuming that is done,
-    simply add the `force_sentry_trace` query parameter to the request and ensure that
-    the `X-Force-Sentry-Trace-Auth` header is set to the same value as the
-    FORCE_SENTRY_TRACE_AUTH_KEY environment variable.
+    FORCE_SENTRY_TRACE_KEY environment variable set. Assuming that is done,
+    simply add the `X-Force-Sentry-Trace-Key` header to any request and make sure it
+    is set to the same value as the FORCE_SENTRY_TRACE_AUTH_KEY environment variable.
     """
 
-    FORCE_SENTRY_TRACE_PARAM = "force_sentry_trace"
-    FORCE_SENTRY_TRACE_HEADER = "X-Force-Sentry-Trace-Auth"
+    FORCE_SENTRY_TRACE_HEADER = "X-Force-Sentry-Trace-Key"
 
     def __init__(self, get_response):
         self.get_response = get_response
-        self.auth_key = settings.FORCE_SENTRY_TRACE_AUTH_KEY
-        if not self.auth_key:
-            logger.warning(
-                "ForceSentryTraceMiddleware initialised without an auth key."
-            )
+        self.auth_key = settings.FORCE_SENTRY_TRACE_KEY
 
     def __call__(self, request):
-        if self.FORCE_SENTRY_TRACE_PARAM in request.GET:
-            auth = request.headers.get(self.FORCE_SENTRY_TRACE_HEADER)
-            if not auth or auth != self.auth_key:
-                raise AuthenticationFailed(
-                    "Incorrect authentication provided for forcing sentry trace."
-                )
-
+        auth = request.headers.get(self.FORCE_SENTRY_TRACE_HEADER)
+        if auth == self.auth_key:
             sentry_sdk.start_transaction(
                 name=f"{request.method} {request.path}", sampled=True
             )

--- a/api/integrations/sentry/middleware.py
+++ b/api/integrations/sentry/middleware.py
@@ -1,14 +1,42 @@
+import logging
+
 import sentry_sdk
+from django.conf import settings
+from rest_framework.exceptions import AuthenticationFailed
+
+logger = logging.getLogger(__name__)
 
 
 class ForceSentryTraceMiddleware:
+    """
+    Middleware class to allow us to force Sentry traces on given requests.
+
+    To use the middleware the application must be running in an environment with the
+    FORCE_SENTRY_TRACE_AUTH_KEY environment variable set. Assuming that is done,
+    simply add the `force_sentry_trace` query parameter to the request and ensure that
+    the `X-Force-Sentry-Trace-Auth` header is set to the same value as the
+    FORCE_SENTRY_TRACE_AUTH_KEY environment variable.
+    """
+
     FORCE_SENTRY_TRACE_PARAM = "force_sentry_trace"
+    FORCE_SENTRY_TRACE_HEADER = "X-Force-Sentry-Trace-Auth"
 
     def __init__(self, get_response):
         self.get_response = get_response
+        self.auth_key = settings.FORCE_SENTRY_TRACE_AUTH_KEY
+        if not self.auth_key:
+            logger.warning(
+                "ForceSentryTraceMiddleware initialised without an auth key."
+            )
 
     def __call__(self, request):
         if self.FORCE_SENTRY_TRACE_PARAM in request.GET:
+            auth = request.headers.get(self.FORCE_SENTRY_TRACE_HEADER)
+            if not auth or auth != self.auth_key:
+                raise AuthenticationFailed(
+                    "Incorrect authentication provided for forcing sentry trace."
+                )
+
             sentry_sdk.start_transaction(
                 name=f"{request.method} {request.path}", sampled=True
             )

--- a/api/integrations/sentry/middleware.py
+++ b/api/integrations/sentry/middleware.py
@@ -1,0 +1,16 @@
+import sentry_sdk
+
+
+class ForceSentryTraceMiddleware:
+    FORCE_SENTRY_TRACE_PARAM = "force_sentry_trace"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if self.FORCE_SENTRY_TRACE_PARAM in request.GET:
+            sentry_sdk.start_transaction(
+                name=f"{request.method} {request.path}", sampled=True
+            )
+
+        return self.get_response(request)

--- a/api/integrations/sentry/tests/test_middleware.py
+++ b/api/integrations/sentry/tests/test_middleware.py
@@ -1,0 +1,24 @@
+from integrations.sentry.middleware import ForceSentryTraceMiddleware
+
+
+def test_force_sentry_trace_middleware_starts_transaction_when_param_present(
+    rf, mocker
+):
+    # Given
+    mock_sentry_sdk = mocker.patch("integrations.sentry.middleware.sentry_sdk")
+
+    mock_response = mocker.MagicMock()
+    middleware = ForceSentryTraceMiddleware(get_response=lambda r: mock_response)
+    request = rf.get(
+        path="/some-endpoint",
+        data={ForceSentryTraceMiddleware.FORCE_SENTRY_TRACE_PARAM: "1"},
+    )
+
+    # When
+    response = middleware(request)
+
+    # Then
+    mock_sentry_sdk.start_transaction.assert_called_once_with(
+        name="GET /some-endpoint", sampled=True
+    )
+    assert response == mock_response

--- a/api/integrations/sentry/tests/test_middleware.py
+++ b/api/integrations/sentry/tests/test_middleware.py
@@ -1,6 +1,3 @@
-import pytest
-from rest_framework.exceptions import AuthenticationFailed
-
 from integrations.sentry.middleware import ForceSentryTraceMiddleware
 
 
@@ -11,16 +8,12 @@ def test_force_sentry_trace_middleware_starts_transaction_when_param_present(
     mock_sentry_sdk = mocker.patch("integrations.sentry.middleware.sentry_sdk")
 
     auth_key = "auth-key"
-    settings.FORCE_SENTRY_TRACE_AUTH_KEY = auth_key
+    settings.FORCE_SENTRY_TRACE_KEY = auth_key
 
     mock_response = mocker.MagicMock()
     middleware = ForceSentryTraceMiddleware(get_response=lambda r: mock_response)
 
-    request = rf.get(
-        path="/some-endpoint",
-        data={ForceSentryTraceMiddleware.FORCE_SENTRY_TRACE_PARAM: "1"},
-        HTTP_X_FORCE_SENTRY_TRACE_AUTH=auth_key,
-    )
+    request = rf.get(path="/some-endpoint", HTTP_X_FORCE_SENTRY_TRACE_KEY=auth_key)
 
     # When
     response = middleware(request)
@@ -32,26 +25,45 @@ def test_force_sentry_trace_middleware_starts_transaction_when_param_present(
     assert response == mock_response
 
 
-def test_force_sentry_trace_middleware_raises_exception_when_auth_incorrect(
+def test_force_sentry_trace_middleware_does_nothing_when_key_incorrect(
     rf, mocker, settings
 ):
     # Given
     mock_sentry_sdk = mocker.patch("integrations.sentry.middleware.sentry_sdk")
 
-    settings.FORCE_SENTRY_TRACE_AUTH_KEY = "auth-key"
+    settings.FORCE_SENTRY_TRACE_KEY = "auth-key"
 
     mock_response = mocker.MagicMock()
     middleware = ForceSentryTraceMiddleware(get_response=lambda r: mock_response)
 
     request = rf.get(
-        path="/some-endpoint",
-        data={ForceSentryTraceMiddleware.FORCE_SENTRY_TRACE_PARAM: "1"},
-        HTTP_X_FORCE_SENTRY_TRACE_AUTH="some-incorrect-auth",
+        path="/some-endpoint", HTTP_X_FORCE_SENTRY_TRACE_KEY="some-incorrect-auth"
     )
 
     # When
-    with pytest.raises(AuthenticationFailed):
-        middleware(request)
+    response = middleware(request)
 
     # Then
     mock_sentry_sdk.start_transaction.assert_not_called()
+    assert response == mock_response
+
+
+def test_force_sentry_trace_middleware_does_nothing_when_key_missing(
+    rf, mocker, settings
+):
+    # Given
+    mock_sentry_sdk = mocker.patch("integrations.sentry.middleware.sentry_sdk")
+
+    settings.FORCE_SENTRY_TRACE_KEY = "auth-key"
+
+    mock_response = mocker.MagicMock()
+    middleware = ForceSentryTraceMiddleware(get_response=lambda r: mock_response)
+
+    request = rf.get(path="/some-endpoint")
+
+    # When
+    response = middleware(request)
+
+    # Then
+    mock_sentry_sdk.start_transaction.assert_not_called()
+    assert response == mock_response

--- a/api/integrations/sentry/tests/test_middleware.py
+++ b/api/integrations/sentry/tests/test_middleware.py
@@ -1,17 +1,25 @@
+import pytest
+from rest_framework.exceptions import AuthenticationFailed
+
 from integrations.sentry.middleware import ForceSentryTraceMiddleware
 
 
 def test_force_sentry_trace_middleware_starts_transaction_when_param_present(
-    rf, mocker
+    rf, mocker, settings
 ):
     # Given
     mock_sentry_sdk = mocker.patch("integrations.sentry.middleware.sentry_sdk")
 
+    auth_key = "auth-key"
+    settings.FORCE_SENTRY_TRACE_AUTH_KEY = auth_key
+
     mock_response = mocker.MagicMock()
     middleware = ForceSentryTraceMiddleware(get_response=lambda r: mock_response)
+
     request = rf.get(
         path="/some-endpoint",
         data={ForceSentryTraceMiddleware.FORCE_SENTRY_TRACE_PARAM: "1"},
+        HTTP_X_FORCE_SENTRY_TRACE_AUTH=auth_key,
     )
 
     # When
@@ -22,3 +30,28 @@ def test_force_sentry_trace_middleware_starts_transaction_when_param_present(
         name="GET /some-endpoint", sampled=True
     )
     assert response == mock_response
+
+
+def test_force_sentry_trace_middleware_raises_exception_when_auth_incorrect(
+    rf, mocker, settings
+):
+    # Given
+    mock_sentry_sdk = mocker.patch("integrations.sentry.middleware.sentry_sdk")
+
+    settings.FORCE_SENTRY_TRACE_AUTH_KEY = "auth-key"
+
+    mock_response = mocker.MagicMock()
+    middleware = ForceSentryTraceMiddleware(get_response=lambda r: mock_response)
+
+    request = rf.get(
+        path="/some-endpoint",
+        data={ForceSentryTraceMiddleware.FORCE_SENTRY_TRACE_PARAM: "1"},
+        HTTP_X_FORCE_SENTRY_TRACE_AUTH="some-incorrect-auth",
+    )
+
+    # When
+    with pytest.raises(AuthenticationFailed):
+        middleware(request)
+
+    # Then
+    mock_sentry_sdk.start_transaction.assert_not_called()


### PR DESCRIPTION
Adds a GET parameter (and corresponding authentication header) to allow us to force sentry traces on a given request. 