### PR TITLE
Support credential urls in webhooks

### DIFF
--- a/frontend/common/data/base/_data.js
+++ b/frontend/common/data/base/_data.js
@@ -81,7 +81,7 @@ module.exports = {
         let url = _url;
         const parts = _url.split(/(https?:\/\/)?(.*?:.*?)@/)
         if (parts.length === 4) {
-            url = parts[1]+parts[parts.length-1]
+            url = (parts[1]||"http://")+parts[parts.length-1]
             options.headers.AUTHORIZATION = `Basic ${btoa(parts[parts.length-2])}`;
         }
 

--- a/frontend/common/data/base/_data.js
+++ b/frontend/common/data/base/_data.js
@@ -55,7 +55,8 @@ module.exports = {
         return this._request('delete', url, data, headers);
     },
 
-    _request(method, url, data, headers = {}) {
+    _request(method, _url, data, headers = {}) {
+
         const options = {
             timeout: 60000,
             method,
@@ -75,6 +76,13 @@ module.exports = {
 
         if (this.token) { // add auth tokens to headers of all requests
             options.headers.AUTHORIZATION = `Token ${this.token}`;
+        }
+
+        let url = _url;
+        const parts = _url.split(/(https?:\/\/)?(.*?:.*?)@/)
+        if (parts.length === 4) {
+            url = parts[1]+parts[parts.length-1]
+            options.headers.AUTHORIZATION = `Basic ${btoa(parts[parts.length-2])}`;
         }
 
         if (data) {

--- a/frontend/env/project_local.js
+++ b/frontend/env/project_local.js
@@ -1,6 +1,6 @@
 module.exports = global.Project = {
     api: 'http://localhost:8000/api/v1/',
-    flagsmithClientAPI: 'https://api.bullet-train.io/api/v1/',
+    flagsmithClientAPI: 'https://api.flagsmith.com/api/v1/',
     flagsmithClientEdgeAPI: 'https://edge.api.flagsmith.com/api/v1/',
     flagsmith: '8KzETdDeMY7xkqkSkY3Gsg',
     debug: false,

--- a/frontend/web/components/TestWebhook.js
+++ b/frontend/web/components/TestWebhook.js
@@ -23,7 +23,7 @@ export default class TheComponent extends Component {
           })
           .catch((e) => {
               if (e.text) {
-                  e.text().then(error => this.setState({ error: `The server returned an error: ${error}` }));
+                  e.text().then(error => this.setState({ error: `The server returned an error: ${error}`, loading:false }));
               } else {
                   this.setState({ error: 'There was an error posting to your webhook.', loading: false });
               }
@@ -43,6 +43,7 @@ export default class TheComponent extends Component {
               {error && <ErrorMessage error={this.state.error}/>}
               {success && <SuccessMessage message="Your API returned with a successful 200 response."/>}
               <Button
+                type="button"
                 id="try-it-btn" disabled={loading||!this.props.webhook} onClick={submit}
                 className="btn btn--with-icon primary"
               >


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

fetch does not support credential based fetching as part of a 


## How did you test this code?

Ran a webhook against https://foo:bar3@httpbin.org/basic-auth/foo/bar3 and checked headers.

![image](https://user-images.githubusercontent.com/8608314/193782244-c3fea971-0379-4d63-b69c-9ba27f9a9c77.png)
