### PR TITLE
Pipedrive qol tweaks

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -826,9 +826,17 @@ PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY = env.str(
 )
 PIPEDRIVE_IGNORE_DOMAINS = env.list(
     "PIPEDRIVE_IGNORE_DOMAINS",
-    ["solidstategroup.com", "flagsmith.com", "bullet-train.io", "restmail.net"],
+    [
+        "gmail.com",
+        "googlemail.com",
+        "outlook.com",
+        "hotmail.com",
+        "icloud.com",
+        "me.com",
+        "aol.com",
+    ],
 )
-PIPEDRIVE_IGNORE_DOMAINS_REGEX = env("PIPEDRIVE_IGNORE_DOMAINS_REGEX", None)
+PIPEDRIVE_IGNORE_DOMAINS_REGEX = env("PIPEDRIVE_IGNORE_DOMAINS_REGEX", r"^yahoo\..*$")
 
 # List of plan ids that support seat upgrades
 AUTO_SEAT_UPGRADE_PLANS = env.list("AUTO_SEAT_UPGRADE_PLANS", default=[])

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -803,7 +803,6 @@ TASK_RUN_METHOD = env.enum(
 ENABLE_TASK_PROCESSOR_HEALTH_CHECK = env.bool(
     "ENABLE_TASK_PROCESSOR_HEALTH_CHECK", default=False
 )
-DISABLE_TASK_PROCESSOR = False  # used to disable task processor in tests
 
 # Real time(server sent events) settings
 SSE_SERVER_BASE_URL = env.str("SSE_SERVER_BASE_URL", None)

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -803,6 +803,7 @@ TASK_RUN_METHOD = env.enum(
 ENABLE_TASK_PROCESSOR_HEALTH_CHECK = env.bool(
     "ENABLE_TASK_PROCESSOR_HEALTH_CHECK", default=False
 )
+DISABLE_TASK_PROCESSOR = False  # used to disable task processor in tests
 
 # Real time(server sent events) settings
 SSE_SERVER_BASE_URL = env.str("SSE_SERVER_BASE_URL", None)
@@ -827,6 +828,7 @@ PIPEDRIVE_IGNORE_DOMAINS = env.list(
     "PIPEDRIVE_IGNORE_DOMAINS",
     ["solidstategroup.com", "flagsmith.com", "bullet-train.io", "restmail.net"],
 )
+PIPEDRIVE_IGNORE_DOMAINS_REGEX = env("PIPEDRIVE_IGNORE_DOMAINS_REGEX", None)
 
 # List of plan ids that support seat upgrades
 AUTO_SEAT_UPGRADE_PLANS = env.list("AUTO_SEAT_UPGRADE_PLANS", default=[])

--- a/api/integrations/lead_tracking/lead_tracking.py
+++ b/api/integrations/lead_tracking/lead_tracking.py
@@ -8,6 +8,11 @@ class LeadTracker(abc.ABC):
     def __init__(self, client: typing.Any = None):
         self.client = client or self._get_client()
 
+    @staticmethod
+    @abc.abstractmethod
+    def should_track(user: FFAdminUser) -> bool:
+        pass
+
     @abc.abstractmethod
     def create_lead(self, user: FFAdminUser):
         pass

--- a/api/integrations/lead_tracking/lead_tracking.py
+++ b/api/integrations/lead_tracking/lead_tracking.py
@@ -11,7 +11,7 @@ class LeadTracker(abc.ABC):
     @staticmethod
     @abc.abstractmethod
     def should_track(user: FFAdminUser) -> bool:
-        pass
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def create_lead(self, user: FFAdminUser):

--- a/api/integrations/lead_tracking/pipedrive/client.py
+++ b/api/integrations/lead_tracking/pipedrive/client.py
@@ -8,6 +8,7 @@ from integrations.lead_tracking.pipedrive.models import (
     PipedriveLead,
     PipedriveOrganization,
     PipedriveOrganizationField,
+    PipedrivePerson,
 )
 
 
@@ -72,19 +73,33 @@ class PipedriveAPIClient:
         self,
         title: str,
         organization_id: int,
+        person_id: int = None,
         custom_fields: typing.Dict[str, typing.Any] = None,
     ) -> PipedriveLead:
+        data = {
+            "title": title,
+            "organization_id": organization_id,
+            **(custom_fields or {}),
+        }
+        if person_id:
+            data["person_id"] = person_id
+
         api_response_data = self._make_request(
-            resource="leads",
+            resource="leads", http_method="post", data=data, expected_status_code=201
+        )
+        return PipedriveLead.from_response_data(api_response_data)
+
+    def create_person(self, name: str, email: str) -> PipedrivePerson:
+        api_response_data = self._make_request(
+            resource="persons",
             http_method="post",
             data={
-                "title": title,
-                "organization_id": organization_id,
-                **(custom_fields or {}),
+                "name": name,
+                "email": email,
             },
             expected_status_code=201,
         )
-        return PipedriveLead.from_response_data(api_response_data)
+        return PipedrivePerson.from_response_data(api_response_data)
 
     def _make_request(
         self,

--- a/api/integrations/lead_tracking/pipedrive/lead_tracker.py
+++ b/api/integrations/lead_tracking/pipedrive/lead_tracker.py
@@ -23,9 +23,7 @@ except ImportError:
 class PipedriveLeadTracker(LeadTracker):
     @staticmethod
     def should_track(user: FFAdminUser):
-        if not (
-            settings.PIPEDRIVE_API_TOKEN and settings.ENABLE_PIPEDRIVE_LEAD_TRACKING
-        ):
+        if not settings.ENABLE_PIPEDRIVE_LEAD_TRACKING:
             return False
 
         domain = user.email_domain

--- a/api/integrations/lead_tracking/pipedrive/lead_tracker.py
+++ b/api/integrations/lead_tracking/pipedrive/lead_tracker.py
@@ -60,9 +60,12 @@ class PipedriveLeadTracker(LeadTracker):
             )
             raise e
 
+        person = self.client.create_person(name=user.full_name, email=user.email)
+
         create_lead_kwargs = {
             "title": user.email,
             "organization_id": organization.id,
+            "person_id": person.id,
             "custom_fields": {},
         }
         if user.sign_up_type:

--- a/api/integrations/lead_tracking/pipedrive/models.py
+++ b/api/integrations/lead_tracking/pipedrive/models.py
@@ -7,6 +7,7 @@ from integrations.lead_tracking.pipedrive.schemas import (
     BasePipedriveCustomFieldSchema,
     PipedriveLeadSchema,
     PipedriveOrganizationSchema,
+    PipedrivePersonSchema,
     PipedriveValueSchema,
 )
 
@@ -111,3 +112,11 @@ class PipedriveOrganizationField(BasePipedriveCustomField):
 
 class PipedriveDealField(BasePipedriveCustomField):
     pass
+
+
+class PipedrivePerson(BasePipedriveModel):
+    schema = PipedrivePersonSchema()
+
+    def __init__(self, name: str, id: int = None):
+        self.name = name
+        self.id = id

--- a/api/integrations/lead_tracking/pipedrive/schemas.py
+++ b/api/integrations/lead_tracking/pipedrive/schemas.py
@@ -36,3 +36,8 @@ class BasePipedriveCustomFieldSchema(BaseSchema):
     name = fields.Str()
     field_type = fields.Str()
     add_visible_flag = fields.Bool()
+
+
+class PipedrivePersonSchema(BaseSchema):
+    name = fields.Str()
+    id = fields.Int()

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -30,6 +30,9 @@ def register_task_handler(task_name: str = None):
             args: typing.Tuple = (),
             kwargs: typing.Dict = None,
         ) -> typing.Optional[Task]:
+            if settings.DISABLE_TASK_PROCESSOR:
+                return
+
             logger.debug("Request to run task '%s' asynchronously.", task_identifier)
 
             kwargs = kwargs or dict()

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -30,9 +30,6 @@ def register_task_handler(task_name: str = None):
             args: typing.Tuple = (),
             kwargs: typing.Dict = None,
         ) -> typing.Optional[Task]:
-            if settings.DISABLE_TASK_PROCESSOR:
-                return
-
             logger.debug("Request to run task '%s' asynchronously.", task_identifier)
 
             kwargs = kwargs or dict()

--- a/api/tests/unit/integrations/lead_tracking/pipedrive/example_api_responses/create_person.json
+++ b/api/tests/unit/integrations/lead_tracking/pipedrive/example_api_responses/create_person.json
@@ -1,0 +1,98 @@
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "company_id": 1,
+    "owner_id": {
+      "id": 1,
+      "name": "Johnny Bravo",
+      "email": "johnny.bravo@testing.com",
+      "has_pic": 0,
+      "pic_hash": null,
+      "active_flag": true,
+      "value": 1
+    },
+    "org_id": null,
+    "name": "Yogi Bear",
+    "first_name": "Yogi",
+    "last_name": "Bear",
+    "open_deals_count": 0,
+    "related_open_deals_count": 0,
+    "closed_deals_count": 0,
+    "related_closed_deals_count": 0,
+    "participant_open_deals_count": 0,
+    "participant_closed_deals_count": 0,
+    "email_messages_count": 0,
+    "activities_count": 0,
+    "done_activities_count": 0,
+    "undone_activities_count": 0,
+    "files_count": 0,
+    "notes_count": 0,
+    "followers_count": 0,
+    "won_deals_count": 0,
+    "related_won_deals_count": 0,
+    "lost_deals_count": 0,
+    "related_lost_deals_count": 0,
+    "active_flag": true,
+    "phone": [
+      {
+        "value": "",
+        "primary": true
+      }
+    ],
+    "email": [
+      {
+        "label": "",
+        "value": "yogi.bear@testing.com",
+        "primary": true
+      }
+    ],
+    "first_char": "y",
+    "update_time": "2023-03-01 17:01:28",
+    "delete_time": null,
+    "add_time": "2023-03-01 17:01:28",
+    "visible_to": "3",
+    "picture_id": null,
+    "next_activity_date": null,
+    "next_activity_time": null,
+    "next_activity_id": null,
+    "last_activity_id": null,
+    "last_activity_date": null,
+    "last_incoming_mail_time": null,
+    "last_outgoing_mail_time": null,
+    "label": null,
+    "org_name": null,
+    "cc_email": "johnnybravo@pipedrivemail.com",
+    "primary_email": "yogi.bear@testing.com",
+    "owner_name": "Johnny Bravo",
+    "48ce4c9eda91f7dd0686311da7d9de760f36412c": null,
+    "c969dcba47bfbf0d1ebdc7725585fa5923d86289": null,
+    "139c0597b60ff87b43fbf8a161c711fe271d840b": null,
+    "59b8dfd809153b4c8d907a43d4267382af527b0d": null,
+    "42ed554baed97917838f615a89d0bb1b95f92664": null,
+    "719adb6116ae3940aabb2cc27c856b36c7ea20f7": null,
+    "3b8ae6152f631d9097f20bfccf84ace0c0aa30dd": null,
+    "adb724817541a261deb317be9713a27cd05c731f": null,
+    "5f8b3dab1eb64632d5f53f6dd6722603133854b9": null,
+    "7480d49272ba86fe23623761907fb61a493ff55d": null,
+    "04acbb84aca70fcf3197d34872347dbd261971bd": null,
+    "44093b7190dc9fab58420b2aae010d968f87669d": null,
+    "2f9d60ffac95d6416cfac3481ec6319fe36a7413": null,
+    "7b273efc901d979329db2529438a5ab11d28c3df": null,
+    "aada9a1b320aae2a0c3acfec9b76f4903a81233a": null,
+    "54f35043438c589847bef00866adcb6a427b2fc2": null,
+    "76289b0ef12853c348615ce1fc2c5c06db23d842": null
+  },
+  "related_objects": {
+    "user": {
+      "13603501": {
+        "id": 13603501,
+        "name": "Johnny Bravo",
+        "email": "johnny.bravo@testing.com",
+        "has_pic": 0,
+        "pic_hash": null,
+        "active_flag": true
+      }
+    }
+  }
+}

--- a/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_client.py
+++ b/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_client.py
@@ -191,3 +191,41 @@ def test_pipedrive_api_client_create_deal_field(
 
     assert organization_field.key == deal_field_key
     assert organization_field.name == deal_field_name
+
+
+@responses.activate
+def test_pipedrive_api_client_create_person(
+    pipedrive_api_client, pipedrive_base_url, pipedrive_api_token
+):
+    # Given
+    example_response_file_name = join(
+        dirname(abspath(__file__)), "example_api_responses/create_person.json"
+    )
+
+    # obtained from file above, duplicated here to simplfiy test
+    person_name = "Yogi Bear"
+    person_email = "yogi.bear@testing.com"
+    person_id = 1
+
+    with open(example_response_file_name) as f:
+        responses.add(
+            method=responses.POST,
+            url=f"{pipedrive_base_url}/persons",
+            json=json.load(f),
+            status=201,
+        )
+
+    # When
+    person = pipedrive_api_client.create_person(name=person_name, email=person_email)
+
+    # Then
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert call.request.params["api_token"] == pipedrive_api_token
+
+    json_request_body = json.loads(call.request.body)
+    assert json_request_body["name"] == person_name
+    assert json_request_body["email"] == person_email
+
+    assert person.name == person_name
+    assert person.id == person_id

--- a/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_lead_tracker.py
+++ b/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_lead_tracker.py
@@ -6,7 +6,10 @@ from integrations.lead_tracking.pipedrive.exceptions import (
 from integrations.lead_tracking.pipedrive.lead_tracker import (
     PipedriveLeadTracker,
 )
-from integrations.lead_tracking.pipedrive.models import PipedriveOrganization
+from integrations.lead_tracking.pipedrive.models import (
+    PipedriveOrganization,
+    PipedrivePerson,
+)
 from users.models import FFAdminUser, SignUpType
 
 
@@ -21,6 +24,9 @@ def test_create_lead_adds_to_existing_organization_if_exists(db, mocker, setting
     mock_pipedrive_client = mocker.MagicMock()
     mock_pipedrive_client.search_organizations.return_value = [organization]
 
+    person = PipedrivePerson(id=1, name="Elmer Fudd")
+    mock_pipedrive_client.create_person.return_value = person
+
     lead_tracker = PipedriveLeadTracker(client=mock_pipedrive_client)
 
     # When
@@ -33,6 +39,7 @@ def test_create_lead_adds_to_existing_organization_if_exists(db, mocker, setting
         "custom_fields": {
             settings.PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY: SignUpType.NO_INVITE.value
         },
+        "person_id": person.id,
     }
     mock_pipedrive_client.create_lead.assert_called_once_with(
         **expected_create_lead_kwargs
@@ -55,6 +62,9 @@ def test_create_lead_creates_new_organization_if_not_exists(db, settings, mocker
     mock_pipedrive_client.search_organizations.return_value = []
     mock_pipedrive_client.create_organization.return_value = organization
 
+    person = PipedrivePerson(id=1, name="Elmer Fudd")
+    mock_pipedrive_client.create_person.return_value = person
+
     lead_tracker = PipedriveLeadTracker(client=mock_pipedrive_client)
 
     # When
@@ -67,6 +77,7 @@ def test_create_lead_creates_new_organization_if_not_exists(db, settings, mocker
         "custom_fields": {
             settings.PIPEDRIVE_SIGN_UP_TYPE_DEAL_FIELD_KEY: SignUpType.NO_INVITE.value
         },
+        "person_id": person.id,
     }
     mock_pipedrive_client.create_lead.assert_called_once_with(
         **expected_create_lead_kwargs

--- a/api/tests/unit/users/test_unit_users_signals.py
+++ b/api/tests/unit/users/test_unit_users_signals.py
@@ -2,14 +2,15 @@ from users.models import FFAdminUser
 from users.signals import create_pipedrive_lead_signal
 
 
-def test_create_pipedrive_lead_signal_calls_task_if_user_created(mocker, settings):
+def test_create_pipedrive_lead_signal_calls_task_if_user_created(
+    mocker, settings, django_user_model
+):
     # Given
     mocked_create_pipedrive_lead = mocker.patch("users.signals.create_pipedrive_lead")
-    user = mocker.MagicMock()
-    settings.PIPEDRIVE_API_TOKEN = "some-token"
+    settings.ENABLE_PIPEDRIVE_LEAD_TRACKING = True
 
     # When
-    create_pipedrive_lead_signal(FFAdminUser, instance=user, created=True)
+    user = django_user_model.objects.create(email="test@example.com")
 
     # Then
     mocked_create_pipedrive_lead.delay.assert_called_once_with(args=(user.id,))

--- a/api/users/signals.py
+++ b/api/users/signals.py
@@ -5,6 +5,9 @@ from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 from django.urls import reverse
 
+from integrations.lead_tracking.pipedrive.lead_tracker import (
+    PipedriveLeadTracker,
+)
 from users.models import FFAdminUser
 from users.tasks import create_pipedrive_lead
 
@@ -22,15 +25,12 @@ def warn_insecure(sender, **kwargs):
 
 @receiver(post_save, sender=FFAdminUser)
 def create_pipedrive_lead_signal(sender, instance, created, **kwargs):
-    if (
-        not (
-            created
-            and (
-                settings.PIPEDRIVE_API_TOKEN or settings.ENABLE_PIPEDRIVE_LEAD_TRACKING
-            )
-        )
-        or instance.email_domain in settings.PIPEDRIVE_IGNORE_DOMAINS
-    ):
+    user: FFAdminUser = instance
+
+    if not (
+        created
+        and (settings.PIPEDRIVE_API_TOKEN or settings.ENABLE_PIPEDRIVE_LEAD_TRACKING)
+    ) or not PipedriveLeadTracker.should_track(user):
         return
 
-    create_pipedrive_lead.delay(args=(instance.id,))
+    create_pipedrive_lead.delay(args=(user.id,))

--- a/api/users/signals.py
+++ b/api/users/signals.py
@@ -1,6 +1,5 @@
 import warnings
 
-from django.conf import settings
 from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 from django.urls import reverse
@@ -27,10 +26,7 @@ def warn_insecure(sender, **kwargs):
 def create_pipedrive_lead_signal(sender, instance, created, **kwargs):
     user: FFAdminUser = instance
 
-    if not (
-        created
-        and (settings.PIPEDRIVE_API_TOKEN or settings.ENABLE_PIPEDRIVE_LEAD_TRACKING)
-    ) or not PipedriveLeadTracker.should_track(user):
+    if not PipedriveLeadTracker.should_track(user):
         return
 
     create_pipedrive_lead.delay(args=(user.id,))

--- a/api/users/tasks.py
+++ b/api/users/tasks.py
@@ -4,18 +4,9 @@ from integrations.lead_tracking.pipedrive.lead_tracker import (
 from task_processor.decorators import register_task_handler
 from users.models import FFAdminUser
 
-_pipedrive = None
-
 
 @register_task_handler()
 def create_pipedrive_lead(user_id: int):
-    pipedrive = _get_pipedrive_lead_tracker()
+    pipedrive = PipedriveLeadTracker()
     user = FFAdminUser.objects.get(id=user_id)
     pipedrive.create_lead(user)
-
-
-def _get_pipedrive_lead_tracker():
-    global _pipedrive
-    if not _pipedrive:
-        _pipedrive = PipedriveLeadTracker()
-    return _pipedrive


### PR DESCRIPTION
## Changes

Updates the Pipedrive Lead Tracking to allow for blacklisting email domains via regex and prevents users that belong to a paid organisation from being tracked. 

Also adds new functionality to create a person to associate with the lead so that we have the first name / last name and email directly available on the lead. 

## How did you test this code?

Added unit tests.
