### PR TITLE
Update permissions for group admins

### DIFF
--- a/api/organisations/permissions/permissions.py
+++ b/api/organisations/permissions/permissions.py
@@ -127,8 +127,12 @@ class UserPermissionGroupPermission(BasePermission):
             return False
 
         return (
-            view.action == "list" and request.user.belongs_to(organisation.id)
-        ) or request.user.has_organisation_permission(organisation, MANAGE_USER_GROUPS)
+            (view.action == "list" and request.user.belongs_to(organisation.id))
+            or view.detail is True  # delegate to has_object_permission
+            or request.user.has_organisation_permission(
+                organisation, MANAGE_USER_GROUPS
+            )
+        )
 
     def has_object_permission(self, request, view, obj):
         organisation_id = view.kwargs.get("organisation_pk")

--- a/api/organisations/permissions/permissions.py
+++ b/api/organisations/permissions/permissions.py
@@ -128,7 +128,7 @@ class UserPermissionGroupPermission(BasePermission):
 
         return (
             (view.action == "list" and request.user.belongs_to(organisation.id))
-            or view.detail is True  # delegate to has_object_permission
+            or view.detail is True  # delegate to has_object_permission / get_queryset
             or request.user.has_organisation_permission(
                 organisation, MANAGE_USER_GROUPS
             )

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -423,6 +423,13 @@ class FFAdminUser(LifecycleModel, AbstractUser):
 
         return all_permission_keys
 
+    def add_to_group(
+        self, group: "UserPermissionGroup", group_admin: bool = False
+    ) -> None:
+        UserPermissionGroupMembership.objects.create(
+            ffadminuser=self, userpermissiongroup=group, group_admin=group_admin
+        )
+
     def is_group_admin(self, group_id) -> bool:
         return UserPermissionGroupMembership.objects.filter(
             ffadminuser=self, userpermissiongroup__id=group_id, group_admin=True

--- a/api/users/tests/test_views.py
+++ b/api/users/tests/test_views.py
@@ -488,3 +488,25 @@ def test_retrieve_user_permission_group_includes_group_admin(
         next(filter(lambda u: u["id"] == group_admin_user.id, users))["group_admin"]
         is True
     )
+
+
+def test_group_admin_can_retrieve_group(organisation, django_user_model, api_client):
+    # Given
+    user = django_user_model.objects.create(email="test@example.com")
+    user.add_organisation(organisation)
+    group = UserPermissionGroup.objects.create(
+        organisation=organisation, name="Test group"
+    )
+    user.add_to_group(group, group_admin=True)
+
+    api_client.force_authenticate(user)
+    url = reverse(
+        "api-v1:organisations:organisation-groups-detail",
+        args=[organisation.id, group.id],
+    )
+
+    # When
+    response = api_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK

--- a/api/users/tests/test_views.py
+++ b/api/users/tests/test_views.py
@@ -285,17 +285,19 @@ class UserPermissionGroupViewSetTestCase(TestCase):
         )
         data = {"name": "New Test Group"}
 
-        responses = [
-            client.post(self.list_url, data=data),
+        create_response = client.post(self.list_url, data=data)
+
+        _404_responses = [
             client.put(self._detail_url(group.id)),
             client.get(self._detail_url(group.id)),
             client.delete(self._detail_url(group.id)),
         ]
 
+        assert create_response.status_code == status.HTTP_403_FORBIDDEN
         assert all(
             [
-                response.status_code == status.HTTP_403_FORBIDDEN
-                for response in responses
+                response.status_code == status.HTTP_404_NOT_FOUND
+                for response in _404_responses
             ]
         )
         assert UserPermissionGroup.objects.filter(name=group_name).exists()

--- a/api/users/tests/test_views.py
+++ b/api/users/tests/test_views.py
@@ -1,9 +1,11 @@
 import json
+import typing
 from unittest.case import TestCase
 
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth import login
+from django.contrib.auth.models import AbstractUser
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -490,7 +492,11 @@ def test_retrieve_user_permission_group_includes_group_admin(
     )
 
 
-def test_group_admin_can_retrieve_group(organisation, django_user_model, api_client):
+def test_group_admin_can_retrieve_group(
+    organisation: Organisation,
+    django_user_model: typing.Type[AbstractUser],
+    api_client: APIClient,
+):
     # Given
     user = django_user_model.objects.create(email="test@example.com")
     user.add_organisation(organisation)


### PR DESCRIPTION
## Changes

Updates permission checks to correctly account for Group admins. Note that as part of this, a request to interact with a particular user permission group from a user that does not have permission to do so will now result in a 404, not a 403 since it no longer appears in the queryset for that user. This is _technically_ a breaking change but it feels like the right behaviour so I would say is a necessary fix.

## How did you test this code?

Added / updated tests. 
