### PR TITLE
Fix float entry

### DIFF
--- a/frontend/common/utils/utils.js
+++ b/frontend/common/utils/utils.js
@@ -347,8 +347,9 @@ module.exports = Object.assign({}, require('./base/_utils'), {
         if (typeof str !== 'string') {
             return str;
         }
-        const isFloat = /^[0-9]+[.]?[0-9]+$/.test(str);
-        const isNum = isFloat || /^\d+$/.test(str);
+
+        const isNum = /^\d+$/.test(str);
+
         if (isNum && parseInt(str) > Number.MAX_SAFE_INTEGER) {
             return `${str}`;
         }

--- a/frontend/web/components/modals/CreateSegment.js
+++ b/frontend/web/components/modals/CreateSegment.js
@@ -441,7 +441,7 @@ const LoadingCreateSegment  = (props) => {
 
     useEffect(()=>{
         if(props.segment) {
-            _data.get(`${Project.api}projects/${props.projectId}/segments/${props.segment}`).then((segment)=> {
+            _data.get(`${Project.api}projects/${props.projectId}/segments/${props.segment}/`).then((segment)=> {
                 setSegmentData(segment);
                 setLoading(false)
             })


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

The change in https://github.com/Flagsmith/flagsmith/pull/1793 meant that segment rules sent floats when they were entered, however this had the unfortunate side effect of not allowing 4.0, since that gets parsed to 4.

Since the backend parses these anyway, I've reverted this change. It still fixes the original issue of displaying float_value.