### PR TITLE
Fix "digital envelope routines::unsupported"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "animejs": "3.0.1",
         "array-find-index": "^1.0.2",
         "babel-eslint": "10.0.1",
-        "babel-loader": "8.2.5",
+        "babel-loader": "8.3.0",
         "babel-plugin-module-resolver": "^4.1.0",
         "babel-plugin-transform-object-rest-spread": "7.0.0-beta.3",
         "babel-plugin-transform-react-remove-prop-types": "0.4.18",
@@ -4354,9 +4354,9 @@
       }
     },
     "node_modules/babel-loader": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-      "integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+      "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
       "dependencies": {
         "find-cache-dir": "^3.3.1",
         "loader-utils": "^2.0.0",
@@ -21307,9 +21307,9 @@
       }
     },
     "babel-loader": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-      "integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+      "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
       "requires": {
         "find-cache-dir": "^3.3.1",
         "loader-utils": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "animejs": "3.0.1",
     "array-find-index": "^1.0.2",
     "babel-eslint": "10.0.1",
-    "babel-loader": "8.2.5",
+    "babel-loader": "8.3.0",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-plugin-transform-object-rest-spread": "7.0.0-beta.3",
     "babel-plugin-transform-react-remove-prop-types": "0.4.18",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Update babel-loader, should solve [https://github.com/Flagsmith/flagsmith/actions/runs/4211899953/jobs/7310632390#step:3:114](https://github.com/Flagsmith/flagsmith/actions/runs/4211899953/jobs/7310632390#step:3:150)