### PR TITLE
Fix docs generation

### DIFF
--- a/api/audit/serializers.py
+++ b/api/audit/serializers.py
@@ -31,5 +31,7 @@ class AuditLogsQueryParamSerializer(serializers.Serializer):
     environments = serializers.ListField(
         child=serializers.IntegerField(min_value=0), required=False
     )
-    is_system_event = serializers.BooleanField(required=False)
+    is_system_event = serializers.BooleanField(
+        required=False, allow_null=True, default=None
+    )
     search = serializers.CharField(max_length=256, required=False)

--- a/api/audit/views.py
+++ b/api/audit/views.py
@@ -28,13 +28,13 @@ class _BaseAuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
         serializer = AuditLogsQueryParamSerializer(data=self.request.GET)
         serializer.is_valid(raise_exception=True)
-        project_id = serializer.data.get("project")
-        environment_ids = serializer.data.get("environments")
 
-        if project_id:
+        if project_id := serializer.data.get("project"):
             q = q & Q(project__id=project_id)
-        if environment_ids:
+        if environment_ids := serializer.data.get("environments"):
             q = q & Q(environment__id__in=environment_ids)
+        if is_system_event := serializer.data.get("is_system_event") is not None:
+            q = q & Q(is_system_event=is_system_event)
 
         search = serializer.data.get("search")
         if search:


### PR DESCRIPTION
## Changes

Should fix https://flagsmith.sentry.io/issues/4218798271/

Weirdly, I can't reproduce it locally and the issue is not apparent in production after clearing cookies / using incognito to access the docs. I'm not sure why cookies would affect the behaviour here but, from the error in sentry, however, this PR should resolve it. 

## How did you test this code?

I haven't unfortunately because I can't reproduce it. I've verified that the existing unit tests are all passing to ensure there are no regressions and that I can still load the API docs locally (although that was possible before the change also). 
