### PR TITLE
Minor update to make the butter-bar sticky

### DIFF
--- a/frontend/web/styles/styles.scss
+++ b/frontend/web/styles/styles.scss
@@ -10,7 +10,9 @@
   text-align: center;
   line-height: 44px;
   margin-top: -10px;
-
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 .display-none {
   display: none !important;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

The change amends slightly the styling of the `.butter-bar` class such that if the page is long it would still be visible at the top of the screen. 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

1. Enable a butter bar
2. Attempt to scroll
3. On scroll, the butter bar should sticky to top.
