### PR TITLE
Prevent concurrent e2e tests against real environments

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -57,6 +57,9 @@ jobs:
         name: Run E2E Tests
         environment: production
         needs: deploy-production-ecs
+        concurrency:
+          group: e2e-tests-prod
+          cancel-in-progress: true
 
         steps:
             - name: Cloning repo

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -57,6 +57,9 @@ jobs:
         name: Run E2E Tests
         environment: staging
         needs: deploy-staging-ecs
+        concurrency:
+          group: e2e-tests-staging
+          cancel-in-progress: true
 
         steps:
             - name: Cloning repo

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -66,3 +66,25 @@ jobs:
                   LOG_LEVEL: "INFO"
               run: |
                   pytest -p no:warnings
+
+    run-tests:
+        runs-on: ubuntu-latest
+        name: Run E2E Tests
+        environment: staging
+        needs: deploy-staging-ecs
+        concurrency:
+          group: e2e-tests-staging
+          cancel-in-progress: true
+
+        steps:
+            - name: Cloning repo
+              uses: actions/checkout@v3
+              with:
+                fetch-depth: 0
+
+            - name: Run E2E tests against staging
+              uses: ./.github/actions/e2e-tests
+              with:
+                e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
+                slack_token: ${{ secrets.SLACK_TOKEN }}
+                environment: staging

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -67,7 +67,6 @@ jobs:
               run: |
                   pytest -p no:warnings
 
-    # dummy commit
     run-tests:
         runs-on: ubuntu-latest
         name: Run E2E Tests

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -66,24 +66,3 @@ jobs:
                   LOG_LEVEL: "INFO"
               run: |
                   pytest -p no:warnings
-
-    run-tests:
-        runs-on: ubuntu-latest
-        name: Run E2E Tests
-        environment: staging
-        concurrency:
-          group: e2e-tests-staging
-          cancel-in-progress: true
-
-        steps:
-            - name: Cloning repo
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 0
-
-            - name: Run E2E tests against staging
-              uses: ./.github/actions/e2e-tests
-              with:
-                e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
-                slack_token: ${{ secrets.SLACK_TOKEN }}
-                environment: staging

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -72,7 +72,6 @@ jobs:
         runs-on: ubuntu-latest
         name: Run E2E Tests
         environment: staging
-        needs: deploy-staging-ecs
         concurrency:
           group: e2e-tests-staging
           cancel-in-progress: true

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -67,6 +67,7 @@ jobs:
               run: |
                   pytest -p no:warnings
 
+    # dummy commit
     run-tests:
         runs-on: ubuntu-latest
         name: Run E2E Tests

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -17,6 +17,9 @@ jobs:
         runs-on: ubuntu-latest
         name: Run E2E Tests
         environment: production
+        concurrency:
+          group: e2e-tests-prod
+          cancel-in-progress: true
 
         steps:
             - name: Cloning repo


### PR DESCRIPTION
## Changes

Prevent concurrent runs of E2E tests against real environments (staging / production) to prevent collisions. 

## How did you test this code?

Added the staging E2E job to the api-pull-request workflow definition and pushed 2 separate commits to confirm that the earlier job was cancelled. 
