### PR TITLE
Add sentry-trace as default header to maintain backwards compatibility

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -307,7 +307,7 @@ MEDIA_URL = "/media/"  # unused but needs to be different from STATIC_URL in dja
 
 CORS_ORIGIN_ALLOW_ALL = True
 FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS = env.list(
-    "FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS", default=[]
+    "FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS", default=["sentry-trace"]
 )
 CORS_ALLOW_HEADERS = [
     *default_headers,


### PR DESCRIPTION
Update following #1181 to ensure that we don't break existing installations.