### PR TITLE
 feat(organisation/users): Add last_login 

### DIFF
--- a/api/features/tests/test_views.py
+++ b/api/features/tests/test_views.py
@@ -152,6 +152,7 @@ class ProjectFeatureTestCase(TestCase):
             "email": user_3.email,
             "first_name": user_3.first_name,
             "last_name": user_3.last_name,
+            "last_login": None,
         }
 
     def test_audit_log_created_when_feature_state_created_for_identity(self):

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -535,12 +535,14 @@ def test_add_owners_adds_owner(client, project):
         "email": user_1.email,
         "first_name": user_1.first_name,
         "last_name": user_1.last_name,
+        "last_login": None,
     }
     assert json_response["owners"][1] == {
         "id": user_2.id,
         "email": user_2.email,
         "first_name": user_2.first_name,
         "last_name": user_2.last_name,
+        "last_login": None,
     }
 
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -57,7 +57,7 @@ class UserListSerializer(serializers.ModelSerializer):
     role = serializers.SerializerMethodField(read_only=True)
     join_date = serializers.SerializerMethodField(read_only=True)
 
-    default_fields = ("id", "email", "first_name", "last_name")
+    default_fields = ("id", "email", "first_name", "last_name", "last_login")
     organisation_users_fields = ("role", "date_joined")
 
     class Meta:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Add last_loigin to ​`/api​/v1​/organisations​/{organisation_pk}​/users​/`

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds unit test
