### PR TITLE
Bring run_in_thread interface in line with delay

### DIFF
--- a/api/edge_api/identities/serializers.py
+++ b/api/edge_api/identities/serializers.py
@@ -172,16 +172,18 @@ class EdgeIdentityFeatureStateSerializer(serializers.Serializer):
 
         # TODO: use async processor instead of `run_in_thread`
         call_environment_webhook_for_feature_state_change.run_in_thread(
-            feature_id=self.instance.feature.id,
-            environment_api_key=identity.environment_api_key,
-            identity_id=identity_id,
-            identity_identifier=identity.identifier,
-            changed_by_user_id=self.context["request"].user.id,
-            new_enabled_state=self.instance.enabled,
-            new_value=new_value,
-            previous_enabled_state=getattr(previous_state, "enabled", None),
-            previous_value=previous_value,
-            timestamp=timezone.now().strftime(WEBHOOK_DATETIME_FORMAT),
+            kwargs={
+                "feature_id": self.instance.feature.id,
+                "environment_api_key": identity.environment_api_key,
+                "identity_id": identity_id,
+                "identity_identifier": identity.identifier,
+                "changed_by_user_id": self.context["request"].user.id,
+                "new_enabled_state": self.instance.enabled,
+                "new_value": new_value,
+                "previous_enabled_state": getattr(previous_state, "enabled", None),
+                "previous_value": previous_value,
+                "timestamp": timezone.now().strftime(WEBHOOK_DATETIME_FORMAT),
+            },
         )
 
         return self.instance

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -45,7 +45,7 @@ def register_task_handler(task_name: str = None):
                 f(*args, **kwargs)
             elif settings.TASK_RUN_METHOD == TaskRunMethod.SEPARATE_THREAD:
                 logger.debug("Running task '%s' in separate thread", task_identifier)
-                run_in_thread(*args, **kwargs)
+                run_in_thread(args=args, kwargs=kwargs)
             else:
                 logger.debug("Creating task for function '%s'...", task_identifier)
                 task = Task.schedule_task(

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -27,12 +27,11 @@ def register_task_handler(task_name: str = None):
         def delay(
             *,
             delay_until: datetime = None,
-            args: typing.Tuple = None,
+            args: typing.Tuple = (),
             kwargs: typing.Dict = None,
         ) -> typing.Optional[Task]:
             logger.debug("Request to run task '%s' asynchronously.", task_identifier)
 
-            args = args or tuple()
             kwargs = kwargs or dict()
 
             if delay_until and settings.TASK_RUN_METHOD != TaskRunMethod.TASK_PROCESSOR:
@@ -58,7 +57,7 @@ def register_task_handler(task_name: str = None):
                 task.save()
                 return task
 
-        def run_in_thread(*args, **kwargs):
+        def run_in_thread(*, args: typing.Tuple = (), kwargs: typing.Dict = None):
             logger.info("Running function %s in unmanaged thread.", f.__name__)
             Thread(target=f, args=args, kwargs=kwargs, daemon=True).start()
 

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
@@ -82,16 +82,18 @@ def test_edge_identity_feature_state_serializer_save_calls_webhook_for_new_overr
 
     # Then
     mock_call_environment_webhook.run_in_thread.assert_called_once_with(
-        feature_id=feature.id,
-        environment_api_key=identity.environment.api_key,
-        identity_id=identity.id,
-        identity_identifier=identity.identifier,
-        changed_by_user_id=admin_user.id,
-        new_enabled_state=new_enabled_state,
-        new_value=new_value,
-        previous_enabled_state=None,
-        previous_value=None,
-        timestamp=now.strftime(WEBHOOK_DATETIME_FORMAT),
+        kwargs={
+            "feature_id": feature.id,
+            "environment_api_key": identity.environment.api_key,
+            "identity_id": identity.id,
+            "identity_identifier": identity.identifier,
+            "changed_by_user_id": admin_user.id,
+            "new_enabled_state": new_enabled_state,
+            "new_value": new_value,
+            "previous_enabled_state": None,
+            "previous_value": None,
+            "timestamp": now.strftime(WEBHOOK_DATETIME_FORMAT),
+        }
     )
 
 
@@ -139,16 +141,18 @@ def test_edge_identity_feature_state_serializer_save_calls_webhook_for_update(
 
     # Then
     mock_call_environment_webhook.run_in_thread.assert_called_once_with(
-        feature_id=feature.id,
-        environment_api_key=identity.environment.api_key,
-        identity_id=identity.id,
-        identity_identifier=identity.identifier,
-        changed_by_user_id=admin_user.id,
-        new_enabled_state=new_enabled_state,
-        new_value=new_value,
-        previous_enabled_state=previous_enabled_state,
-        previous_value=previous_value,
-        timestamp=now.strftime(WEBHOOK_DATETIME_FORMAT),
+        kwargs={
+            "feature_id": feature.id,
+            "environment_api_key": identity.environment.api_key,
+            "identity_id": identity.id,
+            "identity_identifier": identity.identifier,
+            "changed_by_user_id": admin_user.id,
+            "new_enabled_state": new_enabled_state,
+            "new_value": new_value,
+            "previous_enabled_state": previous_enabled_state,
+            "previous_value": previous_value,
+            "timestamp": now.strftime(WEBHOOK_DATETIME_FORMAT),
+        }
     )
 
 

--- a/api/tests/unit/task_processor/test_unit_task_processor_decorators.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_decorators.py
@@ -26,7 +26,7 @@ def test_register_task_handler_run_in_thread(mocker, caplog):
     kwargs = {"bar": "baz"}
 
     # When
-    my_function.run_in_thread(*args, **kwargs)
+    my_function.run_in_thread(args=args, kwargs=kwargs)
 
     # Then
     mock_thread_class.assert_called_once_with(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

1. Fix issue with forwarding identity / trait requests
2. Bring `run_in_thread` interface in line with `delay` to simplify refactors

## How did you test this code?

Updated unit tests