### PR TITLE
feat(last_updated_at): Add X-Flagsmith-Document-Updated-At header

### DIFF
--- a/api/core/constants.py
+++ b/api/core/constants.py
@@ -6,3 +6,5 @@ BOOLEAN = "bool"
 FLOAT = "float"
 
 FLAGSMITH_SIGNATURE_HEADER = "X-Flagsmith-Signature"
+
+FLAGSMITH_UPDATED_AT_HEADER = "X-Flagsmith-Document-Updated-At"

--- a/api/environments/sdk/views.py
+++ b/api/environments/sdk/views.py
@@ -1,3 +1,4 @@
+from core.constants import FLAGSMITH_UPDATED_AT_HEADER
 from django.http import HttpRequest
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -17,4 +18,8 @@ class SDKEnvironmentAPIView(APIView):
         environment_document = Environment.get_environment_document(
             request.environment.api_key
         )
-        return Response(environment_document)
+        updated_at = self.request.environment.updated_at
+        return Response(
+            environment_document,
+            headers={FLAGSMITH_UPDATED_AT_HEADER: updated_at.timestamp()},
+        )

--- a/api/features/tests/test_views.py
+++ b/api/features/tests/test_views.py
@@ -4,6 +4,7 @@ from unittest import TestCase, mock
 
 import pytest
 import pytz
+from core.constants import FLAGSMITH_UPDATED_AT_HEADER
 from django.forms import model_to_dict
 from django.urls import reverse
 from rest_framework import status
@@ -602,6 +603,11 @@ class SDKFeatureStatesTestCase(APITestCase):
         assert len(response_json) == 1
         assert response_json[0]["feature"]["id"] == self.feature.id
         assert response_json[0]["feature_state_value"] == self.environment_fs_value
+        # refresh the last_updated_at
+        self.environment.refresh_from_db()
+        assert response.headers[FLAGSMITH_UPDATED_AT_HEADER] == str(
+            self.environment.updated_at.timestamp()
+        )
 
     def test_get_flags_exclude_disabled(self):
 

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -3,6 +3,7 @@ import typing
 from functools import reduce
 
 from app_analytics.influxdb_wrapper import get_multiple_event_list_for_feature
+from core.constants import FLAGSMITH_UPDATED_AT_HEADER
 from core.permissions import HasMasterAPIKey
 from django.conf import settings
 from django.core.cache import caches
@@ -643,7 +644,11 @@ class SDKFeatureStates(GenericAPIView):
                 many=True,
             ).data
 
-        return Response(data)
+        updated_at = self.request.environment.updated_at
+        return Response(
+            data,
+            headers={FLAGSMITH_UPDATED_AT_HEADER: updated_at.timestamp()},
+        )
 
     @property
     def _additional_filters(self) -> Q:

--- a/api/tests/unit/environments/test_environments_views_sdk_environment.py
+++ b/api/tests/unit/environments/test_environments_views_sdk_environment.py
@@ -1,3 +1,4 @@
+from core.constants import FLAGSMITH_UPDATED_AT_HEADER
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -52,6 +53,9 @@ def test_get_environment_document(
     # Then
     assert response.status_code == status.HTTP_200_OK
     assert response.json()
+    assert response.headers[FLAGSMITH_UPDATED_AT_HEADER] == str(
+        environment.updated_at.timestamp()
+    )
 
 
 def test_get_environment_document_fails_with_invalid_key(


### PR DESCRIPTION
Allow client to check when the document was last updated

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes
Add X-Flagsmith-Document-Updated-At header to allow client to check when the document was last updated

*Please describe.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Add unit tests covering the change
