### PR TITLE
feat(user/groups/views): Add external_id to support saml groups sync 

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -38,7 +38,7 @@ jobs:
                 aws_identity_migration_event_bus_rule_id: identity_migration-b03c433
                 aws_identity_migration_task_role_arn: arn:aws:iam::084060095745:role/task-exec-role-741a7e3
                 aws_task_definitions_directory_path: infrastructure/aws/production
-                flagsmith_saml_revision: v0.2.1
+                flagsmith_saml_revision: v0.3.0
                 flagsmith_workflows_revision: v1.1.0
                 flagsmith_auth_controller_revision: v0.0.1
 

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -38,7 +38,7 @@ jobs:
                 aws_identity_migration_event_bus_rule_id: identity_migration-08330ed
                 aws_identity_migration_task_role_arn: arn:aws:iam::302456015006:role/task-exec-role-6fb76f6
                 aws_task_definitions_directory_path: infrastructure/aws/staging
-                flagsmith_saml_revision: v0.2.1
+                flagsmith_saml_revision: v0.3.0
                 flagsmith_workflows_revision: v1.1.0
                 flagsmith_auth_controller_revision: v0.0.1
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -91,7 +91,7 @@ class UserIdsSerializer(serializers.Serializer):
 class UserPermissionGroupSerializerList(serializers.ModelSerializer):
     class Meta:
         model = UserPermissionGroup
-        fields = ("id", "name", "users", "is_default")
+        fields = ("id", "name", "users", "is_default", "external_id")
         read_only_fields = ("id",)
 
 

--- a/api/users/tests/test_views.py
+++ b/api/users/tests/test_views.py
@@ -415,3 +415,21 @@ def test_user_permission_group_can_update_is_default(
     # and
     user_permission_group.refresh_from_db()
     assert user_permission_group.is_default is True
+
+
+def test_user_permission_group_can_update_external_id(
+    admin_client, organisation, user_permission_group
+):
+    # Given
+    args = [organisation.id, user_permission_group.id]
+    url = reverse("api-v1:organisations:organisation-groups-detail", args=args)
+    external_id = "some_external_id"
+
+    data = {"external_id": external_id, "name": user_permission_group.name}
+
+    # When
+    response = admin_client.put(url, data=data)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["external_id"] == external_id


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

* Add support for saml group sync using external_id on user permission group views 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Add unit test cases
