### PR TITLE
fix(analytics/migration): make analytics db migration implicit

### DIFF
--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -7,6 +7,7 @@ set -e
 
 function migrate () {
     python manage.py waitfordb && python manage.py migrate && python manage.py createcachetable
+    migrate_analytics_db
 }
 function serve() {
     # configuration parameters for statsd. Docs can be found here:
@@ -70,8 +71,6 @@ elif [ "$1" == "dump-organisation-to-s3" ]; then
     dump_organisation_to_s3 "$2" "$3" "$4"
 elif [ "$1" == "dump-organisation-to-local-fs" ]; then
     dump_organisation_to_local_fs "$2" "$3"
-elif [ "$1" == "migrate-analytics-db" ]; then
-    migrate_analytics_db
 else
    echo "ERROR: unrecognised command '$1'"
 fi

--- a/infrastructure/aws/staging/ecs-task-definition-migration.json
+++ b/infrastructure/aws/staging/ecs-task-definition-migration.json
@@ -7,9 +7,7 @@
         {
             "name": "flagsmith-api-migration",
             "command": [
-                "migrate",
-                "&&",
-                "migrate-analytics-db"
+                "migrate"
 
             ],
             "environment": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes
When running `migrate && migrate-analytics-db` migrate is passed to `run-docker.sh` as expected but `migrate-analytics-db` is not, and it runs as a separate command (which fails for the obvious reasons), but since `migrate_analytics_db` bash function does nothing if analytics db  does not exist, hence it makes much more sense to run it implicitly as part of the `migrate` bash function.


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

by running the bash script 
