### PR TITLE
Re-use get_environment_flags_list method to generate queryset

### DIFF
--- a/api/features/tests/test_models.py
+++ b/api/features/tests/test_models.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.db.utils import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
@@ -461,7 +462,8 @@ class FeatureStateTest(TestCase):
 
         # When
         environment_feature_states = FeatureState.get_environment_flags_list(
-            environment=self.environment
+            environment=self.environment,
+            additional_filters=Q(feature_segment=None, identity=None),
         )
 
         # Then

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -19,7 +19,7 @@ def test_feature_state_get_environment_flags_queryset_returns_only_latest_versio
 
     # When
     feature_states = FeatureState.get_environment_flags_queryset(
-        environments=[environment]
+        environment=environment
     )
 
     # Then


### PR DESCRIPTION
This PR aims to: 

 (a) simplify the versions logic so we're having to care about it in fewer places
 (b) improve the performance of the core API feature states endpoints by removing the huge `OR` statements
 (c) improve the performance of the get_environments_flags_list method by using a tuple instead of an object