### PR TITLE
Prevent unauthorized creation of a Terraform API key

### DIFF
--- a/api/api_keys/serializers.py
+++ b/api/api_keys/serializers.py
@@ -18,7 +18,6 @@ class MasterAPIKeySerializer(serializers.ModelSerializer):
             "name",
             "revoked",
             "expiry_date",
-            "organisation",
             "key",
         )
         read_only_fields = ("prefix", "created", "key")

--- a/api/api_keys/views.py
+++ b/api/api_keys/views.py
@@ -17,7 +17,7 @@ class MasterAPIKeyViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return MasterAPIKey.objects.filter(
-            organisation_id=self.kwargs.get("organisation_pk")
+            organisation_id=self.kwargs.get("organisation_pk"), revoked=False
         )
 
     def perform_create(self, serializer):

--- a/api/api_keys/views.py
+++ b/api/api_keys/views.py
@@ -19,3 +19,6 @@ class MasterAPIKeyViewSet(viewsets.ModelViewSet):
         return MasterAPIKey.objects.filter(
             organisation_id=self.kwargs.get("organisation_pk")
         )
+
+    def perform_create(self, serializer):
+        serializer.save(organisation_id=self.kwargs.get("organisation_pk"))

--- a/api/tests/integration/api_keys/test_viewset.py
+++ b/api/tests/integration/api_keys/test_viewset.py
@@ -97,3 +97,31 @@ def test_api_returns_403_if_user_is_not_the_org_admin(non_admin_client, organisa
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_create_master_api_key_ignores_organisation_in_body(admin_client, organisation):
+    # Given
+    list_create_url = reverse(
+        "api-v1:organisations:organisation-master-api-keys-list",
+        args=[organisation],
+    )
+    name = "test_key"
+    data = {"name": name, "organisation": 999}
+
+    # When
+    create_response = admin_client.post(list_create_url, data=data)
+
+    # Then
+    assert create_response.status_code == status.HTTP_201_CREATED
+    key = create_response.json()["key"]
+    assert key is not None
+
+    # and
+    # the key exists in the organisation provided in the URL
+    list_response = admin_client.get(list_create_url)
+    assert list_response.status_code == status.HTTP_200_OK
+    list_response_json = list_response.json()
+    assert list_response_json["count"] == 1
+
+    assert list_response_json["results"][0]["name"] == name
+    assert key.startswith(list_response_json["results"][0]["prefix"])


### PR DESCRIPTION
Resolves vulnerability which allowed admin users from organisation A to create Terraform API keys in organisation B (where the user was not a member of organisation B). 

The issue was related to the use of a URL parameter and a JSON body attribute. The permission check was performed based on the URL parameter, however the key itself was created using the JSON body attribute. 

This PR resolves this by using the URL parameter to create the key itself and ignoring any organisation id passed in the JSON body. 
