### PR TITLE
fix: don't use broken identity document builder

### DIFF
--- a/api/edge_api/identities/serializers.py
+++ b/api/edge_api/identities/serializers.py
@@ -12,7 +12,6 @@ from flag_engine.features.models import (
 from flag_engine.features.models import (
     MultivariateFeatureStateValueModel as EngineMultivariateFeatureStateValueModel,
 )
-from flag_engine.identities.builders import build_identity_dict
 from flag_engine.identities.models import IdentityModel as EngineIdentity
 from flag_engine.utils.exceptions import DuplicateFeatureState
 from pydantic import ValidationError as PydanticValidationError
@@ -24,7 +23,11 @@ from environments.models import Environment
 from features.models import Feature, FeatureState, FeatureStateValue
 from features.multivariate.models import MultivariateFeatureOption
 from features.serializers import FeatureStateValueSerializer
-from util.mappers import map_feature_to_engine, map_mv_option_to_engine
+from util.mappers import (
+    map_engine_identity_to_identity_document,
+    map_feature_to_engine,
+    map_mv_option_to_engine,
+)
 from webhooks.constants import WEBHOOK_DATETIME_FORMAT
 
 from .models import EdgeIdentity
@@ -45,7 +48,9 @@ class EdgeIdentitySerializer(serializers.Serializer):
             raise ValidationError(
                 f"Identity with identifier: {identifier} already exists"
             )
-        EdgeIdentity.dynamo_wrapper.put_item(build_identity_dict(self.instance))
+        EdgeIdentity.dynamo_wrapper.put_item(
+            map_engine_identity_to_identity_document(self.instance)
+        )
         return self.instance
 
 

--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -7,10 +7,7 @@ from boto3.dynamodb.conditions import Key
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from drf_yasg2.utils import swagger_auto_schema
-from flag_engine.identities.builders import (
-    build_identity_dict,
-    build_identity_model,
-)
+from flag_engine.identities.builders import build_identity_model
 from flag_engine.identities.traits.models import TraitModel
 from pyngo import drf_error_details
 from rest_framework import status, viewsets
@@ -56,6 +53,7 @@ from environments.permissions.permissions import NestedEnvironmentPermissions
 from features.models import FeatureState
 from features.permissions import IdentityFeatureStatePermissions
 from projects.exceptions import DynamoNotEnabledError
+from util.mappers import map_engine_identity_to_identity_document
 
 from .exceptions import TraitPersistenceError
 from .models import EdgeIdentity
@@ -184,7 +182,9 @@ class EdgeIdentityViewSet(
             ) from validation_error
         _, traits_updated = identity.update_traits([trait])
         if traits_updated:
-            EdgeIdentity.dynamo_wrapper.put_item(build_identity_dict(identity))
+            EdgeIdentity.dynamo_wrapper.put_item(
+                map_engine_identity_to_identity_document(identity)
+            )
 
         data = trait.dict()
         return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?

## Changes

This PR fixes the internal server error when invoking `/api/v1/environments/{environment_id}/edge-identities`

## How did you test this code?

