### PR TITLE
Chores/fix initial mv percentage

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -56,23 +56,6 @@ const CreateFlag = class extends Component {
         closeModal();
     }
 
-
-    componentDidUpdate(prevProps, prevState, snapshot) {
-        if (!this.props.identity && this.props.environmentVariations !== prevProps.environmentVariations) {
-            if (this.props.environmentVariations && this.props.environmentVariations.length) {
-                this.setState({
-                    multivariate_options: this.state.multivariate_options && this.state.multivariate_options.map((v) => {
-                        const matchingVariation = (this.props.multivariate_options || this.props.environmentVariations).find(e => e.multivariate_feature_option === v.id);
-                        return {
-                            ...v,
-                            default_percentage_allocation: matchingVariation && matchingVariation.percentage_allocation || 0,
-                        };
-                    }),
-                });
-            }
-        }
-    }
-
     onClosing = () => {
         if (this.props.isEdit) {
             return new Promise((resolve) => {

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -56,6 +56,23 @@ const CreateFlag = class extends Component {
         closeModal();
     }
 
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (!this.props.identity && this.props.environmentVariations !== prevProps.environmentVariations) {
+            if (this.props.environmentVariations && this.props.environmentVariations.length) {
+                this.setState({
+                    multivariate_options: this.state.multivariate_options && this.state.multivariate_options.map((v) => {
+                        const matchingVariation = (this.props.multivariate_options || this.props.environmentVariations).find(e => e.multivariate_feature_option === v.id);
+                        return {
+                            ...v,
+                            default_percentage_allocation: v.default_percentage_allocation || (matchingVariation && matchingVariation.percentage_allocation) || 0,
+                        };
+                    }),
+                });
+            }
+        }
+    }
+
     onClosing = () => {
         if (this.props.isEdit) {
             return new Promise((resolve) => {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

We sync default_percentage_allocation to the initial value of variations when they are loaded, for new variations this created a race condition where values would be reset to 0.