### PR TITLE
Optimise / improve sales dashboard search

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/base.html
+++ b/api/sales_dashboard/templates/sales_dashboard/base.html
@@ -19,7 +19,7 @@
   <a class="navbar-brand col-md-3 col-lg-2 mr-0 px-3" href="#">Flagsmith</a>
       <form method="get" action="{% url 'sales_dashboard:index' %}" class="form-inline w-100">
         {% csrf_token %}
-        <input class="form-control mr-sm-2 w-100=" type="search" placeholder="Search" aria-label="Search" name="search" >
+        <input class="form-control mr-sm-2 w-100=" type="search" placeholder="Search" aria-label="Search" name="search" value="{{ search }}">
         <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
     </form>
   <ul class="navbar-nav px-3">

--- a/api/sales_dashboard/templates/sales_dashboard/home.html
+++ b/api/sales_dashboard/templates/sales_dashboard/home.html
@@ -15,24 +15,24 @@
       <div class="sort-form">
         <form action="{% url 'sales_dashboard:index' %}" method="get" class="form-inline float-right">
           <select name="filter_plan" id="filter-plan" class="custom-select m-1">
-            <option value="">Filter Plan</option>
-            <option value="free">Free</option>
-            <option value="start">Start Up</option>
-            <option value="scale">Scale Up</option>
+            <option value="" {% if not filter_plan %}selected{% endif %}>Filter Plan</option>
+            <option value="free" {% if filter_plan == "free" %}selected{% endif %}>Free</option>
+            <option value="start" {% if filter_plan == "start" %}selected{% endif %}>Start Up</option>
+            <option value="scale" {% if filter_plan == "scale" %}selected{% endif %}>Scale Up</option>
           </select>
-          <select name="sort_field" id="sort-field" class="custom-select m-1">
-            <option value="">Sort by...</option>
-            <option value="num_users">Seats</option>
-            <option value="num_projects">Projects</option>
-            <option value="num_features">Flags</option>
-            <option value="num_segments">Segments</option>
-            <option value="num_24h_calls">24h API calls</option>
-            <option value="num_7d_calls">7d API calls</option>
-            <option value="num_30d_calls">30d API calls</option>
+          <select name="sort_field" id="sort-field" class="custom-select m-1" value="{{ sort_field }}">
+            <option value="" {% if not sort_field %}selected{% endif %}>Sort by...</option>
+            <option value="num_users" {% if sort_field == "num_users" %}selected{% endif %}>Seats</option>
+            <option value="num_projects" {% if sort_field == "num_projects" %}selected{% endif %}>Projects</option>
+            <option value="num_features" {% if sort_field == "num_features" %}selected{% endif %}>Flags</option>
+            <option value="num_segments" {% if sort_field == "num_segments" %}selected{% endif %}>Segments</option>
+            <option value="num_24h_calls" {% if sort_field == "num_24h_calls" %}selected{% endif %}>24h API calls</option>
+            <option value="num_7d_calls" {% if sort_field == "num_7d_calls" %}selected{% endif %}>7d API calls</option>
+            <option value="num_30d_calls" {% if sort_field == "num_30d_calls" %}selected{% endif %}>30d API calls</option>
           </select>
           <select name="sort_direction" id="sort-direction" class="custom-select m-1">
-            <option value="ASC">Ascending</option>
-            <option value="DESC">Descending</option>
+            <option value="ASC" {% if not sort_direction or sort_direction == "ASC" %}selected{% endif %}>Ascending</option>
+            <option value="DESC" {% if sort_direction == "DESC" %}selected{% endif %}>Descending</option>
           </select>
           <button type="submit" class="btn btn-primary m-1">Apply</button>
         </form>

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -59,7 +59,8 @@ class OrganisationList(ListView):
                 queryset = queryset.filter(subscription__plan__icontains=filter_plan)
 
         # Annotate the queryset with the organisations usage for the given time periods
-        # and order the queryset with it.
+        # and order the queryset with it. Note: this is done as late as possible to
+        # reduce the impact of the query.
         if settings.INFLUXDB_TOKEN:
             for date_range, limit in (("30d", ""), ("7d", ""), ("24h", "100")):
                 key = f"num_{date_range}_calls"
@@ -92,6 +93,10 @@ class OrganisationList(ListView):
             )[:20]
             data["users"] = users
             data["search"] = search_term
+
+        data["filter_plan"] = self.request.GET.get("filter_plan")
+        data["sort_field"] = self.request.GET.get("sort_field")
+        data["sort_direction"] = self.request.GET.get("sort_direction")
 
         return data
 


### PR DESCRIPTION
This PR is based on a report from Matt A that he received a 504 error when searching for an account on the sales dashboard. 

This PR attempts to improve the search on the sales dashboard by doing a few things: 

 1. Only annotate the queryset with the influxdb data _after_ doing the search (this should reduce the impact of the query)
 2. Only search if the search term is truthy (previously we would search even if the search term was `""`)
 3. Present the current search term to the user after they have completed the search (this one isn't technically an optimisation but a trivial thing to improve the UX)