### PR TITLE
Return identity / segment override numbers on the feature list endpoint

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -140,6 +140,13 @@ def identity(environment):
 
 
 @pytest.fixture()
+def identity_featurestate(identity, feature):
+    return FeatureState.objects.create(
+        identity=identity, feature=feature, environment=identity.environment
+    )
+
+
+@pytest.fixture()
 def trait(identity):
     return Trait.objects.create(
         identity=identity, trait_key=trait_key, string_value=trait_value

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -7,7 +7,7 @@ from core.constants import FLAGSMITH_UPDATED_AT_HEADER
 from core.permissions import HasMasterAPIKey
 from django.conf import settings
 from django.core.cache import caches
-from django.db.models import Q, QuerySet
+from django.db.models import Count, Q, QuerySet
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from drf_yasg2 import openapi
@@ -123,6 +123,28 @@ class FeatureViewSet(viewsets.ModelViewSet):
 
         queryset = self._filter_queryset(queryset)
 
+        if self.action == "list" and "environment" in self.request.query_params:
+            environment_id = self.request.query_params["environment"]
+            queryset = queryset.annotate(
+                num_segment_overrides=Count(
+                    "feature_states",
+                    Q(
+                        feature_states__feature_segment__isnull=False,
+                        feature_states__environment_id=environment_id,
+                    ),
+                ),
+            )
+            if not project.enable_dynamo_db:
+                queryset = queryset.annotate(
+                    num_identity_overrides=Count(
+                        "feature_states",
+                        Q(
+                            feature_states__identity__isnull=False,
+                            feature_states__environment_id=environment_id,
+                        ),
+                    ),
+                )
+
         sort = "%s%s" % (
             "-" if query_data["sort_direction"] == "DESC" else "",
             query_data["sort_field"],
@@ -155,6 +177,7 @@ class FeatureViewSet(viewsets.ModelViewSet):
                 ),
                 user=self.request.user,
             )
+        context["environment_id"] = self.request.query_params.get("environment")
         return context
 
     @swagger_auto_schema(

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -177,7 +177,6 @@ class FeatureViewSet(viewsets.ModelViewSet):
                 ),
                 user=self.request.user,
             )
-        context["environment_id"] = self.request.query_params.get("environment")
         return context
 
     @swagger_auto_schema(

--- a/api/tests/unit/conftest.py
+++ b/api/tests/unit/conftest.py
@@ -117,10 +117,10 @@ def master_api_key_client(master_api_key):
 
 
 @pytest.fixture()
-def dynamo_enabled_project(organisation_one):
+def dynamo_enabled_project(organisation):
     return Project.objects.create(
         name="Dynamo enabled project",
-        organisation=organisation_one,
+        organisation=organisation,
         enable_dynamo_db=True,
     )
 

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -699,3 +699,34 @@ def test_create_segment_overrides_creates_correct_audit_log_messages(
         ).count()
         == 1
     )
+
+
+# @pytest.mark.parametrize(
+#     "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+# )
+def test_list_features_provides_information_on_number_of_overrides(
+    feature,
+    segment,
+    segment_featurestate,
+    identity,
+    identity_featurestate,
+    project,
+    environment,
+    admin_client,
+):
+    # Given
+    url = "%s?environment=%d" % (
+        reverse("api-v1:projects:project-features-list", args=[project.id]),
+        environment.id,
+    )
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    response_json = response.json()
+    assert response_json["count"] == 1
+    assert response_json["results"][0]["num_segment_overrides"] == 1
+    assert response_json["results"][0]["num_identity_overrides"] == 1

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -732,8 +732,11 @@ def test_list_features_provides_information_on_number_of_overrides(
     assert response_json["results"][0]["num_identity_overrides"] == 1
 
 
+@pytest.mark.parametrize(
+    "client", [lazy_fixture("master_api_key_client"), lazy_fixture("admin_client")]
+)
 def test_list_features_provides_segment_overrides_for_dynamo_enabled_project(
-    dynamo_enabled_project, dynamo_enabled_project_environment_one, admin_client
+    dynamo_enabled_project, dynamo_enabled_project_environment_one, client
 ):
     # Given
     feature = Feature.objects.create(
@@ -760,7 +763,7 @@ def test_list_features_provides_segment_overrides_for_dynamo_enabled_project(
     )
 
     # When
-    response = admin_client.get(url)
+    response = client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Changes

Adds 2 new parameters to the list features endpoint to provide the number of identity / segment overrides for that feature in a given environment. 

## How did you test this code?

Added a unit test. 
