### PR TITLE
fix: bump flagsmith-flag-engine to enable Rudderstack support

### DIFF
--- a/api/environments/managers.py
+++ b/api/environments/managers.py
@@ -12,11 +12,12 @@ class EnvironmentManager(SoftDeleteManager):
             .select_related(
                 "project",
                 "project__organisation",
-                "mixpanel_config",
-                "segment_config",
                 "amplitude_config",
-                "heap_config",
                 "dynatrace_config",
+                "heap_config",
+                "mixpanel_config",
+                "rudderstack_config",
+                "segment_config",
             )
             .prefetch_related(
                 Prefetch(

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -139,7 +139,7 @@ drf-yasg2==1.19.3
     # via -r requirements.in
 environs==9.2.0
     # via -r requirements.in
-flagsmith-flag-engine==3.5.0
+flagsmith-flag-engine==3.5.1
     # via -r requirements.in
 google-api-core==1.23.0
     # via


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This bumps flagsmith-flag-engine to a version with Rudderstack integration data serialization fixed.

## How did you test this code?

Verified that Rudderstack integration config is picked up by the document builder.