### PR TITLE
fix(environment/api-key): only send to dynamo if enabled

### DIFF
--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -415,7 +415,6 @@ class EnvironmentAPIKey(LifecycleModel):
 
     @hook(AFTER_SAVE)
     def send_to_dynamo(self):
-        if not dynamo_api_key_table:
-            return
-        env_key_dict = build_environment_api_key_document(self)
-        dynamo_api_key_table.put_item(Item=env_key_dict)
+        if dynamo_api_key_table and self.environment.project.enable_dynamo_db:
+            env_key_dict = build_environment_api_key_document(self)
+            dynamo_api_key_table.put_item(Item=env_key_dict)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Only send api key to dynamodb if dynamo is enabled for the project

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds unit test cases
