### PR TITLE
chore/bump-gunicorn

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -145,7 +145,7 @@ google-auth-httplib2==0.0.4
     # via google-api-python-client
 googleapis-common-protos==1.52.0
     # via google-api-core
-gunicorn==20.0.4
+gunicorn==20.1.0
     # via -r requirements.in
 httplib2==0.19.0
     # via


### PR DESCRIPTION
`gunicorn` package version is pretty old - current version we are using was released 26 Nov 2019 - more info here: https://github.com/benoitc/gunicorn/releases