### PR TITLE
Add trailing slash to getGroup URL

### DIFF
--- a/frontend/common/services/useGroup.ts
+++ b/frontend/common/services/useGroup.ts
@@ -39,7 +39,7 @@ export const groupService = service
       getGroup: builder.query<Res['group'], Req['getGroup']>({
         providesTags: (res) => [{ id: res?.id, type: 'Group' }],
         query: (query: Req['getGroup']) => ({
-          url: `organisations/${query.orgId}/groups/${query.id}`,
+          url: `organisations/${query.orgId}/groups/${query.id}/`,
         }),
       }),
       getGroups: builder.query<Res['groups'], Req['getGroups']>({


### PR DESCRIPTION
## Changes

Adds the trailing slash to the URL used to retrieve a specific group to fix issues in single container setup. 

## How did you test this code?

Using a private cloud deployment, I have verified that the cURL without the trailing slash fails. The cURL with the trailing slash succeeds. 
