### PR TITLE
Enable task processor health check in production

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -154,6 +154,10 @@
                 {
                     "name": "TASK_RUN_METHOD",
                     "value": "TASK_PROCESSOR"
+                },
+                {
+                    "name": "ENABLE_TASK_PROCESSOR_HEALTH_CHECK",
+                    "value": "True"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Enable the task processor health check in production. Note that even if the health check fails, the endpoint will still return 200 OK since the check is not marked as 'essential'.

## How did you test this code?

I have verified that the health check works locally and in staging (https://api-staging.flagsmith.com/health/). I've also verified locally that even if the task processor fails to process tasks, the health check still returns 200 OK. 
