### PR TITLE
Fix environment document generation for scheduled CRs

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -488,8 +488,10 @@ class FeatureState(
             return (
                 self.is_live
                 and (not other.is_live or self.is_more_recent_live_from(other))
-                or self.live_from == other.live_from
-                and self._is_more_recent_version(other)
+                or (
+                    self.live_from == other.live_from
+                    and self._is_more_recent_version(other)
+                )
             )
 
         # if we've reached here, then self is just the environment default. In this case, other is higher priority if
@@ -781,15 +783,7 @@ class FeatureState(
                 feature_state.identity_id,
             )
             current_feature_state = feature_states_dict.get(key)
-            # we use live_from here as a priority over the version since
-            # the version is given when change requests are committed,
-            # hence the version for a feature state that is scheduled
-            # further in the future can be lower than a feature state
-            # whose live_from value is earlier.
-            # See: https://github.com/Flagsmith/flagsmith/issues/2030
-            if not current_feature_state or feature_state.is_more_recent_live_from(
-                current_feature_state
-            ):
+            if not current_feature_state or feature_state > current_feature_state:
                 feature_states_dict[key] = feature_state
 
         return list(feature_states_dict.values())

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -485,14 +485,15 @@ class FeatureState(
             # further in the future can be lower than a feature state
             # whose live_from value is earlier.
             # See: https://github.com/Flagsmith/flagsmith/issues/2030
-            return (
-                self.is_live
-                and (not other.is_live or self.is_more_recent_live_from(other))
-                or (
-                    self.live_from == other.live_from
-                    and self._is_more_recent_version(other)
-                )
-            )
+            if self.is_live:
+                if not other.is_live or self.is_more_recent_live_from(other):
+                    return True
+                elif self.live_from == other.live_from and self._is_more_recent_version(
+                    other
+                ):
+                    return True
+
+            return False
 
         # if we've reached here, then self is just the environment default. In this case, other is higher priority if
         # it has a feature_segment or an identity

--- a/api/features/tests/test_models.py
+++ b/api/features/tests/test_models.py
@@ -448,7 +448,7 @@ class FeatureStateTest(TestCase):
         FeatureState.objects.create(
             feature=self.feature,
             enabled=False,
-            version=3,
+            version=None,
             environment=self.environment,
         )
 

--- a/api/tests/unit/environments/identities/test_identities_models.py
+++ b/api/tests/unit/environments/identities/test_identities_models.py
@@ -31,15 +31,15 @@ def test_identity_get_all_feature_states_gets_latest_committed_version(environme
     feature_state_v2.feature_state_value.save()
 
     # and one which isn't
-    feature_state_v3 = FeatureState.objects.create(
+    not_live_feature_state = FeatureState.objects.create(
         feature=feature,
-        version=3,
+        version=None,
         live_from=None,
         enabled=False,
         environment=environment,
     )
-    feature_state_v3.feature_state_value.string_value = "v3"
-    feature_state_v3.feature_state_value.save()
+    not_live_feature_state.feature_state_value.string_value = "v3"
+    not_live_feature_state.feature_state_value.save()
 
     # When
     identity_feature_states = identity.get_all_feature_states()

--- a/api/tests/unit/features/conftest.py
+++ b/api/tests/unit/features/conftest.py
@@ -6,32 +6,23 @@ from features.models import FeatureState
 @pytest.fixture()
 def feature_state_version_generator(environment, feature, request):
     version_1 = request.param[0]
-    version_2 = request.param[1]
-    expected_result = request.param[2]
+    version_1_live_from = request.param[1]
+    version_2 = request.param[2]
+    version_2_live_from = request.param[3]
+    expected_result = request.param[4]
 
     return (
         FeatureState.objects.create(
-            feature=feature, environment=environment, version=version_1
+            feature=feature,
+            environment=environment,
+            version=version_1,
+            live_from=version_1_live_from,
         ),
         FeatureState.objects.create(
-            feature=feature, environment=environment, version=version_2
-        ),
-        expected_result,
-    )
-
-
-@pytest.fixture()
-def feature_state_live_from_generator(environment, feature, request):
-    live_from_one = request.param[0]
-    live_from_two = request.param[1]
-    expected_result = request.param[2]
-
-    return (
-        FeatureState.objects.create(
-            feature=feature, environment=environment, live_from=live_from_one, version=2
-        ),
-        FeatureState.objects.create(
-            feature=feature, environment=environment, live_from=live_from_two, version=3
+            feature=feature,
+            environment=environment,
+            version=version_2,
+            live_from=version_2_live_from,
         ),
         expected_result,
     )

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -76,33 +76,21 @@ def test_feature_states_get_environment_flags_queryset_filter_using_feature_name
 @pytest.mark.parametrize(
     "feature_state_version_generator",
     (
-        (None, None, False),
-        (2, None, True),
-        (None, 2, False),
-        (2, 3, False),
-        (3, 2, True),
+        # test the default case, this should never be true
+        (None, None, None, None, False),
+        # for the following 6 cases, ensure that we test in both directions
+        (2, now, None, None, True),
+        (None, None, 2, now, False),
+        (2, now, 3, now, False),
+        (3, now, 2, now, True),
+        (3, now, 2, yesterday, True),
+        (3, yesterday, 2, now, False),
     ),
     indirect=True,
 )
-def test_feature_state_gt_operator_for_versions(feature_state_version_generator):
+def test_feature_state_gt_operator(feature_state_version_generator):
     first, second, expected_result = feature_state_version_generator
-    assert (first > second) == expected_result
-
-
-@pytest.mark.parametrize(
-    "feature_state_live_from_generator",
-    (
-        (None, None, False),
-        (now, None, True),
-        (None, now, False),
-        (now, tomorrow, False),
-        (tomorrow, now, True),
-    ),
-    indirect=True,
-)
-def test_feature_state_gt_operator_for_live_from(feature_state_live_from_generator):
-    first, second, expected_result = feature_state_live_from_generator
-    assert (first > second) == expected_result
+    assert (first > second) is expected_result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes

Fixes issue with evaluating versions of the same type. 

Description of the issue that this fixes is described in more detail in a comment [here](https://github.com/Flagsmith/flagsmith/issues/2030#issuecomment-1623629156). 

This change ensures that we rely on the version only if the `live_from` date is the same, otherwise, we rely on the `live_from` date. 

As per the [previous PR](https://github.com/Flagsmith/flagsmith/pull/2036) which attempted to fix this issue, we use `live_from` to determine which flag over the version in most scenarios.

## How did you test this code?

Added a specific test for the issue as reported by a customer. Also updated unit tests where necessary. 

**Some manual tests that we should run in a live environment:** 

Test 1

Create & publish a change request (CR1), scheduled for some time in the future
Create & publish a change request (CR2), scheduled to go live immediately

_Observe that we receive the value from CR2 until the time that CR1 was scheduled for_

Test 2

Create a change request (CR1) scheduled for 5 minutes from now
Create a change request (CR2) scheduled for 2 minutes from now
Publish CR1
Publish CR2

_Observe that we receive the value from CR2 after 2 minutes have passed, until the time that CR1 was scheduled for_ 

Test 3

Create CR (#CR1) scheduled for 2 minutes from now
Create CR (#CR2) scheduled for 5 minutes from now
Publish CR2
Publish CR1

_Observe that we receive the value from CR1 after 2 minutes have passed, until the time that CR2 was scheduled for_ 
