### PR TITLE
Optimise update_traits

### DIFF
--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -170,9 +170,11 @@ class Identity(models.Model):
         :param trait_data_items: list of dictionaries validated by TraitSerializerFull
         :return: queryset of updated trait models
         """
-        current_traits = self.get_all_user_traits()
+        current_traits = {t.trait_key: t for t in self.identity_traits.all()}
 
         keys_to_delete = []
+        new_traits = []
+        updated_traits = []
 
         for trait_data_item in trait_data_items:
             trait_key = trait_data_item["trait_key"]
@@ -186,20 +188,28 @@ class Identity(models.Model):
 
             trait_value_data = Trait.generate_trait_value_data(trait_value)
 
-            if current_traits.filter(trait_key=trait_key).exists():
-                current_trait = current_traits.get(trait_key=trait_key)
+            if trait_key in current_traits:
+                current_trait = current_traits[trait_key]
                 for attr, value in trait_value_data.items():
                     setattr(current_trait, attr, value)
-                current_trait.save()
+                updated_traits.append(current_trait)
             else:
-                # use update_or_create to avoid race condition
-                kwargs = {"trait_key": trait_key, "identity": self}
-                Trait.objects.update_or_create(defaults=trait_value_data, **kwargs)
+                new_traits.append(
+                    Trait(**trait_value_data, trait_key=trait_key, identity=self)
+                )
 
         # delete the traits that had their keys set to None
         if keys_to_delete:
-            current_traits.filter(trait_key__in=keys_to_delete).delete()
+            self.identity_traits.filter(trait_key__in=keys_to_delete).delete()
+
+        Trait.objects.bulk_update(updated_traits, fields=Trait.BULK_UPDATE_FIELDS)
+
+        # use ignore_conflicts to handle race conditions which result in IntegrityError if another request
+        # has added a particular trait_key for the identity while this method has been determining what to
+        # update or create.
+        # See: https://github.com/Flagsmith/flagsmith/issues/370
+        Trait.objects.bulk_create(new_traits, ignore_conflicts=True)
 
         # return the full list of traits for this identity by refreshing from the db
         # TODO: handle this in the above logic to avoid a second hit to the DB
-        return self.get_all_user_traits()
+        return self.identity_traits.all()

--- a/api/environments/identities/traits/models.py
+++ b/api/environments/identities/traits/models.py
@@ -15,6 +15,15 @@ class Trait(models.Model):
         (FLOAT, "Float"),
     )
 
+    # list of fields that should be updated when using bulk update (e.g. in Identity.update_traits())
+    BULK_UPDATE_FIELDS = [
+        "value_type",
+        "string_value",
+        "integer_value",
+        "float_value",
+        "boolean_value",
+    ]
+
     identity = models.ForeignKey(
         "identities.Identity", related_name="identity_traits", on_delete=models.CASCADE
     )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

I believe this will resolve the issues we are currently experiencing at 3pm BST. My understanding (based on database monitoring) is that we're receiving a large number of requests to our identities endpoint which create large numbers of traits. This results in a lot of calls to the `update_or_create` method on the Trait Manager class, causing a lot of table locks and creating a performance issue.  

The main changes are: 

1. I've moved everything to bulk operations (but used `ignore_conflicts` on bulk_create to ensure that we don't regress on #370. 
2. The method now builds a dictionary up front of `trait_key: trait` so that it doesn't have to keep looking in the database to see if a trait already exists.

## How did you test this code?

I've not changed any behaviour, simply optimised the method. The existing unit / E2E tests should test it. 
