### PR TITLE
fix(sensitive-data): use Null/[] as the value

### DIFF
--- a/api/environments/identities/tests/test_views.py
+++ b/api/environments/identities/tests/test_views.py
@@ -841,13 +841,13 @@ def test_get_identities_with_hide_sensitive_data_with_feature_name(
     environment.save()
     base_url = reverse("api-v1:sdk-identities")
     url = f"{base_url}?identifier={identity.identifier}&feature={feature.name}"
-    fs_sensitive_fields = [
+    feature_sensitive_fields = [
         "created_date",
         "description",
         "initial_value",
         "default_enabled",
     ]
-    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
+    fs_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # When
     response = api_client.get(url)
@@ -873,13 +873,13 @@ def test_get_identities_with_hide_sensitive_data(
     environment.save()
     base_url = reverse("api-v1:sdk-identities")
     url = f"{base_url}?identifier={identity.identifier}"
-    fs_sensitive_fields = [
+    feature_sensitive_fields = [
         "created_date",
         "description",
         "initial_value",
         "default_enabled",
     ]
-    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
+    fs_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # When
     response = api_client.get(url)
@@ -910,13 +910,13 @@ def test_post_identities_with_hide_sensitive_data(
         "identifier": identity.identifier,
         "traits": [{"trait_key": "foo", "trait_value": "bar"}],
     }
-    fs_sensitive_fields = [
+    feature_sensitive_fields = [
         "created_date",
         "description",
         "initial_value",
         "default_enabled",
     ]
-    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
+    fs_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # When
     response = api_client.post(

--- a/api/environments/identities/tests/test_views.py
+++ b/api/environments/identities/tests/test_views.py
@@ -17,10 +17,6 @@ from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
 from environments.models import Environment, EnvironmentAPIKey
 from features.models import Feature, FeatureSegment, FeatureState
-from features.serializers import (
-    SDKFeatureSerializer,
-    SDKFeatureStateSerializer,
-)
 from integrations.amplitude.models import AmplitudeConfiguration
 from organisations.models import Organisation, OrganisationRole
 from projects.models import Project
@@ -845,8 +841,13 @@ def test_get_identities_with_hide_sensitive_data_with_feature_name(
     environment.save()
     base_url = reverse("api-v1:sdk-identities")
     url = f"{base_url}?identifier={identity.identifier}&feature={feature.name}"
-    fs_sensitive_fields = SDKFeatureStateSerializer.sensitive_fields
-    feature_sensitive_fields = SDKFeatureSerializer.sensitive_fields
+    fs_sensitive_fields = [
+        "created_date",
+        "description",
+        "initial_value",
+        "default_enabled",
+    ]
+    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # When
     response = api_client.get(url)
@@ -872,8 +873,13 @@ def test_get_identities_with_hide_sensitive_data(
     environment.save()
     base_url = reverse("api-v1:sdk-identities")
     url = f"{base_url}?identifier={identity.identifier}"
-    fs_sensitive_fields = SDKFeatureStateSerializer.sensitive_fields
-    feature_sensitive_fields = SDKFeatureSerializer.sensitive_fields
+    fs_sensitive_fields = [
+        "created_date",
+        "description",
+        "initial_value",
+        "default_enabled",
+    ]
+    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # When
     response = api_client.get(url)
@@ -904,8 +910,13 @@ def test_post_identities_with_hide_sensitive_data(
         "identifier": identity.identifier,
         "traits": [{"trait_key": "foo", "trait_value": "bar"}],
     }
-    fs_sensitive_fields = SDKFeatureStateSerializer.sensitive_fields
-    feature_sensitive_fields = SDKFeatureSerializer.sensitive_fields
+    fs_sensitive_fields = [
+        "created_date",
+        "description",
+        "initial_value",
+        "default_enabled",
+    ]
+    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # When
     response = api_client.post(

--- a/api/environments/sdk/serializers_mixins.py
+++ b/api/environments/sdk/serializers_mixins.py
@@ -4,5 +4,5 @@ class HideSensitiveFieldsSerializerMixin:
         environment = self.context["request"].environment
         if environment.hide_sensitive_data:
             for field in self.sensitive_fields:
-                data.pop(field)
+                data[field] = [] if isinstance(data[field], list) else None
         return data

--- a/api/features/tests/test_views.py
+++ b/api/features/tests/test_views.py
@@ -656,13 +656,13 @@ def test_get_flags_hide_sensitive_data(api_client, environment, feature):
     # When
     api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
     response = api_client.get(url)
-    fs_sensitive_fields = [
+    feature_sensitive_fields = [
         "created_date",
         "description",
         "initial_value",
         "default_enabled",
     ]
-    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
+    fs_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/features/tests/test_views.py
+++ b/api/features/tests/test_views.py
@@ -25,6 +25,10 @@ from features.models import (
     FeatureState,
     FeatureStateValue,
 )
+from features.serializers import (
+    SDKFeatureSerializer,
+    SDKFeatureStateSerializer,
+)
 from organisations.models import Organisation, OrganisationRole
 from permissions.models import PermissionModel
 from projects.models import Project, UserProjectPermission
@@ -656,15 +660,18 @@ def test_get_flags_hide_sensitive_data(api_client, environment, feature):
     # When
     api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
     response = api_client.get(url)
+    fs_sensitive_fields = SDKFeatureStateSerializer.sensitive_fields
+    feature_sensitive_fields = SDKFeatureSerializer.sensitive_fields
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert set(response.json()[0].keys()) == {
-        "feature",
-        "feature_state_value",
-        "enabled",
-    }
-    assert set(response.json()[0]["feature"].keys()) == {"id", "name", "type"}
+    # Check that the sensitive fields are None
+    for flag in response.json():
+        for field in fs_sensitive_fields:
+            assert flag[field] is None
+
+        for field in feature_sensitive_fields:
+            assert flag["feature"][field] is None
 
 
 def test_get_flags__server_key_only_feature__return_expected(

--- a/api/features/tests/test_views.py
+++ b/api/features/tests/test_views.py
@@ -25,10 +25,6 @@ from features.models import (
     FeatureState,
     FeatureStateValue,
 )
-from features.serializers import (
-    SDKFeatureSerializer,
-    SDKFeatureStateSerializer,
-)
 from organisations.models import Organisation, OrganisationRole
 from permissions.models import PermissionModel
 from projects.models import Project, UserProjectPermission
@@ -660,8 +656,13 @@ def test_get_flags_hide_sensitive_data(api_client, environment, feature):
     # When
     api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
     response = api_client.get(url)
-    fs_sensitive_fields = SDKFeatureStateSerializer.sensitive_fields
-    feature_sensitive_fields = SDKFeatureSerializer.sensitive_fields
+    fs_sensitive_fields = [
+        "created_date",
+        "description",
+        "initial_value",
+        "default_enabled",
+    ]
+    feature_sensitive_fields = ["id", "environment", "identity", "feature_segment"]
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -34,4 +34,4 @@ known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','cor
 skip = ['migrations','.venv','.direnv']
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings' ]
+addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings', '-n', 'auto']

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -34,4 +34,4 @@ known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','cor
 skip = ['migrations','.venv','.direnv']
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings', '-n', 'auto']
+addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings' ]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Since some of the clients use strict schema and will break if the key is not part of the response - this change adds the sensitive fields back to the response but makes them Null/[]



