### PR TITLE
fix(self-migrate):don't allow self migrate for large projects

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -656,3 +656,6 @@ SERVE_FE_ASSETS = os.path.exists(BASE_DIR + "/app/templates/webpack/index.html")
 NUM_PROXIES = env.int("NUM_PROXIES", 1)
 
 SAML_USE_NAME_ID_AS_EMAIL = env.bool("SAML_USE_NAME_ID_AS_EMAIL", False)
+
+# Used to control the size(number of identities) of the project that can be self migrated to edge
+MAX_SELF_MIGRATABLE_IDENTITIES = env.int("MAX_SELF_MIGRATABLE_IDENTITIES", 100000)

--- a/api/projects/exceptions.py
+++ b/api/projects/exceptions.py
@@ -9,3 +9,8 @@ class DynamoNotEnabledError(APIException):
 class ProjectMigrationError(APIException):
     status_code = 400
     default_detail = "Migration is either already done or is in progress"
+
+
+class TooManyIdentitiesError(APIException):
+    status_code = 400
+    default_detail = "Too many identities; Please contact support"

--- a/api/projects/tests/test_views.py
+++ b/api/projects/tests/test_views.py
@@ -453,7 +453,7 @@ def test_project_migrate_to_edge_returns_400_if_project_have_too_many_identities
     # Given
     Identity.objects.create(environment=environment, identifier="identity2")
     settings.PROJECT_METADATA_TABLE_NAME_DYNAMO = "some_table"
-    mocker.patch("projects.views.MAX_SELF_MIGRATABLE_IDENTITIES", 1)
+    settings.MAX_SELF_MIGRATABLE_IDENTITIES = 1
     mocked_identity_migrator = mocker.patch("projects.views.IdentityMigrator")
 
     url = reverse("api-v1:projects:project-migrate-to-edge", args=[project.id])

--- a/api/projects/tests/test_views.py
+++ b/api/projects/tests/test_views.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from environments.dynamodb.types import ProjectIdentityMigrationStatus
+from environments.identities.models import Identity
 from organisations.models import Organisation, OrganisationRole
 from organisations.permissions.models import (
     OrganisationPermissionModel,
@@ -444,3 +445,23 @@ def test_project_migrate_to_edge_returns_400_if_can_migrate_is_false(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     mocked_identity_migrator.assert_called_once_with(project.id)
     mocked_identity_migrator.return_value.trigger_migration.assert_not_called()
+
+
+def test_project_migrate_to_edge_returns_400_if_project_have_too_many_identities(
+    admin_client, project, mocker, settings, identity, environment
+):
+    # Given
+    Identity.objects.create(environment=environment, identifier="identity2")
+    settings.PROJECT_METADATA_TABLE_NAME_DYNAMO = "some_table"
+    mocker.patch("projects.views.MAX_SELF_MIGRATABLE_IDENTITIES", 1)
+    mocked_identity_migrator = mocker.patch("projects.views.IdentityMigrator")
+
+    url = reverse("api-v1:projects:project-migrate-to-edge", args=[project.id])
+
+    # When
+    response = admin_client.post(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Too many identities; Please contact support"
+    mocked_identity_migrator.assert_not_called()

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -43,8 +43,6 @@ from projects.serializers import (
     ProjectSerializer,
 )
 
-MAX_SELF_MIGRATABLE_IDENTITIES = 100000
-
 
 @method_decorator(
     name="list",
@@ -130,7 +128,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
         project = self.get_object()
         identity_count = Identity.objects.filter(environment__project=project).count()
 
-        if identity_count > MAX_SELF_MIGRATABLE_IDENTITIES:
+        if identity_count > settings.MAX_SELF_MIGRATABLE_IDENTITIES:
             raise TooManyIdentitiesError()
 
         identity_migrator = IdentityMigrator(project.id)


### PR DESCRIPTION
This PR adds a check to only allow self migrate if the total identities for the given project are less than 100k (decided somewhat randomly, can bump it up a bit though depending on the data and what @matthewelwell and @dabeeeenster  thinks)