### PR TITLE
feat: Add hide sensitive data switch to environment config

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -43,6 +43,7 @@ export type Environment = {
   project: number
   minimum_change_request_approvals?: number
   allow_client_traits: boolean
+  hide_sensitive_data: boolean
 }
 export type Project = {
   id: number

--- a/frontend/web/components/modals/ConfirmToggleEnvFeature.tsx
+++ b/frontend/web/components/modals/ConfirmToggleEnvFeature.tsx
@@ -12,7 +12,7 @@ const ConfirmToggleEnvFeature: FC<ConfirmToggleEnvFeatureType> = ({
   feature,
   featureValue,
   onToggleChange,
-}) => {
+}: ConfirmToggleEnvFeatureType) => {
   const isEnabled = featureValue
   return (
     <div id='confirm-toggle-feature-modal'>

--- a/frontend/web/components/modals/ConfirmToggleEnvFeature.tsx
+++ b/frontend/web/components/modals/ConfirmToggleEnvFeature.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+type ConfirmToggleEnvFeatureType = {
+  description: string
+  feature: string
+  featureValue: boolean
+  onToggleChange?: (value: boolean) => void
+}
+
+const ConfirmToggleEnvFeature: FC<ConfirmToggleEnvFeatureType> = ({
+  description,
+  feature,
+  featureValue,
+  onToggleChange,
+}) => {
+  const isEnabled = featureValue
+  return (
+    <div id='confirm-toggle-feature-modal'>
+      <p>
+        This will turn <strong>{feature}</strong> to{' '}
+        {isEnabled ? (
+          <span className='feature--off'>
+            <strong>"Off"</strong>
+          </span>
+        ) : (
+          <span className='feature--on'>
+            <strong>"On"</strong>
+          </span>
+        )}
+        . <span>{description}</span>
+      </p>
+      <FormGroup className='text-right'>
+        <Button
+          onClick={() => {
+            onToggleChange(!featureValue)
+          }}
+          className='btn btn-primary'
+          id='confirm-toggle-feature-btn'
+        >
+          Confirm changes
+        </Button>
+      </FormGroup>
+    </div>
+  )
+}
+
+export default ConfirmToggleEnvFeature
+
+module.exports = ConfirmToggleEnvFeature

--- a/frontend/web/components/pages/EnvironmentSettingsPage.js
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.js
@@ -160,7 +160,7 @@ const EnvironmentSettingsPage = class extends Component {
 
   confirmToggle = (description, feature, featureValue) => {
     openModal(
-      'Toggle Feature',
+      'Enable "Hide Sensitive Data"',
       <ConfirmToggleEnvFeature
         description={description}
         feature={feature}
@@ -358,14 +358,25 @@ const EnvironmentSettingsPage = class extends Component {
                               <div className='col-md-8 pl-0'>
                                 <h3 className='m-b-0'>Hide sensitive data</h3>
                                 <p>
-                                  Exclude flags' description and tags from data
-                                  returned by API for this environment
+                                  Exclude sensitive data from endpoints
+                                  returning flags and identity information to
+                                  the SDKs or via our REST API. For full
+                                  information on the excluded fields see
+                                  documentation{' '}
+                                  {/* TODO: Update the link below once the documentation is generated. */}
+                                  <ButtonLink
+                                    href='https://docs.flagsmith.com'
+                                    target='_blank'
+                                  >
+                                    here.
+                                  </ButtonLink>
+                                  <br />
+                                  <strong>
+                                    Warning! Enabling this feature will change
+                                    schema returned by the API and could break
+                                    your existing code.
+                                  </strong>
                                 </p>
-                                <strong>
-                                  Warning! Enabling this feature will change the
-                                  schema returned by the API and could break
-                                  your existing code.
-                                </strong>
                               </div>
                               <div className='col-md-4 pr-0 text-right'>
                                 <div>

--- a/frontend/web/components/pages/EnvironmentSettingsPage.js
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.js
@@ -364,7 +364,7 @@ const EnvironmentSettingsPage = class extends Component {
                                   information on the excluded fields see
                                   documentation{' '}
                                   <ButtonLink
-                                    href='https://docs.flagsmith.com/advanced-use/hide-sensitive-data'
+                                    href='https://docs.flagsmith.com/advanced-use/system-administration#hide-sensitive-data'
                                     target='_blank'
                                   >
                                     here.

--- a/frontend/web/components/pages/EnvironmentSettingsPage.js
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.js
@@ -5,6 +5,7 @@ import ConfigProvider from 'common/providers/ConfigProvider'
 import withWebhooks from 'common/providers/withWebhooks'
 import CreateWebhookModal from 'components/modals/CreateWebhook'
 import ConfirmRemoveWebhook from 'components/modals/ConfirmRemoveWebhook'
+import ConfirmToggleEnvFeature from 'components/modals/ConfirmToggleEnvFeature'
 import EditPermissions from 'components/EditPermissions'
 import ServerSideSDKKeys from 'components/ServerSideSDKKeys'
 import PaymentModal from 'components/modals/Payment'
@@ -95,6 +96,7 @@ const EnvironmentSettingsPage = class extends Component {
         banner_text: this.state.banner_text,
         description: description || env.description,
         hide_disabled_flags: this.state.hide_disabled_flags,
+        hide_sensitive_data: !!this.state.hide_sensitive_data,
         minimum_change_request_approvals: has4EyesPermission
           ? this.state.minimum_change_request_approvals
           : null,
@@ -156,10 +158,30 @@ const EnvironmentSettingsPage = class extends Component {
     )
   }
 
+  confirmToggle = (description, feature, featureValue) => {
+    openModal(
+      'Toggle Feature',
+      <ConfirmToggleEnvFeature
+        description={description}
+        feature={feature}
+        featureValue={featureValue}
+        onToggleChange={(value) => {
+          this.setState({ hide_sensitive_data: value }, this.saveEnv)
+          closeModal()
+        }}
+      />,
+    )
+  }
+
   render() {
     const {
       props: { webhooks, webhooksLoading },
-      state: { allow_client_traits, name, use_mv_v2_evaluation },
+      state: {
+        allow_client_traits,
+        hide_sensitive_data,
+        name,
+        use_mv_v2_evaluation,
+      },
     } = this
     const has4EyesPermission = Utils.getPlansPermission('4_EYES')
 
@@ -185,6 +207,7 @@ const EnvironmentSettingsPage = class extends Component {
                   banner_colour: env.banner_colour || Constants.tagColors[0],
                   banner_text: env.banner_text,
                   hide_disabled_flags: env.hide_disabled_flags,
+                  hide_sensitive_data: !!env.hide_sensitive_data,
                   minimum_change_request_approvals: Utils.changeRequestsEnabled(
                     env.minimum_change_request_approvals,
                   )
@@ -327,6 +350,41 @@ const EnvironmentSettingsPage = class extends Component {
                             </Row>
                           )}
                         </div>
+                        {Utils.getFlagsmithHasFeature(
+                          'configure_hide_sensitive_data',
+                        ) && (
+                          <div>
+                            <Row space style={{ marginTop: '1.5rem' }}>
+                              <div className='col-md-8 pl-0'>
+                                <h3 className='m-b-0'>Hide sensitive data</h3>
+                                <p>
+                                  Exclude flags' description and tags from data
+                                  returned by API for this environment
+                                </p>
+                                <strong>
+                                  Warning! Enabling this feature will change the
+                                  schema returned by the API and could break
+                                  your existing code.
+                                </strong>
+                              </div>
+                              <div className='col-md-4 pr-0 text-right'>
+                                <div>
+                                  <Switch
+                                    className='float-right'
+                                    checked={hide_sensitive_data}
+                                    onChange={(v) => {
+                                      this.confirmToggle(
+                                        'The schema returned by the API will change and could break your existing code. Are you sure that you want to change this value?',
+                                        'hide_sensitive_data',
+                                        hide_sensitive_data,
+                                      )
+                                    }}
+                                  />
+                                </div>
+                              </div>
+                            </Row>
+                          </div>
+                        )}
                         <FormGroup className='mt-4'>
                           <Row space>
                             <div className='col-md-8 pl-0'>

--- a/frontend/web/components/pages/EnvironmentSettingsPage.js
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.js
@@ -363,9 +363,8 @@ const EnvironmentSettingsPage = class extends Component {
                                   the SDKs or via our REST API. For full
                                   information on the excluded fields see
                                   documentation{' '}
-                                  {/* TODO: Update the link below once the documentation is generated. */}
                                   <ButtonLink
-                                    href='https://docs.flagsmith.com'
+                                    href='https://docs.flagsmith.com/advanced-use/hide-sensitive-data'
                                     target='_blank'
                                   >
                                     here.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?

## Changes

 - Added "hide sensitive data" switch to environment config.
 - Added ConfirmToggleEnvFeature to confirm the change.
 - Added feature flag `configure_hide_sensitive_data`, If the value is `true`, the hide sensitive data switch will be displayed in the environment settings.
 
## How did you test this code?

- Click on the 'Settings' of an environment.
- Click the hide sensitive data switch to open ConfirmToggleEnvFeature modal.
- Click 'Confirm Changes' button.
