### PR TITLE
Fixes README docker-compose command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ You can run the entire Flagsmith with Docker by running the following command:
 docker-compose -f docker-compose.yml up
 ```
 
-This will use some default settings created in the `docker/docker-compose.yml` file. These should be changed before
+This will use some default settings created in the `docker-compose.yml` file. These should be changed before
 running in any sort of production environments.
 
 ## Resources

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ REST calls to the API.
 You can run the entire Flagsmith with Docker by running the following command:
 
 ```bash
-docker-compose -f docker/docker-compose.yml up
+docker-compose -f docker-compose.yml up
 ```
 
 This will use some default settings created in the `docker/docker-compose.yml` file. These should be changed before


### PR DESCRIPTION
docker-compose.yml moved to root of the repo and is no longer under the `docker` folder