### PR TITLE
Fix NodeJS client docs - update import & add missing assignment

### DIFF
--- a/frontend/common/code-help/init/init-node.js
+++ b/frontend/common/code-help/init/init-node.js
@@ -7,7 +7,7 @@ const ${LIB_NAME} = new Flagsmith({
 const flags = await flagsmith.getEnvironmentFlags();
 
 // Check for a feature
-var isEnabled flags.isFeatureEnabled("${customFeature || FEATURE_NAME}")
+var isEnabled = flags.isFeatureEnabled("${customFeature || FEATURE_NAME}")
 
 // Or, use the value of a feature
 var featureValue = flags.getFeatureValue('${customFeature || FEATURE_NAME_ALT}');

--- a/frontend/common/code-help/init/init-node.js
+++ b/frontend/common/code-help/init/init-node.js
@@ -1,4 +1,4 @@
-module.exports = (envId, { LIB_NAME, FEATURE_NAME, FEATURE_NAME_ALT, NPM_NODE_CLIENT }, customFeature) => `import ${LIB_NAME} from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
+module.exports = (envId, { LIB_NAME, FEATURE_NAME, FEATURE_NAME_ALT, NPM_NODE_CLIENT }, customFeature) => `import Flagsmith from "${NPM_NODE_CLIENT}"; // Add this line if you're using ${LIB_NAME} via npm
 
 const ${LIB_NAME} = new Flagsmith({
     environmentKey: '${envId}'


### PR DESCRIPTION
* The isEnabled example line was missing an assignment operator
* The default import was lowercased which caused a naming conflict with the sdk variable `flagsmith`