### PR TITLE
Prevent known domains in pipedrive

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -798,3 +798,7 @@ PIPEDRIVE_DOMAIN_ORGANIZATION_FIELD_KEY = env.str(
 PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY = env.str(
     "PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY", None
 )
+PIPEDRIVE_IGNORE_DOMAINS = env.list(
+    "PIPEDRIVE_IGNORE_DOMAINS",
+    ["solidstategroup.com", "flagsmith.com", "bullet-train.io"],
+)

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -135,6 +135,10 @@ class FFAdminUser(LifecycleModel, AbstractUser):
     def full_name(self):
         return self.get_full_name()
 
+    @property
+    def email_domain(self):
+        return self.email.split("@")[1]
+
     def get_full_name(self):
         if not self.first_name:
             return None

--- a/api/users/signals.py
+++ b/api/users/signals.py
@@ -22,9 +22,14 @@ def warn_insecure(sender, **kwargs):
 
 @receiver(post_save, sender=FFAdminUser)
 def create_pipedrive_lead_signal(sender, instance, created, **kwargs):
-    if not (
-        created
-        and (settings.PIPEDRIVE_API_TOKEN or settings.ENABLE_PIPEDRIVE_LEAD_TRACKING)
+    if (
+        not (
+            created
+            and (
+                settings.PIPEDRIVE_API_TOKEN or settings.ENABLE_PIPEDRIVE_LEAD_TRACKING
+            )
+        )
+        or instance.email_domain in settings.PIPEDRIVE_IGNORE_DOMAINS
     ):
         return
 

--- a/api/users/tests/test_models.py
+++ b/api/users/tests/test_models.py
@@ -299,3 +299,22 @@ def test_user_create_calls_pipedrive_tracking(mocker, db, settings):
 
     # Then
     mocked_create_pipedrive_lead.delay.assert_called()
+
+
+def test_user_create_does_not_call_pipedrive_tracking_if_ignored_domain(
+    mocker, db, settings
+):
+    # Given
+    mocked_create_pipedrive_lead = mocker.patch("users.signals.create_pipedrive_lead")
+    settings.ENABLE_PIPEDRIVE_LEAD_TRACKING = True
+    settings.PIPEDRIVE_IGNORE_DOMAINS = ["example.com"]
+
+    # When
+    FFAdminUser.objects.create(email="test@example.com")
+
+    # Then
+    mocked_create_pipedrive_lead.delay.assert_not_called()
+
+
+def test_user_email_domain_property():
+    assert FFAdminUser(email="test@example.com").email_domain == "example.com"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add a list of known domains so we can prevent leads being added to Pipedrive. 

## How did you test this code?

Added unit tests
