### PR TITLE
feat(master_api_key): Add support for environments viewset

### DIFF
--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -66,10 +66,9 @@ class MasterAPIKeyEnvironmentPermissions(BasePermission):
         if view.action == "create":
             try:
                 project_id = request.data.get("project")
-                project_lookup = Q(id=project_id)
-                project = Project.objects.get(project_lookup)
+                project = Project.objects.get(id=project_id)
+                return master_api_key.organisation_id == project.organisation.id
 
-                return master_api_key.organisation_id == project.id
             except Project.DoesNotExist:
                 return False
 

--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -1,8 +1,9 @@
 import typing
 
 from django.db.models import Model, Q
+from django.http import HttpRequest
 from rest_framework import exceptions
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import BasePermission, IsAuthenticated
 
 from environments.models import Environment
 from environments.permissions.constants import VIEW_ENVIRONMENT
@@ -24,8 +25,11 @@ class EnvironmentKeyPermissions(BasePermission):
         return True
 
 
-class EnvironmentPermissions(BasePermission):
+class EnvironmentPermissions(IsAuthenticated):
     def has_permission(self, request, view):
+        if not super().has_permission(request, view):
+            return False
+
         if view.action == "create":
             try:
                 project_id = request.data.get("project")
@@ -41,12 +45,46 @@ class EnvironmentPermissions(BasePermission):
         return True
 
     def has_object_permission(self, request, view, obj):
+        if request.user.is_anonymous:
+            return False
+
         if view.action == "clone":
             return request.user.is_project_admin(obj.project)
 
         return request.user.is_environment_admin(obj) or view.action in [
             "user_permissions"
         ]
+
+
+class MasterAPIKeyEnvironmentPermissions(BasePermission):
+    def has_permission(self, request: HttpRequest, view: str) -> bool:
+        master_api_key = getattr(request, "master_api_key", None)
+
+        if not master_api_key:
+            return False
+
+        if view.action == "create":
+            try:
+                project_id = request.data.get("project")
+                project_lookup = Q(id=project_id)
+                project = Project.objects.get(project_lookup)
+
+                return master_api_key.organisation_id == project.id
+            except Project.DoesNotExist:
+                return False
+
+        # return true as list will be handled by view and obj permissions will be handled later
+        return True
+
+    def has_object_permission(
+        self, request: HttpRequest, view: str, obj: Model
+    ) -> bool:
+        master_api_key = getattr(request, "master_api_key", None)
+
+        if not master_api_key:
+            return False
+
+        return master_api_key.organisation_id == obj.project.organisation_id
 
 
 class IdentityPermissions(BasePermission):

--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -65,13 +65,17 @@ class EnvironmentSerializerLight(serializers.ModelSerializer):
             ENVIRONMENT_CREATED_MESSAGE if created else ENVIRONMENT_UPDATED_MESSAGE
         ) % instance.name
         request = self.context.get("request")
+
+        author = None if request.user.is_anonymous else request.user
+        master_api_key = request.master_api_key if request.user.is_anonymous else None
         AuditLog.objects.create(
-            author=getattr(request, "user", None),
+            author=author,
             related_object_id=instance.id,
             related_object_type=RelatedObjectType.ENVIRONMENT.name,
             environment=instance,
             project=instance.project,
             log=message,
+            master_api_key=master_api_key,
         )
 
 

--- a/api/environments/tests/test_views.py
+++ b/api/environments/tests/test_views.py
@@ -4,6 +4,7 @@ from unittest import TestCase, mock
 import pytest
 from core.constants import STRING
 from django.urls import reverse
+from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -19,7 +20,7 @@ from projects.models import (
     ProjectPermissionModel,
     UserProjectPermission,
 )
-from segments.models import EQUAL, Condition, Segment, SegmentRule
+from segments.models import EQUAL, Condition, SegmentRule
 from users.models import FFAdminUser
 from util.tests import Helper
 
@@ -58,28 +59,6 @@ class EnvironmentTestCase(TestCase):
     def tearDown(self) -> None:
         Environment.objects.all().delete()
         AuditLog.objects.all().delete()
-
-    def test_should_create_environments(self):
-        # Given
-        url = reverse("api-v1:environments:environment-list")
-        description = "This is the description"
-        data = {
-            "name": "Test environment",
-            "project": self.project.id,
-            "description": description,
-        }
-
-        # When
-        response = self.client.post(url, data=data)
-
-        # Then
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["description"] == description
-
-        # and user is admin
-        assert UserEnvironmentPermission.objects.filter(
-            user=self.user, admin=True, environment__id=response.json()["id"]
-        ).exists()
 
     def test_should_return_identities_for_an_environment(self):
         # Given
@@ -144,28 +123,6 @@ class EnvironmentTestCase(TestCase):
             == 1
         )
 
-    def test_audit_log_entry_created_when_environment_updated(self):
-        # Given
-        environment = Environment.objects.create(
-            name="Test environment", project=self.project
-        )
-        url = reverse(
-            "api-v1:environments:environment-detail", args=[environment.api_key]
-        )
-        data = {"project": self.project.id, "name": "New name"}
-
-        # When
-        response = self.client.put(url, data=data)
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert (
-            AuditLog.objects.filter(
-                related_object_type=RelatedObjectType.ENVIRONMENT.name
-            ).count()
-            == 1
-        )
-
     def test_audit_log_created_when_feature_state_updated(self):
         # Given
         feature = Feature.objects.create(name="feature", project=self.project)
@@ -192,54 +149,6 @@ class EnvironmentTestCase(TestCase):
 
         # and
         assert AuditLog.objects.first().author
-
-    def test_get_all_trait_keys_for_environment_only_returns_distinct_keys(self):
-        # Given
-        trait_key_one = "trait-key-one"
-        trait_key_two = "trait-key-two"
-
-        environment = Environment.objects.create(
-            project=self.project, name="Test Environment"
-        )
-
-        identity_one = Identity.objects.create(
-            environment=environment, identifier="identity-one"
-        )
-        identity_two = Identity.objects.create(
-            environment=environment, identifier="identity-two"
-        )
-
-        Trait.objects.create(
-            identity=identity_one,
-            trait_key=trait_key_one,
-            string_value="blah",
-            value_type=STRING,
-        )
-        Trait.objects.create(
-            identity=identity_one,
-            trait_key=trait_key_two,
-            string_value="blah",
-            value_type=STRING,
-        )
-        Trait.objects.create(
-            identity=identity_two,
-            trait_key=trait_key_one,
-            string_value="blah",
-            value_type=STRING,
-        )
-
-        url = reverse(
-            "api-v1:environments:environment-trait-keys", args=[environment.api_key]
-        )
-
-        # When
-        res = self.client.get(url)
-
-        # Then
-        assert res.status_code == status.HTTP_200_OK
-
-        # and - only distinct keys are returned
-        assert len(res.json().get("keys")) == 2
 
     def test_delete_trait_keys_deletes_trait_for_all_users_in_that_environment(self):
         # Given
@@ -291,62 +200,6 @@ class EnvironmentTestCase(TestCase):
             identity=identity_one_environment_two, trait_key=trait_key
         ).exists()
 
-    def test_delete_trait_keys_deletes_traits_matching_provided_key_only(self):
-        # Given
-        environment = Environment.objects.create(
-            project=self.project, name="Test Environment"
-        )
-
-        identity = Identity.objects.create(
-            identifier="test-identity", environment=environment
-        )
-
-        trait_to_delete = "trait-key-to-delete"
-        Trait.objects.create(
-            identity=identity,
-            trait_key=trait_to_delete,
-            value_type=STRING,
-            string_value="blah",
-        )
-
-        trait_to_persist = "trait-key-to-persist"
-        Trait.objects.create(
-            identity=identity,
-            trait_key=trait_to_persist,
-            value_type=STRING,
-            string_value="blah",
-        )
-
-        url = reverse(
-            "api-v1:environments:environment-delete-traits", args=[environment.api_key]
-        )
-
-        # When
-        self.client.post(url, data={"key": trait_to_delete})
-
-        # Then
-        assert not Trait.objects.filter(
-            identity=identity, trait_key=trait_to_delete
-        ).exists()
-
-        # and
-        assert Trait.objects.filter(
-            identity=identity, trait_key=trait_to_persist
-        ).exists()
-
-    def test_user_can_list_environment_permission(self):
-        # Given
-        url = reverse("api-v1:environments:environment-permissions")
-
-        # When
-        response = self.client.get(url)
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert (
-            len(response.json()) == 5
-        )  # hard code how many permissions we expect there to be
-
     def test_environment_user_can_get_their_permissions(self):
         # Given
         user = FFAdminUser.objects.create(email="new-test@test.com")
@@ -370,35 +223,6 @@ class EnvironmentTestCase(TestCase):
         assert response.status_code == status.HTTP_200_OK
         assert not response.json()["admin"]
         assert "VIEW_ENVIRONMENT" in response.json()["permissions"]
-
-    def test_get_document(self):
-        # Given
-        # an environment
-        environment = Environment.objects.create(
-            name="Test Environment", project=self.project
-        )
-
-        # and some other sample data to make sure we're testing all of the document
-        Feature.objects.create(name="test_feature", project=self.project)
-        segment = Segment.objects.create(name="My segment", project=self.project)
-        segment_rule = SegmentRule.objects.create(
-            segment=segment, type=SegmentRule.ALL_RULE
-        )
-        Condition.objects.create(
-            operator=EQUAL, property="property", value="value", rule=segment_rule
-        )
-
-        # and the relevant URL to get an environment document
-        url = reverse(
-            "api-v1:environments:environment-get-document", args=[environment.api_key]
-        )
-
-        # When
-        response = self.client.get(url)
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()
 
 
 @pytest.mark.django_db
@@ -672,3 +496,194 @@ class EnvironmentAPIKeyViewSetTestCase(TestCase):
 
         # Then
         assert not EnvironmentAPIKey.objects.filter(id=api_key.id)
+
+
+@pytest.mark.parametrize(
+    "client, is_master_api_key_client",
+    [
+        (lazy_fixture("master_api_key_client"), True),
+        (lazy_fixture("admin_client"), False),
+    ],
+)
+def test_should_create_environments(
+    project, client, admin_user, is_master_api_key_client
+):
+    # Given
+    url = reverse("api-v1:environments:environment-list")
+    description = "This is the description"
+    data = {
+        "name": "Test environment",
+        "project": project.id,
+        "description": description,
+    }
+
+    # When
+    response = client.post(url, data=data)
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["description"] == description
+
+    # and user is admin
+    if not is_master_api_key_client:
+        assert UserEnvironmentPermission.objects.filter(
+            user=admin_user, admin=True, environment__id=response.json()["id"]
+        ).exists()
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_audit_log_entry_created_when_environment_updated(environment, project, client):
+    # Given
+    environment = Environment.objects.create(name="Test environment", project=project)
+    url = reverse("api-v1:environments:environment-detail", args=[environment.api_key])
+    data = {"project": project.id, "name": "New name"}
+
+    # When
+    response = client.put(url, data=data)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        AuditLog.objects.filter(
+            related_object_type=RelatedObjectType.ENVIRONMENT.name
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_get_document(environment, project, client, feature, segment):
+    # Given
+
+    # and some sample data to make sure we're testing all of the document
+    segment_rule = SegmentRule.objects.create(
+        segment=segment, type=SegmentRule.ALL_RULE
+    )
+    Condition.objects.create(
+        operator=EQUAL, property="property", value="value", rule=segment_rule
+    )
+
+    # and the relevant URL to get an environment document
+    url = reverse(
+        "api-v1:environments:environment-get-document", args=[environment.api_key]
+    )
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_get_all_trait_keys_for_environment_only_returns_distinct_keys(
+    identity, client, trait, environment
+):
+    # Given
+    trait_key_one = trait.trait_key
+    trait_key_two = "trait-key-two"
+
+    identity_two = Identity.objects.create(
+        environment=environment, identifier="identity-two"
+    )
+
+    Trait.objects.create(
+        identity=identity,
+        trait_key=trait_key_two,
+        string_value="blah",
+        value_type=STRING,
+    )
+    Trait.objects.create(
+        identity=identity_two,
+        trait_key=trait_key_one,
+        string_value="blah",
+        value_type=STRING,
+    )
+
+    url = reverse(
+        "api-v1:environments:environment-trait-keys", args=[environment.api_key]
+    )
+
+    # When
+    res = client.get(url)
+
+    # Then
+    assert res.status_code == status.HTTP_200_OK
+
+    # and - only distinct keys are returned
+    assert len(res.json().get("keys")) == 2
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_delete_trait_keys_deletes_traits_matching_provided_key_only(
+    environment, client, identity, trait
+):
+    # Given
+    trait_to_delete = trait.trait_key
+    trait_to_persist = "trait-key-to-persist"
+    Trait.objects.create(
+        identity=identity,
+        trait_key=trait_to_persist,
+        value_type=STRING,
+        string_value="blah",
+    )
+
+    url = reverse(
+        "api-v1:environments:environment-delete-traits", args=[environment.api_key]
+    )
+
+    # When
+    client.post(url, data={"key": trait_to_delete})
+
+    # Then
+    assert not Trait.objects.filter(
+        identity=identity, trait_key=trait_to_delete
+    ).exists()
+
+    # and
+    assert Trait.objects.filter(identity=identity, trait_key=trait_to_persist).exists()
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_user_can_list_environment_permission(client, environment):
+    # Given
+    url = reverse("api-v1:environments:environment-permissions")
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        len(response.json()) == 5
+    )  # hard code how many permissions we expect there to be
+
+
+def test_environment_my_permissions_reruns_400_for_master_api_key(
+    master_api_key_client, environment
+):
+    # Given
+    url = reverse(
+        "api-v1:environments:environment-my-permissions", args=[environment.api_key]
+    )
+
+    # When
+    response = master_api_key_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.json()["detail"]
+        == "This endpoint can only be used with a user and not Master API Key"
+    )

--- a/api/tests/integration/environments/test_clone_environment.py
+++ b/api/tests/integration/environments/test_clone_environment.py
@@ -1,6 +1,8 @@
 import json
 
+import pytest
 from django.urls import reverse
+from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from tests.integration.helpers import (
     get_env_feature_states_list_with_api,
@@ -8,14 +10,17 @@ from tests.integration.helpers import (
 )
 
 
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
 def test_clone_environment_clones_feature_states_with_value(
-    admin_client, project, environment, environment_api_key, feature
+    client, project, environment, environment_api_key, feature
 ):
 
     # Firstly, let's update feature state value of the source enviroment
     # fetch the feature state id to update
     feature_state = get_env_feature_states_list_with_api(
-        admin_client, {"environment": environment, "feature": feature}
+        client, {"environment": environment, "feature": feature}
     )["results"][0]["id"]
 
     fs_update_url = reverse(
@@ -31,26 +36,24 @@ def test_clone_environment_clones_feature_states_with_value(
         "feature_segment": None,
     }
     # Update the feature state
-    admin_client.put(
-        fs_update_url, data=json.dumps(data), content_type="application/json"
-    )
+    client.put(fs_update_url, data=json.dumps(data), content_type="application/json")
 
     # Now, clone the environment
     env_name = "Cloned env"
     url = reverse("api-v1:environments:environment-clone", args=[environment_api_key])
-    res = admin_client.post(url, {"name": env_name})
+    res = client.post(url, {"name": env_name})
 
     # Then, check that the clone was successful
     assert res.status_code == status.HTTP_200_OK
 
     # Now, fetch the feature states of the source environment
     source_env_feature_states = get_env_feature_states_list_with_api(
-        admin_client, {"environment": environment}
+        client, {"environment": environment}
     )
 
     # Now, fetch the feature states of the clone enviroment
     clone_env_feature_states = get_env_feature_states_list_with_api(
-        admin_client, {"environment": res.json()["id"]}
+        client, {"environment": res.json()["id"]}
     )
 
     # Finaly, compare the responses


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add master_api_key support to environment views

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Update tests to cover the change
