### PR TITLE
Fix free plan purchasing

### DIFF
--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -356,7 +356,7 @@ const store = Object.assign({}, BaseStore, {
         const organisations = store.getOrganisations();
         const organisation = organisations && organisations.find(v => v.id === id);
         if (organisation) {
-            return !!organisation.subscription;
+            return !!organisation.subscription?.subscription_id;
         }
         return null;
     },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes
Before, if a subscription wasn't falsey, we used this to trigger an upgrade modal when dealing with chargebee. Now, we look specifically for a subscription_id since free plans now have a subscription object.

Have tested this for Free and paid plans.