### PR TITLE
fix first creation of segment in self-hosted context

### DIFF
--- a/frontend/web/components/pages/SegmentsPage.js
+++ b/frontend/web/components/pages/SegmentsPage.js
@@ -1,7 +1,14 @@
 import React, { Component } from 'react';
 import CreateSegmentModal from '../modals/CreateSegment';
-import TryIt from '../TryIt';
 import ConfirmRemoveSegment from '../modals/ConfirmRemoveSegment';
+
+const HowToUseSegmentsMessage = () => (
+    <div className="mt-2">
+        <p className="alert alert-info">
+            In order to use segments, please set the segment_operators remote config value. <a target="_blank" href="https://docs.flagsmith.com/deployment/overview#running-flagsmith-on-flagsmith">Learn about self hosting</a>.
+        </p>
+    </div>
+);
 
 const SegmentsPage = class extends Component {
     static displayName = 'SegmentsPage';
@@ -171,13 +178,7 @@ const SegmentsPage = class extends Component {
                                                         </div>
                                                     </FormGroup>
                                                 </Row>
-                                                {hasNoOperators && (
-                                                    <div className="mt-2">
-                                                        <p className="alert alert-info">
-                                                            In order to use segments, please set the segment_operators remote config value. <a target="_blank" href="https://docs.flagsmith.com/deployment/overview#running-flagsmith-on-flagsmith">Learn about self hosting</a>.
-                                                        </p>
-                                                    </div>
-                                                )}
+                                                {hasNoOperators && <HowToUseSegmentsMessage />}
 
                                                 <FormGroup>
                                                     <PanelSearch
@@ -264,7 +265,7 @@ const SegmentsPage = class extends Component {
                                                 {this.createSegmentPermission(perm => (
                                                     <FormGroup className="text-center">
                                                         <Button
-                                                          disabled={!perm}
+                                                          disabled={!perm || hasNoOperators}
                                                           className="btn-lg btn-primary" id="show-create-segment-btn" data-test="show-create-segment-btn"
                                                           onClick={this.newSegment}
                                                         >
@@ -274,6 +275,7 @@ const SegmentsPage = class extends Component {
                                                         </Button>
                                                     </FormGroup>
                                                 ))}
+                                                {hasNoOperators && <HowToUseSegmentsMessage />}
                                             </div>
                                         )}
 


### PR DESCRIPTION
When starting a brand new instance of flagsmith in self-hosted environment, I couldn't create a segment. This is because I didn't set the `segment_operators` remote config value.
But this was not explained directly in the product. This is a proposition to fix this behavior

closes #1354

### BEFORE
![Screenshot 2022-08-18 at 14 56 43](https://user-images.githubusercontent.com/18406791/185408746-b7077b2c-636e-4350-89df-ed691de53264.png)

### AFTER
![Screenshot 2022-08-18 at 15 32 46](https://user-images.githubusercontent.com/18406791/185408763-f274b318-0b8d-4aff-9966-d058aa5424bd.png)
