### PR TITLE
Remove pip from Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN if [ "${SAML_INSTALLED}" = "1" ]; then apt-get update && apt-get install -y 
 # Install python dependencies
 RUN pip install -r requirements.txt --no-cache-dir --compile
 
+# remove pip
+RUN python -m pip uninstall pip -y
+RUN rm -rf $HOME/.cache/pip
+
 # Compile static Django assets
 RUN python /app/manage.py collectstatic --no-input
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,6 +19,10 @@ RUN apt update && apt install -y xmlsec1
 # Install python dependencies
 RUN pip install -r requirements.txt --no-cache-dir --compile
 
+# remove pip
+RUN python -m pip uninstall pip -y
+RUN rm -rf $HOME/.cache/pip
+
 # Compile static Django assets
 RUN python manage.py collectstatic --no-input
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Remove pip from the docker image after installing python requirements. 

## How did you test this code?

I've manually built the docker image, run it locally and done a quick smoke test. 
