### PR TITLE
improvement/912-update-mixpanel-integration-to-disable-ip-server-location

### DIFF
--- a/api/integrations/mixpanel/mixpanel.py
+++ b/api/integrations/mixpanel/mixpanel.py
@@ -51,4 +51,5 @@ class MixpanelWrapper(AbstractBaseIdentityIntegrationWrapper):
             "$token": self.api_key,
             "$distinct_id": identity.identifier,
             "$set": feature_properties,
+            "$ip": "0",
         }


### PR DESCRIPTION
Fixes #912 

As per https://help.mixpanel.com/hc/en-us/articles/115004499343-Tracking-Geolocation-with-Server-Side-Implementation