### PR TITLE
Allow custom headers in CORS restrictions

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -306,11 +306,13 @@ MEDIA_URL = "/media/"  # unused but needs to be different from STATIC_URL in dja
 # CORS settings
 
 CORS_ORIGIN_ALLOW_ALL = True
-FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS = env.list("FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS", default=[])
+FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS = env.list(
+    "FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS", default=[]
+)
 CORS_ALLOW_HEADERS = [
-    *default_headers, 
+    *default_headers,
     *FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS,
-    "X-Environment-Key", 
+    "X-Environment-Key",
     "X-E2E-Test-Auth-Token",
 ]
 

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -306,12 +306,13 @@ MEDIA_URL = "/media/"  # unused but needs to be different from STATIC_URL in dja
 # CORS settings
 
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_ALLOW_HEADERS = default_headers + (
-    "X-Environment-Key",
+FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS = env.list("FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS", default=[])
+CORS_ALLOW_HEADERS = [
+    *default_headers, 
+    *FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS,
+    "X-Environment-Key", 
     "X-E2E-Test-Auth-Token",
-    "sentry-trace",
-    "baggage",
-)
+]
 
 DEFAULT_FROM_EMAIL = env("SENDER_EMAIL", default="noreply@flagsmith.com")
 EMAIL_CONFIGURATION = {

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -310,6 +310,7 @@ CORS_ALLOW_HEADERS = default_headers + (
     "X-Environment-Key",
     "X-E2E-Test-Auth-Token",
     "sentry-trace",
+    "baggage",
 )
 
 DEFAULT_FROM_EMAIL = env("SENDER_EMAIL", default="noreply@flagsmith.com")


### PR DESCRIPTION
See #449

Basically Sentry is now sending another header of `baggage`.

Is there a reason Flagsmith restricts CORs headers?

The way Sentry works in the browser is that it injects itself into the XMLHttpRequest function and adds a baggage header there. This ends up causing calls to the Flagsmith api to fail. I think the proper way to do it is just allow the sentry flags to pass through

Optionally just allow ALL headers. I am not sure why there are header restrictions in the first place.