### PR TITLE
Switches overlap large feature flag names fixed

### DIFF
--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -292,7 +292,6 @@ class CompareEnvironments extends Component {
                                 <strong
                                   style={{
                                     display: 'flex',
-                                    flex: 1,
                                     justifyContent: 'center',
                                   }}
                                 >

--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -307,7 +307,6 @@ class CompareEnvironments extends Component {
                                 <strong
                                   style={{
                                     display: 'flex',
-                                    flex: 1,
                                     justifyContent: 'center',
                                   }}
                                 >
@@ -354,7 +353,6 @@ class CompareEnvironments extends Component {
                                   <strong
                                     style={{
                                       display: 'flex',
-                                      flex: 1,
                                       justifyContent: 'center',
                                     }}
                                   >
@@ -369,7 +367,6 @@ class CompareEnvironments extends Component {
                                   <strong
                                     style={{
                                       display: 'flex',
-                                      flex: 1,
                                       justifyContent: 'center',
                                     }}
                                   >

--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -158,9 +158,21 @@ class CompareEnvironments extends Component {
                   <div className='list-item'>
                     <Row>
                       <div style={{ width: featureNameWidth }}>
-                        <Tooltip title={<strong>{p.projectFlag.name}</strong>}>
-                          {p.projectFlag.description}
-                        </Tooltip>
+                        {p.projectFlag.description ? (
+                          <Tooltip
+                            title={
+                              <strong style={{ wordWrap: 'break-word' }}>
+                                {p.projectFlag.name}
+                              </strong>
+                            }
+                          >
+                            {p.projectFlag.description}
+                          </Tooltip>
+                        ) : (
+                          <strong style={{ wordWrap: 'break-word' }}>
+                            {p.projectFlag.name}
+                          </strong>
+                        )}
                       </div>
                       <Flex className='mr-2'>
                         <Permission
@@ -175,6 +187,7 @@ class CompareEnvironments extends Component {
                           {({ permission }) => (
                             <FeatureRow
                               condensed
+                              isCompareEnv
                               fadeEnabled={fadeEnabled}
                               fadeValue={fadeValue}
                               environmentFlags={this.state.environmentLeftFlags}
@@ -204,6 +217,7 @@ class CompareEnvironments extends Component {
                           {({ permission }) => (
                             <FeatureRow
                               condensed
+                              isCompareEnv
                               fadeEnabled={fadeEnabled}
                               fadeValue={fadeValue}
                               environmentFlags={
@@ -275,7 +289,13 @@ class CompareEnvironments extends Component {
                             >
                               <span style={{ width: featureNameWidth }} />
                               <Flex>
-                                <strong>
+                                <strong
+                                  style={{
+                                    display: 'flex',
+                                    flex: 1,
+                                    justifyContent: 'center',
+                                  }}
+                                >
                                   {
                                     ProjectStore.getEnvironment(
                                       this.state.environmentLeft,
@@ -284,7 +304,13 @@ class CompareEnvironments extends Component {
                                 </strong>
                               </Flex>
                               <Flex>
-                                <strong>
+                                <strong
+                                  style={{
+                                    display: 'flex',
+                                    flex: 1,
+                                    justifyContent: 'center',
+                                  }}
+                                >
                                   {
                                     ProjectStore.getEnvironment(
                                       this.state.environmentRight,
@@ -325,7 +351,13 @@ class CompareEnvironments extends Component {
                               >
                                 <span style={{ width: featureNameWidth }} />
                                 <Flex>
-                                  <strong>
+                                  <strong
+                                    style={{
+                                      display: 'flex',
+                                      flex: 1,
+                                      justifyContent: 'center',
+                                    }}
+                                  >
                                     {
                                       ProjectStore.getEnvironment(
                                         this.state.environmentLeft,
@@ -334,7 +366,13 @@ class CompareEnvironments extends Component {
                                   </strong>
                                 </Flex>
                                 <Flex>
-                                  <strong>
+                                  <strong
+                                    style={{
+                                      display: 'flex',
+                                      flex: 1,
+                                      justifyContent: 'center',
+                                    }}
+                                  >
                                     {
                                       ProjectStore.getEnvironment(
                                         this.state.environmentRight,

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -114,7 +114,11 @@ class TheComponent extends Component {
           onClick={() =>
             !readOnly && this.editFeature(projectFlag, environmentFlags[id])
           }
-          style={{ overflow: 'hidden', ...(this.props.style || {}) }}
+          style={{
+            flexDirection: this.props.isCompareEnv ? 'column' : 'row',
+            overflow: 'hidden',
+            ...(this.props.style || {}),
+          }}
         >
           <div className={`mr-2 ${this.props.fadeEnabled && 'faded'}`}>
             <Switch
@@ -146,7 +150,10 @@ class TheComponent extends Component {
               }}
             />
           </div>
-          <div className={`mr-2 clickable ${this.props.fadeValue && 'faded'}`}>
+          <div
+            className={`mr-2 clickable ${this.props.fadeValue && 'faded'}`}
+            style={this.props.isCompareEnv && { marginTop: '5px' }}
+          >
             <FeatureValue
               onClick={() =>
                 permission &&


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

 - Break the feature flag large name
 - Feature value was moved below switch
 - Removed the tooltip when the feature flag hasn't description

## How did you test this code?

 - Create a feature flag with a very large name like this_is_an_example_of_a_very_large_feature_flag_name
 - Add a feature value 
 - In the Project left menu, Click on 'Compare'
 - Select two environments
