### PR TITLE
Fix/edge identities all feature states shows wrong version

### DIFF
--- a/api/edge_api/identities/models.py
+++ b/api/edge_api/identities/models.py
@@ -81,9 +81,13 @@ class EdgeIdentity:
         )
         django_environment = Environment.objects.get(api_key=self.environment_api_key)
 
-        q = Q(identity__isnull=True) & (
-            Q(feature_segment__segment__id__in=segment_ids)
-            | Q(feature_segment__isnull=True)
+        q = (
+            Q(version__isnull=False)
+            & Q(identity__isnull=True)
+            & (
+                Q(feature_segment__segment__id__in=segment_ids)
+                | Q(feature_segment__isnull=True)
+            )
         )
         environment_and_segment_feature_states = (
             django_environment.feature_states.select_related(

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -479,7 +479,9 @@ class FeatureState(
             # See: https://github.com/Flagsmith/flagsmith/issues/2030
             is_more_recent_live_from = self.is_more_recent_live_from(other)
             is_more_recent_version = self._is_more_recent_version(other)
-            return is_more_recent_live_from or is_more_recent_version
+            return self.version is not None and (
+                is_more_recent_live_from or is_more_recent_version
+            )
 
         # if we've reached here, then self is just the environment default. In this case, other is higher priority if
         # it has a feature_segment or an identity


### PR DESCRIPTION
## Changes

Fixes an issue in the `edge-featurestates/all` endpoint returning feature states that are not live. 

## How did you test this code?

Added unit test to first verify the issue, then verify it was resolved. 
