### PR TITLE
fix(audit/signal/task): fix race condition on feature creation 

### DIFF
--- a/api/core/signals.py
+++ b/api/core/signals.py
@@ -1,8 +1,10 @@
 from core.models import _AbstractBaseAuditableModel
+from django.conf import settings
 from django.utils import timezone
 from simple_history.models import HistoricalRecords
 
 from audit import tasks
+from task_processor.task_run_method import TaskRunMethod
 from users.models import FFAdminUser
 
 
@@ -22,7 +24,11 @@ def create_audit_log_from_historical_record(
     # document when creating feature states
     # or delay the execution of this task
     # We prefer to delay the execution of the task because of it's low surface area
-    delay_until = timezone.now() + timezone.timedelta(seconds=1)
+    delay_until = (
+        timezone.now() + timezone.timedelta(seconds=1)
+        if settings.TASK_RUN_METHOD == TaskRunMethod.TASK_PROCESSOR
+        else None
+    )
 
     tasks.create_audit_log_from_historical_record.delay(
         kwargs={

--- a/api/core/signals.py
+++ b/api/core/signals.py
@@ -1,4 +1,5 @@
 from core.models import _AbstractBaseAuditableModel
+from django.utils import timezone
 from simple_history.models import HistoricalRecords
 
 from audit import tasks
@@ -11,12 +12,25 @@ def create_audit_log_from_historical_record(
     history_instance,
     **kwargs,
 ):
+    # The environment document in dynamodb is updated based on the post_save signal from the audit log
+    # When creating a new feature, the feature states are created after the feature has been created.
+    # i.e: the below task gets created/scheduled before feature states are created
+    # Usually, there is enough time for the main thread to create the feature states
+    # before the task is executed, but not always.
+    # In those cases, we send the environment document to dynamodb without any feature states for the new feature.
+    # In order to avoid this, either we need to update environment
+    # document when creating feature states
+    # or delay the execution of this task
+    # We prefer to delay the execution of the task because of it's low surface area
+    delay_until = timezone.now() + timezone.timedelta(seconds=1)
+
     tasks.create_audit_log_from_historical_record.delay(
         kwargs={
             "history_instance_id": history_instance.history_id,
             "history_user_id": getattr(history_user, "id", None),
             "history_record_class_path": instance.history_record_class_path,
-        }
+        },
+        delay_until=delay_until,
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes
The environment document in dynamodb is updated based on the post_save signal from the audit log When creating a new feature, the feature states are created after the feature has been created. i.e: the below task gets created/scheduled before feature states are created Usually, there is enough time for the main thread to create the feature states before the task is executed, but not always.
In those cases, we send the environment document to dynamodb without any feature states for the new feature. In order to avoid this, either we need to update environment document when creating feature states
or delay the execution of this task
We prefer to delay the execution of the task because of it's low surface area

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

This will be tested on staging since I can't reproduce it locally 
