### PR TITLE
Prevent deleted integrations from running in Core API

### DIFF
--- a/api/integrations/integration.py
+++ b/api/integrations/integration.py
@@ -18,7 +18,7 @@ IDENTITY_INTEGRATIONS = [
 def identify_integrations(identity, all_feature_states, trait_models=None):
     for integration in IDENTITY_INTEGRATIONS:
         config = getattr(identity.environment, integration.get("relation_name"), None)
-        if config:
+        if config and not config.deleted:
             wrapper = integration.get("wrapper")
             wrapper_instance = wrapper(config)
             user_data = wrapper_instance.generate_user_data(

--- a/api/tests/unit/integrations/test_unit_integration.py
+++ b/api/tests/unit/integrations/test_unit_integration.py
@@ -87,3 +87,21 @@ def test_identify_integrations_calls_every_integration_in_identity_integrations_
     integration_wrapper_b.return_value.identify_user_async.assert_called_with(
         data=integration_b_mocked_generate_user_data.return_value
     )
+
+
+def test_identify_integrations_does_not_call_deleted_integrations(
+    mocker, environment, identity
+):
+    # Given
+    mock_segment_wrapper = mocker.patch(
+        "integrations.segment.segment.SegmentWrapper.identify_user_async"
+    )
+
+    sc = SegmentConfiguration.objects.create(api_key="abc-123", environment=environment)
+    sc.delete()
+
+    # When
+    identify_integrations(identity, identity.get_all_feature_states())
+
+    # Then
+    mock_segment_wrapper.assert_not_called()

--- a/api/tests/unit/integrations/test_unit_integration.py
+++ b/api/tests/unit/integrations/test_unit_integration.py
@@ -1,4 +1,6 @@
 from integrations.amplitude.models import AmplitudeConfiguration
+from integrations.common.models import EnvironmentIntegrationModel
+from integrations.common.wrapper import AbstractBaseIdentityIntegrationWrapper
 from integrations.integration import identify_integrations
 from integrations.segment.models import SegmentConfiguration
 
@@ -34,11 +36,19 @@ def test_identify_integrations_calls_every_integration_in_identity_integrations_
     mocker, identity
 ):
     # Given
-    integration_wrapper_a = mocker.MagicMock()
-    integration_wrapper_b = mocker.MagicMock()
+    integration_wrapper_a = mocker.MagicMock(
+        autospec=AbstractBaseIdentityIntegrationWrapper
+    )
+    integration_wrapper_b = mocker.MagicMock(
+        autospec=AbstractBaseIdentityIntegrationWrapper
+    )
 
-    integration_a_config = mocker.MagicMock()
-    integration_b_config = mocker.MagicMock()
+    integration_a_config = mocker.MagicMock(
+        autospec=EnvironmentIntegrationModel, deleted=False
+    )
+    integration_b_config = mocker.MagicMock(
+        autospec=EnvironmentIntegrationModel, deleted=False
+    )
 
     identity.environment.integration_a_config = integration_a_config
     identity.environment.integration_b_config = integration_b_config

--- a/api/tests/unit/util/mappers/test_unit_mappers_engine.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_engine.py
@@ -29,6 +29,8 @@ from environments.models import Environment
 from features.models import FeatureSegment, FeatureState
 from integrations.common.models import IntegrationsModel
 from integrations.dynatrace.models import DynatraceConfiguration
+from integrations.mixpanel.models import MixpanelConfiguration
+from integrations.segment.models import SegmentConfiguration
 from integrations.webhook.models import WebhookConfiguration
 from segments.models import Segment, SegmentRule
 from util.mappers import engine
@@ -301,6 +303,18 @@ def test_map_environment_to_engine__return_expected(
         feature=feature,
         environment=environment_2,
     )
+    mixpanel_configuration = MixpanelConfiguration.objects.create(
+        environment=environment,
+        api_key="some-key",
+    )
+    webhook_configuration = WebhookConfiguration.objects.create(
+        environment=environment, url="https://my.webhook.com/webhook"
+    )
+    deleted_segment_configuration = SegmentConfiguration.objects.create(
+        environment=environment,
+        api_key="some-key",
+    )
+    deleted_segment_configuration.delete()
 
     expected_feature_model = FeatureModel(
         id=feature.id, name="Test Feature1", type="STANDARD"
@@ -361,10 +375,16 @@ def test_map_environment_to_engine__return_expected(
         amplitude_config=None,
         dynatrace_config=None,
         heap_config=None,
-        mixpanel_config=None,
+        mixpanel_config={
+            "base_url": mixpanel_configuration.base_url,
+            "api_key": mixpanel_configuration.api_key,
+        },
         rudderstack_config=None,
-        segment_config=None,
-        webhook_config=None,
+        segment_config=None,  # note: segment configuration should not appear as it was deleted
+        webhook_config={
+            "url": webhook_configuration.url,
+            "secret": webhook_configuration.secret,
+        },
     )
 
     # When

--- a/api/util/mappers/engine.py
+++ b/api/util/mappers/engine.py
@@ -187,17 +187,19 @@ def map_environment_to_engine(
     }
 
     # Read integrations.
-    integration_configs: dict[str, Optional["EnvironmentIntegrationModel"]] = {
-        attr_name: getattr(environment, attr_name, None)
-        for attr_name in (
-            "amplitude_config",
-            "dynatrace_config",
-            "heap_config",
-            "mixpanel_config",
-            "rudderstack_config",
-            "segment_config",
-        )
-    }
+    integration_configs: dict[str, Optional["EnvironmentIntegrationModel"]] = {}
+    for attr_name in (
+        "amplitude_config",
+        "dynatrace_config",
+        "heap_config",
+        "mixpanel_config",
+        "rudderstack_config",
+        "segment_config",
+    ):
+        integration_config = getattr(environment, attr_name, None)
+        if integration_config and not integration_config.deleted:
+            integration_configs[attr_name] = integration_config
+
     webhook_config: Optional["WebhookConfiguration"] = getattr(
         environment, "webhook_config", None
     )
@@ -257,25 +259,30 @@ def map_environment_to_engine(
 
     # Prepare integrations.
     amplitude_config_model = map_integration_to_engine(
-        integration_configs.pop("amplitude_config"),
+        integration_configs.pop("amplitude_config", None),
     )
     dynatrace_config_model = map_integration_to_engine(
-        integration_configs.pop("dynatrace_config"),
+        integration_configs.pop("dynatrace_config", None),
     )
     heap_config_model = map_integration_to_engine(
-        integration_configs.pop("heap_config"),
+        integration_configs.pop("heap_config", None),
     )
     mixpanel_config_model = map_integration_to_engine(
-        integration_configs.pop("mixpanel_config"),
+        integration_configs.pop("mixpanel_config", None),
     )
     rudderstack_config_model = map_integration_to_engine(
-        integration_configs.pop("rudderstack_config"),
+        integration_configs.pop("rudderstack_config", None),
     )
     segment_config_model = map_integration_to_engine(
-        integration_configs.pop("segment_config"),
+        integration_configs.pop("segment_config", None),
     )
-    webhook_config_model = map_webhook_config_to_engine(
-        webhook_config,
+
+    webhook_config_model = (
+        map_webhook_config_to_engine(
+            webhook_config,
+        )
+        if webhook_config and not webhook_config.deleted
+        else None
     )
 
     return EnvironmentModel(


### PR DESCRIPTION
## Changes

1. Prevent deleted integrations from being triggered by Core API
2. Prevent deleted integrations from being included in environment document. This ensures that (a) they are no longer written to dynamo and, hence, not triggered by Edge and (b) not returned on the environment-document endpoint (although they arguably shouldn't be returned there regardless!

## How did you test this code?

Added unit tests. 
