### PR TITLE
refac(feat/models/get_env_flags): use environment_id instead of obj

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -513,7 +513,7 @@ class FeatureState(LifecycleModel, models.Model):
     @classmethod
     def get_environment_flags_list(
         cls,
-        environment: "Environment",
+        environment_id: int,
         feature_name: str = None,
         additional_filters: Q = None,
     ) -> typing.List["FeatureState"]:
@@ -531,7 +531,7 @@ class FeatureState(LifecycleModel, models.Model):
         feature_states = cls.objects.select_related(
             "feature", "feature_state_value"
         ).filter(
-            environment=environment,
+            environment_id=environment_id,
             live_from__isnull=False,
             live_from__lte=timezone.now(),
             version__isnull=False,
@@ -562,12 +562,12 @@ class FeatureState(LifecycleModel, models.Model):
         return list(feature_states_dict.values())
 
     @classmethod
-    def get_environment_flags_queryset(cls, environment: "Environment") -> QuerySet:
+    def get_environment_flags_queryset(cls, environment_id: int) -> QuerySet:
         """
         Get a queryset of the latest live versions of an environments' feature states
         """
 
-        feature_states_list = cls.get_environment_flags_list(environment)
+        feature_states_list = cls.get_environment_flags_list(environment_id)
         return FeatureState.objects.filter(id__in=[fs.id for fs in feature_states_list])
 
     @classmethod

--- a/api/features/tests/test_models.py
+++ b/api/features/tests/test_models.py
@@ -462,7 +462,7 @@ class FeatureStateTest(TestCase):
 
         # When
         environment_feature_states = FeatureState.get_environment_flags_list(
-            environment=self.environment,
+            environment_id=self.environment.id,
             additional_filters=Q(feature_segment=None, identity=None),
         )
 

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -260,7 +260,7 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):
                 raise PermissionDenied()
 
             queryset = FeatureState.get_environment_flags_queryset(
-                environment=environment
+                environment_id=environment.id
             )
             queryset = self._apply_query_param_filters(queryset)
 
@@ -487,7 +487,7 @@ class SimpleFeatureStateViewSet(
                 )
 
             queryset = FeatureState.get_environment_flags_queryset(
-                environment=environment
+                environment_id=environment.id
             )
             return queryset.select_related("feature_state_value").prefetch_related(
                 "multivariate_feature_state_values"
@@ -528,7 +528,7 @@ class SDKFeatureStates(GenericAPIView):
         if "feature" in request.GET:
 
             feature_states = FeatureState.get_environment_flags_list(
-                environment=request.environment,
+                environment_id=request.environment.id,
                 feature_name=request.GET["feature"],
                 additional_filters=self._additional_filters,
             )
@@ -546,7 +546,7 @@ class SDKFeatureStates(GenericAPIView):
         else:
             data = self.get_serializer(
                 FeatureState.get_environment_flags_list(
-                    environment=request.environment,
+                    environment_id=request.environment.id,
                     additional_filters=self._additional_filters,
                 ),
                 many=True,
@@ -566,7 +566,7 @@ class SDKFeatureStates(GenericAPIView):
         if not data:
             data = self.get_serializer(
                 FeatureState.get_environment_flags_list(
-                    environment=environment,
+                    environment_id=environment.id,
                     additional_filters=self._additional_filters,
                 ),
                 many=True,

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -25,7 +25,7 @@ def test_feature_state_get_environment_flags_queryset_returns_only_latest_versio
 
     # When
     feature_states = FeatureState.get_environment_flags_queryset(
-        environment=environment
+        environment_id=environment.id
     )
 
     # Then
@@ -45,7 +45,7 @@ def test_project_hide_disabled_flags_have_no_effect_on_feature_state_get_environ
 
     # When
     feature_states = FeatureState.get_environment_flags_queryset(
-        environment=environment
+        environment_id=environment.id
     )
     # Then
     assert feature_states.count() == 2


### PR DESCRIPTION
Since `get_environment_flags_list` and `get_environment_flags_queryset`
don't get any advantage from environment being an object  instead
of an int, this creates additional pressure on the caller to fetch
the environment object in order to call those functions 