### PR TITLE
Optimise list segments

### DIFF
--- a/api/segments/tests/test_views.py
+++ b/api/segments/tests/test_views.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 import pytest
 from core.constants import STRING
@@ -269,3 +270,31 @@ def test_get_segment_by_uuid(client, project, segment):
 
     assert response.json()["id"] == segment.id
     assert response.json()["uuid"] == str(segment.uuid)
+
+
+def test_list_segments(django_assert_num_queries, project, admin_client):
+    # Given
+    segments = []
+    for i in range(5):
+        segment = Segment.objects.create(project=project, name=f"segment {i}")
+        all_rule = SegmentRule.objects.create(
+            segment=segment, type=SegmentRule.ALL_RULE
+        )
+        any_rule = SegmentRule.objects.create(rule=all_rule, type=SegmentRule.ANY_RULE)
+        Condition.objects.create(
+            property="foo", value=str(random.randint(0, 10)), rule=any_rule
+        )
+        segments.append(segment)
+
+    # When
+    with django_assert_num_queries(10):
+        # TODO: improve this
+        #  I've removed the N+1 issue using prefetch related but there is still an overlap on permission checks
+        #  and we can probably use varying serializers for the segments since we only allow certain structures via
+        #  the UI (but the serializers allow for infinite nesting)
+        response = admin_client.get(
+            reverse("api-v1:projects:project-segments-list", args=[project.id])
+        )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK

--- a/api/segments/tests/test_views.py
+++ b/api/segments/tests/test_views.py
@@ -274,8 +274,9 @@ def test_get_segment_by_uuid(client, project, segment):
 
 def test_list_segments(django_assert_num_queries, project, admin_client):
     # Given
+    num_segments = 5
     segments = []
-    for i in range(5):
+    for i in range(num_segments):
         segment = Segment.objects.create(project=project, name=f"segment {i}")
         all_rule = SegmentRule.objects.create(
             segment=segment, type=SegmentRule.ALL_RULE
@@ -298,3 +299,6 @@ def test_list_segments(django_assert_num_queries, project, admin_client):
 
     # Then
     assert response.status_code == status.HTTP_200_OK
+
+    response_json = response.json()
+    assert response_json["count"] == num_segments

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -32,7 +32,14 @@ logger = logging.getLogger()
                 "Optionally provide the id of an identity to get only the segments they match",
                 required=False,
                 type=openapi.TYPE_INTEGER,
-            )
+            ),
+            openapi.Parameter(
+                "q",
+                openapi.IN_QUERY,
+                "Search term to find segment with given term in their name",
+                required=False,
+                type=openapi.TYPE_STRING,
+            ),
         ]
     ),
 )
@@ -68,6 +75,10 @@ class SegmentViewSet(viewsets.ModelViewSet):
             else:
                 segment_ids = Identity.dynamo_wrapper.get_segment_ids(identity_pk)
             queryset = queryset.filter(id__in=segment_ids)
+
+        search_term = self.request.query_params.get("q")
+        if search_term:
+            queryset = queryset.filter(name__icontains=search_term)
 
         return queryset
 

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -10,6 +10,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from app.pagination import CustomPagination
 from environments.identities.models import Identity
 from features.models import FeatureState
 from features.serializers import SegmentAssociatedFeatureStateSerializer
@@ -38,6 +39,7 @@ logger = logging.getLogger()
 class SegmentViewSet(viewsets.ModelViewSet):
     serializer_class = SegmentSerializer
     permission_classes = [IsAuthenticated, SegmentPermissions]
+    pagination_class = CustomPagination
 
     def get_queryset(self):
         project = get_object_or_404(

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -46,7 +46,17 @@ class SegmentViewSet(viewsets.ModelViewSet):
             self.request.user.get_permitted_projects(["VIEW_PROJECT"]),
             pk=self.kwargs["project_pk"],
         )
+
         queryset = project.segments.all()
+
+        if self.action == "list":
+            queryset = queryset.prefetch_related(
+                "rules",
+                "rules__conditions",
+                "rules__rules",
+                "rules__rules__conditions",
+                "rules__rules__rules",
+            )
 
         identity_pk = self.request.query_params.get("identity")
         if identity_pk:

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -50,6 +50,8 @@ class SegmentViewSet(viewsets.ModelViewSet):
         queryset = project.segments.all()
 
         if self.action == "list":
+            # TODO: at the moment, the UI only shows the name and description of the segment in the list view.
+            #  we shouldn't return all of the rules and conditions in the list view.
             queryset = queryset.prefetch_related(
                 "rules",
                 "rules__conditions",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Optimise list segments endpoint by: 

 1. Adding custom pagination so the FE can limit the number of segments returned
 2. Add prefetch related to prevent N+1 issues

## How did you test this code?

I've added a test to verify the N+1 issue is fixed. The pagination class is tested elsewhere. 
