### PR TITLE
Add trailing slash to Datadog url if required

### DIFF
--- a/api/integrations/datadog/datadog.py
+++ b/api/integrations/datadog/datadog.py
@@ -11,16 +11,14 @@ EVENTS_API_URI = "api/v1/events"
 
 
 class DataDogWrapper(AbstractBaseEventIntegrationWrapper):
-    def __init__(self, base_url: str, api_key: str):
+    def __init__(self, base_url: str, api_key: str, session: requests.Session = None):
         self.base_url = base_url
-        self.api_key = api_key
-        self.url = f"{self.base_url}{EVENTS_API_URI}?api_key={self.api_key}"
+        if self.base_url[-1] != "/":
+            self.base_url += "/"
+        self.events_url = f"{self.base_url}{EVENTS_API_URI}"
 
-    def _track_event(self, event: dict) -> None:
-        response = requests.post(self.url, data=json.dumps(event))
-        logger.debug(
-            "Sent event to DataDog. Response code was %s" % response.status_code
-        )
+        self.api_key = api_key
+        self.session = session or requests.Session()
 
     @staticmethod
     def generate_event_data(log: str, email: str, environment_name: str) -> dict:
@@ -29,3 +27,11 @@ class DataDogWrapper(AbstractBaseEventIntegrationWrapper):
             "title": "Flagsmith Feature Flag Event",
             "tags": [f"env:{environment_name}"],
         }
+
+    def _track_event(self, event: dict) -> None:
+        response = self.session.post(
+            f"{self.events_url}?api_key={self.api_key}", data=json.dumps(event)
+        )
+        logger.debug(
+            "Sent event to DataDog. Response code was %s" % response.status_code
+        )


### PR DESCRIPTION
- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Build the datadog URL correctly if base url is provided without a trailing slash. 

## How did you test this code?

Updated tests. 
