### PR TITLE
Fix compare environment permissions

### DIFF
--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -170,7 +170,7 @@ class CompareEnvironments extends Component {
                               environmentLeft.minimum_change_request_approvals,
                             ),
                           )}
-                          id={this.props.environmentId}
+                          id={environmentLeft.api_key}
                         >
                           {({ permission }) => (
                             <FeatureRow
@@ -199,7 +199,7 @@ class CompareEnvironments extends Component {
                               environmentRight.minimum_change_request_approvals,
                             ),
                           )}
-                          id={this.props.environmentId}
+                          id={environmentRight.api_key}
                         >
                           {({ permission }) => (
                             <FeatureRow

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -105,7 +105,11 @@ class TheComponent extends Component {
     )
 
     if (this.props.condensed) {
-      return (
+      return Utils.renderWithPermission(
+        permission,
+        Constants.environmentPermissions(
+          Utils.getManageFeaturePermissionDescription(changeRequestsEnabled),
+        ),
         <Row
           onClick={() =>
             !readOnly && this.editFeature(projectFlag, environmentFlags[id])
@@ -155,11 +159,15 @@ class TheComponent extends Component {
               data-test={`feature-value-${this.props.index}`}
             />
           </div>
-        </Row>
+        </Row>,
       )
     }
 
-    return (
+    return Utils.renderWithPermission(
+      permission,
+      Constants.environmentPermissions(
+        Utils.getManageFeaturePermissionDescription(changeRequestsEnabled),
+      ),
       <Row
         style={{ flexWrap: 'nowrap' }}
         className={`list-item ${readOnly ? '' : 'clickable'} ${
@@ -352,7 +360,7 @@ class TheComponent extends Component {
             </Permission>
           )}
         </Row>
-      </Row>
+      </Row>,
     )
   }
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

- Feature rows will now show our standard permission tooltips if they don't have appropriate permissions to edit.
- Compare environment rows will now fetch the correct environment permission

## How did you test this code?

- Invited a user on production to test read only access to production vs development 
![image](https://user-images.githubusercontent.com/8608314/235194459-8d15c9be-d61e-4970-adf4-7b84f2785195.png)

