### PR TITLE
Always write audit logs

### DIFF
--- a/api/audit/tasks.py
+++ b/api/audit/tasks.py
@@ -40,13 +40,6 @@ def create_audit_log_from_historical_record(
     model_class = AuditLog.get_history_record_model_class(history_record_class_path)
     history_instance = model_class.objects.get(history_id=history_instance_id)
 
-    if (
-        history_instance.history_type == "~"
-        and history_instance.diff_against(history_instance.prev_record).changes == []
-    ):
-        # don't write audit log if no changes
-        return
-
     instance = history_instance.instance
     history_user = user_model.objects.filter(id=history_user_id).first()
 

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 
+from audit.constants import FEATURE_DELETED_MESSAGE
 from audit.models import AuditLog, RelatedObjectType
 from environments.identities.models import Identity
 from environments.models import Environment
@@ -464,11 +465,13 @@ def test_audit_logs_created_when_feature_deleted(client, project, feature):
     assert AuditLog.objects.get(
         related_object_type=RelatedObjectType.FEATURE.name,
         related_object_id=feature.id,
+        log=FEATURE_DELETED_MESSAGE % feature.name,
     )
     # and audit logs exists for all feature states for that feature
     assert AuditLog.objects.filter(
         related_object_type=RelatedObjectType.FEATURE_STATE.name,
         related_object_id__in=feature_states_ids,
+        log=FEATURE_DELETED_MESSAGE % feature.name,
     ).count() == len(feature_states_ids)
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Always write audit logs (without checking if anything changed). 

This should (temporarily at least) resolve the issues that we're seeing with feature state values not triggering an environment document rebuild. 

## How did you test this code?

Added unit test to confirm immediate issue is fixed. 
