### PR TITLE
Trigger updated override audit if enabled OR value changes

### DIFF
--- a/api/edge_api/identities/models.py
+++ b/api/edge_api/identities/models.py
@@ -203,7 +203,7 @@ class EdgeIdentity:
                 )
             elif (
                 current_matching_fs.enabled != previous_fs.enabled
-                and current_matching_fs.get_value(self.id)
+                or current_matching_fs.get_value(self.id)
                 != previous_fs.get_value(self.id)
             ):
                 feature_changes[previous_fs.feature.name] = generate_change_dict(

--- a/api/tests/unit/edge_api/identities/test_edge_identity_models.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_models.py
@@ -304,13 +304,24 @@ def test_edge_identity_save_called_generate_audit_records_if_feature_override_re
     )
 
 
+@pytest.mark.parametrize(
+    "initial_enabled, initial_value, new_enabled, new_value",
+    (
+        (True, "initial", True, "updated"),
+        (False, "initial", True, "initial"),
+        (False, "initial", True, "updated"),
+    ),
+)
 def test_edge_identity_save_called_generate_audit_records_if_feature_override_updated(
-    mocker, edge_identity_model, edge_identity_dynamo_wrapper_mock
+    initial_enabled,
+    initial_value,
+    new_enabled,
+    new_value,
+    mocker,
+    edge_identity_model,
+    edge_identity_dynamo_wrapper_mock,
 ):
     # Given
-    initial_enabled = False
-    initial_value = "initial"
-
     mocked_generate_audit_log_records = mocker.patch(
         "edge_api.identities.models.generate_audit_log_records"
     )
@@ -327,9 +338,6 @@ def test_edge_identity_save_called_generate_audit_records_if_feature_override_up
     edge_identity_model.save(user=user)
     edge_identity_dynamo_wrapper_mock.reset_mock()
     mocked_generate_audit_log_records.reset_mock()
-
-    new_enabled = True
-    new_value = "updated"
 
     feature_override = edge_identity_model.get_feature_state_by_featurestate_uuid(
         feature_state_model.featurestate_uuid


### PR DESCRIPTION
## Changes

Fixes issue where update audit log record was not triggered if only enabled or value was changed (not both). 

## How did you test this code?

Added parametrized cases to the unit test. 
