### PR TITLE
Add environments api key table name to migration task definition

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-migration.json
+++ b/infrastructure/aws/production/ecs-task-definition-migration.json
@@ -29,7 +29,11 @@
                 {
                     "name": "ENVIRONMENTS_TABLE_NAME_DYNAMO",
                     "value": "flagsmith_environments"
-               }
+                },
+                {
+                    "name": "ENVIRONMENTS_API_KEY_TABLE_NAME_DYNAMO",
+                    "value": "flagsmith_environment_api_key"
+                }
             ],
             "secrets": [
                 {

--- a/infrastructure/aws/staging/ecs-task-definition-migration.json
+++ b/infrastructure/aws/staging/ecs-task-definition-migration.json
@@ -30,6 +30,10 @@
                 {
                     "name": "ENVIRONMENTS_TABLE_NAME_DYNAMO",
                     "value": "flagsmith_environments"
+                },
+                {
+                    "name": "ENVIRONMENTS_API_KEY_TABLE_NAME_DYNAMO",
+                    "value": "flagsmith_environment_api_key"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Add environments api key table name to migration task definition. 

## How did you test this code?

I haven't tested it, but it's been copied from the configuration in the main API ECS task definition which we know is working. I will test in staging once deployed there. 
