### PR TITLE
fix: respect SIGTERM, faster Flagsmith API shutdowns

### DIFF
--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -17,7 +17,7 @@ function serve() {
 
     python manage.py waitfordb
 
-    gunicorn --bind 0.0.0.0:8000 \
+    exec gunicorn --bind 0.0.0.0:8000 \
              --worker-tmp-dir /dev/shm \
              --timeout ${GUNICORN_TIMEOUT:-30} \
              --workers ${GUNICORN_WORKERS:-3} \


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This runs gunicorn as pid 0 in the API image which will make the app respect SIGTERM, making the dockerized Flagsmith shut down much faster. Up to this point it was up to Docker runtime (e.g., Compose has a 10 second timeout).

## How did you test this code?

Build the image, ran e2e Compose file, shut it down, observed shutdown time less than 10 seconds:

```
 ✔ Container frontend-frontend-1       Stopped ... 0.4s 
 ✔ Container frontend-flagsmith-api-1  Stopped ... 1.0s 
 ✔ Container flagsmith_postgres        Stopped ... 0.1s 
```