### PR TITLE
improvement/node-version-bump

### DIFF
--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -51,10 +51,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup Node.js 14.x
+            - name: Setup Node.js 16.x
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.x
+                  node-version: 16.x
 
             - name: Cache dependencies
               uses: actions/cache@v2

--- a/.github/workflows/frontend-deploy-staging.yml
+++ b/.github/workflows/frontend-deploy-staging.yml
@@ -24,10 +24,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup Node.js 14.x
+            - name: Setup Node.js 16.x
               uses: actions/setup-node@v1
               with:
-                  node-version: 14.x
+                  node-version: 16.x
 
             - name: Cache dependencies
               uses: actions/cache@v2

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -111,7 +111,7 @@
         "testcafe": "^1.17.1"
       },
       "engines": {
-        "node": "14.x",
+        "node": "16.x",
         "npm": "6.x"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "bundledjango": "mkdir -p ../api/app/templates/webpack/ && node node_modules/.bin/webpack --config ./webpack/webpack.config.django.prod.js && rm -f ../api/app/templates/webpack/index.html && rm -f ../api/static/static/project-overrides.js && cp ../api/static/index.html ../api/app/templates/webpack/index.html"
   },
   "engines": {
-    "node": "14.x",
+    "node": "16.x",
     "npm": "6.x"
   },
   "dependencies": {


### PR DESCRIPTION
Now that Vercel supports Node 16 we can upgrade - 14 is only in maintenance and not far from EOL