### PR TITLE
Add timeouts in test cafe config

### DIFF
--- a/frontend/.testcaferc.js
+++ b/frontend/.testcaferc.js
@@ -6,6 +6,8 @@ module.exports = {
     "hostname": "localhost",
     quarantineMode: false,
     skipJsErrors: true,
+    selectorTimeout: 20000,
+    assertionTimeout: 20000,
     cache: true,
     "videoPath": "reports/screen-captures",
     "videoOptions": {

--- a/frontend/e2e/index.cafe.js
+++ b/frontend/e2e/index.cafe.js
@@ -2,9 +2,13 @@ const createTestCafe = require('testcafe');
 const fs = require('fs');
 const path = require('path');
 const { fork } = require('child_process');
-
+const _options = require("../.testcaferc")
 const upload = require('../bin/upload-file');
-
+const options = {
+    ..._options,
+    browsers: process.env.E2E_DEV ? ['chrome'] : ['chrome:headless'],
+    debugOnFail: !!process.env.E2E_DEV
+}
 let testcafe;
 let server;
 const dir = path.join(__dirname, '../reports/screen-captures');
@@ -25,15 +29,13 @@ createTestCafe()
         const runner = testcafe.createRunner();
         return runner
             .src(['./e2e/init.cafe.js'])
-            .browsers(process.env.E2E_DEV ? ['chrome'] : ['chrome:headless']) // always headless
-            .run()
+            .run(options)
             .then((v) => {
                 if (!v) {
                     return runner
                         .src(['./e2e/cafe'])
-                        .browsers(process.env.E2E_DEV ? ['chrome'] : ['chrome:headless'])
                         .concurrency(2)
-                        .run();
+                        .run(options);
                 }
                 return v;
             });


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

- It looks like the assertion timeout is being reached when attempting to create an account in e2e, this ups the timeout and adds the ability to debug failures locally 

## How did you test this code?

- Re-run e2e 10x