### PR TITLE
ECS prod is not using tagged docker images Fixes #835

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -47,7 +47,7 @@ jobs:
             - name: Build, tag, and push image to Amazon ECR
               id: build-image
               env:
-                  IMAGE_TAG: ${{ github.sha }}
+                  IMAGE_TAG: ${{ github.event.release.tag_name }}
               run: |
                   cd api
                   docker build -t $ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile .


### PR DESCRIPTION
As per https://github.community/t/how-to-get-just-the-tag-name/16241/23?page=2

I think this might break if there's no tag, but we would probably want that behaviour on prod