### PR TITLE
Prevent audit log creation for deleted feature states

### DIFF
--- a/api/audit/tests/test_tasks.py
+++ b/api/audit/tests/test_tasks.py
@@ -15,6 +15,32 @@ def test_create_feature_state_went_live_audit_log(change_request_feature_state):
     create_feature_state_went_live_audit_log(feature_state_id)
 
     # Then
-    AuditLog.objects.get(
-        related_object_id=feature_state_id, is_system_event=True, log=message
+    assert (
+        AuditLog.objects.filter(
+            related_object_id=feature_state_id, is_system_event=True, log=message
+        ).count()
+        == 1
+    )
+
+
+def test_create_feature_state_wen_live_audit_log_does_nothing_if_feature_state_deleted(
+    change_request_feature_state,
+):
+    # Given
+    message = FEATURE_STATE_WENT_LIVE_MESSAGE % (
+        change_request_feature_state.feature.name,
+        change_request_feature_state.change_request.title,
+    )
+    change_request_feature_state.delete()
+    feature_state_id = change_request_feature_state.id
+
+    # When
+    create_feature_state_went_live_audit_log(feature_state_id)
+
+    # Then
+    assert (
+        AuditLog.objects.filter(
+            related_object_id=feature_state_id, is_system_event=True, log=message
+        ).count()
+        == 0
     )


### PR DESCRIPTION
## Changes

Prevents AuditLog records being created for scheduled changes when the change request has been deleted. 

## How did you test this code?

Added a new unit test. 
