### PR TITLE
Fix logic for retrieving segments as a project user

### DIFF
--- a/api/segments/permissions.py
+++ b/api/segments/permissions.py
@@ -34,7 +34,7 @@ class SegmentPermissions(IsAuthenticated):
             return False
 
         return request.user.has_project_permission("MANAGE_SEGMENTS", obj.project) or (
-            view.action == "detail"
+            view.action == "retrieve"
             and request.user.has_project_permission("VIEW_PROJECT", obj.project)
         )
 

--- a/api/segments/permissions.py
+++ b/api/segments/permissions.py
@@ -57,5 +57,8 @@ class MasterAPIKeySegmentPermissions(BasePermission):
     def has_object_permission(
         self, request: HttpRequest, view: str, obj: Segment
     ) -> bool:
-        master_api_key = request.master_api_key
-        return master_api_key.organisation_id == obj.project.organisation_id
+        master_api_key = getattr(request, "master_api_key", None)
+        return (
+            master_api_key
+            and master_api_key.organisation_id == obj.project.organisation_id
+        )

--- a/api/segments/tests/test_permissions.py
+++ b/api/segments/tests/test_permissions.py
@@ -99,22 +99,25 @@ class SegmentPermissionsTestCase(TestCase):
         # Then
         assert not result
 
-    def test_project_user_has_no_object_permission(self):
+    def test_project_user_has_object_permission(self):
         # Given
         mock_request.user = self.project_user
 
         # When
-        results = []
-        for action in ("retrieve", "destroy", "update"):
+        for action, expected_result in (
+            ("retrieve", True),
+            ("destroy", False),
+            ("update", False),
+            ("partial_update", False),
+        ):
             mock_view.action = action
-            results.append(
+            # Then
+            assert (
                 segment_permissions.has_object_permission(
                     mock_request, mock_view, self.segment
                 )
+                == expected_result
             )
-
-        # Then
-        assert all(not result for result in results)
 
     def test_environment_admin_can_get_segments_for_an_identity(self):
         # Given


### PR DESCRIPTION
## Changes

Fixes logic for retrieving a segment as a project user. 

## How did you test this code?

Updated the unit test. 
