### PR TITLE
Ignore restmail.net for Pipedrive leads

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -800,5 +800,5 @@ PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY = env.str(
 )
 PIPEDRIVE_IGNORE_DOMAINS = env.list(
     "PIPEDRIVE_IGNORE_DOMAINS",
-    ["solidstategroup.com", "flagsmith.com", "bullet-train.io"],
+    ["solidstategroup.com", "flagsmith.com", "bullet-train.io", "restmail.net"],
 )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Ignore emails with restmail.net domain when creating leads in Pipedrive. 

## How did you test this code?

I have previously verified that other domains in the list do not get added to PIpedrive. I have not explicitly tested this domain. 
