### PR TITLE
Minor updates to Uffizzi GHA workflows to bring in line with other projects

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -30,7 +30,7 @@ jobs:
             type=raw,value=60d
 
       - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -16,7 +16,7 @@ jobs:
       compose-file-cache-key: ${{ env.HASH }}
       pr-number: ${{ env.PR_NUMBER }}
     steps:
-      - name: Download artifacts
+      - name: 'Download artifacts'
         # Fetch output (zip archive) from the workflow run that triggered this workflow.
         uses: actions/github-script@v6
         with:
@@ -29,6 +29,9 @@ jobs:
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "preview-spec"
             })[0];
+            if (matchArtifact === undefined) {
+              throw TypeError('Build Artifact not found!');
+            }
             let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -38,8 +41,9 @@ jobs:
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
 
-      - name: Unzip artifact
+      - name: 'Unzip artifact'
         run: unzip preview-spec.zip
+
       - name: Read Event into ENV
         run: |
           echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
@@ -51,6 +55,7 @@ jobs:
         # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
         if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
         run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+
       - name: Cache Rendered Compose File
         if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
         uses: actions/cache@v3
@@ -61,10 +66,16 @@ jobs:
       - name: Read PR Number From Event Object
         id: pr
         run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+
+      - name: Read Git Ref From Event Object
+        id: ref
+        run: echo "GIT_REF=${{ fromJSON(env.EVENT_JSON).pull_request.head.sha }}" >> $GITHUB_ENV
+
       - name: DEBUG - Print Job Outputs
         if: ${{ runner.debug }}
         run: |
           echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Git Ref: ${{ env.GIT_REF }}"
           echo "Compose file hash: ${{ env.HASH }}"
           cat event.json
 


### PR DESCRIPTION
## Changes

The most important is the error handling when GitHub's Artifact Registry hiccups and does not deliver. This causes a terribly ambiguous error you can see here: https://github.com/Flagsmith/flagsmith/actions/runs/4829275209/jobs/8604115305#step:2:31

## How did you test this code?

These updates are borrowed from other open-source projects that use Uffizzi. Unfortunately these workflows only execute after they're merged to the project's default branch.