### PR TITLE
Fix modal close intercept

### DIFF
--- a/frontend/web/components/modals/base/Modal.tsx
+++ b/frontend/web/components/modals/base/Modal.tsx
@@ -8,7 +8,7 @@ import {
 import { JSXElementConstructor, ReactNode, useCallback, useState } from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
 import Confirm from './ModalConfirm'
-import ModalDefault, { interceptClose } from './ModalDefault'
+import ModalDefault, { interceptClose, setInterceptClose } from './ModalDefault'
 import Alert from './ModalAlert'
 import { getStore } from 'common/store'
 import { Provider } from 'react-redux'
@@ -31,6 +31,7 @@ const withModal = (
         interceptClose().then((result) => {
           if (result) {
             setIsOpen(false)
+            setInterceptClose(null)
           }
         })
       } else {

--- a/frontend/web/components/modals/base/Modal.tsx
+++ b/frontend/web/components/modals/base/Modal.tsx
@@ -28,8 +28,10 @@ const withModal = (
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const toggle = useCallback(() => {
       if (interceptClose && shouldInterceptClose) {
-        interceptClose().then(() => {
-          setIsOpen(false)
+        interceptClose().then((result) => {
+          if (result) {
+            setIsOpen(false)
+          }
         })
       } else {
         setIsOpen(false)

--- a/frontend/web/components/modals/base/Modal.tsx
+++ b/frontend/web/components/modals/base/Modal.tsx
@@ -20,14 +20,14 @@ export const ModalBody = _ModalBody
 
 const withModal = (
   WrappedComponent: JSXElementConstructor<any>,
-  closePointer = 'closeModal',
+  { closePointer = 'closeModal', shouldInterceptClose = false } = {},
 ) => {
   return (props: ModalProps) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [isOpen, setIsOpen] = useState(true)
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const toggle = useCallback(() => {
-      if (interceptClose) {
+      if (interceptClose && shouldInterceptClose) {
         interceptClose().then(() => {
           setIsOpen(false)
         })
@@ -47,8 +47,8 @@ const withModal = (
 }
 
 const _Confirm = withModal(Confirm)
-const _ModalDefault2 = withModal(ModalDefault, 'closeModal2')
-const _ModalDefault = withModal(ModalDefault)
+const _ModalDefault2 = withModal(ModalDefault, { closePointer: 'closeModal2' })
+const _ModalDefault = withModal(ModalDefault, { shouldInterceptClose: true })
 
 export const openConfirm = (global.openConfirm = (
   title: string,

--- a/frontend/web/components/modals/base/ModalDefault.tsx
+++ b/frontend/web/components/modals/base/ModalDefault.tsx
@@ -27,7 +27,10 @@ const ModalDefault: FC<ModalDefault> = ({
 }) => {
   const onDismissClick = async () => {
     if (interceptClose) {
-      await interceptClose()
+      const shouldClose = await interceptClose()
+      if (!shouldClose) {
+        return
+      }
       interceptClose = null
     }
     if (onDismiss) {

--- a/frontend/web/components/modals/base/ModalDefault.tsx
+++ b/frontend/web/components/modals/base/ModalDefault.tsx
@@ -12,7 +12,7 @@ interface ModalDefault {
   className?: string
 }
 
-export let interceptClose: (() => Promise<any>) | null = null
+export let interceptClose: (() => Promise<boolean>) | null = null
 export const setInterceptClose = (promise: () => Promise<any>) => {
   interceptClose = promise
 }

--- a/frontend/web/components/modals/base/ModalDefault.tsx
+++ b/frontend/web/components/modals/base/ModalDefault.tsx
@@ -13,7 +13,7 @@ interface ModalDefault {
 }
 
 export let interceptClose: (() => Promise<boolean>) | null = null
-export const setInterceptClose = (promise: () => Promise<any>) => {
+export const setInterceptClose = (promise: (() => Promise<any>) | null) => {
   interceptClose = promise
 }
 const ModalDefault: FC<ModalDefault> = ({


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

The bootstrap changes introduced a regression where confirmation modals would close the create feature modal regardless of the user's input and re-show the confirmation dialog, this happened for 2 reasons

- Closing a confirmation dialog would trigger the modal intercept as if the original modal was attempting to be closed.
- The modal would be dismissed regardless of the result of the close intercept, it should only close the modal if the intercept resolves with true.

![image](http://g.recordit.co/c5E4LDGuFW.gif)

## How did you test this code?

Confirm / cancel are you sure dialog from the edit feature modal.

![image](http://g.recordit.co/iQiQUDlwDa.gif)
