### PR TITLE
fix(audit/logs/search): don't return audit logs with null environment on environment filter

### DIFF
--- a/api/audit/tests/test_views.py
+++ b/api/audit/tests/test_views.py
@@ -21,9 +21,8 @@ def test_audit_log_can_be_filtered_by_environments(admin_client, project, enviro
     )
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["count"] == 2
+    assert response.json()["count"] == 1
     assert response.json()["results"][0]["environment"]["id"] == audit_env.id
-    assert response.json()["results"][1]["environment"] is None
 
 
 def test_audit_log_can_be_filtered_by_log_text(admin_client, project, environment):

--- a/api/audit/views.py
+++ b/api/audit/views.py
@@ -40,7 +40,7 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         if project:
             q = q & Q(project__id=project)
         if environments:
-            q = q & (Q(environment__id__in=environments) | Q(environment=None))
+            q = q & Q(environment__id__in=environments)
 
         search = serializer.data.get("search")
         if search:

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -2,9 +2,7 @@ import django.core.exceptions
 from rest_framework import serializers
 
 from audit.models import (
-    FEATURE_CREATED_MESSAGE,
     FEATURE_STATE_UPDATED_MESSAGE,
-    FEATURE_UPDATED_MESSAGE,
     IDENTITY_FEATURE_STATE_UPDATED_MESSAGE,
     AuditLog,
     RelatedObjectType,

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -82,30 +82,7 @@ class ListCreateFeatureSerializer(WritableNestedModelSerializer):
         user = validated_data.pop("user")
         instance = super(ListCreateFeatureSerializer, self).create(validated_data)
         instance.owners.add(user)
-        self._create_audit_log(instance, True)
         return instance
-
-    def update(self, instance, validated_data):
-        updated_instance = super(ListCreateFeatureSerializer, self).update(
-            instance, validated_data
-        )
-        self._create_audit_log(updated_instance, False)
-        return updated_instance
-
-    def _create_audit_log(self, instance, created):
-        message = (
-            FEATURE_CREATED_MESSAGE % instance.name
-            if created
-            else FEATURE_UPDATED_MESSAGE % instance.name
-        )
-        request = self.context.get("request")
-        AuditLog.objects.create(
-            author=getattr(request, "user", None),
-            related_object_id=instance.id,
-            related_object_type=RelatedObjectType.FEATURE.name,
-            project=instance.project,
-            log=message,
-        )
 
     def validate_multivariate_options(self, mv_options):
         total_percentage_allocation = sum(

--- a/api/features/tests/test_views.py
+++ b/api/features/tests/test_views.py
@@ -282,15 +282,25 @@ class ProjectFeatureTestCase(TestCase):
         data = {"name": "Test feature flag", "type": "FLAG", "project": self.project.id}
 
         # When
-        self.client.post(url, data=data)
+        response = self.client.post(url, data=data)
+        feature_id = response.json()["id"]
 
         # Then
+
+        # Audit log exists for the feature
         assert (
             AuditLog.objects.filter(
-                related_object_type=RelatedObjectType.FEATURE.name
+                related_object_type=RelatedObjectType.FEATURE.name,
+                related_object_id=feature_id,
             ).count()
             == 1
         )
+        # and Audit log exists for every environment
+        assert AuditLog.objects.filter(
+            related_object_type=RelatedObjectType.FEATURE_STATE.name,
+            project=self.project,
+            environment__in=self.project.environments.all(),
+        ).count() == len(self.project.environments.all())
 
     def test_audit_log_created_when_feature_updated(self):
         # Given


### PR DESCRIPTION
Closes https://github.com/Flagsmith/flagsmith/issues/909