### PR TITLE
Fix SAML build

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -141,7 +141,7 @@ runs:
         echo "Building docker image with URL: "
         echo $ECR_REPOSITORY:$IMAGE_TAG
         cd api
-        docker build -t $ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile .
+        docker build -t $ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile --build-arg SAML_INSTALLED=1 .
         docker push $ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REPOSITORY:$IMAGE_TAG"
       shell: bash


### PR DESCRIPTION
## Changes

Ensure that xmlsec is built in the image before deploying to ECS.

## How did you test this code?

Built the container locally, passing the SAML_INSTALLED build arg to confirm it builds with the xmlsec lib correctly. 
