### PR TITLE
Remove delete constraint from ChangeRequest model

### DIFF
--- a/api/features/workflows/core/exceptions.py
+++ b/api/features/workflows/core/exceptions.py
@@ -12,7 +12,3 @@ class ChangeRequestNotApprovedError(FeatureWorkflowError):
 
 class CannotApproveOwnChangeRequest(FeatureWorkflowError):
     status_code = status.HTTP_400_BAD_REQUEST
-
-
-class ChangeRequestDeletionError(FeatureWorkflowError):
-    status_code = status.HTTP_400_BAD_REQUEST

--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -36,7 +36,6 @@ from features.models import FeatureState
 
 from .exceptions import (
     CannotApproveOwnChangeRequest,
-    ChangeRequestDeletionError,
     ChangeRequestNotApprovedError,
 )
 
@@ -120,16 +119,6 @@ class ChangeRequest(
         self.committed_at = timezone.now()
         self.committed_by = committed_by
         self.save()
-
-    def delete(self, *args, **kwargs):
-        now = timezone.now()
-        if self.committed_at and all(
-            fs.live_from <= now for fs in self.feature_states.all()
-        ):
-            raise ChangeRequestDeletionError(
-                "Cannot delete change request that has been committed."
-            )
-        super().delete(*args, **kwargs)
 
     def get_create_log_message(self, history_instance) -> typing.Optional[str]:
         return CHANGE_REQUEST_CREATED_MESSAGE % self.title

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -15,7 +15,6 @@ from audit.related_object_type import RelatedObjectType
 from features.models import FeatureState
 from features.workflows.core.exceptions import (
     CannotApproveOwnChangeRequest,
-    ChangeRequestDeletionError,
     ChangeRequestNotApprovedError,
 )
 from features.workflows.core.models import (
@@ -500,29 +499,6 @@ def test_committing_cr_after_before_from_schedules_tasks_correctly(
         delay_until=tomorrow,
         args=(change_request_no_required_approvals.feature_states.all().first().id,),
     )
-
-
-def test_cannot_delete_committed_change_request_with_live_feature_states(
-    project, environment, feature, admin_user
-):
-    # Given
-    change_request = ChangeRequest.objects.create(
-        title="Test CR", environment=environment, user=admin_user
-    )
-    FeatureState.objects.create(
-        feature=feature,
-        environment=environment,
-        change_request=change_request,
-        version=None,
-    )
-    change_request.commit(admin_user)
-
-    # When
-    with pytest.raises(ChangeRequestDeletionError):
-        change_request.delete()
-
-    # Then
-    assert change_request.deleted_at is None
 
 
 @pytest.mark.freeze_time()


### PR DESCRIPTION
## Changes

As per #2304, this removes the model level constraint on deleting change requests. The constraint has been moved to the view level [here](https://github.com/Flagsmith/flagsmith-workflows/pull/20). 

## How did you test this code?

Removed current unit test and added a new 'unit' test (more of an integration test really) to confirm that the change fixes the issue described in #2304. 
