### PR TITLE
Optimise bulk traits endpoint

### DIFF
--- a/api/environments/sdk/serializers.py
+++ b/api/environments/sdk/serializers.py
@@ -59,33 +59,46 @@ class SDKCreateUpdateTraitSerializer(serializers.ModelSerializer):
         )[0]
 
 
-class BulkTraitListSerializer(serializers.ListSerializer):
-    def update(self, instance, validated_data):
-        return self.save()
-
-    def save(self, **kwargs):
-        environment = self.context["request"].environment
-
-        # build a dictionary of identifier: trait_data_item
-        identity_trait_items = defaultdict(list)
-        for trait_data_item in self.validated_data:
-            identity_data = trait_data_item.pop("identity")
-            identity_trait_items[identity_data["identifier"]].append(trait_data_item)
-
-        modified_traits = []
-        for identifier, trait_data_items in identity_trait_items.items():
-            identity = Identity.objects.get(
-                identifier=identifier, environment=environment
-            )
-            modified_traits.extend(identity.update_traits(trait_data_items))
-
-        return modified_traits
-
-
 class SDKBulkCreateUpdateTraitSerializer(SDKCreateUpdateTraitSerializer):
     trait_value = TraitValueField(allow_null=True)
 
     class Meta(SDKCreateUpdateTraitSerializer.Meta):
+        class BulkTraitListSerializer(serializers.ListSerializer):
+            """
+            Create a custom ListSerializer that is only used by this serializer to
+            optimise the way in which we create, update and delete traits in the db
+            """
+
+            def update(self, instance, validated_data):
+                return self.save()
+
+            def save(self, **kwargs):
+                identity_trait_items = self._build_identifier_trait_items_dictionary()
+                modified_traits = []
+                for identifier, trait_data_items in identity_trait_items.items():
+                    identity = Identity.objects.get(
+                        identifier=identifier,
+                        environment=self.context["request"].environment,
+                    )
+                    modified_traits.extend(identity.update_traits(trait_data_items))
+                return modified_traits
+
+            def _build_identifier_trait_items_dictionary(
+                self,
+            ) -> typing.Dict[str, typing.List[typing.Dict]]:
+                """
+                build a dictionary of the form
+                {"identifier": [{"trait_key": "key", "trait_value": "value"}, ...]}
+                """
+                identity_trait_items = defaultdict(list)
+                for item in self.validated_data:
+                    # item will be in the format:
+                    # {"identity": {"identifier": "foo"}, "trait_key": "foo", "trait_value": "bar"}
+                    identity_trait_items[item["identity"]["identifier"]].append(
+                        dict((k, v) for k, v in item.items() if k != "identity")
+                    )
+                return identity_trait_items
+
         list_serializer_class = BulkTraitListSerializer
 
 

--- a/api/environments/sdk/serializers.py
+++ b/api/environments/sdk/serializers.py
@@ -76,7 +76,7 @@ class SDKBulkCreateUpdateTraitSerializer(SDKCreateUpdateTraitSerializer):
                 identity_trait_items = self._build_identifier_trait_items_dictionary()
                 modified_traits = []
                 for identifier, trait_data_items in identity_trait_items.items():
-                    identity = Identity.objects.get(
+                    identity, _ = Identity.objects.get_or_create(
                         identifier=identifier,
                         environment=self.context["request"].environment,
                     )

--- a/api/tests/unit/environments/identities/traits/test_unit_traits_serializers.py
+++ b/api/tests/unit/environments/identities/traits/test_unit_traits_serializers.py
@@ -1,0 +1,65 @@
+from core.constants import STRING
+
+from environments.identities.traits.models import Trait
+from environments.sdk.serializers import SDKBulkCreateUpdateTraitSerializer
+
+
+def test_bulk_create_update_serializer_save_many(
+    identity, django_assert_num_queries, mocker
+):
+    # Given
+    # an identity with a trait to update
+    trait_key_to_update = "foo"
+    trait_value_to_update = "bar"
+    Trait.objects.create(
+        identity=identity,
+        trait_key=trait_key_to_update,
+        string_value=trait_value_to_update,
+        value_type=STRING,
+    )
+    # and another which we will delete
+    trait_key_to_delete = "to-delete"
+    Trait.objects.create(
+        identity=identity,
+        trait_key=trait_key_to_delete,
+        value_type=STRING,
+        string_value="irrelevant",
+    )
+
+    # and some data which should create 2 new traits, update one and delete another
+    identity_data = {"identifier": identity.identifier}
+    updated_trait_value = f"{trait_value_to_update} updated"
+    data = [
+        {"trait_key": "new-trait-1", "trait_value": "foo", "identity": identity_data},
+        {"trait_key": "new-trait-2", "trait_value": "foo", "identity": identity_data},
+        {
+            "trait_key": trait_key_to_update,
+            "trait_value": updated_trait_value,
+            "identity": identity_data,
+        },
+        {
+            "trait_key": trait_key_to_delete,
+            "trait_value": None,
+            "identity": identity_data,
+        },
+    ]
+
+    # and a mock request object
+    mocked_request = mocker.MagicMock(environment=identity.environment)
+
+    # When
+    with django_assert_num_queries(6):
+        serializer = SDKBulkCreateUpdateTraitSerializer(
+            data=data,
+            many=True,
+            context={"environment": identity.environment, "request": mocked_request},
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+    # Then
+    assert identity.identity_traits.count() == 3
+    assert (
+        identity.identity_traits.get(trait_key=trait_key_to_update).trait_value
+        == updated_trait_value
+    )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Use a custom list serializer so that we can utilise the previously optimised (here: #1567) `update_traits` method to handle bulk traits endpoint.

## How did you test this code?

Added a unit test to test new list serializer but this shouldn't change the behaviour of the API at all so the existing tests should cover us. 
