### PR TITLE
Split api usage by project and environment

### DIFF
--- a/api/app_analytics/tests/test_influxdb_wrapper.py
+++ b/api/app_analytics/tests/test_influxdb_wrapper.py
@@ -40,14 +40,18 @@ def test_write(monkeypatch):
 
 
 def test_influx_db_query_when_get_events_then_query_api_called(monkeypatch):
-    query = (
-        f'from(bucket:"{read_bucket}") |> range(start: -30d, stop: now()) '
-        f'|> filter(fn:(r) => r._measurement == "api_call")         '
-        f'|> filter(fn: (r) => r["_field"] == "request_count")         '
-        f'|> filter(fn: (r) => r["organisation_id"] == "{org_id}") '
-        f'|> drop(columns: ["organisation", "project", "project_id", "environment", '
-        f'"environment_id"])'
-        f"|> sum()"
+    expected_query = (
+        (
+            f'from(bucket:"{read_bucket}") |> range(start: -30d, stop: now()) '
+            f'|> filter(fn:(r) => r._measurement == "api_call")         '
+            f'|> filter(fn: (r) => r["_field"] == "request_count")         '
+            f'|> filter(fn: (r) => r["organisation_id"] == "{org_id}") '
+            f'|> drop(columns: ["organisation", "project", "project_id", "environment", '
+            f'"environment_id"])'
+            f"|> sum()"
+        )
+        .replace(" ", "")
+        .replace("\n", "")
     )
     mock_influxdb_client = mock.MagicMock()
     monkeypatch.setattr(
@@ -61,7 +65,11 @@ def test_influx_db_query_when_get_events_then_query_api_called(monkeypatch):
     get_events_for_organisation(org_id)
 
     # Then
-    mock_query_api.query.assert_called_once_with(org=influx_org, query=query)
+    mock_query_api.query.assert_called_once()
+
+    call = mock_query_api.query.mock_calls[0]
+    assert call[2]["org"] == influx_org
+    assert call[2]["query"].replace(" ", "").replace("\n", "") == expected_query
 
 
 def test_influx_db_query_when_get_events_list_then_query_api_called(monkeypatch):
@@ -92,14 +100,18 @@ def test_influx_db_query_when_get_events_list_then_query_api_called(monkeypatch)
 def test_influx_db_query_when_get_multiple_events_for_organistation_then_query_api_called(
     monkeypatch,
 ):
-    query = (
-        f'from(bucket:"{read_bucket}") '
-        "|> range(start: -30d, stop: now()) "
-        '|> filter(fn:(r) => r._measurement == "api_call")                   '
-        f'|> filter(fn: (r) => r["organisation_id"] == "{org_id}") '
-        '|> drop(columns: ["organisation", "organisation_id", "type", "project", '
-        '"project_id", "environment", "environment_id", "host"])'
-        "|> aggregateWindow(every: 24h, fn: sum)"
+    expected_query = (
+        (
+            f'from(bucket:"{read_bucket}") '
+            "|> range(start: -30d, stop: now()) "
+            '|> filter(fn:(r) => r._measurement == "api_call")                   '
+            f'|> filter(fn: (r) => r["organisation_id"] == "{org_id}") '
+            '|> drop(columns: ["organisation", "organisation_id", "type", "project", '
+            '"project_id", "environment", "environment_id", "host"])'
+            "|> aggregateWindow(every: 24h, fn: sum)"
+        )
+        .replace(" ", "")
+        .replace("\n", "")
     )
     mock_influxdb_client = mock.MagicMock()
     monkeypatch.setattr(
@@ -113,7 +125,11 @@ def test_influx_db_query_when_get_multiple_events_for_organistation_then_query_a
     get_multiple_event_list_for_organisation(org_id)
 
     # Then
-    mock_query_api.query.assert_called_once_with(org=influx_org, query=query)
+    mock_query_api.query.assert_called_once()
+
+    call = mock_query_api.query.mock_calls[0]
+    assert call[2]["org"] == influx_org
+    assert call[2]["query"].replace(" ", "").replace("\n", "") == expected_query
 
 
 def test_influx_db_query_when_get_multiple_events_for_feature_then_query_api_called(

--- a/api/app_analytics/tests/test_influxdb_wrapper.py
+++ b/api/app_analytics/tests/test_influxdb_wrapper.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
 import app_analytics
+import pytest
 from app_analytics.influxdb_wrapper import (
     InfluxDBWrapper,
+    build_filter_string,
     get_event_list_for_organisation,
     get_events_for_organisation,
     get_multiple_event_list_for_feature,
@@ -97,17 +99,54 @@ def test_influx_db_query_when_get_events_list_then_query_api_called(monkeypatch)
     mock_query_api.query.assert_called_once_with(org=influx_org, query=query)
 
 
-def test_influx_db_query_when_get_multiple_events_for_organistation_then_query_api_called(
-    monkeypatch,
+@pytest.mark.parametrize(
+    "project_id, environment_id, expected_filters",
+    (
+        (
+            None,
+            None,
+            ['r._measurement == "api_call"', f'r["organisation_id"] == "{org_id}"'],
+        ),
+        (
+            1,
+            None,
+            [
+                'r._measurement == "api_call"',
+                f'r["organisation_id"] == "{org_id}"',
+                'r["project_id"] == "1"',
+            ],
+        ),
+        (
+            None,
+            1,
+            [
+                'r._measurement == "api_call"',
+                f'r["organisation_id"] == "{org_id}"',
+                'r["environment_id"] == "1"',
+            ],
+        ),
+        (
+            1,
+            1,
+            [
+                'r._measurement == "api_call"',
+                f'r["organisation_id"] == "{org_id}"',
+                'r["project_id"] == "1"',
+                'r["environment_id"] == "1"',
+            ],
+        ),
+    ),
+)
+def test_influx_db_query_when_get_multiple_events_for_organisation_then_query_api_called(
+    monkeypatch, project_id, environment_id, expected_filters
 ):
     expected_query = (
         (
             f'from(bucket:"{read_bucket}") '
             "|> range(start: -30d, stop: now()) "
-            '|> filter(fn:(r) => r._measurement == "api_call")                   '
-            f'|> filter(fn: (r) => r["organisation_id"] == "{org_id}") '
+            f"{build_filter_string(expected_filters)}"
             '|> drop(columns: ["organisation", "organisation_id", "type", "project", '
-            '"project_id", "environment", "environment_id", "host"])'
+            '"project_id", "environment", "environment_id", "host"]) '
             "|> aggregateWindow(every: 24h, fn: sum)"
         )
         .replace(" ", "")
@@ -122,7 +161,9 @@ def test_influx_db_query_when_get_multiple_events_for_organistation_then_query_a
     mock_influxdb_client.query_api.return_value = mock_query_api
 
     # When
-    get_multiple_event_list_for_organisation(org_id)
+    get_multiple_event_list_for_organisation(
+        org_id, project_id=project_id, environment_id=environment_id
+    )
 
     # Then
     mock_query_api.query.assert_called_once()

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -220,6 +220,11 @@ class InfluxDataSerializer(serializers.Serializer):
     events_list = serializers.ListSerializer(child=serializers.DictField())
 
 
+class InfluxDataQuerySerializer(serializers.Serializer):
+    project_id = serializers.IntegerField(required=False)
+    environment_id = serializers.IntegerField(required=False)
+
+
 class GetHostedPageForSubscriptionUpgradeSerializer(serializers.Serializer):
     plan_id = serializers.CharField(write_only=True)
     subscription_id = serializers.CharField(write_only=True)

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -34,6 +34,7 @@ from organisations.permissions.permissions import (
 )
 from organisations.serializers import (
     GetHostedPageForSubscriptionUpgradeSerializer,
+    InfluxDataQuerySerializer,
     InfluxDataSerializer,
     MultiInvitesSerializer,
     OrganisationSerializerFull,
@@ -206,10 +207,18 @@ class OrganisationViewSet(viewsets.ModelViewSet):
         serializer.save()
         return Response(serializer.data)
 
+    @swagger_auto_schema(query_serializer=InfluxDataQuerySerializer())
     @action(detail=True, methods=["GET"], url_path="influx-data")
     def get_influx_data(self, request, pk):
+        filters = InfluxDataQuerySerializer(data=request.query_params)
+        filters.is_valid(raise_exception=True)
+
         serializer = self.get_serializer(
-            data={"events_list": get_multiple_event_list_for_organisation(pk)}
+            data={
+                "events_list": get_multiple_event_list_for_organisation(
+                    pk, **filters.data
+                )
+            }
         )
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data)


### PR DESCRIPTION
- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add filters for project and environment when getting influx data for an organisation. 

## How did you test this code?

Added / updated unit tests. We should make sure to test this in staging too as I've made some assumptions regarding whitespace in Influx. 