### PR TITLE
Remove flagsmith dev env

### DIFF
--- a/frontend/env/project_e2e.js
+++ b/frontend/env/project_e2e.js
@@ -3,7 +3,7 @@ module.exports = global.Project = {
     api: 'http://flagsmith-api:8000/api/v1/',
     flagsmithClientAPI: 'https://api.bullet-train.io/api/v1/',
     flagsmithClientEdgeAPI: 'https://edge.api.flagsmith.com/api/v1/',
-    flagsmith: '8KzETdDeMY7xkqkSkY3Gsg', // This is our Bullet Train API key - Bullet Train runs on Bullet Train!
+    flagsmith: 'ENktaJnfLVbLifybz34JmX', // This is our Bullet Train API key - Bullet Train runs on Bullet Train!
     debug: false,
     env: 'dev', // This is used for Sentry tracking
     maintenance: false, // trigger maintenance mode

--- a/frontend/env/project_local.js
+++ b/frontend/env/project_local.js
@@ -3,7 +3,7 @@ module.exports = global.Project = {
     api: 'http://localhost:8000/api/v1/',
     flagsmithClientAPI: 'https://api.flagsmith.com/api/v1/',
     flagsmithClientEdgeAPI: 'https://edge.api.flagsmith.com/api/v1/',
-    flagsmith: '8KzETdDeMY7xkqkSkY3Gsg',
+    flagsmith: 'ENktaJnfLVbLifybz34JmX',
     debug: false,
     env: 'dev', // This is used for Sentry tracking
     maintenance: false, // trigger maintenance mode


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

The Flagsmith on Flagsmith development environment isn't very useful, this PR means that we can remove it. It replaces the env variables with the staging one.
