### PR TITLE
Fix/missing stack traces

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -420,7 +420,7 @@ else:
     LOG_LEVEL = env.str("LOG_LEVEL", default="WARNING")
     LOGGING = {
         "version": 1,
-        "disable_existing_loggers": True,
+        "disable_existing_loggers": False,
         "formatters": {
             "generic": {"format": "%(name)-12s %(levelname)-8s %(message)s"},
         },

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -41,6 +41,9 @@ if ENV not in ("local", "dev", "staging", "production"):
 
 DEBUG = env.bool("DEBUG", default=False)
 
+ADMINS = []
+MANAGERS = []
+
 # Enables the sending of telemetry data to the central Flagsmith API for usage tracking
 ENABLE_TELEMETRY = env.bool("ENABLE_TELEMETRY", default=True)
 


### PR DESCRIPTION
- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

 - Prevent disabling existing loggers as it seems to be preventing the django application from writing stack traces to stderr
 - Add empty settings for `ADMINS` and `MANAGERS`  to prevent django from trying to email admins / managers when an exception occurs

## How did you test this code?

Manually using docker as it's an issue that I've been trying to diagnose with a client using k8s. 
