### PR TITLE
improvement/include-flag-analytics-in-sentry-sampling

### DIFF
--- a/api/integrations/sentry/samplers.py
+++ b/api/integrations/sentry/samplers.py
@@ -9,6 +9,7 @@ SDK_ENDPOINTS = (
     "/api/v1/traits",
     "/api/v1/traits/bulk",
     "/api/v1/environment-document",
+    "/api/v1/analytics/flags",
 )
 
 


### PR DESCRIPTION
Currently hitting the Sentry API with a lot of requests that are not sampled