### PR TITLE
chore: bump flag-engine version

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -140,7 +140,7 @@ drf-yasg2==1.19.3
     # via -r requirements.in
 environs==9.2.0
     # via -r requirements.in
-flagsmith-flag-engine==4.0.0
+flagsmith-flag-engine==4.0.1
     # via -r requirements.in
 google-api-core==1.23.0
     # via


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?

## Changes

This bumps flag-engine to the latest version to ensure correct trait data deserialization across both Edge and Core API.

## How did you test this code?

Ensured that unit tests weren't broken.