### PR TITLE
Fix user invite-link regeneration (#2306)

### DIFF
--- a/frontend/common/stores/organisation-store.js
+++ b/frontend/common/stores/organisation-store.js
@@ -207,11 +207,12 @@ const controller = {
   },
   invalidateInviteLink: (link) => {
     const id = AccountStore.getOrganisation().id
+    const role = link.role
     data
       .delete(`${Project.api}organisations/${id}/invite-links/${link.id}/`)
       .then(() =>
         data.post(`${Project.api}organisations/${id}/invite-links/`, {
-          role: 'ADMIN',
+          role: role,
         }),
       )
       .then(() =>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

I have used the 'role' property from the invite link.

## How did you test this code?

Manually

Selected the 'User' invite link and pressed 'Regenerate'
Verified that only 'User' invite link was regenerated
Selected the 'Admin' invite link and pressed 'Regenerate'
Verified that only 'Admin' invite link was regenerated
