### PR TITLE
TaskProcessor: increase number of tasks per iteration

### DIFF
--- a/api/task_processor/management/commands/runprocessor.py
+++ b/api/task_processor/management/commands/runprocessor.py
@@ -47,15 +47,25 @@ class Command(BaseCommand):
             help="Number of millis before running task is considered 'stuck'.",
             default=3000,
         )
+        parser.add_argument(
+            "--queuepopsize",
+            type=int,
+            help="Number of tasks each worker will pop from the queue on each cycle.",
+            default=10,
+        )
 
     def handle(self, *args, **options):
         num_threads = options["numthreads"]
         sleep_interval_ms = options["sleepintervalms"]
         grace_period_ms = options["graceperiodms"]
+        queue_pop_size = options["queuepopsize"]
 
         self._threads.extend(
             [
-                TaskRunner(sleep_interval_millis=sleep_interval_ms)
+                TaskRunner(
+                    sleep_interval_millis=sleep_interval_ms,
+                    queue_pop_size=queue_pop_size,
+                )
                 for _ in range(num_threads)
             ]
         )

--- a/api/task_processor/threads.py
+++ b/api/task_processor/threads.py
@@ -3,13 +3,20 @@ from threading import Thread
 
 from django.utils import timezone
 
-from task_processor.processor import run_next_task
+from task_processor.processor import run_tasks
 
 
 class TaskRunner(Thread):
-    def __init__(self, *args, sleep_interval_millis: int = 2000, **kwargs):
+    def __init__(
+        self,
+        *args,
+        sleep_interval_millis: int = 2000,
+        queue_pop_size: int = 1,
+        **kwargs,
+    ):
         super(TaskRunner, self).__init__(*args, **kwargs)
         self.sleep_interval_millis = sleep_interval_millis
+        self.queue_pop_size = queue_pop_size
         self.last_checked_for_tasks = None
 
         self._stopped = False
@@ -17,7 +24,7 @@ class TaskRunner(Thread):
     def run(self) -> None:
         while not self._stopped:
             self.last_checked_for_tasks = timezone.now()
-            run_next_task()
+            run_tasks(self.queue_pop_size)
             time.sleep(self.sleep_interval_millis / 1000)
 
     def stop(self):

--- a/api/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -8,7 +8,7 @@ from django.test.testcases import TransactionTestCase
 from organisations.models import Organisation
 from task_processor.decorators import register_task_handler
 from task_processor.models import Task, TaskResult, TaskRun
-from task_processor.processor import run_next_task
+from task_processor.processor import run_tasks
 
 
 def test_run_task_runs_task_and_creates_task_run_object_when_success(db):
@@ -18,12 +18,13 @@ def test_run_task_runs_task_and_creates_task_run_object_when_success(db):
     task.save()
 
     # When
-    task_run = run_next_task()
+    task_runs = run_tasks()
 
     # Then
     assert Organisation.objects.filter(name=organisation_name).exists()
 
-    assert TaskRun.objects.filter(task=task).count() == 1
+    assert len(task_runs) == TaskRun.objects.filter(task=task).count() == 1
+    task_run = task_runs[0]
     assert task_run.result == TaskResult.SUCCESS
     assert task_run.started_at
     assert task_run.finished_at
@@ -39,10 +40,11 @@ def test_run_task_runs_task_and_creates_task_run_object_when_failure(db):
     task.save()
 
     # When
-    task_run = run_next_task()
+    task_runs = run_tasks()
 
     # Then
-    assert TaskRun.objects.filter(task=task).count() == 1
+    assert len(task_runs) == TaskRun.objects.filter(task=task).count() == 1
+    task_run = task_runs[0]
     assert task_run.result == TaskResult.FAILURE
     assert task_run.started_at
     assert task_run.finished_at is None
@@ -55,7 +57,7 @@ def test_run_task_runs_task_and_creates_task_run_object_when_failure(db):
 def test_run_next_task_does_nothing_if_no_tasks(db):
     # Given - no tasks
     # When
-    result = run_next_task()
+    result = run_tasks()
     # Then
     assert result is None
     assert not TaskRun.objects.exists()
@@ -75,12 +77,12 @@ def test_run_next_task_runs_tasks_in_correct_order(db):
     task_2.save()
 
     # When
-    task_run_1 = run_next_task()
-    task_run_2 = run_next_task()
+    task_runs_1 = run_tasks()
+    task_runs_2 = run_tasks()
 
     # Then
-    assert task_run_1.task == task_1
-    assert task_run_2.task == task_2
+    assert task_runs_1[0].task == task_1
+    assert task_runs_2[0].task == task_2
 
 
 class TestProcessor(TransactionTestCase):
@@ -106,20 +108,49 @@ class TestProcessor(TransactionTestCase):
 
         # When
         # we spawn a new thread to run the first task (configured to just sleep)
-        task_runner_thread = Thread(target=run_next_task)
+        task_runner_thread = Thread(target=run_tasks)
         threads.append(task_runner_thread)
         task_runner_thread.start()
 
         with transaction.atomic():
             # and subsequently attempt to run another task in the main thread
             time.sleep(1)  # wait for the thread to start and hold the task
-            task_run = run_next_task()
+            task_runs = run_tasks()
 
             # Then
             # the second task is run while the 1st task is held
-            assert task_run.task == task_2
+            assert task_runs[0].task == task_2
 
         [t.join() for t in threads]
+
+
+def test_run_more_than_one_task(db):
+    # Given
+    num_tasks = 5
+
+    tasks = []
+    for _ in range(num_tasks):
+        organisation_name = f"test-org-{uuid.uuid4()}"
+        tasks.append(
+            Task.create(_create_organisation.task_identifier, args=(organisation_name,))
+        )
+    Task.objects.bulk_create(tasks)
+
+    # When
+    task_runs = run_tasks(5)
+
+    # Then
+    assert len(task_runs) == num_tasks
+
+    for task_run in task_runs:
+        assert task_run.result == TaskResult.SUCCESS
+        assert task_run.started_at
+        assert task_run.finished_at
+        assert task_run.error_details is None
+
+    for task in tasks:
+        task.refresh_from_db()
+        assert task.completed
 
 
 @register_task_handler()

--- a/api/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -59,7 +59,7 @@ def test_run_next_task_does_nothing_if_no_tasks(db):
     # When
     result = run_tasks()
     # Then
-    assert result is None
+    assert result == []
     assert not TaskRun.objects.exists()
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Allow the task processor workers to consume more than one task from the queue at a time. This should reduce the number of reads to the `taskprocessor_task` table. I've also optimised the writes so that we're only making one write to the `task` and `taskrun` table per iteration of the worker.   

## How did you test this code?

Update the existing unit tests and created one additional. I've also run the task processor locally with different input values to confirm that it still consumes tasks successfully. 
