### PR TITLE
Fix features swagger documentation

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -136,12 +136,13 @@ class FeatureViewSet(viewsets.ModelViewSet):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context.update(
-            project=get_object_or_404(
-                Project.objects.all(), pk=self.kwargs["project_pk"]
-            ),
-            user=self.request.user,
-        )
+        if self.kwargs.get("project_pk"):
+            context.update(
+                project=get_object_or_404(
+                    Project.objects.all(), pk=self.kwargs["project_pk"]
+                ),
+                user=self.request.user,
+            )
         return context
 
     @swagger_auto_schema(


### PR DESCRIPTION
Currently swagger is failing to render the information for the FeatureViewSet endpoints as it hard errors on retrieving the project_pk from kwargs. 