### PR TITLE
Support domain override from environment

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -870,3 +870,9 @@ SOFTDELETE_CASCADE_ALLOW_DELETE_ALL = False
 
 # Used for serializing and deserializing GenericForeignKey(used in metadata) using the natural key of the object
 SERIALIZATION_MODULES = {"json": "import_export.json_serializers_with_metadata_support"}
+
+# Controls the app domain used in emails (currently invites and change requests).
+# If set, domain stored with `django.contrib.sites` is disregarded.
+DOMAIN_OVERRIDE = env.str("FLAGSMITH_DOMAIN", "")
+# Used when no Django site is specified.
+DEFAULT_DOMAIN = "app.flagsmith.com"

--- a/api/core/helpers.py
+++ b/api/core/helpers.py
@@ -2,11 +2,15 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 
 
-def get_current_site_url(default_domain: str = "app.flagsmith.com"):
-    current_site = Site.objects.filter(id=settings.SITE_ID).first()
+def get_current_site_url():
+    if settings.DOMAIN_OVERRIDE:
+        domain = settings.DOMAIN_OVERRIDE
+    elif current_site := Site.objects.filter(id=settings.SITE_ID).first():
+        domain = current_site.domain
+    else:
+        domain = settings.DEFAULT_DOMAIN
 
-    url = "https://"
-    url += current_site.domain if current_site else default_domain
+    url = "https://" + domain
     return url
 
 

--- a/api/organisations/invites/models.py
+++ b/api/organisations/invites/models.py
@@ -61,9 +61,9 @@ class Invite(AbstractBaseInviteModel):
         db_table = "users_invite"
 
     def save(self, *args, **kwargs):
-        # send email invite before saving invite
+        super().save(*args, **kwargs)
+        # send email invite after saving invite
         self.send_invite_mail()
-        super(Invite, self).save(*args, **kwargs)
 
     def get_invite_uri(self):
         return f"{get_current_site_url()}/invite/{str(self.hash)}"

--- a/api/organisations/invites/models.py
+++ b/api/organisations/invites/models.py
@@ -5,7 +5,12 @@ from django.core.mail import EmailMultiAlternatives
 from django.db import models
 from django.template.loader import get_template
 from django.utils import timezone
-from django_lifecycle import BEFORE_CREATE, LifecycleModelMixin, hook
+from django_lifecycle import (
+    AFTER_CREATE,
+    BEFORE_CREATE,
+    LifecycleModelMixin,
+    hook,
+)
 
 from app.utils import create_hash
 from organisations.invites.exceptions import InviteLinksDisabledError
@@ -47,7 +52,7 @@ class InviteLink(
             raise InviteLinksDisabledError()
 
 
-class Invite(AbstractBaseInviteModel):
+class Invite(LifecycleModelMixin, AbstractBaseInviteModel):
     email = models.EmailField()
     invited_by = models.ForeignKey(
         FFAdminUser, related_name="sent_invites", null=True, on_delete=models.CASCADE
@@ -60,14 +65,10 @@ class Invite(AbstractBaseInviteModel):
         # reference existing table after moving to own app to avoid db inconsistencies
         db_table = "users_invite"
 
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        # send email invite after saving invite
-        self.send_invite_mail()
-
     def get_invite_uri(self):
         return f"{get_current_site_url()}/invite/{str(self.hash)}"
 
+    @hook(AFTER_CREATE)
     def send_invite_mail(self):
         context = {
             "org_name": self.organisation.name,

--- a/api/tests/unit/core/test_helpers.py
+++ b/api/tests/unit/core/test_helpers.py
@@ -1,27 +1,73 @@
+import typing
+
+import pytest
 from core.helpers import get_current_site_url
 from django.contrib.sites.models import Site
 
+if typing.TYPE_CHECKING:
+    from pytest_django.fixtures import SettingsWrapper
 
-def test_get_current_site_url_returns_correct_url_if_site_exists(settings, db):
+pytestmark = pytest.mark.django_db
+
+
+def test_get_current_site_url_returns_correct_url_if_site_exists(
+    settings: "SettingsWrapper",
+) -> None:
     # Given
-    domain = "some-testing-url.com"
-    site = Site.objects.create(name="test_site", domain=domain)
+    expected_domain = "some-testing-url.com"
+    site = Site.objects.create(name="test_site", domain=expected_domain)
     settings.SITE_ID = site.id
 
     # When
     url = get_current_site_url()
 
     # Then
-    assert url == f"https://{domain}"
+    assert url == f"https://{expected_domain}"
 
 
-def test_get_current_site_url_uses_default_url_if_site_does_not_exists(settings, db):
+def test_get_current_site_url_uses_default_url_if_site_does_not_exists(
+    settings: "SettingsWrapper",
+) -> None:
     # Given
-    domain = "some-testing-url.com"
+    expected_domain = "some-testing-url.com"
+    settings.DEFAULT_DOMAIN = expected_domain
     settings.SITE_ID = None
 
     # When
-    url = get_current_site_url(default_domain=domain)
+    url = get_current_site_url()
 
     # Then
-    assert url == f"https://{domain}"
+    assert url == f"https://{expected_domain}"
+
+
+def test_get_current_site__domain_override__with_site__return_expected(
+    settings: "SettingsWrapper",
+) -> None:
+    # Given
+    site = Site.objects.create(name="test_site", domain="should-not-be-used.com")
+    settings.SITE_ID = site.id
+
+    expected_domain = "some-testing-url.com"
+    settings.DOMAIN_OVERRIDE = expected_domain
+
+    # When
+    url = get_current_site_url()
+
+    # Then
+    assert url == f"https://{expected_domain}"
+
+
+def test_get_current_site__domain_override__no_site__return_expected(
+    settings: "SettingsWrapper",
+) -> None:
+    # Given
+    settings.SITE_ID = None
+
+    expected_domain = "some-testing-url.com"
+    settings.DOMAIN_OVERRIDE = expected_domain
+
+    # When
+    url = get_current_site_url()
+
+    # Then
+    assert url == f"https://{expected_domain}"

--- a/api/tests/unit/organisations/invites/test_unit_invites_models.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_models.py
@@ -1,10 +1,38 @@
+import typing
+
 import pytest
+from django.db.utils import IntegrityError
 
 from organisations.invites.exceptions import InviteLinksDisabledError
-from organisations.invites.models import InviteLink
+from organisations.invites.models import Invite, InviteLink
+from organisations.models import Organisation
+
+if typing.TYPE_CHECKING:
+    from django.core.mail import EmailMessage
+    from pytest_django.fixtures import SettingsWrapper
 
 
-def test_cannot_create_invite_link_if_disabled(settings):
+def test_cannot_create_invite_link_if_disabled(settings: "SettingsWrapper") -> None:
+    # Given
     settings.DISABLE_INVITE_LINKS = True
+
+    # When & Then
     with pytest.raises(InviteLinksDisabledError):
         InviteLink.objects.create()
+
+
+@pytest.mark.django_db
+def test_save_invalid_invite__dont_send(mailoutbox: "list[EmailMessage]") -> None:
+    # Given
+    email = "unknown@test.com"
+    organisation = Organisation.objects.create(name="ssg")
+    invite = Invite(email=email, organisation=organisation)
+    invite.save()
+    invalid_invite = Invite(email=email, organisation=organisation)
+
+    # When
+    with pytest.raises(IntegrityError):
+        invalid_invite.save()
+
+    # Then
+    assert len(mailoutbox) == 1


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Flagsmith API has two new settings:
- `DOMAIN_OVERRIDE` (`FLAGSMITH_DOMAIN` env var): forces a domain in emails regardless of `django.contrib.sites` content.
- `DEFAULT_DOMAIN`: a fallback value for cases when neither `DOMAIN_OVERRIDE` nor `SITE_ID` is specified.

## How did you test this code?

- Covered with unit tests.
- Sent a couple invites manually and checked correctness of the URLs in the resulting emails.