### PR TITLE
Add GUNICORN_KEEP_ALIVE to production

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -84,6 +84,10 @@
                     "value": "15"
                 },
                 {
+                    "name": "GUNICORN_KEEP_ALIVE",
+                    "value": "60"
+                },
+                {
                     "name": "IDENTITIES_TABLE_NAME_DYNAMO",
                     "value": "flagsmith_identities"
                 },


### PR DESCRIPTION
Based on the following articles, set the keep alive value in Gunicorn to match that of the load balancer. 

https://aws.amazon.com/premiumsupport/knowledge-center/elb-alb-troubleshoot-502-errors/
https://stackoverflow.com/questions/58945020/intermittent-502-gateway-errors-with-aws-alb-in-front-of-ecs-services-running-ex