### PR TITLE
is_server_key_only functionality

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -205,6 +205,7 @@ export type ProjectFlag = {
   id: number
   initial_value: string
   is_archived: boolean
+  is_server_key_only: boolean
   multivariate_options: MultivariateOption[]
   name: string
   num_identity_overrides: number | null

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -126,6 +126,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
         feature_state_value: projectFlag.initial_value,
         hide_from_client: false,
         is_archived: projectFlag.is_archived,
+        is_server_key_only: projectFlag.is_server_key_only,
         multivariate_options: projectFlag.multivariate_options,
         name: projectFlag.name,
         tags: projectFlag.tags,
@@ -139,6 +140,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
         feature_state_value: identityFlag.feature_state_value,
         hide_from_client: environmentFlag.hide_from_client,
         is_archived: projectFlag.is_archived,
+        is_server_key_only: projectFlag.is_server_key_only,
         multivariate_options: projectFlag.multivariate_options,
         name: projectFlag.name,
         type: projectFlag.type,
@@ -150,6 +152,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
       feature_state_value: environmentFlag.feature_state_value,
       hide_from_client: environmentFlag.hide_from_client,
       is_archived: projectFlag.is_archived,
+      is_server_key_only: projectFlag.is_server_key_only,
       multivariate_options: projectFlag.multivariate_options.map((v) => {
         const matching =
           multivariate_options &&

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -41,6 +41,7 @@ const CreateFlag = class extends Component {
       feature_state_value,
       hide_from_client,
       is_archived,
+      is_server_key_only,
       multivariate_options,
       name,
       tags,
@@ -76,6 +77,7 @@ const CreateFlag = class extends Component {
           ? undefined
           : Utils.getTypedValue(feature_state_value),
       is_archived,
+      is_server_key_only,
       multivariate_options: _.cloneDeep(multivariate_options),
       name,
       period: 30,
@@ -220,6 +222,7 @@ const CreateFlag = class extends Component {
       hide_from_client,
       initial_value,
       is_archived,
+      is_server_key_only,
       name,
     } = this.state
     const projectFlag = {
@@ -260,6 +263,7 @@ const CreateFlag = class extends Component {
             hide_from_client,
             initial_value,
             is_archived,
+            is_server_key_only,
             multivariate_options: this.state.multivariate_options,
             name,
             tags: this.state.tags,
@@ -530,6 +534,25 @@ const CreateFlag = class extends Component {
             placeholder="e.g. 'This determines what size the header is' "
           />
         </FormGroup>
+
+        {!identity && Utils.getFlagsmithHasFeature("is_server_key_only") && (
+            <FormGroup className='mb-4 mr-3 ml-3'>
+              <InputGroup
+                  component={
+                    <Switch
+                        checked={this.state.is_server_key_only}
+                        onChange={(is_server_key_only) =>
+                            this.setState({ is_server_key_only, settingsChanged: true })
+                        }
+                    />
+                  }
+                  type='text'
+                  title='Server-side only'
+                  tooltip='Prevent this feature from being accessed with client-side SDKs.'
+              />
+            </FormGroup>
+        )}
+
         {!identity && isEdit && (
           <FormGroup className='mb-4 mr-3 ml-3'>
             <InputGroup


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Adds server-side only functionality for features.

![image](https://github.com/Flagsmith/flagsmith/assets/8608314/364302d2-28f2-4c9e-9c39-48b13f268a97)
![image](https://github.com/Flagsmith/flagsmith/assets/8608314/4ad6c5bc-c491-4172-abab-1cc7a0a68c8c)