### PR TITLE
Add Makefile

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-max-line-length = 120
-max-complexity = 10
-exclude = .git,__pycache__,*/migrations/*
-
-per-file-ignores = 
-    api/app/settings/local.py: F403, F405
-    api/app/settings/production.py: F403, F405
-    api/app/settings/saas.py: F403, F405

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -45,18 +45,10 @@ jobs:
           cache: pip
 
       - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-all.txt
+        run: make install
 
-      - name: Check black formatting
-        run: black --check .
-
-      - name: Check flake8 linting
-        run: flake8 .
-
-      - name: Check isort imports
-        run: isort --check .
+      - name: Run Linters
+        run: make lint
 
       - name: Create analytics database
         env:
@@ -65,9 +57,5 @@ jobs:
 
       - name: Run Tests
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
-          ANALYTICS_DATABASE_URL:
-            postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/analytics
-          DJANGO_SETTINGS_MODULE: app.settings.test
-        run: |
-          pytest -p no:warnings
+          DOTENV_OVERRIDE_FILE: .env-ci
+        run: make test

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -53,7 +53,6 @@ jobs:
         run: black --check .
 
       - name: Check flake8 linting
-        working-directory: . # working dir should be root due to conflicts with pre-commit
         run: flake8 .
 
       - name: Check isort imports

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ checkstyle.txt
 .python-version
 .env*
 !.env-local
+!.env-ci
 .direnv
 .envrc
 .tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv
 checkstyle.txt
 .python-version
 .env*
+!.env-local
 .direnv
 .envrc
 .tool-versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     hooks:
       - id: flake8
         name: flake8
+        args: [--config, api/.flake8]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics

--- a/api/.env-local
+++ b/api/.env-local
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
+DJANGO_SETTINGS_MODULE=app.settings.local

--- a/api/.flake8
+++ b/api/.flake8
@@ -1,9 +1,9 @@
 [flake8]
 max-line-length = 120
 max-complexity = 10
-exclude = .git,.venv,__pycache__,migrations
+exclude = .git,.venv,.direnv,__pycache__,migrations
 
-per-file-ignores = 
+per-file-ignores =
     app/settings/local.py: F403, F405
     app/settings/production.py: F403, F405
     app/settings/saas.py: F403, F405

--- a/api/.flake8
+++ b/api/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 120
+max-complexity = 10
+exclude = .git,.venv,__pycache__,migrations
+
+per-file-ignores = 
+    app/settings/local.py: F403, F405
+    app/settings/production.py: F403, F405
+    app/settings/saas.py: F403, F405

--- a/api/Makefile
+++ b/api/Makefile
@@ -10,12 +10,16 @@ DOTENV_OVERRIDE_FILE ?= .env
 -include .env-local
 -include $(DOTENV_OVERRIDE_FILE)
 
+.PHONY: install-pip
+install-pip:
+	python -m pip install --upgrade pip
+
 .PHONY: install-packages
 install-packages:
 	pip install -r requirements-all.txt
 
 .PHONY: install
-install: install-packages
+install: install-pip install-packages
 
 .PHONY: lint-black
 lint-black:

--- a/api/Makefile
+++ b/api/Makefile
@@ -60,15 +60,19 @@ docker-build:
 test:
 	pytest $(opts)
 
-.PHONY: migrations
-migrations:
+.PHONY: django-migrations
+django-make-migrations:
 	python manage.py waitfordb
 	python manage.py makemigrations $(opts)
 
-.PHONY: migrate
-migrate:
+.PHONY: django-migrate
+django-migrate:
 	python manage.py waitfordb
 	python manage.py migrate
+
+.PHONY: django-collect-static
+django-collect-static:
+	python manage.py collectstatic --noinput
 
 .PHONY: serve
 serve:

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,71 @@
+.EXPORT_ALL_VARIABLES:
+
+DOCKER_TAG ?= flagsmith/flagsmith-api:local
+
+COMPOSE_FILE ?= ../docker/db.yaml
+COMPOSE_PROJECT_NAME ?= flagsmith
+
+DOTENV_OVERRIDE_FILE ?= .env
+
+-include .env-local
+-include $(DOTENV_OVERRIDE_FILE)
+
+.PHONY: install-packages
+install-packages:
+	pip install -r requirements-all.txt
+
+.PHONY: install
+install: install-packages
+
+.PHONY: lint-black
+lint-black:
+	black --check .
+
+.PHONY: lint-isort
+lint-isort:
+	isort  --check-only --diff .
+
+.PHONY: lint-flake8
+lint-flake8:
+	flake8
+
+.PHONY: lint
+lint: lint-black lint-isort lint-flake8
+
+.PHONY: docker-up
+docker-up:
+	docker-compose up --force-recreate --remove-orphans -d
+	docker-compose ps
+
+.PHONY: docker-down
+docker-down:
+	docker-compose stop
+
+.PHONY: docker-logs
+docker-logs:
+	docker-compose logs --follow
+
+.PHONY: docker-build
+docker-build:
+	@docker build \
+		--tag=$(DOCKER_TAG) \
+		--file=Dockerfile \
+		.
+
+.PHONY: test
+test:
+	pytest $(opts)
+
+.PHONY: migrations
+migrations:
+	python manage.py waitfordb
+	python manage.py makemigrations $(opts)
+
+.PHONY: migrate
+migrate:
+	python manage.py waitfordb
+	python manage.py migrate
+
+.PHONY: serve
+serve:
+	gunicorn --bind 0.0.0.0:8000 app.wsgi --reload

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,4 +33,4 @@ known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','cor
 skip = ['.venv','migrations']
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '-vvvv']
+addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings']

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -24,10 +24,13 @@ exclude = '''
 '''
 
 [tool.isort]
-use_parentheses=true
-multi_line_output=3
-include_trailing_comma=true
-line_length=79
+use_parentheses = true
+multi_line_output = 3
+include_trailing_comma = true
+line_length = 79
 known_first_party=['analytics','app','custom_auth','environments','integrations','organisations','projects','segments','users','webhooks','api','audit','e2etests','features','permissions','util']
 known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','core','coreapi','corsheaders','dj_database_url','django','django_lifecycle','djoser','drf_writable_nested','drf_yasg2','environs','google','influxdb_client','ordered_model','pyotp','pytest','pytz','requests','responses','rest_framework','rest_framework_nested','rest_framework_recursive','sentry_sdk','shortuuid','simple_history','six','telemetry','tests','trench','whitenoise']
-skip = ['migrations']
+skip = ['.venv','migrations']
+
+[tool.pytest.ini_options]
+addopts = ['--ds=app.settings.test', '-vvvv']

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,6 +15,7 @@ exclude = '''
   | \.mypy_cache
   | \.tox
   | \.venv
+  | \.direnv
   | _build
   | buck-out
   | build
@@ -30,7 +31,7 @@ include_trailing_comma = true
 line_length = 79
 known_first_party=['analytics','app','custom_auth','environments','integrations','organisations','projects','segments','users','webhooks','api','audit','e2etests','features','permissions','util']
 known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','core','coreapi','corsheaders','dj_database_url','django','django_lifecycle','djoser','drf_writable_nested','drf_yasg2','environs','google','influxdb_client','ordered_model','pyotp','pytest','pytz','requests','responses','rest_framework','rest_framework_nested','rest_framework_recursive','sentry_sdk','shortuuid','simple_history','six','telemetry','tests','trench','whitenoise']
-skip = ['.venv','migrations']
+skip = ['migrations','.venv','.direnv']
 
 [tool.pytest.ini_options]
 addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings']

--- a/docker/db.yaml
+++ b/docker/db.yaml
@@ -10,6 +10,6 @@ services:
       - 5432:5432
     environment:
       POSTGRES_DB: flagsmith
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: password
 volumes:
   pg_11_data:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Contributes to #2151.

This adds a Makefile along with the default dotenv file to the `api` project and modifies Python tools' configurations to accommodate for those.

The Makefile has been tested and refined for some time. It has been my personal daily driver for a couple of weeks. I went ahead and migrated the API PR workflow to Makefile.

The following targets are added:

- `docker-up`, `docker-logs` and `docker-down`: manage the Docker Compose project to bring up dependencies for Flagsmith API (currently just Postgres defined in `docker/db.yaml`). Configurable via Compose's default environment variables.
- `docker-build`: build the API image and tag it with the `flagsmith-api:local` tag. Tag name configurable.
- `test`: Run Pytest. Pytest configuration resides in `pyproject.toml` now and establishes sane defaults: verbosity level to include full test names and the Django settings module. Additional options may be provided with an `opts` variable.
- `django-migrations`: Autogenerate migrations. Specify appts with an `opts` variable.
- `django-migrate`: Identical to `run-docker.sh`'s `migrate` command.
- `django-serve`: Spin up a gunicorn instance with live-reload enabled.
- `lint`: Runs linters (`lint-black`, `lint-isort` and `lint-flake8`).
- `install`: Installs dependencies (currently just `install-packages`, which installs dev dependencies too).

## How did you test this code?

- Ran every Makefile target and observerd the results:

  1. Linter behaviour is identical to `pre-commit`.
  2. `pytest` runs with correct Django settings module.
  3. Docker Compose brings up the database with correct credentials and applies the default project name.
  4. `make docker-build` applies the configured tag.
  5. `make django-migrate` and `make django-migrations` wait for the database so i.e. `make docker-up django-migrate` won't crash.
  6. `make django-serve` spins up a working API server and the live-reload works.

- `install`, `lint` and `test` targets run in CI!