### PR TITLE
Fixes/e2e edge tests

### DIFF
--- a/frontend/common/stores/organisation-store.js
+++ b/frontend/common/stores/organisation-store.js
@@ -73,7 +73,7 @@ const controller = {
     },
     createProject: (name) => {
         store.saving();
-        const createSampleUser = (res, envName) => data.post(`${Project.api}environments/${res.api_key}/${Utils.getIdentitiesEndpoint()}/`, {
+        const createSampleUser = (res, envName) => data.post(`${Project.api}environments/${res.api_key}/${Utils.getIdentitiesEndpoint(res)}/`, {
             environment: res.id,
             identifier: `${envName}_user_123456`,
         }).then(() => res);

--- a/frontend/common/stores/organisation-store.js
+++ b/frontend/common/stores/organisation-store.js
@@ -73,10 +73,12 @@ const controller = {
     },
     createProject: (name) => {
         store.saving();
-        const createSampleUser = (res, envName) => data.post(`${Project.api}environments/${res.api_key}/${Utils.getIdentitiesEndpoint(res)}/`, {
-            environment: res.id,
-            identifier: `${envName}_user_123456`,
-        }).then(() => res);
+        const createSampleUser = (res, envName, project) => {
+            return data.post(`${Project.api}environments/${res.api_key}/${Utils.getIdentitiesEndpoint(project)}/`, {
+                environment: res.id,
+                identifier: `${envName}_user_123456`,
+            }).then(() => res);
+        }
         if (AccountStore.model.organisations.length === 1 && (!store.model.projects || !store.model.projects.length)) {
             API.trackEvent(Constants.events.CREATE_FIRST_PROJECT);
         }
@@ -85,9 +87,9 @@ const controller = {
             .then((project) => {
                 Promise.all([
                     data.post(`${Project.api}environments/`, { name: 'Development', project: project.id })
-                        .then(res => createSampleUser(res, 'development')),
+                        .then(res => createSampleUser(res, 'development', project)),
                     data.post(`${Project.api}environments/`, { name: 'Production', project: project.id })
-                        .then(res => createSampleUser(res, 'production')),
+                        .then(res => createSampleUser(res, 'production', project)),
                 ]).then((res) => {
                     project.environments = res;
                     store.model.projects = store.model.projects.concat(project);

--- a/frontend/common/utils/utils.js
+++ b/frontend/common/utils/utils.js
@@ -24,75 +24,86 @@ module.exports = Object.assign({}, require('./base/_utils'), {
         return 'ADMIN';
     },
 
-    getTraitEndpointMethod() {
+    getTraitEndpointMethod(_project) {
+        let project = _project ? _project : ProjectStore.model
         if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
             return 'put';
         }
         return 'post';
     },
-    getIsEdge() {
+    getIsEdge(_project) {
+        let project = _project ? _project : ProjectStore.model
         if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
             return true;
         }
         return false;
     },
-    getTraitEndpoint(environmentId, userId) {
+    getTraitEndpoint(environmentId, userId, _project) {
         if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
             return `${Project.api}environments/${environmentId}/edge-identities/${userId}/update-traits/`;
         }
         return `${Project.api}traits/`;
     },
 
-    getShouldSendIdentityToTraits() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    getShouldSendIdentityToTraits(_project) {
+        let project = _project ? _project : ProjectStore.model
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return false;
         }
         return true;
     },
-    getShouldUpdateTraitOnDelete() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    getShouldUpdateTraitOnDelete(_project) {
+        let project = _project ? _project : ProjectStore.model
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return true;
         }
         return false;
     },
 
-    getShouldShowProjectTraits() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    getShouldShowProjectTraits(_project) {
+        let project = _project ? _project : ProjectStore.model
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return false;
         }
         return true;
     },
 
-    getIdentitiesEndpoint() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    getIdentitiesEndpoint(_project) {
+        let project = _project ? _project : ProjectStore.model
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return 'edge-identities';
         }
         return 'identities';
     },
 
-    getSDKEndpoint() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    getSDKEndpoint(_project) {
+        let project = _project ? _project : ProjectStore.model
+
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return Project.flagsmithClientEdgeAPI;
         }
         return Project.api;
     },
 
-    showUserSegments() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    showUserSegments(_project) {
+        let project = _project ? _project : ProjectStore.model
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return false;
         }
         return true;
     },
 
-    getShouldHideIdentityOverridesTab() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    getShouldHideIdentityOverridesTab(_project) {
+        let project = _project ? _project : ProjectStore.model
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return true;
         }
         return false;
     },
 
-    getFeatureStatesEndpoint() {
-        if (flagsmith.hasFeature('edge_identities') && ProjectStore.model && ProjectStore.model.use_edge_identities) {
+    getFeatureStatesEndpoint(_project) {
+        let project = _project ? _project : ProjectStore.model
+        if (flagsmith.hasFeature('edge_identities') && project && project.use_edge_identities) {
             return 'edge-featurestates';
         }
         return 'featurestates';

--- a/frontend/e2e/cafe/segments.cafe.js
+++ b/frontend/e2e/cafe/segments.cafe.js
@@ -70,7 +70,7 @@ test('Segments Test', async () => {
     await createTrait(0, 'trait', 1);
     await createTrait(1, 'trait2', 2);
     await createTrait(2, 'trait3', 3);
-    await assertTextContent(byId('segment-0-name'), 'segment_1');
+    // await assertTextContent(byId('segment-0-name'), 'segment_1'); todo: view user segments disabled in edge
     await waitForElementVisible(byId('user-feature-switch-1-on'));
     await assertTextContent(byId('user-feature-value-0'), '1');
 

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -196,8 +196,8 @@ test('[Initialise]', async () => {
     await gotoTraits();
     await createTrait(0, 'age', 18);
 
-    log('Check user now belongs to segment');
-    await assertTextContent(byId('segment-0-name'), '18_or_19');
+    // log('Check user now belongs to segment');
+    // await assertTextContent(byId('segment-0-name'), '18_or_19');
 
     log('Delete segment trait for user');
     await deleteTrait(0);

--- a/frontend/web/components/Aside.js
+++ b/frontend/web/components/Aside.js
@@ -191,7 +191,9 @@ const Aside = class extends Component {
                                                                       }}
                                                                       className="chip chip--active bg-secondary"
                                                                     >
-                                                                        <a href="https://docs.flagsmith.com/next/advanced-use/edge-api#enabling-the-edge-api" className="text-white font-weight-bold">
+                                                                        <a
+                                                                            data-test={Utils.getIsEdge() ? 'edge-project': "core-project"}
+                                                                            href="https://docs.flagsmith.com/next/advanced-use/edge-api#enabling-the-edge-api" className="text-white font-weight-bold">
                                                                             {Utils.getIsEdge() ? 'Edge' : 'Core'}
                                                                         </a>
                                                                     </span>


### PR DESCRIPTION
This adjusts e2e to ignore testing for being a member of a segment, due to https://github.com/Flagsmith/flagsmith/issues/1133. Also adds a fix for creating identities for a new project