### PR TITLE
Add domain exceptions

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -116,6 +116,10 @@
                 {
                     "name": "PIPEDRIVE_API_LEAD_SOURCE_DEAL_FIELD_KEY",
                     "value": "f001193d9249bb49d631d7c2c516ab72f9ebd204"
+                },
+                {
+                    "name": "PIPEDRIVE_IGNORE_DOMAINS",
+                    "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Re-add exceptions for the following domains so leads do not get sent to Pipedrive. 

solidstategroup.com
flagsmith.com
restmail.net
bullet-train.io

## How did you test this code?

Logic is tested already, this is just adding data. 
