### PR TITLE
Allow users with view environment to retrieve feature states

### DIFF
--- a/api/features/permissions.py
+++ b/api/features/permissions.py
@@ -166,7 +166,6 @@ class EnvironmentFeatureStatePermissions(IsAuthenticated):
             "list": VIEW_ENVIRONMENT,
             "create": UPDATE_FEATURE_STATE,
             "all": VIEW_ENVIRONMENT,
-            "retrieve": VIEW_ENVIRONMENT,
         }
         if not super().has_permission(request, view):
             return False
@@ -186,8 +185,12 @@ class EnvironmentFeatureStatePermissions(IsAuthenticated):
     def has_object_permission(self, request, view, obj):
         if request.user.is_anonymous:
             return False
+
+        action_permission_map = {"retrieve": VIEW_ENVIRONMENT}
+
         return request.user.has_environment_permission(
-            permission=UPDATE_FEATURE_STATE, environment=obj.environment
+            permission=action_permission_map.get(view.action, UPDATE_FEATURE_STATE),
+            environment=obj.environment,
         )
 
 

--- a/api/features/permissions.py
+++ b/api/features/permissions.py
@@ -166,6 +166,7 @@ class EnvironmentFeatureStatePermissions(IsAuthenticated):
             "list": VIEW_ENVIRONMENT,
             "create": UPDATE_FEATURE_STATE,
             "all": VIEW_ENVIRONMENT,
+            "retrieve": VIEW_ENVIRONMENT,
         }
         if not super().has_permission(request, view):
             return False

--- a/api/tests/unit/environments/test_environments_feature_states_views.py
+++ b/api/tests/unit/environments/test_environments_feature_states_views.py
@@ -83,3 +83,33 @@ def test_permitted_user_can_update_feature_state(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_user_with_view_environment_can_retrieve_feature_state(
+    organisation_one_project_one_environment_one,
+    organisation_one_project_one_feature_one,
+    organisation_one_user,
+):
+    # Given
+    environment = organisation_one_project_one_environment_one
+    feature = organisation_one_project_one_feature_one
+
+    feature_state = environment.get_feature_state(feature_id=feature.id)
+    client = get_environment_user_client(
+        user=organisation_one_user,
+        environment=environment,
+        permission_keys=[VIEW_ENVIRONMENT],
+        admin=False,
+    )
+
+    url = reverse(
+        "api-v1:environments:environment-featurestates-detail",
+        args=[environment.api_key, feature_state.id],
+    )
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["id"] == feature_state.id


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Allow users with VIEW_ENVIRONMENT permission to retrieve feature states. 

## How did you test this code?

New test added. 
