### PR TITLE
Fix/slack oauth init permission

### DIFF
--- a/api/integrations/slack/permissions.py
+++ b/api/integrations/slack/permissions.py
@@ -1,15 +1,16 @@
 import logging
 
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import IsAuthenticated
 
 from environments.models import Environment
 
 logger = logging.getLogger(__name__)
 
 
-class OauthInitPermission(BasePermission):
+class OauthInitPermission(IsAuthenticated):
     def has_permission(self, request, view):
-
+        if not super().has_permission(request, view):
+            return False
         logger.debug(
             "OauthInitPermission called with user: %s and view: %s", request.user, view
         )

--- a/api/integrations/slack/permissions.py
+++ b/api/integrations/slack/permissions.py
@@ -1,19 +1,13 @@
-import logging
-
 from rest_framework.permissions import IsAuthenticated
 
 from environments.models import Environment
-
-logger = logging.getLogger(__name__)
 
 
 class OauthInitPermission(IsAuthenticated):
     def has_permission(self, request, view):
         if not super().has_permission(request, view):
             return False
-        logger.debug(
-            "OauthInitPermission called with user: %s and view: %s", request.user, view
-        )
+
         environment = Environment.objects.get(
             api_key=view.kwargs.get("environment_api_key")
         )

--- a/api/tests/integration/slack/test_slack_token_flow.py
+++ b/api/tests/integration/slack/test_slack_token_flow.py
@@ -4,8 +4,22 @@ from django.urls import reverse
 from rest_framework import status
 
 
+def test_slack_oauth_flow_returns_401_if_secret_is_invalid(
+    environment_api_key, api_client
+):
+    # Given
+    base_url = reverse(
+        "api-v1:environments:integrations-slack-slack-oauth-init",
+        args=[environment_api_key],
+    )
+    url = f"{base_url}?signature=not_a_signature"
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
 def test_slack_oauth_flow(
-    mocker, settings, admin_client, environment_api_key, environment
+    mocker, settings, api_client, admin_client, environment_api_key, environment
 ):
     # Given
     settings.SLACK_CLIENT_ID = "slack_id"
@@ -25,7 +39,7 @@ def test_slack_oauth_flow(
         args=[environment_api_key],
     )
     url = f"{base_url}?redirect_url={redirect_url}&signature={signature}"
-    response = admin_client.get(url)
+    response = api_client.get(url)
 
     # Verify the response
     assert response.status_code == status.HTTP_302_FOUND


### PR DESCRIPTION
If the accepted type header is text/html
drf tries to render the html response with a form(if the user have permission)
which results in this method crashing for anonymous users.
This change tackles that by inheriting from IsAuthenticated instead
of BasePermission to make it explicit that this permission class only deals with authenticated users