### PR TITLE
Ignore seat limits when payment enabled flag is disabled 

### DIFF
--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -332,7 +332,7 @@ const OrganisationSettingsPage = class extends Component {
                                 const autoSeats = Utils.getPlansPermission("AUTO_SEATS")
                                 const usedSeats = organisation.num_seats >= max_seats;
                                 const overSeats = paymentsEnabled && organisation.num_seats > max_seats;
-                                const needsUpgradeForAdditionalSeats = overSeats || (!autoSeats && usedSeats);
+                                const needsUpgradeForAdditionalSeats = overSeats || (!autoSeats && usedSeats && paymentsEnabled);
                                 return (
                                     <div>
                                         <Tabs inline transparent value={this.state.tab || 0} onChange={(tab) => this.setState({ tab })}>
@@ -571,11 +571,10 @@ const OrganisationSettingsPage = class extends Component {
                                                                 {isLoading && <div className="centered-container"><Loader /></div>}
                                                                 {!isLoading && (
                                                                     <div>
-
                                                                         <Tabs inline transparent uncontrolled>
                                                                             <TabItem tabLabel="Members">
 
-                                                                                <Row space className="mt-5">
+                                                                                <Row space className="mt-4">
                                                                                     <h3 className="m-b-0">Team Members</h3>
                                                                                     <Button
                                                                                         disabled={needsUpgradeForAdditionalSeats}
@@ -586,7 +585,7 @@ const OrganisationSettingsPage = class extends Component {
                                                                                         Invite members
                                                                                     </Button>
                                                                                 </Row>
-                                                                            <FormGroup className="mt-4">
+                                                                            <FormGroup className="mt-2">
                                                                                 {paymentsEnabled && !isLoading && (
                                                                                     <InfoMessage>
                                                                                         {'You are currently using '}

--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -331,7 +331,7 @@ const OrganisationSettingsPage = class extends Component {
                                 const { max_seats } = subscriptionMeta || organisation.subscription || { max_seats: 1 };
                                 const autoSeats = Utils.getPlansPermission("AUTO_SEATS")
                                 const usedSeats = organisation.num_seats >= max_seats;
-                                const overSeats = organisation.num_seats > max_seats;
+                                const overSeats = paymentsEnabled && organisation.num_seats > max_seats;
                                 const needsUpgradeForAdditionalSeats = overSeats || (!autoSeats && usedSeats);
                                 return (
                                     <div>

--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -330,9 +330,9 @@ const OrganisationSettingsPage = class extends Component {
                             {({ isLoading, name, error, projects, usage, users, invites, influx_data, inviteLinks, subscriptionMeta, invalidateInviteLink }) => {
                                 const { max_seats } = subscriptionMeta || organisation.subscription || { max_seats: 1 };
                                 const autoSeats = Utils.getPlansPermission("AUTO_SEATS")
-                                const usedSeats = organisation.num_seats >= max_seats;
+                                const usedSeats = paymentsEnabled && organisation.num_seats >= max_seats;
                                 const overSeats = paymentsEnabled && organisation.num_seats > max_seats;
-                                const needsUpgradeForAdditionalSeats = overSeats || (!autoSeats && usedSeats && paymentsEnabled);
+                                const needsUpgradeForAdditionalSeats = overSeats || (!autoSeats && usedSeats);
                                 return (
                                     <div>
                                         <Tabs inline transparent value={this.state.tab || 0} onChange={(tab) => this.setState({ tab })}>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

The frontend will now consider the payments enabled feature flag when determining whether a user has used all their seats or is over their seats. 

## How did you test this code?

Viewed an over account on staging vs production flagsmith feature flags.
