### PR TITLE
Prevent duplicate audit log records from being returned by API

### DIFF
--- a/api/audit/views.py
+++ b/api/audit/views.py
@@ -50,6 +50,8 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         search = serializer.data.get("search")
         if search:
             q = q & Q(log__icontains=search)
-        return AuditLog.objects.filter(q).select_related(
-            "project", "environment", "author"
+        return (
+            AuditLog.objects.filter(q)
+            .distinct()
+            .select_related("project", "environment", "author")
         )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Prevent duplicate audit log records being returned

## How did you test this code?

Ran the code locally and verified this prevented duplicate audit log records from being returned. 
