### PR TITLE
PR Preview Environments for Enhancing Maintainer Productivity

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,97 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  build-flagsmith:
+    name: Build and push `Flagsmith`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
+          tags: |
+            type=raw,value=60d
+
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-flagsmith
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          FLAGSMITH_IMAGE=${{ needs.build-flagsmith.outputs.tags }}
+          export FLAGSMITH_IMAGE
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,88 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs:
+      - cache-compose-file
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,99 @@
+# See https://docs.flagsmith.com/deployment/docker for more information on running Flagsmith in Docker
+# This will docker-compose file will run the entire Flagsmith Platform in Docker
+# Uncomment and configure InfluxDB lines below (not neccesary but adds some functionality that requires InfluxDB)
+
+version: '3'
+
+# uffizzi integration
+x-uffizzi:
+  ingress:
+    service: nginx
+    port: 8081
+
+services:
+
+    nginx:
+      image: nginx:alpine
+      volumes:
+        - ./nginx-uffizzi:/etc/nginx
+
+    postgres:
+        image: postgres
+        environment:
+            POSTGRES_PASSWORD: password
+            POSTGRES_DB: flagsmith
+            POSTGRES_USER: postgres
+
+    flagsmith:
+        image: "${FLAGSMITH_IMAGE}"
+        ports:
+            - '8000:8000'
+        deploy:
+          resources:
+            limits:
+              memory: 2000M
+        environment:
+            # All environments variables are available here:
+            # API: https://docs.flagsmith.com/deployment/locally-api#environment-variables
+            # UI: https://docs.flagsmith.com/deployment/locally-frontend#environment-variables
+
+            DJANGO_ALLOWED_HOSTS: '*' # Change this in production
+            DATABASE_URL: postgresql://postgres:password@localhost:5432/flagsmith
+            DISABLE_INFLUXDB_FEATURES: 'true' # set to false to enable InfluxDB
+            PREVENT_SIGNUP: 'false'
+
+            ENV: dev # set to "prod" in production.
+
+            # For more info on configuring InfluxDB - https://docs.flagsmith.com/deployment/overview#influxdb
+            # INFLUXDB_URL: http://localhost:8086/influx
+            # INFLUXDB_BUCKET: flagsmith_api
+            # INFLUXDB_ORG: # Add your influx org id here
+            # INFLUXDB_TOKEN: # Add your influx token here
+
+            # For more info on configuring E-Mails - https://docs.flagsmith.com/deployment/locally-api#environment-variables
+            #
+            # Example SMTP:
+            # EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+            # EMAIL_HOST: mail.example.com
+            # SENDER_EMAIL: flagsmith@example.com
+            # EMAIL_HOST_USER: flagsmith@example.com
+            # EMAIL_HOST_PASSWORD: smtp_account_password
+            # EMAIL_PORT: 587 # optional
+            # EMAIL_USE_TLS: True # optional
+
+            # ENABLE_ADMIN_ACCESS_USER_PASS: True # set to True to enable access to the /admin/ Django backend via your username and password
+            # ALLOW_REGISTRATION_WITHOUT_INVITE: True
+
+            # Enable Task Processor
+            # To use task processor service, uncomment line below and additional 'flagsmith_processor'
+            # container below
+            # TASK_RUN_METHOD: TASK_PROCESSOR  # other options are: SYNCHRONOUSLY, SEPARATE_THREAD (default)
+
+#    Run the asynchronous task processor as a separate container alongside the API.
+#    When enabled, the API will write tasks to a queue (in the PostgreSQL database) for
+#    the processor to consume asynchronously.
+#    Documentation on the processor can be found here:
+#    https://docs.flagsmith.com/advanced-use/task-processor
+#    flagsmith_processor:
+#        build:
+#            dockerfile: api/Dockerfile
+#            context: .
+#        environment:
+#            DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
+#        command:
+#            - "python"
+#            - "manage.py"
+#            - "runprocessor"
+#            - "--sleepintervalms"
+#            - "500"
+#        depends_on:
+#            - flagsmith
+#            - postgres
+
+    # InfluxDB requires additional setup - please see https://docs.flagsmith.com/deployment-overview/#influxdb
+    # Note that InfluxDB is optional, but enabling it will provide additional functionality to the Flagsmith platform
+    # influxdb:
+    #   image: quay.io/influxdb/influxdb:v2.0.3
+    #   container_name: flagsmith_influxdb
+    #   ports:
+    #     - "8086:8086"

--- a/nginx-uffizzi/nginx.conf
+++ b/nginx-uffizzi/nginx.conf
@@ -1,0 +1,20 @@
+
+events {
+    worker_connections 1024; #default
+}
+
+http{
+  server {
+    listen 8081;
+
+    location / {
+          proxy_pass         http://localhost:8000;
+          proxy_redirect     off;
+          proxy_set_header   Host $host;
+
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?

## Description
This PR is adding support for **preview environments for PR events** (opened, sync'ed, reopened, etc) powered by [Uffizzi](https://www.uffizzi.com/). 

The PR uses GHA workflows to build and provision the preview environments. Utilizing docker-compose examples from **Flagsmith's** repo, the PR uses `docker-compose.uffizzi.yml` to build `Flagsmith` from source - this makes sure the latest changes are reflected in the preview. The `docker-compose.uffizzi.yml` also includes a Postgres instance and an Nginx proxy to facilitate mounting other components. 

Once a PR event is triggered — _PR opened, PR synced, review requested_ — the build workflow will build the image, and the preview workflow will either spin up a new preview or update an existing preview. The previews are ephemeral — so they live for only as long as needed. 

A comment will be posted on the PR containing the URL of the preview environment, allowing contributors and maintainers to easily navigate to the preview. 

Fixes - https://github.com/Flagsmith/flagsmith/issues/1738

## Changes
No change has been made in the source of the project for this PR. 

The `docker-compose.uffizzi.yml` file is borrowing major configurations from `docker-compose.yml` in Flagsmith's repo. The `docker-compose.uffizzi.yml` builds 3 different containers:
- **Flagsmith container** (from source, this makes sure the latest changes in the project are reflected in the preview environment)
- **Nginx container** (also exposed as the ingress into the preview environment. The `nginx.conf` file is mounted into the container and this container accepts incoming requests. This will be useful for accessing other UI services, like Influx-dashboard).
- **Postgres container**

The `docker-compose.uffizzi.yml` uses `uffizzi-build.yml` GHA → which is triggered on PR events. Once the build action completes, and the image is built, the `uffizzi-preview.yml` GHA spins up a new preview environment or updates an already existing preview. 

Every new PR will create a fresh preview environment, guaranteeing clean and non-polluted environments for testing changes. 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

In order to test this, I have created a [PR](https://github.com/ShrutiC-git/flagsmith/pull/1) against the main branch of my personal fork of `Flagsmith`. This triggered the workflow to create a new preview environment - [here](https://app.uffizzi.com/github.com/ShrutiC-git/flagsmith/pull/1) and this [comment](https://github.com/ShrutiC-git/flagsmith/pull/1#issuecomment-1347781203), posted on the PR, takes me to the preview environment.

The preview is enabled with sign-up. As you will visit the preview environment, you will be able to either sign-up as a new user or alternatively log in. Upon successful sign-in/sign-up, I was taken to the Flagsmith dashboard. Since I signed up as a free user, I was able to play around and test Flagsmith as a free user — and quite literally had more flags than the UN!

***********

An in-depth study on preview environments can be found [here](https://www.uffizzi.com/preview-environments-guide). Here is another easy read on [where can you use Uffizzi](https://docs.uffizzi.com/use-cases/why-uffizzi/#what-can-i-use-uffizzi-for).

Looking forward to powering preview environments for Flagsmith, and thereby, making reviewing, testing, releasing easy. Please do suggest improvements, ask questions, and/or send along concerns - it will help Uffizzi better align with Flagsmith! 

cc @dabeeeenster @waveywaves