### PR TITLE
Allow CREATE_FEATURE users to update features

### DIFF
--- a/api/features/permissions.py
+++ b/api/features/permissions.py
@@ -11,6 +11,8 @@ ACTION_PERMISSIONS_MAP = {
     "create": "CREATE_FEATURE",
     "add_owners": "CREATE_FEATURE",
     "remove_owners": "CREATE_FEATURE",
+    "update": "CREATE_FEATURE",
+    "partial_update": "CREATE_FEATURE",
 }
 
 
@@ -38,7 +40,7 @@ class FeaturePermissions(BasePermission):
                 ACTION_PERMISSIONS_MAP[view.action], obj.project
             )
 
-        if view.action in ("update", "segments"):
+        if view.action == "segments":
             return request.user.is_project_admin(obj.project)
 
         return False

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -137,7 +137,7 @@ class ListCreateFeatureSerializer(WritableNestedModelSerializer):
 
 
 class UpdateFeatureSerializer(ListCreateFeatureSerializer):
-    """prevent users from changing the value of default enabled after creation"""
+    """prevent users from changing certain values after creation"""
 
     class Meta(ListCreateFeatureSerializer.Meta):
         read_only_fields = ListCreateFeatureSerializer.Meta.read_only_fields + (


### PR DESCRIPTION
Since the permission check for multivariate_options is now handled separately in the serializer (which is kinda hacky but necessary for now), we can safely allow users to update features without being a project admin. 