### PR TITLE
Catch Environment.DoesNotExist exception

### DIFF
--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -4,6 +4,7 @@ import typing
 
 import marshmallow
 from boto3.dynamodb.conditions import Key
+from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from drf_yasg2.utils import swagger_auto_schema
 from flag_engine.api.schemas import APITraitSchema
@@ -149,7 +150,9 @@ class EdgeIdentityViewSet(
         """
         Get environment object from URL parameters in request.
         """
-        return Environment.objects.get(api_key=self.kwargs["environment_api_key"])
+        return get_object_or_404(
+            Environment, api_key=self.kwargs["environment_api_key"]
+        )
 
     def perform_destroy(self, instance):
         EdgeIdentity.dynamo_wrapper.delete_item(instance["composite_key"])

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_views.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_views.py
@@ -71,3 +71,17 @@ def test_user_with_manage_identity_permission_can_delete_identity(
     edge_identity_dynamo_wrapper_mock.delete_item.assert_called_with(
         identity_document_without_fs["composite_key"]
     )
+
+
+def test_edge_identity_viewset_returns_404_for_invalid_environment_key(admin_client):
+    # Given
+    api_key = "not-valid"
+    url = reverse(
+        "api-v1:environments:environment-edge-identities-list", args=[api_key]
+    )
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Changes

Catches Environment.DoesNotExist exception when an invalid environment is provided to edge-identities endpoint. 

## How did you test this code?

Added unit test. 
