### PR TITLE
fix(alert): use chargebee metadata where available

### DIFF
--- a/api/organisations/management/commands/check_if_organisations_over_plan_limit.py
+++ b/api/organisations/management/commands/check_if_organisations_over_plan_limit.py
@@ -1,6 +1,9 @@
 from django.core.management import BaseCommand
 
 from organisations.models import Organisation
+from organisations.subscriptions.subscription_service import (
+    get_subscription_metadata,
+)
 from users.models import FFAdminUser
 
 
@@ -14,6 +17,7 @@ class Command(BaseCommand):
 
 
 def send_alert(organisation):
+    subscription_metadata = get_subscription_metadata(organisation)
     FFAdminUser.send_alert_to_admin_users(
         subject="Organisation over number of seats",
         message="Organisation %s has used %d seats which is over their plan limit of %d "
@@ -21,7 +25,7 @@ def send_alert(organisation):
         % (
             str(organisation.name),
             organisation.num_seats,
-            organisation.subscription.max_seats,
+            subscription_metadata.seats,
             organisation.subscription.plan,
         ),
     )

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -93,7 +93,8 @@ class Organisation(LifecycleModelMixin, AbstractBaseExportableModel):
 
     def over_plan_seats_limit(self):
         if self.has_subscription():
-            return self.num_seats > self.subscription.max_seats
+            susbcription_metadata = self.subscription.get_subscription_metadata()
+            return self.num_seats > susbcription_metadata.seats
 
         return self.num_seats > MAX_SEATS_IN_FREE_PLAN
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Update over_plan_seat_limit to use metadata from Chargebee; update email command/task to use chargebee metadata

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

unit test cases for over_plan_seat_limit; 
and manually verify alert method
