### PR TITLE
Fix / refactor update_caches logic

### DIFF
--- a/api/organisations/subscription_info_cache.py
+++ b/api/organisations/subscription_info_cache.py
@@ -58,7 +58,7 @@ def update_caches():
 
 
 def _update_caches_with_influx_data(
-    organisation_info_cache_dict: "OrganisationSubscriptionInformationCacheDict",
+    organisation_info_cache_dict: OrganisationSubscriptionInformationCacheDict,
 ) -> None:
     """
     Mutates the provided organisation_info_cache_dict in place to add information about the organisation's
@@ -73,18 +73,18 @@ def _update_caches_with_influx_data(
         for org_id, calls in org_calls.items():
             subscription_info_cache = organisation_info_cache_dict.get(org_id)
             if not subscription_info_cache:
-                # TODO: I don't think this is a valid case but worth checking / handling
+                # I don't think this is a valid case but worth checking / handling
                 continue
             setattr(subscription_info_cache, key, calls)
 
 
 def _update_caches_with_chargebee_data(
-    organisations: typing.Iterable["Organisation"],
-    organisation_info_cache_dict: "OrganisationSubscriptionInformationCacheDict",
+    organisations: typing.Iterable[Organisation],
+    organisation_info_cache_dict: OrganisationSubscriptionInformationCacheDict,
 ):
     """
     Mutates the provided organisation_info_cache_dict in place to add information about the organisation's
-    chargebee plan information.
+    chargebee plan.
     """
     if not settings.CHARGEBEE_API_KEY:
         return

--- a/api/organisations/subscription_info_cache.py
+++ b/api/organisations/subscription_info_cache.py
@@ -1,0 +1,64 @@
+import typing
+
+from app_analytics.influxdb_wrapper import get_top_organisations
+from django.conf import settings
+
+from .chargebee import get_subscription_metadata
+from .subscriptions.constants import CHARGEBEE
+
+if typing.TYPE_CHECKING:
+    from .models import Organisation, OrganisationSubscriptionInformationCache
+
+    OrganisationSubscriptionInformationCacheDict = typing.Dict[
+        int, OrganisationSubscriptionInformationCache
+    ]
+
+
+def update_caches_with_influx_data(
+    organisation_info_cache_dict: "OrganisationSubscriptionInformationCacheDict",
+) -> None:
+    """
+    Mutates the provided organisation_info_cache_dict in place to add information about the organisation's
+    influx usage.
+    """
+    if not settings.INFLUXDB_TOKEN:
+        return
+
+    for date_range, limit in (("30d", ""), ("7d", ""), ("24h", "100")):
+        key = f"api_calls_{date_range}"
+        org_calls = get_top_organisations(date_range, limit)
+        for org_id, calls in org_calls.items():
+            subscription_info_cache = organisation_info_cache_dict.get(org_id)
+            if not subscription_info_cache:
+                # TODO: I don't think this is a valid case but worth checking / handling
+                continue
+            setattr(subscription_info_cache, key, calls)
+
+
+def update_caches_with_chargebee_data(
+    organisations: typing.Iterable["Organisation"],
+    organisation_info_cache_dict: "OrganisationSubscriptionInformationCacheDict",
+):
+    """
+    Mutates the provided organisation_info_cache_dict in place to add information about the organisation's
+    chargebee plan information.
+    """
+    if not settings.CHARGEBEE_API_KEY:
+        return
+
+    for organisation in organisations:
+        subscription = getattr(organisation, "subscription", None)
+        if (
+            not subscription
+            or subscription.subscription_id is None
+            or subscription.payment_method != CHARGEBEE
+        ):
+            continue
+
+        metadata = get_subscription_metadata(subscription.subscription_id)
+        if not metadata:
+            continue
+
+        subscription_info_cache = organisation_info_cache_dict[organisation.id]
+        subscription_info_cache.allowed_seats = metadata.seats
+        subscription_info_cache.allowed_30d_api_calls = metadata.api_calls

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -1,7 +1,5 @@
-from organisations.models import (
-    Organisation,
-    OrganisationSubscriptionInformationCache,
-)
+from organisations import subscription_info_cache
+from organisations.models import Organisation
 from organisations.subscriptions.subscription_service import (
     get_subscription_metadata,
 )
@@ -35,4 +33,4 @@ def send_org_over_limit_alert(organisation_id):
 
 @register_task_handler()
 def update_organisation_subscription_information_caches():
-    OrganisationSubscriptionInformationCache.update_caches()
+    subscription_info_cache.update_caches()

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -13,7 +13,7 @@ def test_organisation_subscription_information_cache_update_caches(
 
     organisation_usage = {"24h": 25123, "7d": 182957, "30d": 804564}
     mocked_get_top_organisations = mocker.patch(
-        "organisations.models.get_top_organisations"
+        "organisations.subscription_info_cache.get_top_organisations"
     )
     mocked_get_top_organisations.side_effect = lambda t, _: {
         organisation.id: organisation_usage.get(t)
@@ -21,7 +21,7 @@ def test_organisation_subscription_information_cache_update_caches(
 
     chargebee_metadata = ChargebeeObjMetadata(seats=15, api_calls=1000000)
     mocked_get_subscription_metadata = mocker.patch(
-        "organisations.models.get_subscription_metadata"
+        "organisations.subscription_info_cache.get_subscription_metadata"
     )
     mocked_get_subscription_metadata.return_value = chargebee_metadata
 
@@ -50,3 +50,14 @@ def test_organisation_subscription_information_cache_update_caches(
         organisation.subscription_information_cache.allowed_30d_api_calls
         == chargebee_metadata.api_calls
     )
+
+    mocked_get_subscription_metadata.assert_called_once_with(
+        chargebee_subscription.subscription_id
+    )
+
+    assert mocked_get_top_organisations.call_count == 3
+    assert [call.args for call in mocked_get_top_organisations.call_args_list] == [
+        ("30d", ""),
+        ("7d", ""),
+        ("24h", "100"),
+    ]

--- a/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
+++ b/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
@@ -1,11 +1,9 @@
 from organisations.chargebee.metadata import ChargebeeObjMetadata
-from organisations.models import OrganisationSubscriptionInformationCache
+from organisations.subscription_info_cache import update_caches
 from task_processor.task_run_method import TaskRunMethod
 
 
-def test_organisation_subscription_information_cache_update_caches(
-    mocker, organisation, chargebee_subscription, settings
-):
+def test_update_caches(mocker, organisation, chargebee_subscription, settings):
     # Given
     settings.CHARGEBEE_API_KEY = "api-key"
     settings.INFLUXDB_TOKEN = "token"
@@ -26,7 +24,7 @@ def test_organisation_subscription_information_cache_update_caches(
     mocked_get_subscription_metadata.return_value = chargebee_metadata
 
     # When
-    OrganisationSubscriptionInformationCache.update_caches()
+    update_caches()
 
     # Then
     assert organisation.subscription_information_cache.updated_at

--- a/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
+++ b/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
@@ -54,7 +54,7 @@ def test_update_caches(mocker, organisation, chargebee_subscription, settings):
     )
 
     assert mocked_get_top_organisations.call_count == 3
-    assert [call.args for call in mocked_get_top_organisations.call_args_list] == [
+    assert [call[0] for call in mocked_get_top_organisations.call_args_list] == [
         ("30d", ""),
         ("7d", ""),
         ("24h", "100"),


### PR DESCRIPTION
refactor CB / influx logic to separate module

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

 * Fix the logic in the update_caches() method (use subscription_id when calling get_subscription_metadata instead of organisation object)
 * Refactor all logic associated with updating the caches to a separate, specific, module. 

## How did you test this code?

Updated the unit test
