### PR TITLE
Allow FE to send missing multivariate_feature_state_values

### DIFF
--- a/api/edge_api/identities/serializers.py
+++ b/api/edge_api/identities/serializers.py
@@ -105,7 +105,7 @@ class EdgeIdentityFeatureStateSerializer(serializers.Serializer):
 
     def save(self, **kwargs):
         identity = self.context["view"].identity
-        feature_state_value = self.validated_data.pop("feature_state_value")
+        feature_state_value = self.validated_data.pop("feature_state_value", None)
         if not self.instance:
             self.instance = EngineFeatureStateModel(**self.validated_data)
             try:
@@ -115,10 +115,13 @@ class EdgeIdentityFeatureStateSerializer(serializers.Serializer):
                     "Feature state already exists."
                 ) from e
         self.instance.set_value(feature_state_value)
-        self.instance.enabled = self.validated_data["enabled"]
-        self.instance.multivariate_feature_state_values = self.validated_data[
-            "multivariate_feature_state_values"
-        ]
+        self.instance.enabled = self.validated_data.get(
+            "enabled", self.instance.enabled
+        )
+        self.instance.multivariate_feature_state_values = self.validated_data.get(
+            "multivariate_feature_state_values",
+            self.instance.multivariate_feature_state_values,
+        )
 
         try:
             identity_dict = build_identity_dict(identity)

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
@@ -1,0 +1,39 @@
+from flag_engine.api.document_builders import build_identity_document
+from flag_engine.identities.builders import build_identity_model
+
+from edge_api.identities.serializers import EdgeIdentityFeatureStateSerializer
+
+
+def test_edge_identity_feature_state_serializer_save_allows_missing_mvfsvs(
+    mocker, identity, feature
+):
+    # Given
+    identity_model = build_identity_model(build_identity_document(identity))
+    view = mocker.MagicMock(identity=identity_model)
+
+    serializer = EdgeIdentityFeatureStateSerializer(
+        data={"feature_state_value": "foo", "feature": feature.id},
+        context={"view": view},
+    )
+
+    mock_dynamo_wrapper = mocker.patch(
+        "edge_api.identities.serializers.Identity.dynamo_wrapper"
+    )
+
+    # When
+    serializer.is_valid(raise_exception=True)
+    result = serializer.save()
+
+    # Then
+    assert result
+
+    mock_dynamo_wrapper.put_item.assert_called_once()
+    saved_identity_record, *_ = mock_dynamo_wrapper.put_item.call_args.args
+    assert saved_identity_record["identifier"] == identity.identifier
+    assert len(saved_identity_record["identity_features"]) == 1
+
+    saved_identity_feature_state = saved_identity_record["identity_features"][0]
+    assert saved_identity_feature_state["multivariate_feature_state_values"] == []
+    assert saved_identity_feature_state["featurestate_uuid"]
+    assert saved_identity_feature_state["enabled"] is False
+    assert saved_identity_feature_state["feature"]["id"] == feature.id

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
@@ -28,7 +28,7 @@ def test_edge_identity_feature_state_serializer_save_allows_missing_mvfsvs(
     assert result
 
     mock_dynamo_wrapper.put_item.assert_called_once()
-    saved_identity_record, *_ = mock_dynamo_wrapper.put_item.call_args.args
+    saved_identity_record = mock_dynamo_wrapper.put_item.call_args[0][0]
     assert saved_identity_record["identifier"] == identity.identifier
     assert len(saved_identity_record["identity_features"]) == 1
 


### PR DESCRIPTION
The FE doesn't send `multivariate_feature_state_values` in the request to create an identity override unless it has to. Since our API states `multivariate_feature_state_values` is not required, we should handle this case ourselves. 