### PR TITLE
Exclude author email from change request group assignments

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -293,5 +293,8 @@ class ChangeRequestGroupAssignment(AbstractBaseExportableModel, LifecycleModel):
                 f"{settings.WORKFLOWS_LOGIC_MODULE_PATH}.tasks"
             )
             workflows_tasks.notify_group_of_change_request_assignment.delay(
-                kwargs={"change_request_group_assignment_id": self.id}
+                kwargs={
+                    "change_request_group_assignment_id": self.id,
+                    "exclude_emails": [self.change_request.user.email],
+                }
             )

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -595,6 +595,7 @@ def test_change_request_group_assignment_sends_notification_emails_to_group_user
     # Then
     workflows_logic_tasks_module_mock.notify_group_of_change_request_assignment.delay.assert_called_once_with(
         kwargs={
-            "change_request_group_assignment_id": change_request_group_assignment.id
+            "change_request_group_assignment_id": change_request_group_assignment.id,
+            "exclude_emails": [change_request.user.email],
         }
     )


### PR DESCRIPTION
## Changes

Prevents change request authors from being notified of the request to review when they assign groups they belong to. 

TODO: update workflows version. 

## How did you test this code?

Updated unit test. 
