### PR TITLE
Reduce complexity of monitoring endpoint

### DIFF
--- a/api/task_processor/serializers.py
+++ b/api/task_processor/serializers.py
@@ -3,6 +3,3 @@ from rest_framework import serializers
 
 class MonitoringSerializer(serializers.Serializer):
     waiting = serializers.IntegerField(read_only=True)
-    scheduled = serializers.IntegerField(read_only=True)
-    completed = serializers.IntegerField(read_only=True)
-    failed = serializers.IntegerField(read_only=True)

--- a/api/task_processor/views.py
+++ b/api/task_processor/views.py
@@ -7,9 +7,9 @@ from task_processor.models import Task
 from task_processor.serializers import MonitoringSerializer
 
 
+@swagger_auto_schema(method="GET", responses={200: MonitoringSerializer()})
 @api_view(http_method_names=["GET"])
 @permission_classes([IsAuthenticated, IsAdminUser])
-@swagger_auto_schema(responses={200: MonitoringSerializer()})
 def monitoring(request, **kwargs):
     waiting_tasks = Task.objects.filter(num_failures__lt=3, completed=False).count()
     return Response(

--- a/api/task_processor/views.py
+++ b/api/task_processor/views.py
@@ -1,11 +1,9 @@
-from django.db.models import Count, Q
-from django.utils import timezone
 from drf_yasg2.utils import swagger_auto_schema
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
-from task_processor.models import Task, TaskResult
+from task_processor.models import Task
 from task_processor.serializers import MonitoringSerializer
 
 
@@ -13,16 +11,7 @@ from task_processor.serializers import MonitoringSerializer
 @permission_classes([IsAuthenticated, IsAdminUser])
 @swagger_auto_schema(responses={200: MonitoringSerializer()})
 def monitoring(request, **kwargs):
-    qs = Task.objects.annotate(num_task_runs=Count("task_runs")).aggregate(
-        waiting=Count(
-            "id", filter=Q(num_task_runs=0, scheduled_for__lte=timezone.now())
-        ),
-        scheduled=Count("id", filter=Q(scheduled_for__gt=timezone.now())),
-        completed=Count(
-            "id",
-            filter=Q(task_runs__result=TaskResult.SUCCESS),
-        ),
-        failed=Count("id", filter=Q(num_failures__gte=3)),
+    waiting_tasks = Task.objects.filter(num_failures__lt=3, completed=False).count()
+    return Response(
+        data={"waiting": waiting_tasks}, headers={"Content-Type": "application/json"}
     )
-    serializer = MonitoringSerializer(instance=qs)
-    return Response(data=serializer.data, headers={"Content-Type": "application/json"})


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Reduce complexity of monitoring query.

## How did you test this code?

I've run the API manually with the task processor enabled (but without running the task processor) itself and confirmed that the endpoint correctly reflects the amount of tasks waiting for processing. 
