### PR TITLE
Fix postgres analytics in docker compose

### DIFF
--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -94,7 +94,6 @@ def register_recurring_task(
             defaults={
                 "serialized_args": RecurringTask.serialize_data(args or tuple()),
                 "serialized_kwargs": RecurringTask.serialize_data(kwargs or dict()),
-                "is_locked": False,
             },
         )
         return task

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -94,6 +94,7 @@ def register_recurring_task(
             defaults={
                 "serialized_args": RecurringTask.serialize_data(args or tuple()),
                 "serialized_kwargs": RecurringTask.serialize_data(kwargs or dict()),
+                "is_locked": False,
             },
         )
         return task

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       context: .
     environment:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
+      USE_POSTGRES_FOR_ANALYTICS: 'True' # Store API and Flag Analytics data in Postgres
     entrypoint:
       - 'python'
       - 'manage.py'


### PR DESCRIPTION
## Changes

Add the relevant environment variable to the task_processor service in the docker-compose.yml file. 

Note: at one point in completing this PR, I also saw some exceptions thrown on startup of the task processor related to creating the RecurringTask model. To resolve this, I added the `is_locked` attribute to the `update_or_create` call. This was seemingly necessary as it was otherwise explicitly trying to set the field to `null`. I'm not entirely sure why this was but I'm thinking it was some kind of race condition regarding the migrations as I'm no longer able to reproduce the issue.  

## How did you test this code?

Ran the docker compose with the docker image built locally to verify that the analytics were processed correctly. 
