### PR TITLE
Add hideInviteLinks to FE project overrides EP

### DIFF
--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -71,6 +71,7 @@ app.get('/config/project-overrides', (req, res) => {
         { name: 'amplitude', value: process.env.AMPLITUDE_API_KEY },
         { name: 'delighted', value: process.env.DELIGHTED_API_KEY },
         { name: 'capterraKey', value: process.env.CAPTERRA_API_KEY },
+        { name: 'hideInviteLinks', value: process.env.DISABLE_INVITE_LINKS },
     ];
     const output = values.map(getVariable).join('');
 

--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -71,7 +71,7 @@ app.get('/config/project-overrides', (req, res) => {
         { name: 'amplitude', value: process.env.AMPLITUDE_API_KEY },
         { name: 'delighted', value: process.env.DELIGHTED_API_KEY },
         { name: 'capterraKey', value: process.env.CAPTERRA_API_KEY },
-        { name: 'hideInviteLinks', value: process.env.DISABLE_INVITE_LINKS },
+        { name: 'hideInviteLinks', value: envToBool('DISABLE_INVITE_LINKS', false) },
     ];
     const output = values.map(getVariable).join('');
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add hideInviteLinks to FE project overrides endpoint so that it works for multi containers as well as single containers. 

## How did you test this code?

Run in docker compose and verified that invite links are hidden in a multi container build setup. 
