### PR TITLE
Feature: Do not open edit segment override in a new tab

### DIFF
--- a/frontend/common/services/useSegment.ts
+++ b/frontend/common/services/useSegment.ts
@@ -44,6 +44,7 @@ export const segmentService = service
       updateSegment: builder.mutation<Res['segment'], Req['updateSegment']>({
         invalidatesTags: (q, e, arg) => [
           { id: `LIST${arg.projectId}`, type: 'Segment' },
+          { id: `${arg.segment.id}`, type: 'Segment' },
         ],
         query: (query: Req['updateSegment']) => ({
           body: query.segment,

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -10,6 +10,8 @@ import SegmentSelect from './SegmentSelect'
 import JSONReference from './JSONReference'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import InfoMessage from './InfoMessage'
+import Permission from 'common/providers/Permission'
+import Constants from 'common/constants'
 
 const arrayMoveMutate = (array, from, to) => {
   array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0])
@@ -42,6 +44,7 @@ const SegmentOverrideInner = class Override extends React.Component {
       multivariateOptions,
       name,
       onSortEnd,
+      projectId,
       readOnly,
       setSegmentEditId,
       setShowCreateSegment,
@@ -144,15 +147,28 @@ const SegmentOverrideInner = class Override extends React.Component {
                 </button>
               )}
               {
-                <ButtonLink
-                  onClick={() => {
-                    setShowCreateSegment(true)
-                    setSegmentEditId(v.segment)
-                  }}
-                  className='ml-2'
+                <Permission
+                  id={projectId}
+                  permission={'MANAGE_SEGMENTS'}
+                  level={'project'}
                 >
-                  Edit Segment
-                </ButtonLink>
+                  {({ permission }) =>
+                    Utils.renderWithPermission(
+                      permission,
+                      Constants.projectPermissions('Manage Segments'),
+                      <ButtonLink
+                        disabled={!permission}
+                        onClick={() => {
+                          setShowCreateSegment(true)
+                          setSegmentEditId(v.segment)
+                        }}
+                        className='ml-2'
+                      >
+                        Edit Segment
+                      </ButtonLink>,
+                    )
+                  }
+                </Permission>
               }
             </Row>
           </div>

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -146,7 +146,7 @@ const SegmentOverrideInner = class Override extends React.Component {
                   <RemoveIcon />
                 </button>
               )}
-              {
+              {!!v.id && (
                 <Permission
                   id={projectId}
                   permission={'MANAGE_SEGMENTS'}
@@ -156,20 +156,37 @@ const SegmentOverrideInner = class Override extends React.Component {
                     Utils.renderWithPermission(
                       permission,
                       Constants.projectPermissions('Manage Segments'),
-                      <ButtonLink
-                        disabled={!permission}
-                        onClick={() => {
-                          setShowCreateSegment(true)
-                          setSegmentEditId(v.segment)
-                        }}
-                        className='ml-2'
-                      >
-                        Edit Segment
-                      </ButtonLink>,
+                      <>
+                        {v.is_feature_specific ? (
+                          <ButtonLink
+                            disabled={!permission}
+                            onClick={() => {
+                              setShowCreateSegment(true)
+                              setSegmentEditId(v.segment)
+                            }}
+                            className='ml-2'
+                          >
+                            Edit Segment
+                          </ButtonLink>
+                        ) : (
+                          <ButtonLink
+                            disabled={!permission}
+                            target='_blank'
+                            href={`${document.location.origin}/project/${this.props.projectId}/environment/${this.props.environmentId}/segments?id=${v.segment}`}
+                            onClick={() => {
+                              setShowCreateSegment(true)
+                              setSegmentEditId(v.segment)
+                            }}
+                            className='ml-2'
+                          >
+                            Edit Segment
+                          </ButtonLink>
+                        )}
+                      </>,
                     )
                   }
                 </Permission>
-              }
+              )}
             </Row>
           </div>
         </Row>

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -176,6 +176,7 @@ const SegmentOverrideInner = class Override extends React.Component {
                             className='ml-2'
                           >
                             Edit Segment
+                            <ion className={'ion ml-1 ion-md-open'} />
                           </ButtonLink>
                         )}
                       </>,

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -10,6 +10,8 @@ import SegmentSelect from './SegmentSelect'
 import JSONReference from './JSONReference'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import InfoMessage from './InfoMessage'
+import { getStore } from 'common/store'
+import { segmentService } from 'common/services/useSegment'
 
 const arrayMoveMutate = (array, from, to) => {
   array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0])
@@ -463,6 +465,7 @@ class TheComponent extends Component {
         : SegmentOverrideList
 
     const visibleValues = value && value.filter((v) => !v.toRemove)
+    const store = getStore()
 
     return (
       <div>
@@ -538,6 +541,7 @@ class TheComponent extends Component {
                   segmentEditId: undefined,
                 })
                 this.props.setShowCreateSegment(false)
+                store.dispatch(segmentService.util.resetApiState())
               }}
               onCancel={() => {
                 this.setState({ segmentEditId: undefined })

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -43,6 +43,8 @@ const SegmentOverrideInner = class Override extends React.Component {
       name,
       onSortEnd,
       readOnly,
+      setSegmentEditId,
+      setShowCreateSegment,
       setValue,
       setVariations,
       toggle,
@@ -141,15 +143,17 @@ const SegmentOverrideInner = class Override extends React.Component {
                   <RemoveIcon />
                 </button>
               )}
-              {this.props.showEditSegment && (
+              {
                 <ButtonLink
-                  target='_blank'
-                  href={`${document.location.origin}/project/${this.props.projectId}/environment/${this.props.environmentId}/segments?id=${v.segment}`}
+                  onClick={() => {
+                    setShowCreateSegment(true)
+                    setSegmentEditId(v.segment)
+                  }}
                   className='ml-2'
                 >
                   Edit Segment
                 </ButtonLink>
-              )}
+              }
             </Row>
           </div>
         </Row>
@@ -280,6 +284,8 @@ const SegmentOverrideListInner = ({
   onSortEnd,
   projectId,
   readOnly,
+  setSegmentEditId,
+  setShowCreateSegment,
   setValue,
   setVariations,
   showEditSegment,
@@ -304,6 +310,8 @@ const SegmentOverrideListInner = ({
             index={index}
             readOnly={readOnly}
             value={value}
+            setSegmentEditId={setSegmentEditId}
+            setShowCreateSegment={setShowCreateSegment}
             confirmRemove={() => confirmRemove(index)}
             controlValue={controlValue}
             toggle={() => toggle(index)}
@@ -341,7 +349,7 @@ class TheComponent extends Component {
 
   constructor(props) {
     super(props)
-    this.state = {}
+    this.state = { segmentEditId: undefined }
   }
 
   addItem = () => {
@@ -412,6 +420,10 @@ class TheComponent extends Component {
   setValue = (i, value) => {
     this.props.value[i].value = value
     this.props.onChange(this.props.value)
+  }
+
+  setSegmentEditId = (id) => {
+    this.setState({ segmentEditId: id })
   }
 
   setVariations = (i, value) => {
@@ -487,7 +499,7 @@ class TheComponent extends Component {
                 </Button>
               </div>
             )}
-          {this.props.showCreateSegment && (
+          {this.props.showCreateSegment && !this.state.segmentEditId && (
             <div className='text-left panel--grey mt-2'>
               <CreateSegmentModal
                 onComplete={(segment) => {
@@ -515,6 +527,25 @@ class TheComponent extends Component {
                 projectId={this.props.projectId}
               />
             </div>
+          )}
+          {this.props.showCreateSegment && this.state.segmentEditId && (
+            <CreateSegmentModal
+              segment={this.state.segmentEditId}
+              isEdit
+              condensed
+              onComplete={() => {
+                this.setState({
+                  segmentEditId: undefined,
+                })
+                this.props.setShowCreateSegment(false)
+              }}
+              onCancel={() => {
+                this.setState({ segmentEditId: undefined })
+                this.props.setShowCreateSegment(false)
+              }}
+              environmentId={this.props.environmentId}
+              projectId={this.props.projectId}
+            />
           )}
           {visibleValues &&
             !!visibleValues.length &&
@@ -559,9 +590,11 @@ class TheComponent extends Component {
                       showEditSegment={this.props.showEditSegment}
                       environmentId={this.props.environmentId}
                       projectId={this.props.projectId}
+                      setShowCreateSegment={this.props.setShowCreateSegment}
                       items={value.map((v) => ({
                         ...v,
                       }))}
+                      setSegmentEditId={this.setSegmentEditId}
                       onSortEnd={this.onSortEnd}
                     />
                     <div className='text-left mt-4'>

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -10,8 +10,6 @@ import SegmentSelect from './SegmentSelect'
 import JSONReference from './JSONReference'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import InfoMessage from './InfoMessage'
-import { getStore } from 'common/store'
-import { segmentService } from 'common/services/useSegment'
 
 const arrayMoveMutate = (array, from, to) => {
   array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0])
@@ -465,7 +463,6 @@ class TheComponent extends Component {
         : SegmentOverrideList
 
     const visibleValues = value && value.filter((v) => !v.toRemove)
-    const store = getStore()
 
     return (
       <div>
@@ -541,7 +538,6 @@ class TheComponent extends Component {
                   segmentEditId: undefined,
                 })
                 this.props.setShowCreateSegment(false)
-                store.dispatch(segmentService.util.resetApiState())
               }}
               onCancel={() => {
                 this.setState({ segmentEditId: undefined })

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -173,10 +173,6 @@ const SegmentOverrideInner = class Override extends React.Component {
                             disabled={!permission}
                             target='_blank'
                             href={`${document.location.origin}/project/${this.props.projectId}/environment/${this.props.environmentId}/segments?id=${v.segment}`}
-                            onClick={() => {
-                              setShowCreateSegment(true)
-                              setSegmentEditId(v.segment)
-                            }}
                             className='ml-2'
                           >
                             Edit Segment


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

- Edit segment in the same tab

## How did you test this code?

Tested that editing segments works from a feature for both global and feature specific segments. 
