### PR TITLE
fix: Fixes #2201 Displays NotFoundPage component on unreachable routes

### DIFF
--- a/frontend/web/routes.js
+++ b/frontend/web/routes.js
@@ -163,7 +163,7 @@ export default (
         component={BetaFeaturesPage}
       />
       <Route path='/create' exact component={CreateOrganisationPage} />
-      <Route component={NotFoundPage} />
+      <Route path='*' component={NotFoundPage} />
     </Switch>
   </App>
 )


### PR DESCRIPTION
This PR solves issue #2201 
* If a default route is not found, the user is shown `NotFoundComponent`.
