### PR TITLE
chore: fix docs formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,23 +4,27 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
       - id: black
         language_version: python3
         exclude: migrations
+
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
         name: flake8
         args: [--config, api/.flake8]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: check-yaml
+
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.6
+    rev: v3.0.0
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
     hooks:
       - id: check-yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -47,7 +47,7 @@ control whether the button shows. Create a flag called `show_demo_button`, and l
 OK so we've set up our flag; now let's bring it into our application. We have a (pretty small!) web page:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
  <head>
   <meta charset="utf-8" />
@@ -122,7 +122,7 @@ the state of the flag and set the display visibility based on the result.
 Our entire webpage now reads like this:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
  <head>
   <meta charset="utf-8" />

--- a/docs/versioned_docs/version-v1.0/quickstart.md
+++ b/docs/versioned_docs/version-v1.0/quickstart.md
@@ -47,7 +47,7 @@ Flags can either a `Boolean` value, a `String` value, or a combination of both. 
 OK so we've set up our flag; now let's bring it into our application. We have a (very!) simple web page:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
  <head>
   <meta charset="utf-8" />
@@ -122,7 +122,7 @@ the state of the flag and set the display visibility based on the result.
 Our entire webpage now reads like this:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
  <head>
   <meta charset="utf-8" />


### PR DESCRIPTION
Needed to upgrade to prettier 3 in pre commit. This now matches the github action docs linter