### PR TITLE
Correct logic to prevent vercel previews on forks

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -132,13 +132,13 @@ jobs:
           tags: flagsmith/flagsmith-frontend:testing
 
   web-deploy-branch-production:
+    # don't run this on PRs from forks (as the secrets are not available)
+    if: github.event.pull_request.head.repo.full_name == 'Flagsmith/flagsmith'
     concurrency:
       group: deploy-frontend-production-${{github.ref}}
       cancel-in-progress: true
     name: Vercel Production Deployment
     runs-on: ubuntu-latest
-    # don't run this on PRs from forks (as the secrets are not available)
-    if: github.repository == 'Flagsmith/flagsmith'
     environment: production
     steps:
       - name: Cloning repo
@@ -160,13 +160,13 @@ jobs:
           env: prod
 
   web-deploy-branch-staging:
+    # don't run this on PRs from forks (as the secrets are not available)
+    if: github.event.pull_request.head.repo.full_name == 'Flagsmith/flagsmith'
     concurrency:
       group: deploy-frontend-staging-${{github.ref}}
       cancel-in-progress: true
     name: Vercel Staging Deployment
     runs-on: ubuntu-latest
-    # don't run this on PRs from forks (as the secrets are not available)
-    if: github.repository == 'Flagsmith/flagsmith'
     environment: staging
     steps:
       - name: Cloning repo


### PR DESCRIPTION
## Changes

Correct github context access to prevent workflows that rely on secrets from running on PRs from forked repositories. 

## How did you test this code?

Ran in a fork here: #2053 . 
