### PR TITLE
Use generic action for running E2E tests against production

### DIFF
--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -22,22 +22,14 @@ jobs:
             - name: Cloning repo
               uses: actions/checkout@v3
               with:
-                  fetch-depth: 0
+                fetch-depth: 0
 
-            - name: Run E2E Tests
-              env:
-                  E2E_TEST_TOKEN_PROD: ${{ secrets.E2E_TEST_TOKEN }}
-                  ENV: prod
-                  SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-                  STATIC_ASSET_CDN_URL: /
-              run: |
-                  wget -q ${{ secrets.CHROME_URL }}
-                  sudo apt install --allow-downgrades -y ./google-chrome*.deb -f
-                  google-chrome --version
-                  node -v
-                  npm i
-                  npm run env
-                  npm run test
+            - name: Run E2E tests against production
+              uses: ./.github/actions/e2e-tests
+              with:
+                e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
+                slack_token: ${{ secrets.SLACK_TOKEN }}
+                environment: prod
 
     deploy-production:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Use the reusable action for running E2E tests against production before deploying the frontend. 

## How did you test this code?

I haven't but the E2E tests passed in the API deploy production workflow [here](https://github.com/Flagsmith/flagsmith/actions/runs/4222891675) but failed in the frontend deploy production workflow [here](https://github.com/Flagsmith/flagsmith/actions/runs/4222692817/jobs/7332180571), indicating that this change should work. 
