### PR TITLE
Add AUTO_SEAT_UPGRADE_PLANS env var to production

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -166,6 +166,10 @@
                 {
                     "name": "ENABLE_PIPEDRIVE_LEAD_TRACKING",
                     "value": "True"
+                },
+                {
+                    "name": "AUTO_SEAT_UPGRADE_PLANS",
+                    "value": "scale-up,scale-up-v2,scale-up-annual-v2"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Adds the environment variable to define which plans can utilise the auto upgrade functionality. This was removed (somewhat) accidentally as part of #1786. 

## How did you test this code?

This was previously tested as working in production prior to #1786 and is currently enabled and working in staging. 
