### PR TITLE
Fix issue committing scheduled change requests in the wrong order

### DIFF
--- a/api/audit/tasks.py
+++ b/api/audit/tasks.py
@@ -50,6 +50,7 @@ def create_audit_log_from_historical_record(
 
     if (
         history_instance.history_type == "~"
+        and history_instance.prev_record
         and not history_instance.diff_against(history_instance.prev_record).changes
     ):
         return

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -760,6 +760,12 @@ class FeatureState(
                 feature_state.identity_id,
             )
             current_feature_state = feature_states_dict.get(key)
+            # we use live_from here as a priority over the version since
+            # the version is given when change requests are committed,
+            # hence the version for a feature state that is scheduled
+            # further in the future can be lower than a feature state
+            # whose live_from value is earlier.
+            # See: https://github.com/Flagsmith/flagsmith/issues/2030
             if (
                 not current_feature_state
                 or feature_state.live_from > current_feature_state.live_from

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -762,7 +762,11 @@ class FeatureState(
             current_feature_state = feature_states_dict.get(key)
             if (
                 not current_feature_state
-                or feature_state.version > current_feature_state.version
+                or feature_state.live_from > current_feature_state.live_from
+                or (
+                    feature_state.live_from == current_feature_state.live_from
+                    and feature_state.version > current_feature_state.version
+                )
             ):
                 feature_states_dict[key] = feature_state
 

--- a/api/tests/unit/features/conftest.py
+++ b/api/tests/unit/features/conftest.py
@@ -18,3 +18,20 @@ def feature_state_version_generator(environment, feature, request):
         ),
         expected_result,
     )
+
+
+@pytest.fixture()
+def feature_state_live_from_generator(environment, feature, request):
+    live_from_one = request.param[0]
+    live_from_two = request.param[1]
+    expected_result = request.param[2]
+
+    return (
+        FeatureState.objects.create(
+            feature=feature, environment=environment, live_from=live_from_one, version=2
+        ),
+        FeatureState.objects.create(
+            feature=feature, environment=environment, live_from=live_from_two, version=3
+        ),
+        expected_result,
+    )

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -90,6 +90,22 @@ def test_feature_state_gt_operator_for_versions(feature_state_version_generator)
 
 
 @pytest.mark.parametrize(
+    "feature_state_live_from_generator",
+    (
+        (None, None, False),
+        (now, None, True),
+        (None, now, False),
+        (now, tomorrow, False),
+        (tomorrow, now, True),
+    ),
+    indirect=True,
+)
+def test_feature_state_gt_operator_for_live_from(feature_state_live_from_generator):
+    first, second, expected_result = feature_state_live_from_generator
+    assert (first > second) == expected_result
+
+
+@pytest.mark.parametrize(
     "version, live_from, expected_is_live",
     (
         (1, yesterday, True),


### PR DESCRIPTION
## Changes

Fixes issue where scheduled flags can be returned incorrectly if they were committed in the 'wrong' order. 

Note: this may end up causing some confusion in that there can be a higher version in the db which is not the one that is returned when retrieving the flags. 

## How did you test this code?

Added a unit test. 