### PR TITLE
Chores/add enterprise saas annual v2

### DIFF
--- a/frontend/common/utils/utils.js
+++ b/frontend/common/utils/utils.js
@@ -3,6 +3,13 @@ const semver = require('semver');
 const ProjectStore = require('../../common/stores/project-store');
 
 let flagsmithBetaFeatures = null;
+const planNames = {
+    free: 'Free',
+    scaleUp: 'Scale-Up',
+    sideProject: 'Side Project',
+    startup:  'Startup',
+    enterprise:  'Enterprise'
+}
 module.exports = Object.assign({}, require('./base/_utils'), {
     numberWithCommas(x) {
         return x.toString()
@@ -441,20 +448,21 @@ module.exports = Object.assign({}, require('./base/_utils'), {
     },
     getPlanPermission: (plan, permission) => {
         let valid = true;
+        const planName = Utils.getPlanName(plan)
         if (!Utils.getFlagsmithHasFeature('plan_based_access')) {
             return true;
         }
-        if (!plan || plan === 'free') {
+        if (!plan || planName === planNames.free) {
             return false;
         }
         const date = AccountStore.getDate();
         const cutOff = moment('03-11-20', 'DD-MM-YY');
-        if (date && moment(date)
-            .valueOf() < cutOff.valueOf()) {
-            return true;
-        }
-        const isSideProjectOrGreater = !plan.includes('side-project');
-        const isScaleupOrGreater = !plan.includes('side-project') && !plan.includes('startup');
+        // if (date && moment(date)
+        //     .valueOf() < cutOff.valueOf()) {
+        //     return true;
+        // }
+        const isSideProjectOrGreater = planName !== planNames.sideProject;
+        const isScaleupOrGreater = isSideProjectOrGreater && planName!== planNames.startup;
         switch (permission) {
             case 'FLAG_OWNERS': {
                 valid = isScaleupOrGreater;
@@ -500,27 +508,18 @@ module.exports = Object.assign({}, require('./base/_utils'), {
     },
 
     getPlanName: (plan) => {
-        switch (plan) {
-            case 'side-project':
-            case 'side-project-annual':
-                return 'Side Project';
-            case 'startup':
-            case 'startup-annual':
-            case 'startup-v2':
-            case 'startup-annual-v2':
-                return 'Startup';
-            case 'scale-up':
-            case 'scale-up-annual':
-            case 'scale-up-v2':
-            case 'scale-up-annual-v2':
-            case 'scale-up-12-months-v2':
-                return 'Scale-Up';
-            case 'enterprise':
-            case 'enterprise-annual':
-            case 'enterprise-saas-annual-v2':
-                return 'Enterprise';
-            default:
-                return 'Free';
+        if (plan && plan.includes("scale-up")) {
+            return planNames.scaleUp;
         }
+        if (plan && plan.includes("side-project")) {
+            return planNames.sideProject;
+        }
+        if (plan && plan.includes("startup")) {
+            return planNames.startup;
+        }
+        if (plan && plan.includes("enterprise")) {
+            return planNames.enterprise;
+        }
+        return planNames.free
     },
 });

--- a/frontend/common/utils/utils.js
+++ b/frontend/common/utils/utils.js
@@ -517,6 +517,7 @@ module.exports = Object.assign({}, require('./base/_utils'), {
                 return 'Scale-Up';
             case 'enterprise':
             case 'enterprise-annual':
+            case 'enterprise-saas-annual-v2':
                 return 'Enterprise';
             default:
                 return 'Free';


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This simplifies plan logic in determining tier as well as displaying a plan name. Previously, we added each plan slug manually where as now we will check the slug for keywords such as startup.

## How did you test this code?

Checked existing scaleup, free organisations and force simulated enterprise plans.