### PR TITLE
logging(task/processor): Add logging to identify task causing DB error

### DIFF
--- a/api/task_processor/processor.py
+++ b/api/task_processor/processor.py
@@ -3,6 +3,7 @@ import traceback
 import typing
 
 from django.db import transaction
+from django.db.utils import DatabaseError
 from django.utils import timezone
 
 from task_processor.models import (
@@ -89,6 +90,13 @@ def _run_task(task: Task) -> typing.Optional[typing.Tuple[Task, TaskRun]]:
 
         task_run.finished_at = timezone.now()
         task.mark_success()
+    except DatabaseError as e:
+        logger.error(
+            "Database error while running task %s:  %s",
+            task.id,
+            e,
+            exc_info=True,
+        )
     except Exception:
         task.mark_failure()
 

--- a/api/task_processor/threads.py
+++ b/api/task_processor/threads.py
@@ -1,9 +1,12 @@
+import logging
 import time
 from threading import Thread
 
 from django.utils import timezone
 
 from task_processor.processor import run_recurring_tasks, run_tasks
+
+logger = logging.getLogger(__name__)
 
 
 class TaskRunner(Thread):
@@ -24,7 +27,10 @@ class TaskRunner(Thread):
     def run(self) -> None:
         while not self._stopped:
             self.last_checked_for_tasks = timezone.now()
-            run_tasks(self.queue_pop_size)
+            try:
+                run_tasks(self.queue_pop_size)
+            except Exception as e:
+                logger.exception(e)
             run_recurring_tasks(self.queue_pop_size)
             time.sleep(self.sleep_interval_millis / 1000)
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Wrap run_tasks in try/except to avoid thread from dying 
Catch and log DatabaseError caused by tasks to identify it

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Running task processor manually on a task that raises an Integrity Error 