### PR TITLE
Fix duplicate segment condition audit messages

### DIFF
--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -76,9 +76,19 @@ class Segment(
         return "Segment - %s" % self.name
 
     @staticmethod
-    def id_exists_in_rules_data(rules_data: typing.List[dict]):
+    def id_exists_in_rules_data(rules_data: typing.List[dict]) -> bool:
+        """
+        Given a list of segment rules, return whether any of the rules or conditions contain an id.
+
+        :param rules_data: list of segment rules (in the form {"id": 1, "rules": [], "conditions": [], "typing": ""})
+        :return: boolean value detailing whether any id attributes were found
+        """
+
         _rules_data = deepcopy(rules_data)
         for rule_data in _rules_data:
+            if rule_data.get("id"):
+                return True
+
             conditions_to_check = rule_data.get("conditions", [])
             rules_to_check = rule_data.get("rules", [])
 
@@ -93,6 +103,8 @@ class Segment(
                 condition = conditions_to_check.pop()
                 if condition.get("id"):
                     return True
+
+        return False
 
     def does_identity_match(
         self, identity: "Identity", traits: typing.List["Trait"] = None

--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+from copy import deepcopy
 
 import semver
 from core.constants import BOOLEAN, FLOAT, INTEGER
@@ -73,6 +74,25 @@ class Segment(
 
     def __str__(self):
         return "Segment - %s" % self.name
+
+    @staticmethod
+    def id_exists_in_rules_data(rules_data: typing.List[dict]):
+        _rules_data = deepcopy(rules_data)
+        for rule_data in _rules_data:
+            conditions_to_check = rule_data.get("conditions", [])
+            rules_to_check = rule_data.get("rules", [])
+
+            while rules_to_check:
+                rule = rules_to_check.pop()
+                if rule.get("id"):
+                    return True
+                rules_to_check.extend(rule.get("rules", []))
+                conditions_to_check.extend(rule.get("conditions", []))
+
+            while conditions_to_check:
+                condition = conditions_to_check.pop()
+                if condition.get("id"):
+                    return True
 
     def does_identity_match(
         self, identity: "Identity", traits: typing.List["Trait"] = None

--- a/api/segments/serializers.py
+++ b/api/segments/serializers.py
@@ -3,21 +3,17 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import ListSerializer
 from rest_framework_recursive.fields import RecursiveField
 
-from segments.models import Condition, Segment, SegmentRule
-
-from . import models
+from segments.models import PERCENTAGE_SPLIT, Condition, Segment, SegmentRule
 
 
 class ConditionSerializer(serializers.ModelSerializer):
     class Meta:
-        model = models.Condition
-        fields = ("operator", "property", "value", "description")
+        model = Condition
+        fields = ("id", "operator", "property", "value", "description")
 
     def validate(self, attrs):
         super(ConditionSerializer, self).validate(attrs)
-        if attrs.get("operator") != models.PERCENTAGE_SPLIT and not attrs.get(
-            "property"
-        ):
+        if attrs.get("operator") != PERCENTAGE_SPLIT and not attrs.get("property"):
             raise ValidationError({"property": ["This field may not be blank."]})
         return attrs
 
@@ -32,15 +28,15 @@ class RuleSerializer(serializers.ModelSerializer):
     rules = ListSerializer(child=RecursiveField(), required=False)
 
     class Meta:
-        model = models.SegmentRule
-        fields = ("type", "rules", "conditions")
+        model = SegmentRule
+        fields = ("id", "type", "rules", "conditions")
 
 
 class SegmentSerializer(serializers.ModelSerializer):
     rules = RuleSerializer(many=True)
 
     class Meta:
-        model = models.Segment
+        model = Segment
         fields = "__all__"
 
     def validate(self, attrs):
@@ -59,12 +55,17 @@ class SegmentSerializer(serializers.ModelSerializer):
         """
         rules_data = validated_data.pop("rules", [])
         segment = Segment.objects.create(**validated_data)
-        self._create_segment_rules(rules_data, segment=segment, is_create=True)
+        self._update_or_create_segment_rules(
+            rules_data, segment=segment, is_create=True
+        )
         return segment
 
     def update(self, instance, validated_data):
-        rules_data = validated_data.pop("rules", [])
+        # use the initial data since we need the ids included to determine which to update & which to create
+        rules_data = self.initial_data.pop("rules", [])
         self._update_segment_rules(rules_data, segment=instance)
+        # remove rules from validated data to prevent error trying to create segment with nested rules
+        del validated_data["rules"]
         return super().update(instance, validated_data)
 
     def _update_segment_rules(self, rules_data, segment=None):
@@ -72,10 +73,15 @@ class SegmentSerializer(serializers.ModelSerializer):
         Since we don't have a unique identifier for the rules / conditions for the update, we assume that the client
         passes up the new configuration for the rules of the segment and simply wipe the old ones and create new ones
         """
-        segment.rules.set([])
-        self._create_segment_rules(rules_data, segment=segment)
+        # traverse the rules / conditions tree - if no ids are provided, then maintain the previous behaviour (clear
+        # existing rules and create the ones that were sent)
+        # note: we do this to preserve backwards compatibility after adding logic to include the id in requests
+        if not Segment.id_exists_in_rules_data(rules_data):
+            segment.rules.set([])
 
-    def _create_segment_rules(
+        self._update_or_create_segment_rules(rules_data, segment=segment)
+
+    def _update_or_create_segment_rules(
         self, rules_data, segment=None, rule=None, is_create: bool = False
     ):
         if all(x is None for x in {segment, rule}):
@@ -85,26 +91,34 @@ class SegmentSerializer(serializers.ModelSerializer):
             child_rules = rule_data.pop("rules", [])
             conditions = rule_data.pop("conditions", [])
 
-            child_rule = self._create_segment_rule(rule_data, segment, rule)
+            child_rule = self._update_or_create_segment_rule(
+                rule_data, segment=segment, rule=rule
+            )
 
-            self._create_conditions(conditions, child_rule, is_create=is_create)
+            self._update_or_create_conditions(
+                conditions, child_rule, is_create=is_create
+            )
 
-            self._create_segment_rules(child_rules, rule=child_rule)
+            self._update_or_create_segment_rules(
+                child_rules, rule=child_rule, is_create=is_create
+            )
 
     @staticmethod
-    def _create_segment_rule(rule_data, segment, rule):
-        if segment:
-            segment_rule = SegmentRule.objects.create(segment=segment, **rule_data)
-        else:
-            segment_rule = SegmentRule.objects.create(rule=rule, **rule_data)
-
+    def _update_or_create_segment_rule(
+        rule_data: dict, segment: Segment = None, rule: SegmentRule = None
+    ):
+        segment_rule, _ = SegmentRule.objects.update_or_create(
+            id=rule_data.pop("id", None),
+            defaults={"segment": segment, "rule": rule, **rule_data},
+        )
         return segment_rule
 
     @staticmethod
-    def _create_conditions(conditions_data, rule, is_create: bool = False):
+    def _update_or_create_conditions(conditions_data, rule, is_create: bool = False):
         for condition in conditions_data:
-            Condition.objects.create(
-                rule=rule, created_with_segment=is_create, **condition
+            Condition.objects.update_or_create(
+                id=condition.pop("id", None),
+                defaults={**condition, "created_with_segment": is_create, "rule": rule},
             )
 
 

--- a/api/segments/tests/test_models.py
+++ b/api/segments/tests/test_models.py
@@ -10,25 +10,6 @@ from segments.models import PERCENTAGE_SPLIT, Condition, Segment, SegmentRule
 
 
 @pytest.mark.django_db
-class SegmentTestCase(TestCase):
-    def setUp(self) -> None:
-        self.organisation = Organisation.objects.create(name="Test Org")
-        self.project = Project.objects.create(
-            name="Test Project", organisation=self.organisation
-        )
-        self.environment = Environment.objects.create(
-            name="Test Environment", project=self.project
-        )
-        self.identity = Identity.objects.create(
-            environment=self.environment, identifier="test_identity"
-        )
-
-    def tearDown(self) -> None:
-        Segment.objects.all().delete()
-        Identity.objects.all().delete()
-
-
-@pytest.mark.django_db
 class SegmentRuleTest(TestCase):
     def setUp(self) -> None:
         self.organisation = Organisation.objects.create(name="Test Org")

--- a/api/segments/tests/test_views.py
+++ b/api/segments/tests/test_views.py
@@ -357,3 +357,164 @@ def test_create_segments_with_description_condition(project, client):
         "description"
     ]
     assert segment_condition_description_value == "test-description"
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_update_segment_add_new_condition(project, client, segment, segment_rule):
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail", args=[project.id, segment.id]
+    )
+    nested_rule = SegmentRule.objects.create(
+        rule=segment_rule, type=SegmentRule.ANY_RULE
+    )
+    existing_condition = Condition.objects.create(
+        rule=nested_rule, property="foo", operator=EQUAL, value="bar"
+    )
+
+    new_condition_property = "foo2"
+    new_condition_value = "bar"
+    data = {
+        "name": segment.name,
+        "project": project.id,
+        "rules": [
+            {
+                "id": segment_rule.id,
+                "type": segment_rule.type,
+                "rules": [
+                    {
+                        "id": nested_rule.id,
+                        "type": nested_rule.type,
+                        "rules": [],
+                        "conditions": [
+                            # existing condition
+                            {
+                                "id": existing_condition.id,
+                                "property": existing_condition.property,
+                                "operator": existing_condition.operator,
+                                "value": existing_condition.value,
+                            },
+                            # new condition
+                            {
+                                "property": new_condition_property,
+                                "operator": EQUAL,
+                                "value": new_condition_value,
+                            },
+                        ],
+                    }
+                ],
+                "conditions": [],
+            }
+        ],
+    }
+
+    # When
+    response = client.put(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    assert nested_rule.conditions.count() == 2
+    assert (
+        nested_rule.conditions.order_by("-id").first().property
+        == new_condition_property
+    )
+    assert nested_rule.conditions.order_by("-id").first().value == new_condition_value
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_update_segment_delete_existing_condition(
+    project, client, segment, segment_rule
+):
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail", args=[project.id, segment.id]
+    )
+    nested_rule = SegmentRule.objects.create(
+        rule=segment_rule, type=SegmentRule.ANY_RULE
+    )
+    existing_condition = Condition.objects.create(
+        rule=nested_rule, property="foo", operator=EQUAL, value="bar"
+    )
+
+    data = {
+        "name": segment.name,
+        "project": project.id,
+        "rules": [
+            {
+                "id": segment_rule.id,
+                "type": segment_rule.type,
+                "rules": [
+                    {
+                        "id": nested_rule.id,
+                        "type": nested_rule.type,
+                        "rules": [],
+                        "conditions": [
+                            {
+                                "id": existing_condition.id,
+                                "property": existing_condition.property,
+                                "operator": existing_condition.operator,
+                                "value": existing_condition.value,
+                                "delete": True,
+                            },
+                        ],
+                    }
+                ],
+                "conditions": [],
+            }
+        ],
+    }
+
+    # When
+    response = client.put(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    assert nested_rule.conditions.count() == 0
+
+
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
+def test_update_segment_delete_existing_rule(project, client, segment, segment_rule):
+    # Given
+    url = reverse(
+        "api-v1:projects:project-segments-detail", args=[project.id, segment.id]
+    )
+    nested_rule = SegmentRule.objects.create(
+        rule=segment_rule, type=SegmentRule.ANY_RULE
+    )
+
+    data = {
+        "name": segment.name,
+        "project": project.id,
+        "rules": [
+            {
+                "id": segment_rule.id,
+                "type": segment_rule.type,
+                "rules": [
+                    {
+                        "id": nested_rule.id,
+                        "type": nested_rule.type,
+                        "rules": [],
+                        "conditions": [],
+                    }
+                ],
+                "conditions": [],
+                "delete": True,
+            }
+        ],
+    }
+
+    # When
+    response = client.put(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    assert segment_rule.conditions.count() == 0

--- a/api/tests/unit/segments/test_unit_segments_models.py
+++ b/api/tests/unit/segments/test_unit_segments_models.py
@@ -1,4 +1,12 @@
-from segments.models import EQUAL, PERCENTAGE_SPLIT, Condition
+import pytest
+
+from segments.models import (
+    EQUAL,
+    PERCENTAGE_SPLIT,
+    Condition,
+    Segment,
+    SegmentRule,
+)
 
 
 def test_percentage_split_calculation_divides_value_by_100_before_comparison(
@@ -123,3 +131,46 @@ def test_condition_get_update_log_message(segment, segment_rule, mocker):
 
     # Then
     assert msg == f"Condition updated on segment '{segment.name}'."
+
+
+@pytest.mark.parametrize(
+    "rules_data, expected_result",
+    (
+        (
+            [{"id": 1, "rules": [], "conditions": [], "type": SegmentRule.ALL_RULE}],
+            True,
+        ),
+        ([{"rules": [], "conditions": [], "type": SegmentRule.ALL_RULE}], False),
+        (
+            [
+                {
+                    "rules": [
+                        {
+                            "id": 1,
+                            "rules": [],
+                            "conditions": [],
+                            "type": SegmentRule.ALL_RULE,
+                        }
+                    ],
+                    "conditions": [],
+                    "type": SegmentRule.ALL_RULE,
+                }
+            ],
+            True,
+        ),
+        (
+            [
+                {
+                    "rules": [],
+                    "conditions": [
+                        {"id": 1, "property": "foo", "operator": EQUAL, "value": "bar"}
+                    ],
+                    "type": SegmentRule.ALL_RULE,
+                }
+            ],
+            True,
+        ),
+    ),
+)
+def test_segment_id_exists_in_rules_data(rules_data, expected_result):
+    assert Segment.id_exists_in_rules_data(rules_data) == expected_result


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

NOTE: This should not be merged until the FE has completed their work. 

### Current issue

When updating the rules / conditions for a segment, currently, we rely on removing all the current rules / segments and then creating new ones based on the data that is sent up by the frontend. 

### Solution

Return the `"id"` attribute on the rules and segments so that the FE can pass them up and we will update them in place. 

### Caveats

 * Although the Flagsmith frontend works for update without any changes as it automatically includes the id in the PUT request that it now gets from the GET request I've added some logic to verify if there are any `"id"` attributes in the data. If there aren't, then I've maintained the previous behaviour (which will end up in more AuditLog records than expected but at least doesn't break the API). 
 * I've added a new (non-model) field to the Rule and Condition serializers which allows the frontend to mark them for deletion. The alternative was to create endpoints to delete Rules and Conditions by ID but this would be trickier from the FE point of view. 

## How did you test this code?

Added tests. 
