### PR TITLE
Add pipedrive env vars

### DIFF
--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -94,6 +94,18 @@
                 {
                     "name": "SSE_SERVER_BASE_URL",
                     "value": "https://origin.realtime-staging.flagsmith.com"
+                },
+                {
+                    "name": "PIPEDRIVE_BASE_API_URL",
+                    "value": "https://testing-sandbox.pipedrive.com/api/v1"
+                },
+                {
+                    "name": "PIPEDRIVE_DOMAIN_ORGANIZATION_FIELD_KEY",
+                    "value": "1eb559f404db4ca931cf6b45b99a69f592dee321"
+                },
+                {
+                    "name": "PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY",
+                    "value": "3f142ca82a69c31c2f592b372bd1bb41dfe3407e"
                 }
             ],
             "secrets": [
@@ -140,6 +152,10 @@
                 {
                     "name": "SSE_AUTHENTICATION_TOKEN",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:SSE_AUTHENTICATION_TOKEN::"
+                },
+                {
+                    "name": "PIPEDRIVE_API_TOKEN",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:PIPEDRIVE_API_TOKEN::"
                 }
             ],
             "logConfiguration": {

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -226,7 +226,6 @@
                     "name": "SSE_AUTHENTICATION_TOKEN",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:SSE_AUTHENTICATION_TOKEN::"
                 }
-
             ],
             "logConfiguration": {
                 "logDriver": "awslogs",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Added required env vars for Pipedrive integration in staging. Note that these variables are only needed by the task processor in environments using TASK_RUN_METHOD=TASK_PROCESSOR

## How did you test this code?

There are unit tests covering the functionality. This should allow us to end to end test the functionality. 
