### PR TITLE
Fix swagger generation

### DIFF
--- a/api/api/urls/deprecated.py
+++ b/api/api/urls/deprecated.py
@@ -8,9 +8,9 @@ app_name = "deprecated"
 
 urlpatterns = [
     url(
-        r"^identities/(?P<identifier>[-\w@%.]+)/traits/(?P<trait_key>[-\w.]+)",
+        r"^identities/(?P<identifier>[-\w@%.]+)/traits/(?P<trait_key>[-\w.]+)$",
         SDKTraitsDeprecated.as_view(),
     ),
     url(r"^identities/(?P<identifier>[-\w@%.]+)/", SDKIdentitiesDeprecated.as_view()),
-    url(r"^flags/(?P<identifier>[-\w@%.]+)", SDKFeatureStates.as_view()),
+    url(r"^flags/(?P<identifier>[-\w@%.]+)$", SDKFeatureStates.as_view()),
 ]

--- a/api/api/urls/v1.py
+++ b/api/api/urls/v1.py
@@ -1,8 +1,8 @@
 from app_analytics.views import SDKAnalyticsFlags, SelfHostedTelemetryAPIView
 from django.conf.urls import url
 from django.urls import include
-from drf_yasg2 import openapi
-from drf_yasg2.views import get_schema_view
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
 from rest_framework import authentication, permissions, routers
 
 from environments.identities.traits.views import SDKTraits
@@ -20,8 +20,8 @@ schema_view = get_schema_view(
         contact=openapi.Contact(email="support@flagsmith.com"),
     ),
     public=True,
-    permission_classes=(permissions.AllowAny,),
-    authentication_classes=(authentication.SessionAuthentication,),
+    permission_classes=[permissions.AllowAny],
+    authentication_classes=[authentication.SessionAuthentication],
 )
 
 traits_router = routers.DefaultRouter()

--- a/api/app/pagination.py
+++ b/api/app/pagination.py
@@ -2,8 +2,8 @@ import base64
 import json
 from collections import OrderedDict
 
-from drf_yasg2 import openapi
-from drf_yasg2.inspectors import PaginatorInspector
+from drf_yasg import openapi
+from drf_yasg.inspectors import PaginatorInspector
 from flag_engine.identities.builders import build_identity_model
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -123,7 +123,7 @@ INSTALLED_APPS = [
     "app",
     "e2etests",
     "simple_history",
-    "drf_yasg2",
+    "drf_yasg",
     "audit",
     "permissions",
     "projects.tags",

--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -7,7 +7,7 @@ from app_analytics.analytics_db_service import (
 from app_analytics.tasks import track_feature_evaluation
 from app_analytics.track import track_feature_evaluation_influxdb
 from django.conf import settings
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.fields import IntegerField

--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -10,9 +10,11 @@ from django.conf import settings
 from drf_yasg2.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.fields import IntegerField
 from rest_framework.generics import CreateAPIView, GenericAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.serializers import Serializer
 from telemetry.serializers import TelemetrySerializer
 
 from environments.authentication import EnvironmentKeyAuthentication
@@ -37,6 +39,27 @@ class SDKAnalyticsFlags(GenericAPIView):
 
     permission_classes = (EnvironmentKeyPermissions,)
     authentication_classes = (EnvironmentKeyAuthentication,)
+
+    def get_serializer_class(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Serializer
+
+        environment_feature_names = set(
+            FeatureState.objects.filter(
+                environment=self.request.environment,
+                feature_segment=None,
+                identity=None,
+            ).values_list("feature__name", flat=True)
+        )
+
+        class _AnalyticsSerializer(Serializer):
+            def get_fields(self):
+                return {
+                    feature_name: IntegerField(required=False)
+                    for feature_name in environment_feature_names
+                }
+
+        return _AnalyticsSerializer
 
     def post(self, request, *args, **kwargs):
         """

--- a/api/audit/views.py
+++ b/api/audit/views.py
@@ -1,6 +1,6 @@
 from django.db.models import Q, QuerySet
 from django.utils.decorators import method_decorator
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import IsAuthenticated
 

--- a/api/custom_auth/oauth/views.py
+++ b/api/custom_auth/oauth/views.py
@@ -1,6 +1,6 @@
 import logging
 
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny

--- a/api/custom_auth/views.py
+++ b/api/custom_auth/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import user_logged_out
 from django.utils.decorators import method_decorator
 from djoser.views import UserViewSet
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import api_view, permission_classes

--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -6,7 +6,7 @@ import pydantic
 from boto3.dynamodb.conditions import Key
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from flag_engine.identities.builders import build_identity_model
 from flag_engine.identities.traits.models import TraitModel
 from pyngo import drf_error_details

--- a/api/environments/identities/serializers.py
+++ b/api/environments/identities/serializers.py
@@ -1,6 +1,6 @@
 import typing
 
-from drf_yasg2.utils import swagger_serializer_method
+from drf_yasg.utils import swagger_serializer_method
 from flag_engine.features.models import FeatureStateModel
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError

--- a/api/environments/identities/traits/views.py
+++ b/api/environments/identities/traits/views.py
@@ -60,6 +60,9 @@ class TraitViewSet(viewsets.ModelViewSet):
         """
         Override queryset to filter based on the parent identity.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return Trait.objects.none()
+
         return Trait.objects.filter(identity=self.identity)
 
     def get_permissions(self):

--- a/api/environments/identities/traits/views.py
+++ b/api/environments/identities/traits/views.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from django.core.exceptions import BadRequest
 from django.db.models import Q
-from drf_yasg2 import openapi
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -43,6 +43,9 @@ class IdentityViewSet(viewsets.ModelViewSet):
     pagination_class = CustomPagination
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Identity.objects.none()
+
         environment = self.get_environment_from_request()
         queryset = Identity.objects.filter(environment=environment)
 

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response

--- a/api/environments/permissions/views.py
+++ b/api/environments/permissions/views.py
@@ -21,6 +21,9 @@ class UserEnvironmentPermissionsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, NestedEnvironmentPermissions]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return UserEnvironmentPermission.objects.none()
+
         if not self.kwargs.get("environment_api_key"):
             raise ValidationError("Missing environment key.")
 
@@ -52,6 +55,9 @@ class UserPermissionGroupEnvironmentPermissionsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, NestedEnvironmentPermissions]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return UserPermissionGroupEnvironmentPermission.objects.none()
+
         if not self.kwargs.get("environment_api_key"):
             raise ValidationError("Missing environment key.")
 

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 import logging
 
 from django.utils.decorators import method_decorator
-from drf_yasg2 import openapi
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError

--- a/api/features/feature_segments/views.py
+++ b/api/features/feature_segments/views.py
@@ -2,7 +2,7 @@ import logging
 
 from core.permissions import HasMasterAPIKey
 from django.utils.decorators import method_decorator
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404

--- a/api/features/feature_segments/views.py
+++ b/api/features/feature_segments/views.py
@@ -37,6 +37,9 @@ class FeatureSegmentViewSet(
     permission_classes = [IsAuthenticated | HasMasterAPIKey]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return FeatureSegment.objects.none()
+
         if hasattr(self.request, "master_api_key"):
             permitted_projects = Project.objects.filter(
                 organisation_id=self.request.master_api_key.organisation_id

--- a/api/features/multivariate/views.py
+++ b/api/features/multivariate/views.py
@@ -1,5 +1,5 @@
 from core.permissions import HasMasterAPIKey
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.generics import get_object_or_404

--- a/api/features/multivariate/views.py
+++ b/api/features/multivariate/views.py
@@ -41,6 +41,9 @@ class MultivariateFeatureOptionViewSet(viewsets.ModelViewSet):
         ]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return MultivariateFeatureOption.objects.none()
+
         feature = get_object_or_404(Feature, pk=self.kwargs["feature_pk"])
         return feature.multivariate_options.all()
 

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -12,8 +12,8 @@ from django.core.cache import caches
 from django.db.models import Q, QuerySet
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-from drf_yasg2 import openapi
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.exceptions import NotFound, ValidationError

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -98,7 +98,6 @@ def get_feature_by_uuid(request, uuid):
 )
 class FeatureViewSet(viewsets.ModelViewSet):
     permission_classes = [FeaturePermissions | MasterAPIKeyFeaturePermissions]
-    filterset_fields = ["is_archived"]
     pagination_class = CustomPagination
 
     def get_serializer_class(self):
@@ -111,6 +110,9 @@ class FeatureViewSet(viewsets.ModelViewSet):
         }.get(self.action, ProjectFeatureSerializer)
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Feature.objects.none()
+
         if self.request.user.is_anonymous:
             accessible_projects = (
                 self.request.master_api_key.organisation.projects.all()
@@ -315,6 +317,9 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):
         """
         Override queryset to filter based on provided URL parameters.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FeatureState.objects.none()
+
         environment_api_key = self.kwargs["environment_api_key"]
 
         try:
@@ -496,6 +501,9 @@ class IdentityFeatureStateViewSet(BaseFeatureStateViewSet):
     permission_classes = [IsAuthenticated, IdentityFeatureStatePermissions]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return FeatureState.objects.none()
+
         return super().get_queryset().filter(identity__pk=self.kwargs["identity_pk"])
 
     @action(methods=["GET"], detail=False)

--- a/api/integrations/common/views.py
+++ b/api/integrations/common/views.py
@@ -15,6 +15,9 @@ class IntegrationCommonViewSet(viewsets.ModelViewSet):
     model_class = None
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return self.model_class.objects.none()
+
         environment_api_key = self.kwargs["environment_api_key"]
 
         try:

--- a/api/integrations/datadog/views.py
+++ b/api/integrations/datadog/views.py
@@ -11,6 +11,9 @@ class DataDogConfigurationViewSet(viewsets.ModelViewSet):
     pagination_class = None  # set here to ensure documentation is correct
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return DataDogConfiguration.objects.none()
+
         project = get_object_or_404(
             self.request.user.get_permitted_projects(["VIEW_PROJECT"]),
             pk=self.kwargs["project_pk"],

--- a/api/integrations/new_relic/views.py
+++ b/api/integrations/new_relic/views.py
@@ -11,6 +11,9 @@ class NewRelicConfigurationViewSet(viewsets.ModelViewSet):
     pagination_class = None  # set here to ensure documentation is correct
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return NewRelicConfiguration.objects.none()
+
         project = get_object_or_404(
             self.request.user.get_permitted_projects(["VIEW_PROJECT"]),
             pk=self.kwargs["project_pk"],

--- a/api/metadata/views.py
+++ b/api/metadata/views.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.utils.decorators import method_decorator
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError

--- a/api/metadata/views.py
+++ b/api/metadata/views.py
@@ -35,6 +35,9 @@ class MetadataFieldViewSet(viewsets.ModelViewSet):
     serializer_class = MetadataFieldSerializer
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return MetadataField.objects.none()
+
         queryset = MetadataField.objects.filter(organisation__users=self.request.user)
         if self.action == "list":
             serializer = MetadataFieldQuerySerializer(data=self.request.query_params)

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -83,6 +83,9 @@ class InviteLinkViewSet(
     pagination_class = None
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return InviteLink.objects.none()
+
         organisation_pk = self.kwargs.get("organisation_pk")
         user = self.request.user
         organisation = Organisation.objects.get(id=organisation_pk)
@@ -120,6 +123,9 @@ class InviteViewSet(
         }.get(self.action, InviteListSerializer)
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Invite.objects.none()
+
         organisation_pk = self.kwargs.get("organisation_pk")
         user = self.request.user
 

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -23,6 +23,7 @@ from organisations.exceptions import (
     SubscriptionNotFound,
 )
 from organisations.models import (
+    Organisation,
     OrganisationRole,
     OrganisationWebhook,
     Subscription,
@@ -86,6 +87,8 @@ class OrganisationViewSet(viewsets.ModelViewSet):
         return context
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Organisation.objects.none()
         return self.request.user.organisations.all()
 
     def get_throttles(self):
@@ -299,6 +302,9 @@ class OrganisationWebhookViewSet(viewsets.ModelViewSet, TriggerSampleWebhookMixi
     webhook_type = WebhookType.ORGANISATION
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return OrganisationWebhook.objects.none()
+
         if "organisation_pk" not in self.kwargs:
             raise ValidationError("Missing required path parameter 'organisation_pk'")
 

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -9,7 +9,7 @@ from app_analytics.influxdb_wrapper import (
     get_multiple_event_list_for_organisation,
 )
 from django.contrib.sites.shortcuts import get_current_site
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.decorators import action, api_view, authentication_classes

--- a/api/projects/tags/views.py
+++ b/api/projects/tags/views.py
@@ -3,6 +3,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 
 from . import serializers
+from .models import Tag
 from .permissions import TagPermissions
 
 
@@ -11,6 +12,9 @@ class TagViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, TagPermissions]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Tag.objects.none()
+
         project = get_object_or_404(
             self.request.user.get_permitted_projects(["VIEW_PROJECT"]),
             pk=self.kwargs["project_pk"],

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.utils.decorators import method_decorator
-from drf_yasg2 import openapi
-from drf_yasg2.utils import no_body, swagger_auto_schema
+from drf_yasg import openapi
+from drf_yasg.utils import no_body, swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.exceptions import ValidationError

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -26,6 +26,7 @@ from projects.exceptions import (
     TooManyIdentitiesError,
 )
 from projects.models import (
+    Project,
     ProjectPermissionModel,
     UserPermissionGroupProjectPermission,
     UserProjectPermission,
@@ -72,6 +73,9 @@ class ProjectViewSet(viewsets.ModelViewSet):
     pagination_class = None
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Project.objects.none()
+
         if hasattr(self.request, "master_api_key"):
             queryset = self.request.master_api_key.organisation.projects.all()
         else:
@@ -183,6 +187,9 @@ class BaseProjectPermissionsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, IsProjectAdmin]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return self.model_class.objects.none()
+
         if not self.kwargs.get("project_pk"):
             raise ValidationError("Missing project pk.")
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -30,7 +30,7 @@ multi_line_output = 3
 include_trailing_comma = true
 line_length = 79
 known_first_party=['analytics','app','custom_auth','environments','integrations','organisations','projects','segments','users','webhooks','api','audit','e2etests','features','permissions','util']
-known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','core','coreapi','corsheaders','dj_database_url','django','django_lifecycle','djoser','drf_writable_nested','drf_yasg2','environs','google','influxdb_client','ordered_model','pyotp','pytest','pytz','requests','responses','rest_framework','rest_framework_nested','rest_framework_recursive','sentry_sdk','shortuuid','simple_history','six','telemetry','tests','trench','whitenoise']
+known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','core','coreapi','corsheaders','dj_database_url','django','django_lifecycle','djoser','drf_writable_nested','drf_yasg','environs','google','influxdb_client','ordered_model','pyotp','pytest','pytz','requests','responses','rest_framework','rest_framework_nested','rest_framework_recursive','sentry_sdk','shortuuid','simple_history','six','telemetry','tests','trench','whitenoise']
 skip = ['migrations','.venv','.direnv']
 
 [tool.pytest.ini_options]

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -30,7 +30,7 @@ django-ordered-model
 django-ses
 django-axes
 django-admin-sso
-drf-yasg2
+drf-yasg
 django-debug-toolbar
 sentry-sdk
 environs

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -45,13 +45,9 @@ chargebee==2.7.7
 charset-normalizer==3.0.1
     # via requests
 coreapi==2.3.3
-    # via
-    #   -r requirements.in
-    #   drf-yasg2
+    # via -r requirements.in
 coreschema==0.0.4
-    # via
-    #   coreapi
-    #   drf-yasg2
+    # via coreapi
 cryptography==39.0.1
     # via
     #   azure-identity
@@ -81,7 +77,7 @@ django==3.2.19
     #   djangorestframework-simplejwt
     #   djoser
     #   drf-nested-routers
-    #   drf-yasg2
+    #   drf-yasg
     #   opencensus-ext-django
     #   pyngo
     #   social-auth-app-django
@@ -123,7 +119,7 @@ djangorestframework==3.12.1
     #   djangorestframework-recursive
     #   djangorestframework-simplejwt
     #   drf-nested-routers
-    #   drf-yasg2
+    #   drf-yasg
 djangorestframework-api-key==2.2.0
     # via -r requirements.in
 djangorestframework-recursive==0.1.2
@@ -136,7 +132,7 @@ drf-nested-routers==0.92.1
     # via -r requirements.in
 drf-writable-nested==0.6.2
     # via -r requirements.in
-drf-yasg2==1.19.3
+drf-yasg==1.21.6
     # via -r requirements.in
 environs==9.2.0
     # via -r requirements.in
@@ -169,7 +165,7 @@ httplib2==0.19.0
 idna==3.4
     # via requests
 inflection==0.5.1
-    # via drf-yasg2
+    # via drf-yasg
 influxdb-client==1.28.0
     # via -r requirements.in
 itypes==1.2.0
@@ -216,7 +212,7 @@ packaging==23.0
     # via
     #   -r requirements.in
     #   django-lifecycle
-    #   drf-yasg2
+    #   drf-yasg
 portalocker==2.4.0
     # via msal-extensions
 protobuf==3.18.3
@@ -276,13 +272,16 @@ python-http-client==3.3.7
     #   sendgrid
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2020.4
+pytz==2023.3
     # via
     #   django
     #   django-ses
+    #   drf-yasg
     #   google-api-core
     #   influxdb-client
     #   twilio
+pyyaml==6.0
+    # via drf-yasg
 requests==2.31.0
     # via
     #   -r requirements.in
@@ -304,8 +303,6 @@ rsa==4.7
     # via
     #   google-auth
     #   oauth2client
-ruamel-yaml==0.17.20
-    # via drf-yasg2
 rudder-sdk-python==1.0.5
     # via -r requirements.in
 rx==3.1.1
@@ -334,7 +331,6 @@ six==1.16.0
     #   azure-identity
     #   django-simple-history
     #   django-softdelete
-    #   drf-yasg2
     #   google-api-core
     #   google-api-python-client
     #   google-auth
@@ -365,7 +361,7 @@ typing-extensions==4.5.0
 uritemplate==3.0.1
     # via
     #   coreapi
-    #   drf-yasg2
+    #   drf-yasg
     #   google-api-python-client
 urllib3==1.26.14
     # via

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -2,8 +2,8 @@ import logging
 
 from core.permissions import HasMasterAPIKey
 from django.utils.decorators import method_decorator
-from drf_yasg2 import openapi
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.generics import get_object_or_404

--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -50,6 +50,9 @@ class SegmentViewSet(viewsets.ModelViewSet):
     pagination_class = CustomPagination
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Segment.objects.none()
+
         if hasattr(self.request, "master_api_key"):
             permitted_projects = self.request.master_api_key.organisation.projects.all()
         else:

--- a/api/task_processor/views.py
+++ b/api/task_processor/views.py
@@ -1,4 +1,4 @@
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response

--- a/api/tests/unit/api/test_unit_api.py
+++ b/api/tests/unit/api/test_unit_api.py
@@ -1,0 +1,14 @@
+import pytest
+from django.urls import reverse
+from pytest_lazyfixture import lazy_fixture
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.mark.parametrize(
+    "client", (lazy_fixture("api_client"), lazy_fixture("admin_client"))
+)
+def test_swagger_docs_generation(client: APIClient) -> None:
+    url = reverse("api-v1:schema-swagger-ui")
+    response = client.get(url)
+    assert response.status_code == status.HTTP_200_OK

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.generic.edit import FormView
-from drf_yasg2.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.exceptions import PermissionDenied

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -149,6 +149,9 @@ class UserPermissionGroupViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, UserPermissionGroupPermission]
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return UserPermissionGroup.objects.none()
+
         organisation_pk = self.kwargs.get("organisation_pk")
         organisation = Organisation.objects.get(id=organisation_pk)
 
@@ -175,7 +178,7 @@ class UserPermissionGroupViewSet(viewsets.ModelViewSet):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        if self.detail is True:
+        if not getattr(self, "swagger_fake_view", False) and self.detail is True:
             with suppress(ValueError):
                 context["group_admins"] = UserPermissionGroupMembership.objects.filter(
                     userpermissiongroup__id=int(self.kwargs["pk"]), group_admin=True


### PR DESCRIPTION
## Changes

1. Replace unsupported [drf-yasg2](https://pypi.org/project/drf-yasg2/) with [drf-yasg](https://pypi.org/project/drf-yasg/)
2. Fix warnings and exceptions in swagger generation process

Note: there are some warnings spat to the logs still in the django-trench views. We can either submit a PR to their repo (although it's been dormant since 2022) or fork the repo (preferred). 

## How did you test this code?

Ran the application locally and verified that swagger docs are generated successfully and without warnings (in our own views at least). 
