### PR TITLE
Add xmlsec to private cloud builds and re-add google-re2 to all dockerfiles

### DIFF
--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -83,6 +83,8 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   context: .
+                  build-args: |
+                      SAML_INSTALLED: 1
 
             - name: Image digest
               run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -4,6 +4,8 @@ on:
     push:
         tags:
             - "*"
+        branches:
+            - "improvement/docker-fixes"
 
 env:
   FLAGSMITH_SAML_REVISION: v0.1.2

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -86,7 +86,7 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   context: .
                   build-args: |
-                      SAML_INSTALLED: 1
+                      SAML_INSTALLED=1
 
             - name: Image digest
               run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN if [ "${TARGETARCH}" != "amd64" ]; then apt-get update && apt-get install -y
 # Install re2
 ARG GOOGLE_RE2_VERSION="0.2.20220401"
 ARG TARGETPLATFORM
+RUN pip install google-re2==${GOOGLE_RE2_VERSION}
+
+# Install SAML dependency if required
+ARG SAML_INSTALLED="0"
+RUN if [ "${SAML_INSTALLED}" = "1" ]; then apt-get update && apt-get install -y xmlsec1 && echo "true" > xmlsec-installed.txt; fi;
 
 # Install python dependencies
 RUN pip install -r requirements.txt --no-cache-dir --compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install google-re2==${GOOGLE_RE2_VERSION}
 
 # Install SAML dependency if required
 ARG SAML_INSTALLED="0"
-RUN if [ "${SAML_INSTALLED}" = "1" ]; then apt-get update && apt-get install -y xmlsec1 && echo "true" > xmlsec-installed.txt; fi;
+RUN if [ "${SAML_INSTALLED}" = "1" ]; then apt-get update && apt-get install -y xmlsec1; fi;
 
 # Install python dependencies
 RUN pip install -r requirements.txt --no-cache-dir --compile

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,6 +8,7 @@ RUN if [ "${TARGETARCH}" != "amd64" ]; then apt-get update && apt-get install -y
 # Install re2
 ARG GOOGLE_RE2_VERSION="0.2.20220401"
 ARG TARGETPLATFORM
+RUN pip install google-re2==${GOOGLE_RE2_VERSION}
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Somehow the actual install of google-re2 got removed (likely in a git merge). 

Also adds xmlsec1 to private cloud builds. 