### PR TITLE
fix(chargebee/subscription): handle invalid(i.e: none or empty)

### DIFF
--- a/api/organisations/chargebee/chargebee.py
+++ b/api/organisations/chargebee/chargebee.py
@@ -102,6 +102,10 @@ def get_hosted_page_url_for_subscription_upgrade(
 def get_subscription_metadata(
     subscription_id: str,
 ) -> typing.Optional[ChargebeeObjMetadata]:
+    if not (subscription_id and subscription_id.strip() != ""):
+        logger.warning("Subscription id is empty or None")
+        return None
+
     with suppress(ChargebeeAPIError):
         if subscription_id == TRIAL_SUBSCRIPTION_ID:
             return ChargebeeObjMetadata()

--- a/api/organisations/chargebee/tests/test_chargebee.py
+++ b/api/organisations/chargebee/tests/test_chargebee.py
@@ -351,3 +351,21 @@ def test_get_subscription_metadata_returns_null_if_chargebee_error(
 
     # Then
     assert subscription_metadata is None
+
+
+@pytest.mark.parametrize(
+    "subscription_id",
+    [None, "", " "],
+)
+def test_get_subscription_metadata_returns_none_for_invalid_subscription_id(
+    mocker, chargebee_object_metadata, subscription_id
+):
+    # Given
+    mocked_chargebee = mocker.patch("organisations.chargebee.chargebee.chargebee")
+
+    # When
+    subscription_metadata = get_subscription_metadata(subscription_id)
+
+    # Then
+    mocked_chargebee.Subscription.retrieve.assert_not_called()
+    assert subscription_metadata is None


### PR DESCRIPTION
chargebee raises Exception instead of ChargebeeAPIError if subscription id is none or empty string hence
we need to handle it explicitly by returning None and not calling the api

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

chargebee raises Exception instead of ChargebeeAPIError
if subscription id is none or empty string hence
we need to handle it explicitly by returning None and not
calling the api

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds unit test case that covers the change
