### PR TITLE
Enable pipedrive lead tracking task generation

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -785,6 +785,9 @@ SSE_AUTHENTICATION_TOKEN = env.str("SSE_AUTHENTICATION_TOKEN", None)
 
 DISABLE_INVITE_LINKS = env.bool("DISABLE_INVITE_LINKS", False)
 
+# use a separate boolean setting so that we add it to the API containers in environments
+# where we're running the task processor, so we avoid creating unnecessary tasks
+ENABLE_PIPEDRIVE_LEAD_TRACKING = env.bool("ENABLE_PIPEDRIVE_LEAD_TRACKING", False)
 PIPEDRIVE_API_TOKEN = env.str("PIPEDRIVE_API_TOKEN", None)
 PIPEDRIVE_BASE_API_URL = env.str(
     "PIPEDRIVE_BASE_API_URL", "https://flagsmith.pipedrive.com/api/v1"

--- a/api/users/signals.py
+++ b/api/users/signals.py
@@ -22,7 +22,10 @@ def warn_insecure(sender, **kwargs):
 
 @receiver(post_save, sender=FFAdminUser)
 def create_pipedrive_lead_signal(sender, instance, created, **kwargs):
-    if not created or not settings.PIPEDRIVE_API_TOKEN:
+    if not (
+        created
+        and (settings.PIPEDRIVE_API_TOKEN or settings.ENABLE_PIPEDRIVE_LEAD_TRACKING)
+    ):
         return
 
     create_pipedrive_lead.delay(args=(instance.id,))

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -160,12 +160,16 @@
                     "value": "60"
                 },
                 {
-                  "name":  "LOG_LEVEL",
-                  "value": "INFO"
+                    "name":  "LOG_LEVEL",
+                    "value": "INFO"
                 },
                 {
                     "name": "SSE_SERVER_BASE_URL",
                     "value": "https://origin.realtime-staging.flagsmith.com"
+                },
+                {
+                    "name": "ENABLE_PIPEDRIVE_LEAD_TRACKING",
+                    "value": "True"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Allows us to enable lead tracking in environments where the API containers don't know about the Pipedrive API token (i.e. environments where we have the task processor running)

## How did you test this code?

I tested pipedrive lead tracking in staging and verified that it wasn't currently working. It's clear that this is the issue and my solution will resolve it. Will be tested in staging before replicating the settings in production. 
