### PR TITLE
Remove deleted / old versions from overrides data

### DIFF
--- a/api/features/dataclasses.py
+++ b/api/features/dataclasses.py
@@ -1,0 +1,19 @@
+import typing
+from dataclasses import dataclass
+
+
+@dataclass
+class EnvironmentFeatureOverridesData:
+    """
+    Dataclass to hold the information about the number of overrides for a given feature in a given
+    environment.
+    """
+
+    num_segment_overrides: int = 0
+    num_identity_overrides: typing.Optional[int] = None
+
+    def add_identity_override(self):
+        if self.num_identity_overrides is None:
+            self.num_identity_overrides = 1
+        else:
+            self.num_identity_overrides += 1

--- a/api/features/dataclasses.py
+++ b/api/features/dataclasses.py
@@ -7,12 +7,20 @@ class EnvironmentFeatureOverridesData:
     """
     Dataclass to hold the information about the number of overrides for a given feature in a given
     environment.
+
+    Note that num_identity_overrides can be None to represent that the environment in question
+    is edge enabled (and hence we can't currently determine how many identity overrides there are).
     """
 
     num_segment_overrides: int = 0
     num_identity_overrides: typing.Optional[int] = None
 
     def add_identity_override(self):
+        """
+        Add an identity override to the dataclass.
+
+        This special method is here to simplify null checking logic.
+        """
         if self.num_identity_overrides is None:
             self.num_identity_overrides = 1
         else:

--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -184,10 +184,16 @@ class ListCreateFeatureSerializer(DeleteBeforeUpdateWritableNestedModelSerialize
         return attrs
 
     def get_num_segment_overrides(self, instance) -> int:
-        return getattr(instance, "num_segment_overrides", 0)
+        try:
+            return self.context["overrides_data"][instance.id].num_segment_overrides
+        except (KeyError, AttributeError):
+            return 0
 
     def get_num_identity_overrides(self, instance) -> typing.Optional[int]:
-        return getattr(instance, "num_identity_overrides", None)
+        try:
+            return self.context["overrides_data"][instance.id].num_identity_overrides
+        except (KeyError, AttributeError):
+            return None
 
 
 class UpdateFeatureSerializer(ListCreateFeatureSerializer):

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 
+from environments.identities.models import Identity
 from environments.models import Environment
 from features.models import Feature, FeatureSegment, FeatureState
 from features.workflows.core.models import ChangeRequest
@@ -323,6 +324,15 @@ def test_feature_get_overrides_data(
         environment=environment,
         feature_segment=feature_segment_for_feature_3,
     )
+
+    # and an override for another identity that has been deleted
+    another_identity = Identity.objects.create(
+        identifier="another-identity", environment=environment
+    )
+    fs_to_delete = FeatureState.objects.create(
+        feature=feature, environment=environment, identity=another_identity
+    )
+    fs_to_delete.delete()
 
     # When
     overrides_data = Feature.get_overrides_data(environment.id)

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -295,3 +295,44 @@ def test_feature_segment_update_priorities_when_changes(
             "master_api_key_id": mocked_request.master_api_key.id,
         }
     )
+
+
+def test_feature_get_overrides_data(
+    feature,
+    environment,
+    identity,
+    segment,
+    feature_segment,
+    identity_featurestate,
+    segment_featurestate,
+):
+    # Given
+    # we create some other features with overrides to ensure we're only getting data
+    # for each individual feature
+    feature_2 = Feature.objects.create(project=feature.project, name="feature_2")
+    FeatureState.objects.create(
+        feature=feature_2, environment=environment, identity=identity
+    )
+
+    feature_3 = Feature.objects.create(project=feature.project, name="feature_3")
+    feature_segment_for_feature_3 = FeatureSegment.objects.create(
+        feature=feature_3, segment=segment, environment=environment
+    )
+    FeatureState.objects.create(
+        feature=feature_3,
+        environment=environment,
+        feature_segment=feature_segment_for_feature_3,
+    )
+
+    # When
+    overrides_data = Feature.get_overrides_data(environment.id)
+
+    # Then
+    assert overrides_data[feature.id].num_identity_overrides == 1
+    assert overrides_data[feature.id].num_segment_overrides == 1
+
+    assert overrides_data[feature_2.id].num_identity_overrides == 1
+    assert overrides_data[feature_2.id].num_segment_overrides == 0
+
+    assert overrides_data[feature_3.id].num_identity_overrides is None
+    assert overrides_data[feature_3.id].num_segment_overrides == 1


### PR DESCRIPTION
## Changes

Fixes an issue with the logic for including segment / identity override information in the request to list features. Previously, the code did not account for deleted feature states or old versions (although the latter is unnecessary since we don't version segment / identity overrides yet). 

## How did you test this code?

Existing unit test + new test. 
