### PR TITLE
feat(sdk/identities/post): Add support for deleting a trait

### DIFF
--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -132,6 +132,11 @@ class Identity(models.Model):
         :return: list of TraitModels
         """
         trait_models = []
+
+        # Remove traits having Null(None) values
+        trait_data_items = filter(
+            lambda trait: trait["trait_value"] is not None, trait_data_items
+        )
         for trait_data_item in trait_data_items:
             trait_key = trait_data_item["trait_key"]
             trait_value = trait_data_item["trait_value"]

--- a/api/environments/identities/traits/serializers.py
+++ b/api/environments/identities/traits/serializers.py
@@ -21,7 +21,7 @@ class TraitSerializerFull(serializers.ModelSerializer):
 
 
 class TraitSerializerBasic(serializers.ModelSerializer):
-    trait_value = TraitValueField()
+    trait_value = TraitValueField(allow_null=True)
 
     class Meta:
         model = Trait


### PR DESCRIPTION
Update SDK identities post endpoint to allow null for trait values
as a marker for them to be deleted