### PR TITLE
allow admins to toggle flags on overrides

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -804,15 +804,15 @@ const CreateFlag = class extends Component {
                                                                 }
                                                               renderRow={({ id, feature_state_value, enabled, identity }) => (
                                                                   <Row
-                                                                    onClick={() => {
-                                                                        window.open(`${document.location.origin}/project/${this.props.projectId}/environment/${this.props.environmentId}/users/${identity.identifier}/${identity.id}?flag=${projectFlag.name}`, '_blank');
-                                                                    }} space className="list-item cursor-pointer"
+                                                                    space className="list-item cursor-pointer"
                                                                     key={id}
                                                                   >
-                                                                      <Flex>
+                                                                      <Flex onClick={() => {
+                                                                        window.open(`${document.location.origin}/project/${this.props.projectId}/environment/${this.props.environmentId}/users/${identity.identifier}/${identity.id}?flag=${projectFlag.name}`, '_blank');
+                                                                      }}>
                                                                           {identity.identifier}
                                                                       </Flex>
-                                                                      <Switch disabled checked={enabled}/>
+                                                                      <Switch checked={enabled} onChange={() => this.toggleUserFlag({ id, identity, enabled })}/>
                                                                       <div className="ml-2">
                                                                           {feature_state_value && (
                                                                           <FeatureValue


### PR DESCRIPTION
Hello me again!
Playing a lot with your product to make it work in our codebase. Overall it looks really great!
I said it already but will say it again: great job and thank you!

I don't know if it was done on purpose but right now an admin can add identity overrides for some users, toggle the value for all of them (enable all/disable all) but can't toggle back a value only for one user. IMO this doesn't make sense but maybe I'm wrong.

This is a proposal to fix this

### BEFORE
https://user-images.githubusercontent.com/18406791/185660632-9ef63766-15d6-4b8a-b6b6-bf8f1b0caa36.mov

### AFTER
https://user-images.githubusercontent.com/18406791/185660605-4bee7dd3-0b1d-4d16-9d3d-810e18d1dfe5.mov
