### PR TITLE
Prevent auto seat upgrade code from running unless configured

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -815,6 +815,4 @@ PIPEDRIVE_IGNORE_DOMAINS = env.list(
 )
 
 # List of plan ids that support seat upgrades
-AUTO_SEAT_UPGRADE_PLANS = env.list(
-    "AUTO_SEAT_UPGRADE_PLANS", ["scale-up", "scale-up-v2", "scale-up-annual-v2"]
-)
+AUTO_SEAT_UPGRADE_PLANS = env.list("AUTO_SEAT_UPGRADE_PLANS", default=[])

--- a/api/organisations/invites/tests/test_views.py
+++ b/api/organisations/invites/tests/test_views.py
@@ -149,9 +149,15 @@ def test_create_invite_with_permission_groups(
 
 
 def test_create_invite_returns_400_if_seats_are_over(
-    admin_client, organisation, user_permission_group, admin_user, subscription
+    admin_client,
+    organisation,
+    user_permission_group,
+    admin_user,
+    subscription,
+    settings,
 ):
     # Given
+    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
     url = reverse(
         "api-v1:organisations:organisation-invites-list",
         args=[organisation.pk],
@@ -223,12 +229,13 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit(
     test_user_client,
     organisation,
     admin_user,
-    mocker,
     invite_object,
     url,
     subscription,
+    settings,
 ):
     # Given
+    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
     url = reverse(url, args=[invite_object.hash])
 
     # When

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -129,7 +129,8 @@ class InviteViewSet(
         subscription_metadata = organisation.subscription.get_subscription_metadata()
 
         if (
-            organisation.num_seats >= subscription_metadata.seats
+            len(settings.AUTO_SEAT_UPGRADE_PLANS) > 0
+            and organisation.num_seats >= subscription_metadata.seats
             and not organisation.subscription.can_auto_upgrade_seats
         ):
             raise SubscriptionDoesNotSupportSeatUpgrade()

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -156,9 +156,12 @@ class FFAdminUser(LifecycleModel, AbstractUser):
 
     def join_organisation_from_invite(self, invite: "AbstractBaseInviteModel"):
         organisation = invite.organisation
-        susbcription_metadata = organisation.subscription.get_subscription_metadata()
+        subscription_metadata = organisation.subscription.get_subscription_metadata()
 
-        if invite.organisation.num_seats >= susbcription_metadata.seats:
+        if (
+            len(settings.AUTO_SEAT_UPGRADE_PLANS) > 0
+            and invite.organisation.num_seats >= subscription_metadata.seats
+        ):
             organisation.subscription.add_single_seat()
 
         self.add_organisation(organisation, role=OrganisationRole(invite.role))

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -170,6 +170,10 @@
                 {
                     "name": "ENABLE_PIPEDRIVE_LEAD_TRACKING",
                     "value": "True"
+                },
+                {
+                    "name": "AUTO_SEAT_UPGRADE_PLANS",
+                    "value": "scale-up,scale-up-v2,scale-up-annual-v2"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Prevent code to auto upgrade seats / prevent new invites if no plans are configured. 

## How did you test this code?

Existing unit tests should cover this functionality. 
