### PR TITLE
Add EDGE_RELEASE_DATETIME env var to production

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -145,7 +145,7 @@
                 },
                 {
                     "name": "EDGE_RELEASE_DATETIME",
-                    "value": "2022-06-07T12:00:00Z"
+                    "value": "2022-06-07T10:00:00Z"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -142,6 +142,10 @@
                 {
                     "name": "CACHE_BAD_ENVIRONMENTS_SECONDS",
                     "value": "60"
+                },
+                {
+                    "name": "EDGE_RELEASE_DATETIME",
+                    "value": "2022-06-07T12:00:00Z"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Defaults new signups to the Edge API by default. 