### PR TITLE
Stringify uuid

### DIFF
--- a/api/edge_api/identities/models.py
+++ b/api/edge_api/identities/models.py
@@ -168,7 +168,7 @@ class EdgeIdentity:
                     "identifier": self.identifier,
                     "user_id": getattr(user, "id", None),
                     "changes": changes,
-                    "identity_uuid": self.identity_uuid,
+                    "identity_uuid": str(self.identity_uuid),
                     "master_api_key_id": getattr(master_api_key, "id", None),
                 }
             )

--- a/api/tests/unit/edge_api/identities/test_edge_identity_models.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_models.py
@@ -253,7 +253,7 @@ def test_edge_identity_save_called_generate_audit_records_if_feature_override_ad
                     }
                 }
             },
-            "identity_uuid": edge_identity_model.identity_uuid,
+            "identity_uuid": str(edge_identity_model.identity_uuid),
             "master_api_key_id": None,
         }
     )
@@ -298,7 +298,7 @@ def test_edge_identity_save_called_generate_audit_records_if_feature_override_re
                     }
                 }
             },
-            "identity_uuid": edge_identity_model.identity_uuid,
+            "identity_uuid": str(edge_identity_model.identity_uuid),
             "master_api_key_id": None,
         }
     )
@@ -356,7 +356,7 @@ def test_edge_identity_save_called_generate_audit_records_if_feature_override_up
                     }
                 }
             },
-            "identity_uuid": edge_identity_model.identity_uuid,
+            "identity_uuid": str(edge_identity_model.identity_uuid),
             "master_api_key_id": None,
         }
     )


### PR DESCRIPTION
## Changes

Fixes error generating audit logs for edge identities because UUID is not JSON serializable. 

## How did you test this code?

Updating unit tests. 
