### PR TITLE
improvement/add robots.txt

### DIFF
--- a/api/app/templates/robots.txt
+++ b/api/app/templates/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
+from django.views.generic.base import TemplateView
 
 from users.views import password_reset_redirect
 
@@ -32,6 +33,10 @@ urlpatterns = [
         name="project_overrides",
     ),
     path("processor/", include("task_processor.urls")),
+    path(
+        "robots.txt",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+    ),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Stop google indexing self-hosted installs. 

~~I havent applied this to the dedicated front end builds as we want google to index our SaaS version. This will need https://github.com/Flagsmith/flagsmith/issues/2287~~

The Front end image already does this here https://github.com/Flagsmith/flagsmith/blob/d5cd937036ee28473548da358c7f11288f267cc2/frontend/api/index.js#L158