### PR TITLE
Add log message when writing unhealthy threads

### DIFF
--- a/api/task_processor/thread_monitoring.py
+++ b/api/task_processor/thread_monitoring.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import os
 import typing
 from threading import Thread
 
 UNHEALTHY_THREADS_FILE_PATH = "/tmp/task-processor-unhealthy-threads.json"
+
+logger = logging.getLogger(__name__)
 
 
 def clear_unhealthy_threads():
@@ -12,8 +15,11 @@ def clear_unhealthy_threads():
 
 
 def write_unhealthy_threads(unhealthy_threads: typing.List[Thread]):
+    unhealthy_thread_names = [t.name for t in unhealthy_threads]
+    logger.error("Writing unhealthy threads: %s", unhealthy_thread_names)
+
     with open(UNHEALTHY_THREADS_FILE_PATH, "w+") as f:
-        f.write(json.dumps([t.name for t in unhealthy_threads]))
+        f.write(json.dumps(unhealthy_thread_names))
 
 
 def get_unhealthy_thread_names() -> typing.List[str]:


### PR DESCRIPTION
## Changes

Adds a log message when writing to unhealthy threads file for monitoring purposes. 

## How did you test this code?

Updated unit test