### PR TITLE
Chores/fix datadog widget

### DIFF
--- a/frontend/common/stores/project-store.js
+++ b/frontend/common/stores/project-store.js
@@ -1,8 +1,9 @@
+import { getIsWidget } from '../../web/components/pages/WidgetPage';
+
 const BaseStore = require('./base/_store');
 const OrganisationStore = require('./organisation-store');
 
 const data = require('../data/base/_data');
-const { getIsWidget } = require("../../web/components/pages/WidgetPage");
 
 const controller = {
 
@@ -32,7 +33,7 @@ const controller = {
                     cb();
                 }
             }).catch(() => {
-                if(!getIsWidget()) {
+                if (!getIsWidget()) {
                     document.location.href = '/404?entity=project';
                 }
             });
@@ -54,7 +55,7 @@ const controller = {
                     cb();
                 }
             }).catch(() => {
-                if(!getIsWidget()) {
+                if (!getIsWidget()) {
                     document.location.href = '/404?entity=project';
                 }
             });

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -112,7 +112,7 @@ class TheComponent extends Component {
         return (
             <Row
               style={{ flexWrap: 'nowrap' }}
-              className={`list-item clickable ${this.props.widget?"py-1":"py-2"}`} key={id} space
+              className={`list-item ${readOnly?"":"clickable"} ${this.props.widget?"py-1":"py-2"}`} key={id} space
               data-test={`feature-item-${this.props.index}`}
             >
                 <div
@@ -121,7 +121,7 @@ class TheComponent extends Component {
                 >
                     <div>
                         <Row>
-                            <ButtonLink className="mr-2">
+                            <ButtonLink className={`mr-2 ${readOnly?"cursor-default":""}`}>
                                 {name}
                             </ButtonLink>
                             {projectFlag.owners && !!projectFlag.owners.length ? (

--- a/frontend/web/components/pages/WidgetPage.tsx
+++ b/frontend/web/components/pages/WidgetPage.tsx
@@ -3,15 +3,16 @@ import TagSelect from '../TagSelect';
 import TagStore from '../../../common/stores/tags-store';
 import {Tag} from '../AddEditTags';
 import FeatureRow from '../FeatureRow';
-import FeatureListStore from '../../../common/stores/feature-list-store';
-import ProjectStore from '../../../common/stores/project-store';
+import FeatureListStore from 'common/stores/feature-list-store';
+import ProjectStore from 'common/stores/project-store';
 import {useCustomWidgetOptionString} from '@datadog/ui-extensions-react';
 import client from "../datadog-client";
-import NavIconSmall from '../svg/NavIconSmall';
 import AuditLog from "../AuditLog";
 import {getStore} from "../../../common/store";
 import {Provider} from 'react-redux';
 import OrgEnvironmentSelect from "../OrgEnvironmentSelect";
+import { resolveAuthFlow } from '@datadog/ui-extensions-sdk';
+import InfoMessage from '../InfoMessage';
 let isWidget = false;
 export const getIsWidget = ()=> {
     return isWidget;
@@ -22,6 +23,13 @@ type FeatureListType = {
     environmentId: string
     pageSize: number
     hideTags: boolean
+}
+
+
+const PermissionError = ()=> {
+    return <InfoMessage>
+        Please check you have access to the project and environment within the widget settings.
+    </InfoMessage>
 }
 
 const FeatureList = class extends Component<FeatureListType> {
@@ -55,13 +63,6 @@ const FeatureList = class extends Component<FeatureListType> {
         }
     }
 
-    componentWillUnmount() {
-        document.body.classList.remove("widget-mode")
-    }
-    componentWillUnmount() {
-        document.body.classList.add("widget-mode")
-    }
-
     componentDidMount = () => {
         API.trackPage(Constants.pages.FEATURES);
         this.getTags(this.props.projectId);
@@ -82,7 +83,7 @@ const FeatureList = class extends Component<FeatureListType> {
 
     onError = (error) => {
         // Kick user back out to projects
-        this.setState({ error });
+        this.setState({ error: true });
         if (typeof closeModal !== 'undefined') {
             closeModal();
             toast('We could not create this feature, please check the name is not in use.');
@@ -106,12 +107,14 @@ const FeatureList = class extends Component<FeatureListType> {
         const { projectId, environmentId } = this.props;
         const readOnly = Utils.getFlagsmithHasFeature('read_only_mode');
         const environment = ProjectStore.getEnvironment(environmentId);
-
+        const error = this.state.error
         return (
             <div className="widget-container" data-test="features-page" id="features-page">
                 <FeatureListProvider onSave={this.onSave} onError={this.onError}>
-                    {({ projectFlags, environmentFlags }, { toggleFlag, removeFlag }) => {
-                        const isLoading = FeatureListStore.isLoading;
+                    {({ projectFlags, environmentFlags, isLoading }, { toggleFlag, editFlag, removeFlag }) => {
+                        if(error){
+                            return <PermissionError/>
+                        }
                         return (
                             <div>
                                 {isLoading && (!projectFlags || !projectFlags.length) && <div className="centered-container"><Loader/></div>}
@@ -224,6 +227,9 @@ const FeatureList = class extends Component<FeatureListType> {
 
 
 export default function Widget() {
+    useEffect(()=>{
+        document.body.classList.add("widget-mode")
+    },[])
     const projectId = useCustomWidgetOptionString(client, 'Project');
     const environmentId = useCustomWidgetOptionString(client, 'Environment');
     const pageSize = useCustomWidgetOptionString(client, 'PageSize') || "5";
@@ -231,6 +237,9 @@ export default function Widget() {
     const isAudit = id === "flagsmith_audit_widget";
     const hideTags = useCustomWidgetOptionString(client, 'HideTags') === "Yes";
     if (!API.getCookie("t")) {
+        resolveAuthFlow({
+            isAuthenticated: false,
+        });
         return null
     }
     const [error, setError] = useState<string|null>(null);

--- a/frontend/web/styles/components/_switch.scss
+++ b/frontend/web/styles/components/_switch.scss
@@ -242,3 +242,14 @@ $switch-width: 55px;
     transform: scale(1);
   }
 }
+
+.widget-mode {
+  .rc-switch {
+    cursor: default;
+    opacity: 1;
+    @extend .rc-switch;
+    &.rc-switch-checked {
+      @extend .rc-switch-checked;
+    }
+  }
+}

--- a/frontend/web/styles/styles.scss
+++ b/frontend/web/styles/styles.scss
@@ -70,6 +70,9 @@ bold, strong {
 .cursor-pointer {
   cursor: pointer;
 }
+.cursor-default {
+  cursor: default;
+}
 
 .gif {
   position: relative;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

- Fixes a regression that was crashing the Datadog widget
- Makes the readonly appearance of feature flags less like disabled in widget mode
- Made the cursor default when rendering a readonly flag
- If the user gets logged out, redirect them to the Datadog auth view
- Display a readable error when trying to use a project and environment you do not have access to / is invalid
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/8608314/220915268-07c04407-b418-4f4e-b33b-f8856bdb58a4.png">


## How did you test this code?

Ran the widget

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/8608314/220914882-8a6c8d57-ab4e-47c3-a85a-ad0e1532c2f9.png">
