### PR TITLE
Only search custom fields for organizations

### DIFF
--- a/api/integrations/lead_tracking/pipedrive/client.py
+++ b/api/integrations/lead_tracking/pipedrive/client.py
@@ -40,7 +40,7 @@ class PipedriveAPIClient:
         api_response_data = self._make_request(
             resource="organizations/search",
             http_method="get",
-            query_params={"term": search_term},
+            query_params={"term": search_term, "fields": "custom_fields"},
         )
         return [
             PipedriveOrganization.from_response_data(org["item"])

--- a/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_client.py
+++ b/api/tests/unit/integrations/lead_tracking/pipedrive/test_unit_pipedrive_client.py
@@ -117,6 +117,7 @@ def test_pipedrive_api_client_search_organizations(
     call = responses.calls[0]
     assert call.request.params["api_token"] == pipedrive_api_token
     assert call.request.params["term"] == search_term
+    assert call.request.params["fields"] == "custom_fields"
 
     assert len(organizations) == 1
     assert organizations[0].name == result_organization_name


### PR DESCRIPTION
## Changes

Only search Organizations by custom fields in Pipedrive. 

## How did you test this code?

Updated unit test + verified manually that only custom fields are searched. 
