### PR TITLE
Prevent audit log messages being created for FS when new environment created

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -721,6 +721,11 @@ class FeatureState(
             # feature states
             return
 
+        if self.environment.created_date > self.feature.created_date:
+            # Don't create an audit log record for feature states created when
+            # creating an environment
+            return
+
         if self.identity_id:
             return audit_helpers.get_identity_override_created_audit_message(self)
         elif self.feature_segment_id:

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -161,12 +161,20 @@ def test_feature_state_get_create_log_message_returns_nothing_if_uncommitted_cha
     ),
 )
 def test_feature_state_get_create_log_message_calls_correct_helper_function(
-    mocker, feature_segment_id, identity_id, expected_function_name
+    mocker,
+    feature_segment_id,
+    identity_id,
+    environment,
+    feature,
+    expected_function_name,
 ):
     # Given
     mock_audit_helpers = mocker.patch("features.models.audit_helpers")
     feature_state = FeatureState(
-        feature_segment_id=feature_segment_id, identity_id=identity_id
+        feature_segment_id=feature_segment_id,
+        identity_id=identity_id,
+        environment=environment,
+        feature=feature,
     )
 
     # When


### PR DESCRIPTION
- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Prevent audit log messages being generated when creating features states when a new environment is created. 

## How did you test this code?

Added 2 new unit tests. 
