### PR TITLE
Use concrete arguments for args and kwargs in delay and task create methods

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -138,7 +138,7 @@ class ChangeRequest(LifecycleModelMixin, AbstractBaseExportableModel):
             if not previous_live_from or feature_state.live_from != previous_live_from:
                 rebuild_environment_document.delay(
                     delay_util=feature_state.live_from,
-                    environment_id=self.environment_id,
+                    kwargs={"environment_id": self.environment_id},
                 )
             previous_live_from = feature_state.live_from
 

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -25,8 +25,14 @@ def register_task_handler(task_name: str = None):
         register_task(task_identifier, f)
 
         def delay(
-            *args, delay_until: datetime = None, **kwargs
+            *,
+            delay_until: datetime = None,
+            args: typing.Tuple = None,
+            kwargs: typing.Dict = None,
         ) -> typing.Optional[Task]:
+            args = args or tuple()
+            kwargs = kwargs or dict()
+
             if delay_until and settings.TASK_RUN_METHOD != TaskRunMethod.TASK_PROCESSOR:
                 logger.warning(
                     "Cannot schedule tasks to run in the future without task processor."
@@ -44,8 +50,8 @@ def register_task_handler(task_name: str = None):
                 task = Task.schedule_task(
                     schedule_for=delay_until or timezone.now(),
                     task_identifier=task_identifier,
-                    *args,
-                    **kwargs,
+                    args=args,
+                    kwargs=kwargs,
                 )
                 task.save()
                 return task

--- a/api/task_processor/health.py
+++ b/api/task_processor/health.py
@@ -11,7 +11,7 @@ from task_processor.tasks import create_health_check_model
 def is_processor_healthy(max_tries: int = 5, factor: float = 0.1) -> bool:
     health_check_model_uuid = str(uuid.uuid4())
 
-    create_health_check_model.delay(health_check_model_uuid)
+    create_health_check_model.delay(args=(health_check_model_uuid,))
 
     @backoff.on_predicate(
         backoff.expo,

--- a/api/task_processor/models.py
+++ b/api/task_processor/models.py
@@ -29,18 +29,29 @@ class Task(models.Model):
         ]
 
     @classmethod
-    def create(cls, task_identifier: str, *args, **kwargs) -> "Task":
+    def create(
+        cls,
+        task_identifier: str,
+        *,
+        args: typing.Tuple[typing.Any] = None,
+        kwargs: typing.Dict[str, typing.Any] = None,
+    ) -> "Task":
         return Task(
             task_identifier=task_identifier,
-            serialized_args=cls._serialize_data(args),
-            serialized_kwargs=cls._serialize_data(kwargs),
+            serialized_args=cls._serialize_data(args or tuple()),
+            serialized_kwargs=cls._serialize_data(kwargs or dict()),
         )
 
     @classmethod
     def schedule_task(
-        cls, schedule_for: datetime, task_identifier: str, *args, **kwargs
+        cls,
+        schedule_for: datetime,
+        task_identifier: str,
+        *,
+        args: typing.Tuple[typing.Any] = None,
+        kwargs: typing.Dict[str, typing.Any] = None,
     ) -> "Task":
-        task = cls.create(task_identifier, *args, **kwargs)
+        task = cls.create(task_identifier=task_identifier, args=args, kwargs=kwargs)
         task.scheduled_for = schedule_for
         return task
 

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -412,5 +412,5 @@ def test_schedule_environment_rebuild_schedules_rebuild_environment_task(
     # Then
     mock_rebuild_environment_document.delay.assert_called_once_with(
         delay_util=tomorrow,
-        environment_id=change_request_no_required_approvals.environment_id,
+        kwargs={"environment_id": change_request_no_required_approvals.environment_id},
     )

--- a/api/tests/unit/task_processor/test_unit_task_processor_models.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_models.py
@@ -13,7 +13,7 @@ def test_task_run():
     args = ["foo"]
     kwargs = {"arg_two": "bar"}
 
-    task = Task.create(my_callable.task_identifier, *args, **kwargs)
+    task = Task.create(my_callable.task_identifier, args=args, kwargs=kwargs)
 
     # When
     result = task.run()

--- a/api/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -14,7 +14,7 @@ from task_processor.processor import run_next_task
 def test_run_task_runs_task_and_creates_task_run_object_when_success(db):
     # Given
     organisation_name = f"test-org-{uuid.uuid4()}"
-    task = Task.create(_create_organisation.task_identifier, organisation_name)
+    task = Task.create(_create_organisation.task_identifier, args=(organisation_name,))
     task.save()
 
     # When
@@ -64,10 +64,14 @@ def test_run_next_task_does_nothing_if_no_tasks(db):
 def test_run_next_task_runs_tasks_in_correct_order(db):
     # Given
     # 2 tasks
-    task_1 = Task.create(_create_organisation.task_identifier, "task 1 organisation")
+    task_1 = Task.create(
+        _create_organisation.task_identifier, args=("task 1 organisation",)
+    )
     task_1.save()
 
-    task_2 = Task.create(_create_organisation.task_identifier, "task 2 organisation")
+    task_2 = Task.create(
+        _create_organisation.task_identifier, args=("task 2 organisation",)
+    )
     task_2.save()
 
     # When
@@ -89,12 +93,12 @@ class TestProcessor(TransactionTestCase):
         # 2 tasks
         # One which is configured to just sleep for 3 seconds, to simulate a task
         # being held for a short period of time
-        task_1 = Task.create(_sleep.task_identifier, 3)
+        task_1 = Task.create(_sleep.task_identifier, args=(3,))
         task_1.save()
 
         # and another which should create an organisation
         task_2 = Task.create(
-            _create_organisation.task_identifier, "task 2 organisation"
+            _create_organisation.task_identifier, args=("task 2 organisation",)
         )
         task_2.save()
 


### PR DESCRIPTION
Previously, it was a little confusing to understand what arguments were being passed on to the task function and which were required for the creation of the task itself. This should clear that up so it's obvious in all cases. I've used the `*` argument in certain places to ensure that certain arguments are passed as kwargs to avoid any confusion. 