### PR TITLE
Fix node16 warnings in ECS deploy action

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -68,7 +68,7 @@ runs:
 
     steps:
       - name: Checkout SAML package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
             repository: flagsmith/flagsmith-saml
             token: ${{ inputs.github_access_token }}
@@ -83,7 +83,7 @@ runs:
         shell: bash
 
       - name: Checkout Workflows Logic package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: flagsmith/flagsmith-workflows
           token: ${{ inputs.github_access_token }}
@@ -95,7 +95,7 @@ runs:
         shell: bash
 
       - name: Checkout Auth Controller package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: flagsmith/flagsmith-auth-controller
           token: ${{ inputs.github_access_token }}
@@ -115,7 +115,7 @@ runs:
         shell: bash
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ inputs.aws_access_key_id }}
           aws-secret-access-key: ${{ inputs.aws_secret_access_key }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Update github actions to latest versions. 

## How did you test this code?

I've not tested it as it would mean unnecessarily deploying to an ECS environment. actions/checkout@v3 is used elsewhere in our workflows so is well tested. The configure-aws-credentials action will be tested when we merge this PR (and hence deploy to staging). 
