### PR TITLE
Handle scheduled tasks in monitoring

### DIFF
--- a/api/task_processor/serializers.py
+++ b/api/task_processor/serializers.py
@@ -3,5 +3,6 @@ from rest_framework import serializers
 
 class MonitoringSerializer(serializers.Serializer):
     waiting = serializers.IntegerField(read_only=True)
+    scheduled = serializers.IntegerField(read_only=True)
     completed = serializers.IntegerField(read_only=True)
     failed = serializers.IntegerField(read_only=True)


### PR DESCRIPTION
## Changes

Adds logic to handle scheduled tasks in the monitoring endpoint. 

## How did you test this code?

Manually by running the API locally and hitting the endpoint via postman. 
