### PR TITLE
Ensure new_state is added when new_enabled_state provided

### DIFF
--- a/api/edge_api/identities/tasks.py
+++ b/api/edge_api/identities/tasks.py
@@ -52,7 +52,7 @@ def call_environment_webhook_for_feature_state_change(
             value=previous_value,
         )
 
-    if new_value is not None and new_value is not None:
+    if new_enabled_state is not None and new_value is not None:
         data["new_state"] = Webhook.generate_webhook_feature_state_data(
             feature=feature,
             environment=environment,

--- a/api/edge_api/identities/tasks.py
+++ b/api/edge_api/identities/tasks.py
@@ -42,7 +42,7 @@ def call_environment_webhook_for_feature_state_change(
         "new_state": None,
     }
 
-    if previous_enabled_state is not None and previous_value is not None:
+    if previous_enabled_state is not None:
         data["previous_state"] = Webhook.generate_webhook_feature_state_data(
             feature=feature,
             environment=environment,
@@ -52,7 +52,7 @@ def call_environment_webhook_for_feature_state_change(
             value=previous_value,
         )
 
-    if new_enabled_state is not None and new_value is not None:
+    if new_enabled_state is not None:
         data["new_state"] = Webhook.generate_webhook_feature_state_data(
             feature=feature,
             environment=environment,

--- a/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
+++ b/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
@@ -14,8 +14,12 @@ from environments.models import Webhook
 from webhooks.webhooks import WebhookEventType
 
 
+@pytest.mark.parametrize(
+    "new_enabled_state, new_value",
+    ((True, "foo"), (False, "foo"), (True, None), (False, None)),
+)
 def test_call_environment_webhook_for_feature_state_change_with_new_state_only(
-    mocker, environment, feature, identity, admin_user
+    mocker, environment, feature, identity, admin_user, new_value, new_enabled_state
 ):
     # Given
     mock_call_environment_webhooks = mocker.patch(
@@ -31,8 +35,6 @@ def test_call_environment_webhook_for_feature_state_change_with_new_state_only(
     )
 
     now_isoformat = timezone.now().isoformat()
-    new_enabled_state = True
-    new_value = "foo"
 
     # When
     call_environment_webhook_for_feature_state_change(
@@ -120,8 +122,26 @@ def test_call_environment_webhook_for_feature_state_change_with_previous_state_o
     assert data["timestamp"] == now_isoformat
 
 
+@pytest.mark.parametrize(
+    "previous_enabled_state, previous_value, new_enabled_state, new_value",
+    (
+        (True, None, True, "foo"),
+        (True, "foo", False, "foo"),
+        (True, "foo", True, "bar"),
+        (True, None, False, None),
+        (False, None, True, None),
+    ),
+)
 def test_call_environment_webhook_for_feature_state_change_with_both_states(
-    mocker, environment, feature, identity, admin_user
+    mocker,
+    environment,
+    feature,
+    identity,
+    admin_user,
+    previous_enabled_state,
+    previous_value,
+    new_enabled_state,
+    new_value,
 ):
     # Given
     mock_call_environment_webhooks = mocker.patch(
@@ -137,11 +157,6 @@ def test_call_environment_webhook_for_feature_state_change_with_both_states(
     )
 
     now_isoformat = timezone.now().isoformat()
-    previous_enabled_state = False
-    previous_value = "foo"
-
-    new_enabled_state = True
-    new_value = "bar"
 
     # When
     call_environment_webhook_for_feature_state_change(


### PR DESCRIPTION
## Changes

Fixes bug in webhook data when the value of a feature state is None (which is perfectly valid). 

## How did you test this code?

Updated existing tests to add parametrized cases
