### PR TITLE
Hide disabled flags per environment

### DIFF
--- a/frontend/web/components/pages/EnvironmentSettingsPage.js
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.js
@@ -13,6 +13,14 @@ import TabItem from '../base/forms/TabItem'
 import JSONReference from "../JSONReference";
 import ColourSelect from '../tags/ColourSelect';
 import Constants from 'common/constants';
+import Switch from '../Switch';
+
+const showDisabledFlagOptions = [
+    {label:"Inherit from Project", value: null},
+    {label:"Disabled", value: false},
+    {label:"Enabled", value: true},
+]
+
 const EnvironmentSettingsPage = class extends Component {
     static displayName = 'EnvironmentSettingsPage'
 
@@ -74,6 +82,7 @@ const EnvironmentSettingsPage = class extends Component {
         AppActions.editEnv(Object.assign({}, env, {
             name: name || env.name,
             description: description || env.description,
+            hide_disabled_flags:  this.state.hide_disabled_flags,
             allow_client_traits: !!this.state.allow_client_traits,
             banner_text: this.state.banner_text,
             banner_colour: this.state.banner_colour,
@@ -146,6 +155,7 @@ const EnvironmentSettingsPage = class extends Component {
                                     banner_colour: env.banner_colour || Constants.tagColors[0],
                                     banner_text: env.banner_text,
                                     allow_client_traits: !!env.allow_client_traits,
+                                    hide_disabled_flags: env.hide_disabled_flags,
                                     minimum_change_request_approvals: Utils.changeRequestsEnabled(env.minimum_change_request_approvals) ? env.minimum_change_request_approvals : null,
                                 });
                             }, 10);
@@ -202,6 +212,31 @@ const EnvironmentSettingsPage = class extends Component {
                                                     </form>
                                                 </div>
                                                 <div>
+                                                {Utils.getFlagsmithHasFeature("hide_disabled_flags_environment") && (
+                                                    <Row className="mb-4" space>
+                                                        <div className="col-md-8 pl-0">
+                                                            <h3 className="m-b-0">Hide disabled flags from SDKs</h3>
+                                                            <p className="mb-0">
+                                                                To prevent letting your users know about your upcoming features
+                                                                and to cut down on payload, enabling this will prevent the API
+                                                                from returning features that are disabled. You can also manage this in <Link to={`/project/${this.props.match.params.projectId}/settings`}>Project settings</Link>.
+                                                            </p>
+                                                        </div>
+                                                        <div className="col-md-3 text-right">
+                                                            <Select
+                                                                className={"text-left"}
+                                                                value={(showDisabledFlagOptions.find((v)=>v.value===this.state.hide_disabled_flags)||showDisabledFlagOptions[0])}
+                                                                onChange={(v) => {
+                                                                    this.setState({hide_disabled_flags:v.value}, this.saveEnv)
+                                                                }}
+                                                                options={
+                                                                    showDisabledFlagOptions
+                                                                }
+                                                                data-test="js-hide-disabled-flags" disabled={isSaving}
+                                                            />
+                                                        </div>
+                                                    </Row>
+                                                )}
                                                 <Row space>
                                                     <div className="col-md-8 pl-0">
                                                         <h3 className="m-b-0">Environment Banner</h3>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Allows users to set hide disabled flags per environment as well as the ability to use the project's settings. This is enabled via the **hide_disabled_flags_environment** flag.

## How did you test this code?

Saved the setting against an environment
