### PR TITLE
fix: avoid running docker-based e2e concurrently

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -10,6 +10,7 @@ jobs:
   run-e2e-tests:
     runs-on: ubuntu-latest
     name: Full E2E tests
+    concurrency: e2e-tests
 
     services:
       postgres:
@@ -52,6 +53,7 @@ jobs:
   run-e2e-tests-docker-unified:
     runs-on: ubuntu-latest
     name: Full E2E tests with unified image in Docker
+    concurrency: e2e-tests
 
     steps:
       - name: Cloning repo


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

This workflow change ensures that Docker-based E2E tests are not run concurrently.
This doubles the workflow runtime but (hopefully) eliminates all of the flakiness problems we've been encountering with E2E. 

## How did you test this code?

This is tested by running the GH pull request workflow.