### PR TITLE
Bump workflows version 1.2.1

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -39,7 +39,7 @@ jobs:
           aws_identity_migration_task_role_arn: arn:aws:iam::084060095745:role/task-exec-role-741a7e3
           aws_task_definitions_directory_path: infrastructure/aws/production
           flagsmith_saml_revision: v1.0.2
-          flagsmith_workflows_revision: v1.2.0
+          flagsmith_workflows_revision: v1.2.1
           flagsmith_auth_controller_revision: v0.0.1
 
       - name: Deploy task processor to Production

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -39,7 +39,7 @@ jobs:
           aws_identity_migration_task_role_arn: arn:aws:iam::302456015006:role/task-exec-role-6fb76f6
           aws_task_definitions_directory_path: infrastructure/aws/staging
           flagsmith_saml_revision: v1.0.2
-          flagsmith_workflows_revision: v1.2.0
+          flagsmith_workflows_revision: v1.2.1
           flagsmith_auth_controller_revision: v0.0.1
 
       - name: Deploy task processor to Staging

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   FLAGSMITH_SAML_REVISION: v1.0.2
-  FLAGSMITH_WORKFLOWS_REVISION: v1.0.4
+  FLAGSMITH_WORKFLOWS_REVISION: v1.2.1
 
 jobs:
   build-dockerhub:


### PR DESCRIPTION
## Changes

Bump workflows version to 1.2.1 in all GH actions. 

## How did you test this code?

Tests are run in workflows repo as per PR [here](https://github.com/Flagsmith/flagsmith-workflows/pull/17). 
