### PR TITLE
Fix audit log messages not written for overrides

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -809,15 +809,15 @@ class FeatureState(
             # feature states
             return
 
-        if self.environment.created_date > self.feature.created_date:
-            # Don't create an audit log record for feature states created when
-            # creating an environment
-            return
-
         if self.identity_id:
             return audit_helpers.get_identity_override_created_audit_message(self)
         elif self.feature_segment_id:
             return audit_helpers.get_segment_override_created_audit_message(self)
+
+        if self.environment.created_date > self.feature.created_date:
+            # Don't create an audit log record for feature states created when
+            # creating an environment
+            return
 
         return audit_helpers.get_environment_feature_state_created_audit_message(self)
 

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -205,6 +205,24 @@ def test_feature_state_get_create_log_message_returns_null_if_environment_create
     assert log is None
 
 
+def test_feature_state_get_create_log_message_returns_value_if_environment_created_after_feature_for_override(
+    feature, mocker, identity
+):
+    # Given
+    environment = Environment.objects.create(
+        name="Test environment", project=feature.project
+    )
+    feature_state = FeatureState.objects.create(
+        environment=environment, feature=feature, identity=identity
+    )
+
+    # When
+    log = feature_state.get_create_log_message(mocker.MagicMock())
+
+    # Then
+    assert log is not None
+
+
 def test_feature_state_get_create_log_message_returns_message_if_environment_created_before_feature(
     environment, mocker
 ):


### PR DESCRIPTION
## Changes

Fixes an issue where audit log records are not written for identity / segment overrides when the feature was created before the environment. 

## How did you test this code?

Added unit test. 
