### PR TITLE
fix(sales/dashboard): use organisation as filter arg

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/home.html
+++ b/api/sales_dashboard/templates/sales_dashboard/home.html
@@ -58,7 +58,7 @@
           </thead>
           <tbody>
             {% for org in object_list %}
-              {% load_subcription_metadata org.id %}
+              {% load_subcription_metadata org %}
             <tr class="{% if org.has_subscription and not org.is_paid %}table-danger{% elif org.num_seats > subscription_metadata.seats %}table-warning{% endif %}">
               <td>{{org.id}}</td>
               <td><a href="/sales-dashboard/organisations/{{org.id}}">{{org.name}}</a></td>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Fix load_subcription_metadata receiving org ID instead of org object

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

manually by running local server with Chargebee enabled 
