### PR TITLE
Prevent duplicate leads in pipedrive

### DIFF
--- a/api/integrations/lead_tracking/pipedrive/client.py
+++ b/api/integrations/lead_tracking/pipedrive/client.py
@@ -47,6 +47,17 @@ class PipedriveAPIClient:
             for org in api_response_data["items"]
         ]
 
+    def search_persons(self, search_term: str) -> typing.List[PipedrivePerson]:
+        api_response_data = self._make_request(
+            resource="persons/search",
+            http_method="get",
+            query_params={"term": search_term},
+        )
+        return [
+            PipedrivePerson.from_response_data(person["item"])
+            for person in api_response_data["items"]
+        ]
+
     def create_organization_field(
         self, name: str, field_type: str = "varchar"
     ) -> PipedriveOrganizationField:
@@ -126,5 +137,7 @@ class PipedriveAPIClient:
             raise PipedriveAPIError(
                 f"Response code was {response.status_code}. Expected {expected_status_code}"
             )
+
+        print(response.json())
 
         return response.json()["data"]

--- a/api/integrations/lead_tracking/pipedrive/client.py
+++ b/api/integrations/lead_tracking/pipedrive/client.py
@@ -138,6 +138,4 @@ class PipedriveAPIClient:
                 f"Response code was {response.status_code}. Expected {expected_status_code}"
             )
 
-        print(response.json())
-
         return response.json()["data"]

--- a/api/tests/unit/integrations/lead_tracking/pipedrive/example_api_responses/search_persons.json
+++ b/api/tests/unit/integrations/lead_tracking/pipedrive/example_api_responses/search_persons.json
@@ -1,0 +1,35 @@
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "result_score": 0.149775,
+        "item": {
+          "id": 1,
+          "type": "person",
+          "name": "Johnny Bravo",
+          "phones": [],
+          "emails": [
+            "johnnybravo@cartoonnetwork.com"
+          ],
+          "primary_email": "johnnybravo@cartoonnetwork.com",
+          "visible_to": 3,
+          "owner": {
+            "id": 1
+          },
+          "organization": null,
+          "custom_fields": [],
+          "notes": [],
+          "update_time": "2023-03-14 12:09:06"
+        }
+      }
+    ]
+  },
+  "additional_data": {
+    "pagination": {
+      "start": 0,
+      "limit": 100,
+      "more_items_in_collection": false
+    }
+  }
+}

--- a/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_client.py
+++ b/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_client.py
@@ -124,6 +124,42 @@ def test_pipedrive_api_client_search_organizations(
 
 
 @responses.activate
+def test_pipedrive_api_client_search_persons(
+    pipedrive_api_client, pipedrive_base_url, pipedrive_api_token
+):
+    # Given
+    example_response_file_name = join(
+        dirname(abspath(__file__)), "example_api_responses/search_persons.json"
+    )
+
+    # obtained from file above, duplicated here to simplify test
+    search_term = "johnnybravo@mailinator.com"
+    result_person_name = "Johnny Bravo"
+    result_person_id = 1
+
+    with open(example_response_file_name) as f:
+        responses.add(
+            method=responses.GET,
+            url=f"{pipedrive_base_url}/persons/search",
+            json=json.load(f),
+            status=200,
+        )
+
+    # When
+    persons = pipedrive_api_client.search_persons(search_term=search_term)
+
+    # Then
+    assert len(responses.calls) == 1
+    call = responses.calls[0]
+    assert call.request.params["api_token"] == pipedrive_api_token
+    assert call.request.params["term"] == search_term
+
+    assert len(persons) == 1
+    assert persons[0].name == result_person_name
+    assert persons[0].id == result_person_id
+
+
+@responses.activate
 def test_pipedrive_api_client_create_organization_field(
     pipedrive_api_client, pipedrive_base_url, pipedrive_api_token
 ):

--- a/api/users/signals.py
+++ b/api/users/signals.py
@@ -26,6 +26,9 @@ def warn_insecure(sender, **kwargs):
 def create_pipedrive_lead_signal(sender, instance, created, **kwargs):
     user: FFAdminUser = instance
 
+    if not created:
+        return False
+
     if not PipedriveLeadTracker.should_track(user):
         return
 


### PR DESCRIPTION
## Changes

This PR includes 2 main changes: 

 * Only create leads in Pipedrive when a user is first created, not whenever the user is saved
 * If there is an existing person, don't create a new one

## How did you test this code?

Added unit tests
