### PR TITLE
improvement/fix-image-tags-in-docker

### DIFF
--- a/.github/workflows/api-docker-publish-image.yml
+++ b/.github/workflows/api-docker-publish-image.yml
@@ -21,13 +21,6 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Write git info to Docker image
-              run: |
-                  cd api
-                  echo ${{ env.GITHUB_REF_SLUG }} > CI_COMMIT_REF_NAME
-                  echo ${GITHUB_SHA} > CI_COMMIT_SHA
-                  echo ${{ steps.meta-build.outputs.tags }} > IMAGE_TAG
-
             - name: Docker metadata
               id: meta
               uses: docker/metadata-action@v3
@@ -40,6 +33,12 @@ jobs:
                       type=ref,event=branch
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
+
+            - name: Write git info to Docker image
+              run: |
+                  cd api
+                  echo ${GITHUB_SHA} > CI_COMMIT_SHA
+                  echo ${{ steps.meta.outputs.tags }} > IMAGE_TAG
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v1

--- a/.github/workflows/frontend-docker-publish-image.yml
+++ b/.github/workflows/frontend-docker-publish-image.yml
@@ -33,24 +33,14 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-            - name: Inject slug/short variables
-              uses: rlespinasse/github-slug-action@v3.x
-
-            - name: Docker metadata
-              id: meta-build
-              uses: docker/metadata-action@v4
-              with:
-                  images: |
-                      flagsmith/flagsmith-frontend
-                  tags: |
-                      type=ref,event=branch
-
             - name: Docker metadata
               id: meta
-              uses: crazy-max/ghaction-docker-meta@v2
+              uses: docker/metadata-action@v3
               with:
                   images: |
                       flagsmith/flagsmith-frontend
+                  flavor: |
+                      latest=${{ startsWith(github.ref, 'refs/heads/main') }}
                   tags: |
                       type=ref,event=branch
                       type=semver,pattern={{version}}
@@ -59,9 +49,8 @@ jobs:
             - name: Write git info to Docker image
               run: |
                   cd api
-                  echo ${{ env.GITHUB_REF_SLUG }} > CI_COMMIT_REF_NAME
                   echo ${GITHUB_SHA} > CI_COMMIT_SHA
-                  echo ${{ steps.meta-build.outputs.tags }} > IMAGE_TAG
+                  echo ${{ steps.meta.outputs.tags }} > IMAGE_TAG
 
             - name: Download features
               run: >

--- a/.github/workflows/frontend-e2e-docker-publish-image.yml
+++ b/.github/workflows/frontend-e2e-docker-publish-image.yml
@@ -38,7 +38,7 @@ jobs:
               uses: docker/metadata-action@v3
               with:
                   images: |
-                      flagsmith/flagsmith-frontend
+                      flagsmith/flagsmith-e2e-tests
                   flavor: |
                       latest=${{ startsWith(github.ref, 'refs/heads/main') }}
                   tags: |

--- a/.github/workflows/frontend-e2e-docker-publish-image.yml
+++ b/.github/workflows/frontend-e2e-docker-publish-image.yml
@@ -33,24 +33,14 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-            - name: Inject slug/short variables
-              uses: rlespinasse/github-slug-action@v3.x
-
             - name: Docker metadata
-              id: meta-build
+              id: meta
               uses: docker/metadata-action@v3
               with:
                   images: |
-                      flagsmith/flagsmith-e2e-tests
-                  tags: |
-                      type=ref,event=branch
-
-            - name: Docker metadata
-              id: meta
-              uses: crazy-max/ghaction-docker-meta@v2
-              with:
-                  images: |
-                      flagsmith/flagsmith-e2e-tests
+                      flagsmith/flagsmith-frontend
+                  flavor: |
+                      latest=${{ startsWith(github.ref, 'refs/heads/main') }}
                   tags: |
                       type=ref,event=branch
                       type=semver,pattern={{version}}

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -49,7 +49,6 @@ jobs:
             - name: Write git info to Docker image
               run: |
                   cd api
-                  echo ${{ env.GITHUB_REF_SLUG }} > CI_COMMIT_REF_NAME
                   echo ${GITHUB_SHA} > CI_COMMIT_SHA
                   echo ${{ steps.meta-build.outputs.tags }} > IMAGE_TAG
 

--- a/.github/workflows/platform-docker-publish-image.yml
+++ b/.github/workflows/platform-docker-publish-image.yml
@@ -21,7 +21,6 @@ jobs:
             - name: Write git info to Docker image
               run: |
                   cd api
-                  echo ${{ env.GITHUB_REF_SLUG }} > CI_COMMIT_REF_NAME
                   echo ${GITHUB_SHA} > CI_COMMIT_SHA
                   echo ${{ steps.meta-build.outputs.tags }} > IMAGE_TAG
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ checkstyle.txt
 .elasticbeanstalk/
 
 # These get baked into the docker container on build
-src/CI_COMMIT_REF_NAME
 src/CI_COMMIT_SHA
 src/IMAGE_TAG
 

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -11,7 +11,6 @@ def create_hash():
 def get_version_info():
     """Reads the version info baked into src folder of the docker container"""
     version_json = {
-        "CI_COMMIT_REF_NAME": get_file("./src/CI_COMMIT_REF_NAME"),
         "CI_COMMIT_SHA": get_file("./src/CI_COMMIT_SHA"),
         "IMAGE_TAG": get_file("./src/IMAGE_TAG"),
     }


### PR DESCRIPTION
Looks like this functionality was just flat out broken. I've cleaned it up so all actions use the same setup. 

CI_COMMIT_REF_NAME never really worked properly and not worth the effort. 