### PR TITLE
Fix lead tracking custom fields

### DIFF
--- a/api/integrations/lead_tracking/pipedrive/lead_tracker.py
+++ b/api/integrations/lead_tracking/pipedrive/lead_tracker.py
@@ -26,9 +26,13 @@ class PipedriveLeadTracker(LeadTracker):
             )
             raise e
 
-        create_lead_kwargs = {"title": user.email, "organization_id": organization.id}
+        create_lead_kwargs = {
+            "title": user.email,
+            "organization_id": organization.id,
+            "custom_fields": {},
+        }
         if user.sign_up_type:
-            create_lead_kwargs[
+            create_lead_kwargs["custom_fields"][
                 settings.PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY
             ] = user.sign_up_type
 

--- a/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_lead_tracker.py
+++ b/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_lead_tracker.py
@@ -30,7 +30,9 @@ def test_create_lead_adds_to_existing_organization_if_exists(db, mocker, setting
     expected_create_lead_kwargs = {
         "title": user.email,
         "organization_id": organization.id,
-        settings.PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY: SignUpType.NO_INVITE.value,
+        "custom_fields": {
+            settings.PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY: SignUpType.NO_INVITE.value
+        },
     }
     mock_pipedrive_client.create_lead.assert_called_once_with(
         **expected_create_lead_kwargs
@@ -62,7 +64,9 @@ def test_create_lead_creates_new_organization_if_not_exists(db, settings, mocker
     expected_create_lead_kwargs = {
         "title": user.email,
         "organization_id": organization.id,
-        settings.PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY: SignUpType.NO_INVITE.value,
+        "custom_fields": {
+            settings.PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY: SignUpType.NO_INVITE.value
+        },
     }
     mock_pipedrive_client.create_lead.assert_called_once_with(
         **expected_create_lead_kwargs


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Fixes bug in the creation of new leads in Pipedrive. We were passing any custom fields directly as kwargs to the client method, rather than passing a dictionary of custom fields as we should have been. 

## How did you test this code?

Fixed unit tests. 
