### PR TITLE
Remove filter on draft PRs to run tests

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -13,7 +13,6 @@ defaults:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: API Unit Tests
 

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   run-e2e-tests:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: Full E2E tests
 
@@ -51,7 +50,6 @@ jobs:
         run: docker logs $API_CONTAINER_ID
 
   run-e2e-tests-docker-unified:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: Full E2E tests with unified image in Docker
 


### PR DESCRIPTION
## Changes

Ensures unit and E2E tests are run on draft PRs. 

## How did you test this code?

Created the PR as a draft PR, verified that tests were run, then converted to 'ready for review'. 
