### PR TITLE
fix(infra/deploy/req.txt): Add new line after appending req.txt

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -72,7 +72,7 @@ runs:
         run: |
           mv ./flagsmith-saml/saml ./api
           cat ./flagsmith-saml/requirements.txt >> ./api/requirements.txt
-          echo "" >> ./api/requirements.txt
+          echo "" >> ./api/requirements.txt  # add a new line so that future concatenation works
         shell: bash
 
       - name: Checkout Workflows Logic package
@@ -99,7 +99,7 @@ runs:
         run: |
           mv ./flagsmith-auth-controller/auth_controller ./api
           cat ./flagsmith-auth-controller/requirements.txt >> ./api/requirements.txt
-          echo "" >> ./api/requirements.txt
+          echo "" >> ./api/requirements.txt # add a new line so that future concatenation works
         shell: bash
 
       - name: Set ECR tag

--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -72,6 +72,7 @@ runs:
         run: |
           mv ./flagsmith-saml/saml ./api
           cat ./flagsmith-saml/requirements.txt >> ./api/requirements.txt
+          echo "" >> ./api/requirements.txt
         shell: bash
 
       - name: Checkout Workflows Logic package
@@ -98,6 +99,7 @@ runs:
         run: |
           mv ./flagsmith-auth-controller/auth_controller ./api
           cat ./flagsmith-auth-controller/requirements.txt >> ./api/requirements.txt
+          echo "" >> ./api/requirements.txt
         shell: bash
 
       - name: Set ECR tag


### PR DESCRIPTION
Appending anything to a file using ` cat file >>` does not add a new line, so if you have to cat twice and don't want them to be on the same line, you should add a new line. 
PS: in our case, it was `ERROR: Could not find a version that satisfies the requirement pysaml2==7.0.0django-multiselectfield==0.1.12 `