### PR TITLE
feat(token/rotation): add endpoint to delete token

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.cache import cache
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
 from api_keys.models import MasterAPIKey
@@ -31,6 +32,11 @@ trait_value = "value1"
 @pytest.fixture()
 def test_user(django_user_model):
     return django_user_model.objects.create(email="user@example.com")
+
+
+@pytest.fixture()
+def auth_token(test_user):
+    return Token.objects.create(user=test_user)
 
 
 @pytest.fixture()

--- a/api/custom_auth/tests/end_to_end/test_custom_auth_integration.py
+++ b/api/custom_auth/tests/end_to_end/test_custom_auth_integration.py
@@ -7,7 +7,7 @@ from django.core import mail
 from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, override_settings
+from rest_framework.test import APIClient, APITestCase, override_settings
 
 from organisations.invites.models import Invite
 from organisations.models import Organisation
@@ -329,3 +329,19 @@ def test_get_user_is_not_throttled(admin_client, settings, reset_cache):
         response = admin_client.get(url)
         # Then
         assert response.status_code == status.HTTP_200_OK
+
+
+def test_delete_token(test_user, auth_token):
+    # Given
+    url = reverse("api-v1:custom_auth:delete-token")
+    client = APIClient(HTTP_AUTHORIZATION=f"Token {auth_token.key}")
+
+    # When
+    response = client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # and - if we try to delete the token again(i.e: access anything that uses is_authenticated)
+    # we should will get 401
+    assert client.delete(url).status_code == status.HTTP_401_UNAUTHORIZED

--- a/api/custom_auth/urls.py
+++ b/api/custom_auth/urls.py
@@ -5,6 +5,7 @@ from custom_auth.views import (
     CustomAuthTokenLoginOrRequestMFACode,
     CustomAuthTokenLoginWithMFACode,
     ThrottledUserViewSet,
+    delete_token,
 )
 
 app_name = "custom_auth"
@@ -24,6 +25,7 @@ urlpatterns = [
         name="mfa-authtoken-login-code",
     ),
     path("", include(throttled_user_router.urls)),
+    path("token/", delete_token, name="delete-token"),
     # NOTE: endpoints provided by `djoser.urls`
     # are deprecated and will be removed in the next Major release
     path("", include("djoser.urls")),

--- a/api/custom_auth/views.py
+++ b/api/custom_auth/views.py
@@ -1,4 +1,10 @@
+from django.contrib.auth import user_logged_out
 from djoser.views import UserViewSet
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from trench.views.authtoken import (
     AuthTokenLoginOrRequestMFACode,
@@ -35,3 +41,13 @@ class ThrottledUserViewSet(UserViewSet):
         if self.action == "create":
             throttles = [ScopedRateThrottle()]
         return throttles
+
+
+@api_view(["DELETE"])
+@permission_classes([IsAuthenticated])
+def delete_token(request):
+    Token.objects.filter(user=request.user).delete()
+    user_logged_out.send(
+        sender=request.user.__class__, request=request, user=request.user
+    )
+    return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?


Add endpoint to allow a user to delete their token 

*Please describe.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Add unit test case 
