### PR TITLE
fix(request-forwarding): use threads instead of task processor

### DIFF
--- a/api/environments/identities/tests/test_views.py
+++ b/api/environments/identities/tests/test_views.py
@@ -712,7 +712,7 @@ class SDKIdentitiesTestCase(APITestCase):
         mock_send_identity_update_message.delay.assert_not_called()
 
     @override_settings(EDGE_API_URL="http://localhost")
-    @mock.patch("environments.identities.views.forward_identity_request")
+    @mock.patch("environments.identities.views.forward_identity_request", autospec=True)
     def test_post_identities_calls_forward_identity_request_with_correct_arguments(
         self, mocked_forward_identity_request
     ):
@@ -731,7 +731,7 @@ class SDKIdentitiesTestCase(APITestCase):
         self.client.post(url, data=json.dumps(data), content_type="application/json")
 
         # Then
-        args, kwargs = mocked_forward_identity_request.delay.call_args_list[0]
+        args, kwargs = mocked_forward_identity_request.run_in_thread.call_args_list[0]
         assert args == ()
         assert kwargs["args"][0] == "POST"
         assert kwargs["args"][1].get("X-Environment-Key") == self.environment.api_key
@@ -740,7 +740,7 @@ class SDKIdentitiesTestCase(APITestCase):
         assert kwargs["kwargs"]["request_data"] == data
 
     @override_settings(EDGE_API_URL="http://localhost")
-    @mock.patch("environments.identities.views.forward_identity_request")
+    @mock.patch("environments.identities.views.forward_identity_request", autospec=True)
     def test_get_identities_calls_forward_identity_request_with_correct_arguments(
         self, mocked_forward_identity_request
     ):
@@ -752,7 +752,7 @@ class SDKIdentitiesTestCase(APITestCase):
         self.client.get(url)
 
         # Then
-        args, kwargs = mocked_forward_identity_request.delay.call_args_list[0]
+        args, kwargs = mocked_forward_identity_request.run_in_thread.call_args_list[0]
         assert args == ()
         assert kwargs["args"][0] == "GET"
         assert kwargs["args"][1].get("X-Environment-Key") == self.environment.api_key

--- a/api/environments/identities/traits/tests/test_views.py
+++ b/api/environments/identities/traits/tests/test_views.py
@@ -475,7 +475,9 @@ class SDKTraitsTest(APITestCase):
         )
 
     @override_settings(EDGE_API_URL="http://localhost")
-    @mock.patch("environments.identities.traits.views.forward_trait_request")
+    @mock.patch(
+        "environments.identities.traits.views.forward_trait_request", autospec=True
+    )
     def test_post_trait_calls_forward_trait_request_with_correct_arguments(
         self, mocked_forward_trait_request
     ):
@@ -487,7 +489,7 @@ class SDKTraitsTest(APITestCase):
         self.client.post(url, data=data, content_type=self.JSON)
 
         # Then
-        args, kwargs = mocked_forward_trait_request.delay.call_args_list[0]
+        args, kwargs = mocked_forward_trait_request.run_in_thread.call_args_list[0]
         assert args == ()
         assert kwargs["args"][0] == "POST"
         assert kwargs["args"][1].get("X-Environment-Key") == self.environment.api_key
@@ -495,7 +497,9 @@ class SDKTraitsTest(APITestCase):
         assert kwargs["args"][3] == json.loads(data)
 
     @override_settings(EDGE_API_URL="http://localhost")
-    @mock.patch("environments.identities.traits.views.forward_trait_request")
+    @mock.patch(
+        "environments.identities.traits.views.forward_trait_request", autospec=True
+    )
     def test_increment_value_calls_forward_trait_request_with_correct_arguments(
         self, mocked_forward_trait_request
     ):
@@ -511,7 +515,7 @@ class SDKTraitsTest(APITestCase):
         self.client.post(url, data=data)
 
         # Then
-        args, kwargs = mocked_forward_trait_request.delay.call_args_list[0]
+        args, kwargs = mocked_forward_trait_request.run_in_thread.call_args_list[0]
         assert args == ()
         assert kwargs["args"][0] == "POST"
         assert kwargs["args"][1].get("X-Environment-Key") == self.environment.api_key
@@ -523,7 +527,9 @@ class SDKTraitsTest(APITestCase):
         assert kwargs["args"][3]["trait_value"]
 
     @override_settings(EDGE_API_URL="http://localhost")
-    @mock.patch("environments.identities.traits.views.forward_trait_requests")
+    @mock.patch(
+        "environments.identities.traits.views.forward_trait_requests", autospec=True
+    )
     def test_bulk_create_traits_calls_forward_trait_request_with_correct_arguments(
         self, mocked_forward_trait_requests
     ):
@@ -550,7 +556,7 @@ class SDKTraitsTest(APITestCase):
         # Then
 
         # Then
-        args, kwargs = mocked_forward_trait_requests.delay.call_args_list[0]
+        args, kwargs = mocked_forward_trait_requests.run_in_thread.call_args_list[0]
         assert args == ()
         assert kwargs["args"][0] == "PUT"
         assert kwargs["args"][1].get("X-Environment-Key") == self.environment.api_key

--- a/api/environments/identities/traits/views.py
+++ b/api/environments/identities/traits/views.py
@@ -220,7 +220,7 @@ class SDKTraits(mixins.CreateModelMixin, viewsets.GenericViewSet):
         response = super(SDKTraits, self).create(request, *args, **kwargs)
         response.status_code = status.HTTP_200_OK
         if settings.EDGE_API_URL and request.environment.project.enable_dynamo_db:
-            forward_trait_request.delay(
+            forward_trait_request.run_in_thread(
                 args=(
                     request.method,
                     dict(request.headers),
@@ -245,7 +245,7 @@ class SDKTraits(mixins.CreateModelMixin, viewsets.GenericViewSet):
             # Convert the payload to the structure expected by /traits
             payload = serializer.data.copy()
             payload.update({"identity": {"identifier": payload.pop("identifier")}})
-            forward_trait_request.delay(
+            forward_trait_request.run_in_thread(
                 args=(
                     request.method,
                     dict(request.headers),
@@ -286,7 +286,7 @@ class SDKTraits(mixins.CreateModelMixin, viewsets.GenericViewSet):
             serializer.save()
 
             if settings.EDGE_API_URL and request.environment.project.enable_dynamo_db:
-                forward_trait_requests.delay(
+                forward_trait_requests.run_in_thread(
                     args=(
                         request.method,
                         dict(request.headers),

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -162,7 +162,7 @@ class SDKIdentities(SDKAPIView):
             .get_or_create(identifier=identifier, environment=request.environment)
         )
         if settings.EDGE_API_URL and request.environment.project.enable_dynamo_db:
-            forward_identity_request.delay(
+            forward_identity_request.run_in_thread(
                 args=(
                     request.method,
                     dict(request.headers),
@@ -201,7 +201,7 @@ class SDKIdentities(SDKAPIView):
         instance = serializer.save()
 
         if settings.EDGE_API_URL and request.environment.project.enable_dynamo_db:
-            forward_identity_request.delay(
+            forward_identity_request.run_in_thread(
                 args=(
                     request.method,
                     dict(request.headers),


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Forward requests to edge using threads instead of tasks

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Includes unit tests
