### PR TITLE
Add segment_name to feature segment list serializer

### DIFF
--- a/api/features/feature_segments/serializers.py
+++ b/api/features/feature_segments/serializers.py
@@ -29,13 +29,18 @@ class FeatureSegmentQuerySerializer(serializers.Serializer):
 
 
 class FeatureSegmentListSerializer(serializers.ModelSerializer):
+    segment_name = serializers.SerializerMethodField()
+
     class Meta:
         model = FeatureSegment
-        fields = ("id", "segment", "priority", "environment")
-        read_only_fields = ("id", "segment", "priority", "environment")
+        fields = ("id", "segment", "priority", "environment", "segment_name")
+        read_only_fields = ("id", "segment", "priority", "environment", "segment_name")
 
     def get_value(self, instance):
         return instance.get_value()
+
+    def get_segment_name(self, instance: FeatureSegment) -> str:
+        return instance.segment.name
 
 
 class FeatureSegmentChangePrioritiesSerializer(serializers.Serializer):

--- a/api/features/feature_segments/views.py
+++ b/api/features/feature_segments/views.py
@@ -50,7 +50,7 @@ class FeatureSegmentViewSet(
                 data=self.request.query_params
             )
             filter_serializer.is_valid(raise_exception=True)
-            return queryset.filter(**filter_serializer.data)
+            return queryset.select_related("segment").filter(**filter_serializer.data)
 
         return queryset
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add segment_name to FeatureSegmentListSerializer to prevent the FE from needing to get the segments when displaying Segment overrides in the UI. 

## How did you test this code?

Updated existing unit test. 
