### PR TITLE
cross-platform dev script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,8 @@
     "start": "cross-env NODE_ENV=production node ./api/index",
     "typecheck": "tsc",
     "dev": "cross-env npm run env && npx nodemon --watch ./api --ignore server/config/config.json --watch webpack --exec node ./api",
-    "bundle": "node npx webpack --config ./webpack/webpack.config.prod.js",
-    "bundledjango": "mkdir -p ../api/app/templates/webpack/ && node npx webpack --config ./webpack/webpack.config.django.prod.js && rm -f ../api/app/templates/webpack/index.html && rm -f ../api/static/static/project-overrides.js && cp ../api/static/index.html ../api/app/templates/webpack/index.html"
+    "bundle": "npx webpack --config ./webpack/webpack.config.prod.js",
+    "bundledjango": "mkdir -p ../api/app/templates/webpack/ && npx webpack --config ./webpack/webpack.config.django.prod.js && rm -f ../api/app/templates/webpack/index.html && rm -f ../api/static/static/project-overrides.js && cp ../api/static/index.html ../api/app/templates/webpack/index.html"
   },
   "engines": {
     "node": "16.x",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "npx eslint --fix .",
     "start": "cross-env NODE_ENV=production node ./api/index",
     "typecheck": "tsc",
-    "dev": "cross-env npm run env && node_modules/.bin/nodemon --watch ./api --ignore server/config/config.json --watch webpack --exec node ./api",
+    "dev": "cross-env npm run env && npx nodemon --watch ./api --ignore server/config/config.json --watch webpack --exec node ./api",
     "bundle": "node node_modules/.bin/webpack --config ./webpack/webpack.config.prod.js",
     "bundledjango": "mkdir -p ../api/app/templates/webpack/ && node node_modules/.bin/webpack --config ./webpack/webpack.config.django.prod.js && rm -f ../api/app/templates/webpack/index.html && rm -f ../api/static/static/project-overrides.js && cp ../api/static/index.html ../api/app/templates/webpack/index.html"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,8 @@
     "start": "cross-env NODE_ENV=production node ./api/index",
     "typecheck": "tsc",
     "dev": "cross-env npm run env && npx nodemon --watch ./api --ignore server/config/config.json --watch webpack --exec node ./api",
-    "bundle": "node node_modules/.bin/webpack --config ./webpack/webpack.config.prod.js",
-    "bundledjango": "mkdir -p ../api/app/templates/webpack/ && node node_modules/.bin/webpack --config ./webpack/webpack.config.django.prod.js && rm -f ../api/app/templates/webpack/index.html && rm -f ../api/static/static/project-overrides.js && cp ../api/static/index.html ../api/app/templates/webpack/index.html"
+    "bundle": "node npx webpack --config ./webpack/webpack.config.prod.js",
+    "bundledjango": "mkdir -p ../api/app/templates/webpack/ && node npx webpack --config ./webpack/webpack.config.django.prod.js && rm -f ../api/app/templates/webpack/index.html && rm -f ../api/static/static/project-overrides.js && cp ../api/static/index.html ../api/app/templates/webpack/index.html"
   },
   "engines": {
     "node": "16.x",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

The dev script to run the frontend application was calling node_modules/.bin/nodemon, this is not supported by windows terminal. This changes it to use ``npx``

## How did you test this code?

Ran on OSX
