### PR TITLE
Fix feature segment priority evaluations

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -464,11 +464,18 @@ class FeatureState(
                 )
             return True
 
-        if self.feature_segment_id:
+        if (
+            self.feature_segment_id
+            and self.feature_segment_id != other.feature_segment_id
+        ):
             # Return true if other_feature_state has a lower priority feature segment and not an identity overridden
             # flag, else False.
             return not (
-                other.identity_id or self.feature_segment < other.feature_segment
+                other.identity_id
+                or (
+                    other.feature_segment_id
+                    and self.feature_segment < other.feature_segment
+                )
             )
 
         if self.type == other.type:

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -380,3 +380,39 @@ def test_feature_get_overrides_data(
 
     assert overrides_data[feature_3.id].num_identity_overrides is None
     assert overrides_data[feature_3.id].num_segment_overrides == 1
+
+
+def test_feature_state_gt_operator_for_multiple_versions_of_segment_overrides(
+    feature, segment, feature_segment, environment
+):
+    # Given
+    v1_segment_override = FeatureState.objects.create(
+        feature=feature, environment=environment, feature_segment=feature_segment
+    )
+    v2_segment_override = FeatureState.objects.create(
+        feature=feature,
+        environment=environment,
+        feature_segment=feature_segment,
+        version=2,
+    )
+
+    # Then
+    assert v2_segment_override > v1_segment_override
+
+
+def test_feature_state_gt_operator_for_segment_overrides_and_environment_default(
+    feature, segment, feature_segment, environment
+):
+    # Given
+    segment_override = FeatureState.objects.create(
+        feature=feature, environment=environment, feature_segment=feature_segment
+    )
+    environment_default = FeatureState.objects.get(
+        feature=feature,
+        environment=environment,
+        feature_segment__isnull=True,
+        identity__isnull=True,
+    )
+
+    # Then
+    assert segment_override > environment_default


### PR DESCRIPTION
## Changes

This PR fixes 2 issues identified in the logic to compare feature states: 

 1. The logic would throw a hard exception if we ever compared an environment default feature state against a segment override. Fortunately, we never hit this issue since the environment default would always be the first feature state to be created and the ordering for the FeatureState model is based on its id, therefore we would never compare that way around. 
 2. The logic doesn't work for feature states that have the same feature segment but are versioned differently. Again, this is not something that happens in production usage since we don't have the functionality to version segment overrides. 

## How did you test this code?

Added unit test cases for the above 2 issues. 
