### PR TITLE
Add is_feature_specific to feature segment view set

### DIFF
--- a/api/features/feature_segments/serializers.py
+++ b/api/features/feature_segments/serializers.py
@@ -30,16 +30,27 @@ class FeatureSegmentQuerySerializer(serializers.Serializer):
 
 class FeatureSegmentListSerializer(serializers.ModelSerializer):
     segment_name = serializers.SerializerMethodField()
+    is_feature_specific = serializers.SerializerMethodField()
 
     class Meta:
         model = FeatureSegment
-        fields = ("id", "uuid", "segment", "priority", "environment", "segment_name")
+        fields = (
+            "id",
+            "uuid",
+            "segment",
+            "priority",
+            "environment",
+            "segment_name",
+            "is_feature_specific",
+        )
         read_only_fields = (
             "id",
             "uuid",
             "segment",
             "priority",
             "environment",
+            "segment_name",
+            "is_feature_specific",
         )
 
     def get_value(self, instance):
@@ -47,6 +58,9 @@ class FeatureSegmentListSerializer(serializers.ModelSerializer):
 
     def get_segment_name(self, instance: FeatureSegment) -> str:
         return instance.segment.name
+
+    def get_is_feature_specific(self, instance: FeatureSegment) -> bool:
+        return instance.segment.feature is not None
 
 
 class FeatureSegmentChangePrioritiesSerializer(serializers.Serializer):


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add `is_feature_specific` attribute to FeatureSegment so that FE can present the label in the list of segment overrides. 

## How did you test this code?

Added unit test. 
