### PR TITLE
Update examples urls links moved to a new repo

### DIFF
--- a/docs/docs/clients/client-side/javascript.md
+++ b/docs/docs/clients/client-side/javascript.md
@@ -11,7 +11,7 @@ projects. The source code for the client is available on [Github](https://github
 Example applications for a variety of JavaScript frameworks such as React, Vue and Angular, as well as React Native, can
 be found here:
 
-- [Flagsmith Framework Examples](https://github.com/Flagsmith/flagsmith-js-examples)
+- [Flagsmith Framework Examples](https://github.com/Flagsmith/flagsmith-js-examples/tree/main
 
 ## Installation
 

--- a/docs/docs/clients/client-side/nextjs-and-ssr.md
+++ b/docs/docs/clients/client-side/nextjs-and-ssr.md
@@ -9,13 +9,12 @@ The JavaScript Library contains a bundled isomorphic library, allowing you to fe
 application with the resulting state.
 
 Example applications for a variety of Next.js and SSR can be found
-[here](https://github.com/flagsmith/flagsmith-js-client/tree/main/examples/nextjs).
+[here](https://github.com/flagsmith/flagsmith-js-examples/tree/main/nextjs).
 
-Example applications for Svelte be found
-[here](https://github.com/flagsmith/flagsmith-js-client/tree/main/examples/svelte).
+Example applications for Svelte be found [here](https://github.com/flagsmith/flagsmith-js-examples/tree/main/svelte).
 
 An example application for Next.js middleware can be found
-[here](https://github.com/flagsmith/flagsmith-js-client/tree/main/examples/nextjs-middleware).
+[here](https://github.com/flagsmith/flagsmith-js-examples/tree/main/nextjs-middleware).
 
 ## Installation
 

--- a/docs/docs/clients/client-side/react.md
+++ b/docs/docs/clients/client-side/react.md
@@ -10,9 +10,9 @@ re-renders.
 
 Example applications for a variety of React, React Native and Next.js can be found here:
 
-- [Usage with React](https://github.com/Flagsmith/flagsmith-js-client/tree/main/examples/react)
-- [Usage with React Native](https://github.com/Flagsmith/flagsmith-js-client/tree/main/examples/react)
-- [Usage with Next.js](https://github.com/Flagsmith/flagsmith-js-client/tree/main/examples/nextjs)
+- [Usage with React](https://github.com/Flagsmith/flagsmith-js-examples/tree/main/react)
+- [Usage with React Native](https://github.com/Flagsmith/flagsmith-js-examples/tree/main/react)
+- [Usage with Next.js](https://github.com/Flagsmith/flagsmith-js-examples/tree/main/nextjs)
 
 ## Installation
 

--- a/docs/versioned_docs/version-v1.0/clients/client-side/javascript.md
+++ b/docs/versioned_docs/version-v1.0/clients/client-side/javascript.md
@@ -11,7 +11,7 @@ projects. The source code for the client is available on [Github](https://github
 Example applications for a variety of Javascript frameworks such as React, Vue and Angular, as well as React Native, can
 be found here:
 
-- [Flagsmith Framework Examples](https://github.com/flagsmith/flagsmith-js-client/tree/main/examples)
+- [Flagsmith Framework Examples](https://github.com/flagsmith/flagsmith-js-examples/tree/main)
 
 ## Installation
 

--- a/docs/versioned_docs/version-v1.0/clients/client-side/nextjs-and-ssr.md
+++ b/docs/versioned_docs/version-v1.0/clients/client-side/nextjs-and-ssr.md
@@ -9,7 +9,7 @@ The JavaScript Library contains a bundled isomorphic library, allowing you to fe
 application with the resulting state.
 
 Example applications for a variety of Next.js and SSR can be found
-[here](https://github.com/flagsmith/flagsmith-js-client/tree/main/examples/nextjs).
+[here](https://github.com/flagsmith/flagsmith-js-examples/tree/main/nextjs).
 
 ## Installation
 

--- a/docs/versioned_docs/version-v1.0/clients/client-side/react.md
+++ b/docs/versioned_docs/version-v1.0/clients/client-side/react.md
@@ -10,9 +10,9 @@ re-renders.
 
 Example applications for a variety of React, React Native and Next.js can be found here:
 
-- [Usage with React](https://github.com/Flagsmith/flagsmith-js-client/tree/main/examples/react)
-- [Usage with React Native](https://github.com/Flagsmith/flagsmith-js-client/tree/main/examples/react)
-- [Usage with Next.js](https://github.com/Flagsmith/flagsmith-js-client/tree/main/examples/nextjs)
+- [Usage with React](https://github.com/Flagsmith/flagsmith-js-examples/tree/main/react)
+- [Usage with React Native](https://github.com/Flagsmith/flagsmith-js-examples/tree/main/react)
+- [Usage with Next.js](https://github.com/Flagsmith/flagsmith-js-examples/tree/main/nextjs)
 
 ## Installation
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?

## Changes
Since the JS examples have been moved to a new repository, the links referring to those examples in the docs need to be updated.

## How did you test this code?
Manually.
Go to the documents and verify that the links referring to JS examples are leding tothe right repository pages.
