### PR TITLE
feat: run-task-processor Docker entrypoint command

### DIFF
--- a/api/core/management/commands/waitfordb.py
+++ b/api/core/management/commands/waitfordb.py
@@ -1,43 +1,86 @@
 import logging
 import time
 from argparse import ArgumentParser
-from datetime import datetime
+from typing import Any
 
 from django.core.management import BaseCommand
 from django.db import OperationalError, connections
+from django.db.migrations.executor import MigrationExecutor
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser: ArgumentParser):
+    def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
             "--waitfor",
             type=int,
+            dest="wait_for",
             help="Number of seconds to wait for db to become available.",
             default=5,
         )
+        parser.add_argument(
+            "--migrations",
+            action="store_true",
+            dest="should_wait_for_migrations",
+            help="Whether to wait until all migrations are applied.",
+            default=False,
+        )
+        parser.add_argument(
+            "--database",
+            type=str,
+            dest="database",
+            help=(
+                'The database to wait for ("default", "analytics").'
+                'Defaults to the "default" database.'
+            ),
+            default="default",
+        )
 
-    def handle(self, *args, **options):
-        wait_for = options["waitfor"]
-        start = datetime.now()
+    def handle(
+        self,
+        *args: Any,
+        wait_for: int,
+        should_wait_for_migrations: bool,
+        database: str,
+        **options: Any,
+    ) -> None:
+        start = time.monotonic()
         wait_between_checks = 0.25
 
         logger.info("Checking if database is ready for connections.")
 
         while True:
-            if (datetime.now() - start).total_seconds() > wait_for:
+            if time.monotonic() - start > wait_for:
                 msg = f"Failed to connect to DB within {wait_for} seconds."
                 logger.error(msg)
                 exit(msg)
 
-            conn = connections.create_connection("default")
+            conn = connections.create_connection(database)
             try:
                 with conn.temporary_connection() as cursor:
                     cursor.execute("SELECT 1")
                 logger.info("Successfully connected to the database.")
-                return
+                break
             except OperationalError:
                 logger.warning("Database not yet ready for connections.")
 
             time.sleep(wait_between_checks)
+
+        if should_wait_for_migrations:
+            logger.info("Checking for applied migrations.")
+
+            while True:
+                if time.monotonic() - start > wait_for:
+                    msg = f"Didn't detect applied migrations for {wait_for} seconds."
+                    logger.error(msg)
+                    exit(msg)
+
+                conn = connections[database]
+                executor = MigrationExecutor(conn)
+                if not executor.migration_plan(executor.loader.graph.leaf_nodes()):
+                    logger.info("No pending migrations detected, good to go.")
+                    return
+
+                logger.warning("Migrations not yet applied.")
+                time.sleep(wait_between_checks)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       # To use task processor service, uncomment line below and additional 'flagsmith_processor'
       # container below
       TASK_RUN_METHOD: TASK_PROCESSOR # other options are: SYNCHRONOUSLY, SEPARATE_THREAD (default)
-
       # For more info on configuring E-Mails - https://docs.flagsmith.com/deployment/locally-api#environment-variables
       #
       # Example SMTP:
@@ -61,12 +60,8 @@ services:
       context: .
     environment:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
-    entrypoint:
-      - 'python'
-      - 'manage.py'
-      - 'runprocessor'
-      - '--sleepintervalms'
-      - '500'
+    command:
+      - run-task-processor
     depends_on:
       - flagsmith
       - postgres

--- a/docs/docs/deployment/configuration/task-processor.md
+++ b/docs/docs/deployment/configuration/task-processor.md
@@ -40,9 +40,7 @@ A basic docker-compose setup might look like:
        environment:
            DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
        command:
-           - "python"
-           - "manage.py"
-           - "runprocessor"
+           - run-task-processor
        depends_on:
            - flagsmith
            - postgres


### PR DESCRIPTION
* Add ability to wait for migrations via waitdb command

* Add run-task-processor entrypoint command

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

* Added ability to wait for migrations via `waitdb` command.
* Added the `run-task-processor` entrypoint command

## How did you test this code?

Built a Docker image locally and tested the new entrypoint it with the flagsmith/self-hosted docker-compose file.