### PR TITLE
feat(mv-options): make mv options crud possible using master-api-key and uuid

### DIFF
--- a/api/api/urls/v1.py
+++ b/api/api/urls/v1.py
@@ -34,6 +34,7 @@ urlpatterns = [
     url(r"^projects/", include("projects.urls"), name="projects"),
     url(r"^environments/", include("environments.urls"), name="environments"),
     url(r"^features/", include("features.urls"), name="features"),
+    url(r"^multivariate/", include("features.multivariate.urls"), name="multivariate"),
     url(r"^segments/", include("segments.urls"), name="segments"),
     url(r"^users/", include("users.urls")),
     url(r"^e2etests/", include("e2etests.urls")),

--- a/api/features/multivariate/serializers.py
+++ b/api/features/multivariate/serializers.py
@@ -15,12 +15,14 @@ class NestedMultivariateFeatureOptionSerializer(serializers.ModelSerializer):
 
         fields = (
             "id",
+            "uuid",
             "type",
             "integer_value",
             "string_value",
             "boolean_value",
             "default_percentage_allocation",
         )
+        read_only_fields = ("uuid",)
 
 
 class MultivariateFeatureOptionSerializer(NestedMultivariateFeatureOptionSerializer):

--- a/api/features/multivariate/urls.py
+++ b/api/features/multivariate/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from features.multivariate.views import get_mv_feature_option_by_uuid
+
+app_name = "multivariate"
+
+urlpatterns = [
+    path(
+        "options/get-by-uuid/<uuid:uuid>/",
+        get_mv_feature_option_by_uuid,
+        name="get-mv-feature-option-by-uuid",
+    ),
+]

--- a/api/features/multivariate/views.py
+++ b/api/features/multivariate/views.py
@@ -1,31 +1,37 @@
 from rest_framework import viewsets
 from rest_framework.generics import get_object_or_404
-from rest_framework.permissions import IsAuthenticated
 
 from features.models import Feature
-from projects.permissions import IsProjectAdmin, NestedProjectPermissions
+from projects.permissions import (
+    NestedProjectMasterAPIKeyPermissions,
+    NestedProjectPermissions,
+)
 
 from .serializers import MultivariateFeatureOptionSerializer
 
 
 class MultivariateFeatureOptionViewSet(viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticated, IsProjectAdmin]
+    permission_classes = [
+        NestedProjectPermissions | NestedProjectMasterAPIKeyPermissions
+    ]
     serializer_class = MultivariateFeatureOptionSerializer
 
     def get_permissions(self):
+        action_permission_map = {
+            "list": "VIEW_PROJECT",
+            "detail": "VIEW_PROJECT",
+            "create": "CREATE_FEATURE",
+            "update": "CREATE_FEATURE",
+            "partial_update": "CREATE_FEATURE",
+            "destroy": "CREATE_FEATURE",
+        }
+
+        permission_kwargs = {
+            "action_permission_map": action_permission_map,
+            "get_project_from_object_callable": lambda o: o.feature.project,
+        }
         return [
-            IsAuthenticated(),
-            NestedProjectPermissions(
-                action_permission_map={
-                    "list": "VIEW_PROJECT",
-                    "detail": "VIEW_PROJECT",
-                    "create": "CREATE_FEATURE",
-                    "update": "CREATE_FEATURE",
-                    "partial_update": "CREATE_FEATURE",
-                    "destroy": "CREATE_FEATURE",
-                },
-                get_project_from_object_callable=lambda o: o.feature.project,
-            ),
+            permission(**permission_kwargs) for permission in self.permission_classes
         ]
 
     def get_queryset(self):

--- a/api/features/multivariate/views.py
+++ b/api/features/multivariate/views.py
@@ -1,5 +1,10 @@
+from core.permissions import HasMasterAPIKey
+from drf_yasg2.utils import swagger_auto_schema
 from rest_framework import viewsets
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from features.models import Feature
 from projects.permissions import (
@@ -7,6 +12,7 @@ from projects.permissions import (
     NestedProjectPermissions,
 )
 
+from .models import MultivariateFeatureOption
 from .serializers import MultivariateFeatureOptionSerializer
 
 
@@ -37,3 +43,21 @@ class MultivariateFeatureOptionViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         feature = get_object_or_404(Feature, pk=self.kwargs["feature_pk"])
         return feature.multivariate_options.all()
+
+
+@swagger_auto_schema(
+    responses={200: MultivariateFeatureOptionSerializer()}, method="get"
+)
+@api_view(["GET"])
+@permission_classes([IsAuthenticated | HasMasterAPIKey])
+def get_mv_feature_option_by_uuid(request, uuid):
+    if getattr(request, "master_api_key", None):
+        accessible_projects = request.master_api_key.organisation.projects.all()
+    else:
+        accessible_projects = request.user.get_permitted_projects(["VIEW_PROJECT"])
+    qs = MultivariateFeatureOption.objects.filter(
+        feature__project__in=accessible_projects
+    )
+    mv_option = get_object_or_404(qs, uuid=uuid)
+    serializer = MultivariateFeatureOptionSerializer(instance=mv_option)
+    return Response(serializer.data)

--- a/api/projects/permissions.py
+++ b/api/projects/permissions.py
@@ -101,6 +101,7 @@ class IsProjectAdmin(BasePermission):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+
         self._view_kwarg_name = project_pk_view_kwarg_attribute_name
         self._get_project_from_object_callable = get_project_from_object_callable
 

--- a/api/projects/permissions.py
+++ b/api/projects/permissions.py
@@ -90,7 +90,7 @@ class MasterAPIKeyProjectPermissions(BasePermission):
         return master_api_key.organisation_id == obj.organisation_id
 
 
-class IsProjectAdmin(IsAuthenticated):
+class IsProjectAdmin(BasePermission):
     def __init__(
         self,
         *args,
@@ -105,15 +105,9 @@ class IsProjectAdmin(IsAuthenticated):
         self._get_project_from_object_callable = get_project_from_object_callable
 
     def has_permission(self, request, view):
-        if not super().has_permission(request, view):
-            return False
-
         return request.user.is_project_admin(self._get_project(view)) or view.detail
 
     def has_object_permission(self, request, view, obj):
-        if request.user.is_anonymous:
-            return False
-
         return request.user.is_project_admin(
             self._get_project_from_object_callable(obj)
         )

--- a/api/projects/permissions.py
+++ b/api/projects/permissions.py
@@ -193,6 +193,6 @@ class NestedProjectMasterAPIKeyPermissions(BasePermission):
         return False
 
     def has_object_permission(
-        self, request: HttpRequest, view: str, obj: Project
+        self, request: HttpRequest, view: str, obj: Model
     ) -> bool:
         return self.has_permission(request, view)

--- a/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
+++ b/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
@@ -18,7 +18,7 @@ def test_multivariate_feature_options_view_set_get_permissions():
 
     # Then
     # NOTE: since we are using or(|) operator in the viewset `get_permission` returns
-    # an instance of `OR` object which store the permission in attributes named `op1` and `op2`
+    # an instance of `OR` object which store the permissions in attributes named `op1` and `op2`
     # ref: https://github.com/encode/django-rest-framework/blob/3.9.x/rest_framework/permissions.py#L71
     assert len(permissions) == 1
     assert isinstance(permissions[0].op1, NestedProjectPermissions)

--- a/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
+++ b/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
@@ -17,6 +17,9 @@ def test_multivariate_feature_options_view_set_get_permissions():
     permissions = view_set.get_permissions()
 
     # Then
+    # NOTE: since we are using or(|) operator in the viewset `get_permission` returns
+    # an instance of `OR` object which store the permission in attributes named `op1` and `op2`
+    # ref: https://github.com/encode/django-rest-framework/blob/3.9.x/rest_framework/permissions.py#L71
     assert len(permissions) == 1
     assert isinstance(permissions[0].op1, NestedProjectPermissions)
     assert permissions[0].op1.action_permission_map == {

--- a/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
+++ b/api/tests/unit/features/multivariate/test_unit_multivariate_views.py
@@ -1,3 +1,10 @@
+import uuid
+
+import pytest
+from django.urls import reverse
+from pytest_lazyfixture import lazy_fixture
+from rest_framework import status
+
 from features.multivariate.views import MultivariateFeatureOptionViewSet
 from projects.permissions import NestedProjectPermissions
 
@@ -10,9 +17,9 @@ def test_multivariate_feature_options_view_set_get_permissions():
     permissions = view_set.get_permissions()
 
     # Then
-    assert len(permissions) == 2
-    assert isinstance(permissions[1], NestedProjectPermissions)
-    assert permissions[1].action_permission_map == {
+    assert len(permissions) == 1
+    assert isinstance(permissions[0].op1, NestedProjectPermissions)
+    assert permissions[0].op1.action_permission_map == {
         "list": "VIEW_PROJECT",
         "detail": "VIEW_PROJECT",
         "create": "CREATE_FEATURE",
@@ -20,3 +27,40 @@ def test_multivariate_feature_options_view_set_get_permissions():
         "partial_update": "CREATE_FEATURE",
         "destroy": "CREATE_FEATURE",
     }
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_get_mv_feature_option_by_uuid(client, project, multivariate_feature):
+    # Given
+    mv_option_uuid = multivariate_feature.multivariate_options.first().uuid
+    url = reverse(
+        "api-v1:multivariate:get-mv-feature-option-by-uuid", args=[str(mv_option_uuid)]
+    )
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["uuid"] == str(mv_option_uuid)
+    assert response.data["feature"] == multivariate_feature.id
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_get_mv_feature_option_by_uuid_returns_404_if_mv_option_does_not_exists(
+    client, project
+):
+    # Given
+    url = reverse(
+        "api-v1:multivariate:get-mv-feature-option-by-uuid", args=[str(uuid.uuid4())]
+    )
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

* Add mv option crud support to master-api-key
* Add api to get multivariate option by uuid

## How did you test this code?

Unit tests
