### PR TITLE
Ensure use_mv_v2_evaluation is passed through to feature state evaluation

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -211,8 +211,21 @@ def change_request(environment, admin_user):
 
 
 @pytest.fixture()
-def feature_state(feature, environment):
-    return FeatureState.objects.filter(environment=environment, feature=feature).first()
+def feature_state(feature: Feature, environment: Environment) -> FeatureState:
+    return FeatureState.objects.get(environment=environment, feature=feature)
+
+
+@pytest.fixture()
+def feature_state_with_value(environment: Environment) -> FeatureState:
+    feature = Feature.objects.create(
+        name="feature_with_value",
+        initial_value="foo",
+        default_enabled=True,
+        project=environment.project,
+    )
+    return FeatureState.objects.get(
+        environment=environment, feature=feature, feature_segment=None, identity=None
+    )
 
 
 @pytest.fixture()

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -603,7 +603,13 @@ class FeatureState(
         return feature_state_value and feature_state_value.value
 
     def get_feature_state_value(self, identity: "Identity" = None) -> typing.Any:
-        identity_hash_key = identity.get_hash_key() if identity else None
+        identity_hash_key = (
+            identity.get_hash_key(
+                use_mv_v2_evaluation=identity.environment.use_mv_v2_evaluation
+            )
+            if identity
+            else None
+        )
         return self.get_feature_state_value_by_hash_key(identity_hash_key)
 
     def get_feature_state_value_defaults(self) -> dict:

--- a/api/features/tests/test_models.py
+++ b/api/features/tests/test_models.py
@@ -606,4 +606,4 @@ def test_get_feature_state_value_for_multivariate_features(
     # the correct value is returned
     assert feature_state_value == value
     # and the correct call is made to get the multivariate feature state value
-    mock_get_mv_feature_state_value.assert_called_once_with(str(identity.id))
+    mock_get_mv_feature_state_value.assert_called_once_with(identity.composite_key)

--- a/api/features/tests/test_models.py
+++ b/api/features/tests/test_models.py
@@ -592,6 +592,35 @@ def test_get_feature_state_value_for_multivariate_features(
     mock_mv_feature_state_value = mock.MagicMock(value=value)
     mock_get_mv_feature_state_value.return_value = mock_mv_feature_state_value
 
+    environment.use_mv_v2_evaluation = False
+    environment.save()
+
+    feature_state = FeatureState.objects.get(
+        environment=environment,
+        feature=multivariate_feature,
+        identity=None,
+        feature_segment=None,
+    )
+
+    # When
+    feature_state_value = feature_state.get_feature_state_value(identity=identity)
+
+    # Then
+    # the correct value is returned
+    assert feature_state_value == value
+    # and the correct call is made to get the multivariate feature state value
+    mock_get_mv_feature_state_value.assert_called_once_with(str(identity.id))
+
+
+@mock.patch.object(FeatureState, "get_multivariate_feature_state_value")
+def test_get_feature_state_value_for_multivariate_features_mv_v2_evaluation(
+    mock_get_mv_feature_state_value, environment, multivariate_feature, identity
+):
+    # Given
+    value = "value"
+    mock_mv_feature_state_value = mock.MagicMock(value=value)
+    mock_get_mv_feature_state_value.return_value = mock_mv_feature_state_value
+
     feature_state = FeatureState.objects.get(
         environment=environment,
         feature=multivariate_feature,

--- a/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
+++ b/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
@@ -31,13 +31,14 @@ def test_amplitude_when_generate_user_data_with_correct_values_then_success():
 
     config = AmplitudeConfiguration(api_key=api_key)
     amplitude_wrapper = AmplitudeWrapper(config)
-    identity = Identity(identifier="user123")
 
     organisation = Organisation.objects.create(name="Test Org")
     project = Project.objects.create(name="Test Project", organisation=organisation)
-    Environment.objects.create(name="Test Environment 1", project=project)
+    environment = Environment.objects.create(name="Test Environment 1", project=project)
     feature = Feature.objects.create(name="Test Feature", project=project)
     feature_states = FeatureState.objects.filter(feature=feature)
+
+    identity = Identity(identifier="user123", environment=environment)
 
     # When
     user_data = amplitude_wrapper.generate_user_data(

--- a/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
+++ b/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
@@ -28,7 +28,7 @@ def test_amplitude_when_generate_user_data_with_correct_values_then_success(
     feature_state: FeatureState,
     feature_state_with_value: FeatureState,
     identity: Identity,
-):
+) -> None:
     # Given
     api_key = "123key"
 
@@ -43,9 +43,7 @@ def test_amplitude_when_generate_user_data_with_correct_values_then_success(
     # Then
     feature_properties = {
         feature_state.feature.name: feature_state.enabled,
-        feature_state_with_value.feature.name: feature_state_with_value.get_feature_state_value(
-            identity=identity
-        ),
+        feature_state_with_value.feature.name: "foo",  # hardcoded here from the feature_state_with_value fixture
     }
 
     expected_user_data = {

--- a/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
+++ b/api/tests/unit/integrations/amplitude/test_unit_amplitude.py
@@ -2,14 +2,12 @@ import pytest
 
 from environments.identities.models import Identity
 from environments.models import Environment
-from features.models import Feature, FeatureState
+from features.models import FeatureState
 from integrations.amplitude.amplitude import (
     AMPLITUDE_API_URL,
     AmplitudeWrapper,
 )
 from integrations.amplitude.models import AmplitudeConfiguration
-from organisations.models import Organisation
-from projects.models import Project
 
 
 def test_amplitude_initialized_correctly():
@@ -25,34 +23,30 @@ def test_amplitude_initialized_correctly():
 
 
 @pytest.mark.django_db
-def test_amplitude_when_generate_user_data_with_correct_values_then_success():
+def test_amplitude_when_generate_user_data_with_correct_values_then_success(
+    environment: Environment,
+    feature_state: FeatureState,
+    feature_state_with_value: FeatureState,
+    identity: Identity,
+):
     # Given
     api_key = "123key"
 
     config = AmplitudeConfiguration(api_key=api_key)
     amplitude_wrapper = AmplitudeWrapper(config)
 
-    organisation = Organisation.objects.create(name="Test Org")
-    project = Project.objects.create(name="Test Project", organisation=organisation)
-    environment = Environment.objects.create(name="Test Environment 1", project=project)
-    feature = Feature.objects.create(name="Test Feature", project=project)
-    feature_states = FeatureState.objects.filter(feature=feature)
-
-    identity = Identity(identifier="user123", environment=environment)
-
     # When
     user_data = amplitude_wrapper.generate_user_data(
-        identity=identity, feature_states=feature_states
+        identity=identity, feature_states=[feature_state, feature_state_with_value]
     )
 
     # Then
-    feature_properties = {}
-
-    for feature_state in feature_states:
-        value = feature_state.get_feature_state_value()
-        feature_properties[feature_state.feature.name] = (
-            value if (feature_state.enabled and value) else feature_state.enabled
-        )
+    feature_properties = {
+        feature_state.feature.name: feature_state.enabled,
+        feature_state_with_value.feature.name: feature_state_with_value.get_feature_state_value(
+            identity=identity
+        ),
+    }
 
     expected_user_data = {
         "user_id": identity.identifier,

--- a/api/tests/unit/integrations/heap/test_unit_heap.py
+++ b/api/tests/unit/integrations/heap/test_unit_heap.py
@@ -14,14 +14,15 @@ def test_heap_when_generate_user_data_with_correct_values_then_success():
     # Given
     api_key = "123key"
     config = HeapConfiguration(api_key=api_key)
-    identity = Identity(identifier="user123")
     heap_wrapper = HeapWrapper(config)
 
     organisation = Organisation.objects.create(name="Test Org")
     project = Project.objects.create(name="Test Project", organisation=organisation)
-    Environment.objects.create(name="Test Environment 1", project=project)
+    environment = Environment.objects.create(name="Test Environment 1", project=project)
     feature = Feature.objects.create(name="Test Feature", project=project)
     feature_states = FeatureState.objects.filter(feature=feature)
+
+    identity = Identity(identifier="user123", environment=environment)
 
     # When
     user_data = heap_wrapper.generate_user_data(

--- a/api/tests/unit/integrations/heap/test_unit_heap.py
+++ b/api/tests/unit/integrations/heap/test_unit_heap.py
@@ -13,7 +13,7 @@ def test_heap_when_generate_user_data_with_correct_values_then_success(
     feature_state: FeatureState,
     feature_state_with_value: FeatureState,
     identity: Identity,
-):
+) -> None:
     # Given
     api_key = "123key"
     config = HeapConfiguration(api_key=api_key)
@@ -31,9 +31,7 @@ def test_heap_when_generate_user_data_with_correct_values_then_success(
         "event": "Flagsmith Feature Flags",
         "properties": {
             feature_state.feature.name: feature_state.enabled,
-            feature_state_with_value.feature.name: feature_state_with_value.get_feature_state_value(
-                identity=identity
-            ),
+            feature_state_with_value.feature.name: "foo",  # hardcoded here from the feature_state_with_value fixture
         },
     }
     assert expected_user_data == user_data

--- a/api/tests/unit/integrations/segment/test_unit_segment.py
+++ b/api/tests/unit/integrations/segment/test_unit_segment.py
@@ -25,7 +25,7 @@ def test_segment_when_generate_user_data_with_correct_values_then_success(
     feature_state: FeatureState,
     feature_state_with_value: FeatureState,
     identity: Identity,
-):
+) -> None:
     # Given
     api_key = "123key"
     config = SegmentConfiguration(api_key=api_key)
@@ -39,9 +39,7 @@ def test_segment_when_generate_user_data_with_correct_values_then_success(
     # Then
     feature_properties = {
         feature_state.feature.name: feature_state.enabled,
-        feature_state_with_value.feature.name: feature_state_with_value.get_feature_state_value(
-            identity=identity
-        ),
+        feature_state_with_value.feature.name: "foo",  # hardcoded here from the feature_state_with_value fixture
     }
 
     expected_user_data = {

--- a/api/tests/unit/integrations/segment/test_unit_segment.py
+++ b/api/tests/unit/integrations/segment/test_unit_segment.py
@@ -27,13 +27,14 @@ def test_segment_when_generate_user_data_with_correct_values_then_success():
     api_key = "123key"
     config = SegmentConfiguration(api_key=api_key)
     segment_wrapper = SegmentWrapper(config)
-    identity = Identity(identifier="user123")
 
     organisation = Organisation.objects.create(name="Test Org")
     project = Project.objects.create(name="Test Project", organisation=organisation)
-    Environment.objects.create(name="Test Environment 1", project=project)
+    environment = Environment.objects.create(name="Test Environment 1", project=project)
     feature = Feature.objects.create(name="Test Feature", project=project)
     feature_states = FeatureState.objects.filter(feature=feature)
+
+    identity = Identity(identifier="user123", environment=environment)
 
     # When
     user_data = segment_wrapper.generate_user_data(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Ensures that the environment `use_mv_v2_evaluation` attribute is passed through to the retrieval of the flag value in the Core API code path. 

## How did you test this code?

Added new unit test and updated existing. 
