### PR TITLE
Drop support for arm/v7 in api / platform docker images

### DIFF
--- a/.github/workflows/api-docker-publish-image.yml
+++ b/.github/workflows/api-docker-publish-image.yml
@@ -71,7 +71,7 @@ jobs:
               if: ${{ startsWith(github.ref, 'refs/tags/') }}
               uses: docker/build-push-action@v2
               with:
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  platforms: linux/amd64,linux/arm64
                   file: api/Dockerfile
                   context: api/
                   push: true

--- a/.github/workflows/platform-docker-publish-image.yml
+++ b/.github/workflows/platform-docker-publish-image.yml
@@ -67,7 +67,7 @@ jobs:
               if: ${{ startsWith(github.ref, 'refs/tags/') }}
               uses: docker/build-push-action@v2
               with:
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  platforms: linux/amd64,linux/arm64
                   file: Dockerfile
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN if [ "${TARGETARCH}" != "amd64" ]; then apt-get update && apt-get install -y
 # Install re2
 ARG GOOGLE_RE2_VERSION="0.2.20220401"
 ARG TARGETPLATFORM
-# re2 is broken on arm/v7 platform, so dont try to install it; fall back to standard re
-RUN if [ "${TARGETPLATFORM}" != "linux/arm/v7" ]; then pip install google-re2==${GOOGLE_RE2_VERSION}; fi;
 
 # Install python dependencies
 RUN pip install -r requirements.txt --no-cache-dir --compile

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,8 +8,6 @@ RUN if [ "${TARGETARCH}" != "amd64" ]; then apt-get update && apt-get install -y
 # Install re2
 ARG GOOGLE_RE2_VERSION="0.2.20220401"
 ARG TARGETPLATFORM
-# re2 is broken on arm/v7 platform, so dont try to install it; fall back to standard re
-RUN if [ "${TARGETPLATFORM}" != "linux/arm/v7" ]; then pip install google-re2==${GOOGLE_RE2_VERSION}; fi;
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Since the introduction of the opencensus libraries, added in #1051, added a dependency on the cryptography library, we are no longer able to reliably build linux/arm/v7 docker images. 

Since this architecture no longer seems widely used (outside of raspberry pi devices before ~feb 2022), this PR removes the architecture from our docker build steps. Note that I've left it in for frontend builds since there is no issue with the frontend image on arm/v7. 