### PR TITLE
Disable invite link usage if disabled

### DIFF
--- a/api/organisations/invites/tests/test_views.py
+++ b/api/organisations/invites/tests/test_views.py
@@ -207,3 +207,17 @@ def test_join_organisation_alerts_admin_users_if_exceeds_plan_limit(
     mocked_send_org_over_limit_alert.delay.assert_called_once_with(
         args=(organisation.id,)
     )
+
+
+def test_join_organisation_from_link_returns_403_if_invite_links_disabled(
+    test_user_client, organisation, invite_link, settings
+):
+    # Given
+    settings.DISABLE_INVITE_LINKS = True
+    url = reverse("api-v1:users:user-join-organisation-link", args=[invite_link.hash])
+
+    # When
+    response = test_user_client.post(url)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.decorators import action, api_view
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.mixins import (
     CreateModelMixin,
     DestroyModelMixin,
@@ -52,6 +54,9 @@ def join_organisation_from_email(request, hash):
 
 @api_view(["POST"])
 def join_organisation_from_link(request, hash):
+    if settings.DISABLE_INVITE_LINKS:
+        raise PermissionDenied("Invite links are disabled.")
+
     invite = get_object_or_404(InviteLink, hash=hash)
 
     if invite.is_expired:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

If DISABLE_INVITE_LINKS is set to true, we currently prevent their creation / visibility in the dashboard, but we also should  not allow invite links to be used. 

## How did you test this code?

Added a unit test. 
