### PR TITLE
fix(task-processor/logging): use warning level

### DIFF
--- a/api/task_processor/thread_monitoring.py
+++ b/api/task_processor/thread_monitoring.py
@@ -16,7 +16,7 @@ def clear_unhealthy_threads():
 
 def write_unhealthy_threads(unhealthy_threads: typing.List[Thread]):
     unhealthy_thread_names = [t.name for t in unhealthy_threads]
-    logger.error("Writing unhealthy threads: %s", unhealthy_thread_names)
+    logger.warning("Writing unhealthy threads: %s", unhealthy_thread_names)
 
     with open(UNHEALTHY_THREADS_FILE_PATH, "w+") as f:
         f.write(json.dumps(unhealthy_thread_names))

--- a/api/tests/unit/task_processor/test_unit_task_processor_thread_monitoring.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_thread_monitoring.py
@@ -48,7 +48,7 @@ def test_write_unhealthy_threads(caplog, settings):
         json.dumps([t.name for t in threads])
     )
     assert len(caplog.records) == 1
-    assert caplog.record_tuples[0][1] == 40  # ERROR
+    assert caplog.record_tuples[0][1] == 30  # WARNING
     assert caplog.record_tuples[0][2] == "Writing unhealthy threads: %s" % [
         t.name for t in threads
     ]


### PR DESCRIPTION
Use warning level instead of error to avoid blowing up sentry

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Use warning level instead of error to avoid blowing up sentry

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Tested manually to make sure they do not get shipped to sentry 