### PR TITLE
Fix force sentry transaction logic

### DIFF
--- a/api/integrations/sentry/middleware.py
+++ b/api/integrations/sentry/middleware.py
@@ -29,6 +29,6 @@ class ForceSentryTraceMiddleware:
             with sentry_sdk.start_transaction(name=transaction_name, sampled=True):
                 response = self.get_response(request)
         else:
-            response = self.get_response()
+            response = self.get_response(request)
 
         return response

--- a/api/integrations/sentry/middleware.py
+++ b/api/integrations/sentry/middleware.py
@@ -25,8 +25,10 @@ class ForceSentryTraceMiddleware:
     def __call__(self, request):
         auth = request.headers.get(self.FORCE_SENTRY_TRACE_HEADER)
         if auth == self.auth_key:
-            sentry_sdk.start_transaction(
-                name=f"{request.method} {request.path}", sampled=True
-            )
+            transaction_name = f"{request.method} {request.path}"
+            with sentry_sdk.start_transaction(name=transaction_name, sampled=True):
+                response = self.get_response(request)
+        else:
+            response = self.get_response()
 
-        return self.get_response(request)
+        return response

--- a/api/integrations/sentry/tests/test_middleware.py
+++ b/api/integrations/sentry/tests/test_middleware.py
@@ -6,6 +6,10 @@ def test_force_sentry_trace_middleware_starts_transaction_when_param_present(
 ):
     # Given
     mock_sentry_sdk = mocker.patch("integrations.sentry.middleware.sentry_sdk")
+    mock_start_transaction_context_manager = mocker.MagicMock()
+    mock_sentry_sdk.start_transaction.return_value = (
+        mock_start_transaction_context_manager
+    )
 
     auth_key = "auth-key"
     settings.FORCE_SENTRY_TRACE_KEY = auth_key
@@ -22,6 +26,7 @@ def test_force_sentry_trace_middleware_starts_transaction_when_param_present(
     mock_sentry_sdk.start_transaction.assert_called_once_with(
         name="GET /some-endpoint", sampled=True
     )
+    mock_start_transaction_context_manager.__enter__.assert_called_once()
     assert response == mock_response
 
 


### PR DESCRIPTION
Found a new area of the documentation [here](https://docs.sentry.io/platforms/python/performance/instrumentation/custom-instrumentation/) that suggested the `start_transaction` method should be used as a context manager. 