### PR TITLE
improvement/define-dashboard-sentry-sample-rate

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -128,6 +128,10 @@
                     "value": "0.0005"
                 },
                 {
+                    "name": "DASHBOARD_ENDPOINTS_SENTRY_TRACE_SAMPLE_RATE",
+                    "value": "0.1"
+                },
+                {
                     "name": "SLACK_CLIENT_ID",
                     "value": "937916178726.1924685747446"
                 },


### PR DESCRIPTION
This is to override the app default of `1.0`