### PR TITLE
feat(sales-dashboard): show environment-document calls

### DIFF
--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -155,7 +155,7 @@ def get_multiple_event_list_for_organisation(organisation_id: int):
 
     :param organisation_id: an id of the organisation to get usage for
 
-    :return: a number of requests for flags, traits, identities
+    :return: a number of requests for flags, traits, identities, environment-document
     """
     results = InfluxDBWrapper.influx_query_manager(
         filters=f'|> filter(fn:(r) => r._measurement == "api_call") \

--- a/api/sales_dashboard/templates/sales_dashboard/organisation.html
+++ b/api/sales_dashboard/templates/sales_dashboard/organisation.html
@@ -183,6 +183,11 @@ var myChart = new Chart(ctx, {
         label: 'Traits',
         data: {{traits}},
         backgroundColor: '#EBCCD1',
+      },
+      {
+        label: 'Environment Documents',
+        data: {{environment_documents}},
+        backgroundColor: '#368BD1',
       }
     ]
   },

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -152,6 +152,9 @@ def organisation_info(request, organisation_id):
         "traits": mark_safe(json.dumps(event_list["traits"])),
         "identities": mark_safe(json.dumps(event_list["identities"])),
         "flags": mark_safe(json.dumps(event_list["flags"])),
+        "environment_documents": mark_safe(
+            json.dumps(event_list["environment-document"])
+        ),
         "labels": mark_safe(json.dumps(labels)),
         "api_calls": {
             # TODO: this could probably be reduced to a single influx request
@@ -170,6 +173,9 @@ def organisation_info(request, organisation_id):
         context["traits"] = mark_safe(json.dumps(event_list["traits"]))
         context["identities"] = mark_safe(json.dumps(event_list["identities"]))
         context["flags"] = mark_safe(json.dumps(event_list["flags"]))
+        context["environment_documents"] = mark_safe(
+            json.dumps(event_list["environment-document"])
+        )
         context["labels"] = mark_safe(json.dumps(labels))
 
     return HttpResponse(template.render(context, request))


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add Environment Documents call to sales dashboard.
PS: I am open to changing the colour of environment document

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
By running local server with influx db api_dev bucket

UI Changes:

![temp_delete_me](https://user-images.githubusercontent.com/18366226/193732022-cabda226-5539-4097-82fc-0f77e80cf176.png)

