### PR TITLE
Prevent vercel preview deployments for forks

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -137,6 +137,8 @@ jobs:
       cancel-in-progress: true
     name: Vercel Production Deployment
     runs-on: ubuntu-latest
+    # don't run this on PRs from forks (as the secrets are not available)
+    if: github.repository == 'Flagsmith/flagsmith'
     environment: production
     steps:
       - name: Cloning repo
@@ -163,6 +165,8 @@ jobs:
       cancel-in-progress: true
     name: Vercel Staging Deployment
     runs-on: ubuntu-latest
+    # don't run this on PRs from forks (as the secrets are not available)
+    if: github.repository == 'Flagsmith/flagsmith'
     environment: staging
     steps:
       - name: Cloning repo


### PR DESCRIPTION
## Changes

Skip vercel preview deployments for PRs from forks.

## How did you test this code?

Took the code from the flutter repository where is has already been tested. 
