### PR TITLE
Disable task processor health check

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -154,10 +154,6 @@
                 {
                     "name": "TASK_RUN_METHOD",
                     "value": "TASK_PROCESSOR"
-                },
-                {
-                    "name": "ENABLE_TASK_PROCESSOR_HEALTH_CHECK",
-                    "value": "True"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -156,10 +156,6 @@
                     "value": "TASK_PROCESSOR"
                 },
                 {
-                    "name": "ENABLE_TASK_PROCESSOR_HEALTH_CHECK",
-                    "value": "True"
-                },
-                {
                     "name": "CACHE_ENVIRONMENT_DOCUMENT_SECONDS",
                     "value": "60"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Disable task processor health check. We now have the Queue Depth custom metric being added to cloudwatch which should provide us with more information about whether the task processor is healthy or not. 

## How did you test this code?

Not possible to test locally. Will confirm once in staging that the task processor health check no longer runs. 
