### PR TITLE
fix(settings): use smtp.EmailBacked as default if `SENDGRID_API_KEY` is not defined

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 import importlib
 import json
-import logging
 import os
 import sys
 import warnings
@@ -399,17 +398,17 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_VERIFICATION = "none"  # TODO: configure email verification
 
 # Set up Email
-EMAIL_BACKEND = env(
-    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+SENDGRID_API_KEY = env("SENDGRID_API_KEY", default=None)
+
+DEFAULT_EMAIL_BACKEND = (
+    "sgbackend.SendGridBackend"
+    if SENDGRID_API_KEY
+    else "django.core.mail.backends.smtp.EmailBackend"
 )
 
-if EMAIL_BACKEND == "sgbackend.SendGridBackend":
-    SENDGRID_API_KEY = env("SENDGRID_API_KEY", default=None)
-    if not SENDGRID_API_KEY:
-        logging.info(
-            "`SENDGRID_API_KEY` has not been configured. You will not receive emails."
-        )
-elif EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend":
+EMAIL_BACKEND = env("EMAIL_BACKEND", default=DEFAULT_EMAIL_BACKEND)
+
+if EMAIL_BACKEND == "django.core.mail.backends.smtp.EmailBackend":
     EMAIL_HOST = env("EMAIL_HOST", default="localhost")
     EMAIL_HOST_USER = env("EMAIL_HOST_USER", default=None)
     EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD", default=None)

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -399,7 +399,10 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_VERIFICATION = "none"  # TODO: configure email verification
 
 # Set up Email
-EMAIL_BACKEND = env("EMAIL_BACKEND", default="sgbackend.SendGridBackend")
+EMAIL_BACKEND = env(
+    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+)
+
 if EMAIL_BACKEND == "sgbackend.SendGridBackend":
     SENDGRID_API_KEY = env("SENDGRID_API_KEY", default=None)
     if not SENDGRID_API_KEY:

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -400,6 +400,8 @@ ACCOUNT_EMAIL_VERIFICATION = "none"  # TODO: configure email verification
 # Set up Email
 SENDGRID_API_KEY = env("SENDGRID_API_KEY", default=None)
 
+# NOTE: Use `sgbackend.SendGridBackend` as default
+# if `SENDGRID_API_KEY` is set in order to maintain backwards compatibility
 DEFAULT_EMAIL_BACKEND = (
     "sgbackend.SendGridBackend"
     if SENDGRID_API_KEY


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

The problem with using `SendGridBackend` is that
it does not fail silently if `SENDGRID_API_KEY` is not set

We did consider using `dummy.emailbackend` as the default, but that does not make much sense for `DEBUG=False`(i.e: non development) kind of environments since we still want to send_mail with `fail_silently=False` to raise error


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Tested manually by causing an exception with `DEBUG=False`
