### PR TITLE
Fix/sales dashboard slowness

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/home.html
+++ b/api/sales_dashboard/templates/sales_dashboard/home.html
@@ -32,7 +32,6 @@
             <option value="num_users" {% if sort_field == "num_users" %}selected{% endif %}>Seats</option>
             <option value="num_projects" {% if sort_field == "num_projects" %}selected{% endif %}>Projects</option>
             <option value="num_features" {% if sort_field == "num_features" %}selected{% endif %}>Flags</option>
-            <option value="num_segments" {% if sort_field == "num_segments" %}selected{% endif %}>Segments</option>
             <option value="subscription_information_cache__api_calls_24h" {% if sort_field == "subscription_information_cache__api_calls_24h" %}selected{% endif %}>24h API calls</option>
             <option value="subscription_information_cache__api_calls_7d" {% if sort_field == "subscription_information_cache__api_calls_7d" %}selected{% endif %}>7d API calls</option>
             <option value="subscription_information_cache__api_calls_30d" {% if sort_field == "subscription_information_cache__api_calls_30d" %}selected{% endif %}>30d API calls</option>
@@ -57,7 +56,6 @@
               <th>Max API Calls</th>
               <th>Projects</th>
               <th>Flags</th>
-              <th>Segments</th>
               <th>24h</th>
               <th>7d</th>
               <th>30d</th>
@@ -74,7 +72,6 @@
               <td>{{org.subscription_information_cache.allowed_30d_api_calls|default:50000}}</td>
               <td>{{org.num_projects}}</td>
               <td>{{org.num_features}}</td>
-              <td>{{org.num_segments}}</td>
               <td>{{org.subscription_information_cache.api_calls_24h|intcomma|default:0}}</td>
               <td>{{org.subscription_information_cache.api_calls_7d|intcomma|default:0}}</td>
               <td>{{org.subscription_information_cache.api_calls_30d|intcomma|default:0}}</td>

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -75,7 +75,7 @@ class OrganisationList(ListView):
         queryset = (
             queryset.order_by(sort_field)
             if sort_direction == "ASC"
-            else queryset.order_by(F("sort_field").desc(nulls_last=True))
+            else queryset.order_by(F(sort_field).desc(nulls_last=True))
         )
 
         return queryset

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -37,7 +37,8 @@ from organisations.tasks import (
 from .forms import EmailUsageForm, MaxAPICallsForm, MaxSeatsForm
 
 OBJECTS_PER_PAGE = 10
-DEFAULT_ORGANISATION_SORT = "-subscription_information_cache__api_calls_30d"
+DEFAULT_ORGANISATION_SORT = "subscription_information_cache__api_calls_30d"
+DEFAULT_ORGANISATION_SORT_DIRECTION = "DESC"
 
 
 class OrganisationList(ListView):
@@ -68,7 +69,9 @@ class OrganisationList(ListView):
                 queryset = queryset.filter(subscription__plan__icontains=filter_plan)
 
         sort_field = self.request.GET.get("sort_field", DEFAULT_ORGANISATION_SORT)
-        sort_direction = self.request.GET.get("sort_direction", "ASC")
+        sort_direction = self.request.GET.get(
+            "sort_direction", DEFAULT_ORGANISATION_SORT_DIRECTION
+        )
         queryset = (
             queryset.order_by(sort_field)
             if sort_direction == "ASC"

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -68,15 +68,16 @@ class OrganisationList(ListView):
             else:
                 queryset = queryset.filter(subscription__plan__icontains=filter_plan)
 
-        order_by = DEFAULT_ORGANISATION_SORT
-        if self.request.GET.get("sort_field"):
-            sort_field = self.request.GET["sort_field"]
-            sort_direction = (
-                "-" if self.request.GET.get("sort_direction", "ASC") == "DESC" else ""
-            )
-            order_by = f"{sort_direction}{sort_field}"
+        sort_field = self.request.GET.get("sort_field", DEFAULT_ORGANISATION_SORT)
+        queryset = queryset.order_by(f"{sort_field}")
+        sort_direction = self.request.GET.get("sort_direction", "ASC")
+        queryset = (
+            queryset.asc()
+            if sort_direction == "ASC"
+            else queryset.desc(nulls_last=True)
+        )
 
-        return queryset.order_by(order_by)
+        return queryset
 
     def get_context_data(self, **kwargs):
         data = super().get_context_data(**kwargs)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

 1. Ensure null values are sorted last (this occurs mostly when a new organisation appears since the last cache update)
 2. Remove segments from the overview page since, seemingly, it's slowing down the query from <1s to ~10s. I think it's just caused by having multiple outer joins from projects (which itself is an outer join). I figured features are a more useful statistic at a glance. 

## How did you test this code?

Ran the sales dashboard locally and verified that segments are no longer shown on the page and that new organisations (that don't have a cache object) are ordered at the bottom of the list on descending queries. 
