### PR TITLE
Only write warning log for failures to write records to influx

### DIFF
--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -60,8 +60,13 @@ class InfluxDBWrapper:
     def write(self):
         try:
             self.write_api.write(bucket=settings.INFLUXDB_BUCKET, record=self.records)
-        except HTTPError as e:
-            capture_exception(e)
+        except HTTPError:
+            logger.warning("Failed to write records to Influx.")
+            logger.debug(
+                "Records: %s. Bucket: %s",
+                self.records,
+                settings.INFLUXDB_BUCKET,
+            )
 
     @staticmethod
     def influx_query_manager(


### PR DESCRIPTION
As we're billed by sentry based on the number of errors we send, we need to prevent connection errors with InfluxDB from spamming our Sentry account. 