### PR TITLE
Remove group_admin attribute from list groups

### DIFF
--- a/api/organisations/permissions/serializers.py
+++ b/api/organisations/permissions/serializers.py
@@ -4,10 +4,7 @@ from organisations.permissions.models import (
     UserOrganisationPermission,
     UserPermissionGroupOrganisationPermission,
 )
-from users.serializers import (
-    UserListSerializer,
-    UserPermissionGroupSerializerList,
-)
+from users.serializers import UserListSerializer, UserPermissionGroupSerializer
 
 
 class UserOrganisationPermissionUpdateCreateSerializer(serializers.ModelSerializer):
@@ -33,4 +30,4 @@ class UserPermissionGroupOrganisationPermissionUpdateCreateSerializer(
 class UserPermissionGroupOrganisationPermissionListSerializer(
     UserPermissionGroupOrganisationPermissionUpdateCreateSerializer
 ):
-    group = UserPermissionGroupSerializerList()
+    group = UserPermissionGroupSerializer()

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -9,10 +9,7 @@ from projects.models import (
     UserPermissionGroupProjectPermission,
     UserProjectPermission,
 )
-from users.serializers import (
-    UserListSerializer,
-    UserPermissionGroupSerializerList,
-)
+from users.serializers import UserListSerializer, UserPermissionGroupSerializer
 
 
 class ProjectSerializer(serializers.ModelSerializer):
@@ -84,4 +81,4 @@ class CreateUpdateUserPermissionGroupProjectPermissionSerializer(
 class ListUserPermissionGroupProjectPermissionSerializer(
     CreateUpdateUserPermissionGroupProjectPermissionSerializer
 ):
-    group = UserPermissionGroupSerializerList()
+    group = UserPermissionGroupSerializer()

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -88,11 +88,21 @@ class UserIdsSerializer(serializers.Serializer):
         return data
 
 
-class UserPermissionGroupSerializerList(serializers.ModelSerializer):
+class UserPermissionGroupSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserPermissionGroup
         fields = ("id", "name", "users", "is_default", "external_id")
         read_only_fields = ("id",)
+
+
+class ListUserPermissionGroupMembershipSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FFAdminUser
+        fields = ("id", "email", "first_name", "last_name", "last_login")
+
+
+class ListUserPermissionGroupSerializer(UserPermissionGroupSerializer):
+    users = ListUserPermissionGroupMembershipSerializer(many=True, read_only=True)
 
 
 class UserPermissionGroupMembershipSerializer(serializers.ModelSerializer):
@@ -106,7 +116,7 @@ class UserPermissionGroupMembershipSerializer(serializers.ModelSerializer):
         return instance.id in self.context.get("group_admins", [])
 
 
-class UserPermissionGroupSerializerDetail(UserPermissionGroupSerializerList):
+class UserPermissionGroupSerializerDetail(UserPermissionGroupSerializer):
     # TODO: remove users from here and just add a summary of number of users
     users = UserPermissionGroupMembershipSerializer(many=True, read_only=True)
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -31,6 +31,7 @@ from users.models import (
     UserPermissionGroupMembership,
 )
 from users.serializers import (
+    ListUserPermissionGroupSerializer,
     ListUsersQuerySerializer,
     UserIdsSerializer,
     UserListSerializer,
@@ -145,7 +146,6 @@ def password_reset_redirect(request, uidb64, token):
 
 class UserPermissionGroupViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, UserPermissionGroupPermission]
-    serializer_class = UserPermissionGroupSerializerDetail
 
     def get_queryset(self):
         organisation_pk = self.kwargs.get("organisation_pk")
@@ -161,6 +161,11 @@ class UserPermissionGroupViewSet(viewsets.ModelViewSet):
             )
 
         return qs
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return UserPermissionGroupSerializerDetail
+        return ListUserPermissionGroupSerializer
 
     def get_serializer_context(self):
         context = super().get_serializer_context()


### PR DESCRIPTION
## Changes

Removes the `group_admin` attribute from the user objects when listing user permission groups. The group_admin attribute was added to the response data, but only worked for the retrieve endpoint. 

## How did you test this code?

Existing tests should cover it. 
