### PR TITLE
Reduce number of queries made when getting environment document

### DIFF
--- a/api/environments/managers.py
+++ b/api/environments/managers.py
@@ -33,6 +33,8 @@ class EnvironmentManager(Manager):
                 "project__segments__rules",
                 "project__segments__rules__rules",
                 "project__segments__rules__conditions",
+                "project__segments__rules__rules__conditions",
+                "project__segments__rules__rules__rules",
                 Prefetch(
                     "project__segments__feature_segments",
                     queryset=FeatureSegment.objects.select_related("segment"),

--- a/api/environments/sdk/views.py
+++ b/api/environments/sdk/views.py
@@ -2,6 +2,7 @@ from django.http import HttpRequest
 from flag_engine.django_transform.document_builders import (
     build_environment_document,
 )
+from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -17,7 +18,11 @@ class SDKEnvironmentAPIView(APIView):
         return [EnvironmentKeyAuthentication(required_key_prefix="ser.")]
 
     def get(self, request: HttpRequest) -> Response:
-        environment = Environment.objects.select_related(
-            "project", "project__organisation"
-        ).get(api_key=request.environment.api_key)
+        try:
+            environment = Environment.objects.filter_for_document_builder(
+                api_key=request.environment.api_key
+            ).get()
+        except Environment.DoesNotExist:
+            raise NotFound("Environment does not exist for given key.")
+
         return Response(build_environment_document(environment))


### PR DESCRIPTION
Optimise get environment document endpoint so it's now creating 100s of queries. This shouldn't be too useful for SaaS since anyone using the new SDKs (which use this endpoint) should be using the Edge API but for self hosted customers this could have been a large issue. 