### PR TITLE
refac(slack/channel-join/error-handling): catch slackApiError

### DIFF
--- a/api/integrations/slack/exceptions.py
+++ b/api/integrations/slack/exceptions.py
@@ -16,6 +16,5 @@ class SlackConfigurationDoesNotExist(APIException):
     default_detail = "Slack api token not found. Please generate the token using oauth"
 
 
-class SlackChannelJoinError(BaseException):
-    def __init__(self, msg: str):
-        super().__init__(msg)
+class SlackChannelJoinError(Exception):
+    pass

--- a/api/integrations/slack/exceptions.py
+++ b/api/integrations/slack/exceptions.py
@@ -14,3 +14,8 @@ class FrontEndRedirectURLNotFound(APIException):
 class SlackConfigurationDoesNotExist(APIException):
     status_code = 400
     default_detail = "Slack api token not found. Please generate the token using oauth"
+
+
+class SlackChannelJoinError(BaseException):
+    def __init__(self, msg: str):
+        super().__init__(msg)

--- a/api/integrations/slack/models.py
+++ b/api/integrations/slack/models.py
@@ -1,9 +1,6 @@
 from django.db import models
-from django_lifecycle import BEFORE_SAVE, LifecycleModel, hook
 
 from projects.models import Project
-
-from .slack import SlackWrapper
 
 
 class SlackConfiguration(models.Model):
@@ -14,7 +11,7 @@ class SlackConfiguration(models.Model):
     created_date = models.DateTimeField(auto_now_add=True)
 
 
-class SlackEnvironment(LifecycleModel):
+class SlackEnvironment(models.Model):
     slack_configuration = models.ForeignKey(
         SlackConfiguration, related_name="env_config", on_delete=models.CASCADE
     )

--- a/api/integrations/slack/models.py
+++ b/api/integrations/slack/models.py
@@ -33,11 +33,5 @@ class SlackEnvironment(LifecycleModel):
     )
     enabled = models.BooleanField(default=True)
 
-    @hook(BEFORE_SAVE)
-    def join_channel(self):
-        SlackWrapper(
-            api_token=self.slack_configuration.api_token, channel_id=self.channel_id
-        ).join_channel()
-
     class Meta:
         unique_together = ("slack_configuration", "environment")

--- a/api/tests/integration/slack/conftest.py
+++ b/api/tests/integration/slack/conftest.py
@@ -46,7 +46,7 @@ def slack_environment_config(
         args=[environment_api_key],
     )
     env_config = {"channel_id": "channel_id1", "enabled": True}
-    mocker.patch("integrations.slack.models.SlackWrapper.join_channel")
+    mocker.patch("integrations.slack.serializers.SlackWrapper.join_channel")
     response = admin_client.post(
         url,
         data=json.dumps(env_config),

--- a/api/tests/unit/integrations/slack/test_unit_slack.py
+++ b/api/tests/unit/integrations/slack/test_unit_slack.py
@@ -1,3 +1,7 @@
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from integrations.slack.exceptions import SlackChannelJoinError
 from integrations.slack.slack import SlackChannel, SlackWrapper
 
 
@@ -65,6 +69,20 @@ def test_join_channel_makes_correct_call(mocker, mocked_slack_internal_client):
 
     # Then
     mocked_slack_internal_client.conversations_join.assert_called_with(channel=channel)
+
+
+def test_join_channel_raises_slack_channel_join_error_on_slack_api_error(
+    mocker, mocked_slack_internal_client
+):
+    # Given
+    channel = "channel_1"
+    api_token = "random_token"
+    mocked_slack_internal_client.conversations_join.side_effect = SlackApiError(
+        message="server_error", response={"error": "some_error_code"}
+    )
+    # Then
+    with pytest.raises(SlackChannelJoinError):
+        SlackWrapper(api_token=api_token, channel_id=channel).join_channel()
 
 
 def test_get_bot_token_makes_correct_calls(


### PR DESCRIPTION
call join_channel before saving the configuration and return
400 if that fails