### PR TITLE
Add pagination class to segments

### DIFF
--- a/api/segments/tests/test_views.py
+++ b/api/segments/tests/test_views.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 import pytest
 from core.constants import STRING
@@ -269,3 +270,31 @@ def test_get_segment_by_uuid(client, project, segment):
 
     assert response.json()["id"] == segment.id
     assert response.json()["uuid"] == str(segment.uuid)
+
+
+def test_list_segments(django_assert_num_queries, project, admin_client):
+    # Given
+    segments = []
+    for i in range(5):
+        segment = Segment.objects.create(project=project, name=f"segment {i}")
+        all_rule = SegmentRule.objects.create(
+            segment=segment, type=SegmentRule.ALL_RULE
+        )
+        any_rule = SegmentRule.objects.create(rule=all_rule, type=SegmentRule.ANY_RULE)
+        Condition.objects.create(
+            property="foo", value=str(random.randint(0, 10)), rule=any_rule
+        )
+        segments.append(segment)
+
+    # When
+    with django_assert_num_queries(10):
+        # TODO: improve this
+        #  I've removed the N+1 issue using prefetch related but there is still an overlap on permission checks
+        #  and we can probably use varying serializers for the segments since we only allow certain structures via
+        #  the UI (but the serializers allow for infinite nesting)
+        response = admin_client.get(
+            reverse("api-v1:projects:project-segments-list", args=[project.id])
+        )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -10,6 +10,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from app.pagination import CustomPagination
 from environments.identities.models import Identity
 from features.models import FeatureState
 from features.serializers import SegmentAssociatedFeatureStateSerializer
@@ -38,6 +39,7 @@ logger = logging.getLogger()
 class SegmentViewSet(viewsets.ModelViewSet):
     serializer_class = SegmentSerializer
     permission_classes = [IsAuthenticated, SegmentPermissions]
+    pagination_class = CustomPagination
 
     def get_queryset(self):
         project = get_object_or_404(

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -46,7 +46,17 @@ class SegmentViewSet(viewsets.ModelViewSet):
             self.request.user.get_permitted_projects(["VIEW_PROJECT"]),
             pk=self.kwargs["project_pk"],
         )
+
         queryset = project.segments.all()
+
+        if self.action == "list":
+            queryset = queryset.prefetch_related(
+                "rules",
+                "rules__conditions",
+                "rules__rules",
+                "rules__rules__conditions",
+                "rules__rules__rules",
+            )
 
         identity_pk = self.request.query_params.get("identity")
         if identity_pk:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Adds custom pagination class to segments view set to allow FE to restrict the number of segments returned in one request. 

## How did you test this code?

I haven't added any tests for this for 2 reasons: 
 1. The behaviour should remain the same
 2. The pagination class is tested elsewhere
