### PR TITLE
ci: Move pre-commit to each sub-repo

### DIFF
--- a/api/.pre-commit-config.yaml
+++ b/api/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        language_version: python3
+        exclude: migrations
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        name: flake8
+        args: [--config, api/.flake8]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0
+    hooks:
+      - id: prettier

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged --allow-empty
+npx lint-staged --allow-empty || exit 1

--- a/frontend/lint-staged.config.js
+++ b/frontend/lint-staged.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  '*.{js,jsx}': ['suppress-exit-code eslint --fix'],
+  '*.{ts,tsx}': [
+    'suppress-exit-code eslint --fix',
+    () => 'tsc --skipLibCheck --noEmit',
+  ],
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -155,8 +155,5 @@
     "ssgrtk": "^0.3.4",
     "testcafe": "^2.2.0",
     "typescript": "4.6.4"
-  },
-  "lint-staged": {
-    "*.{js,tsx,ts}": "suppress-exit-code eslint --fix"
   }
 }

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+set -e
 # Run checks in api folder
 echo "Starting pre-commit in 'api' folder:"
 cd api
@@ -8,7 +9,7 @@ pre-commit run
 # Run checks in frontend folder
 echo "Starting pre-commit in 'frontend' folder:"
 cd ../frontend
-bash .husky/pre-commit
+.husky/pre-commit
 
 # Run checks in docs folder
 echo "Starting pre-commit in 'docs' folder:"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "Starting pre-commit in 'api' folder:"
+cd api
+pre-commit run
+
+echo "Starting pre-commit in 'frontend' folder:"
+cd ../frontend
+bash .husky/pre-commit
+

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,10 +1,16 @@
 #!/bin/sh
 
+# Run checks in api folder
 echo "Starting pre-commit in 'api' folder:"
 cd api
 pre-commit run
 
+# Run checks in frontend folder
 echo "Starting pre-commit in 'frontend' folder:"
 cd ../frontend
 bash .husky/pre-commit
 
+# Run checks in docs folder
+echo "Starting pre-commit in 'docs' folder:"
+cd ../docs
+npm run prettier:fix


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?

## Changes

Use pure Githooks in root folder of the mono repo to run the hooks in api and frontend repos correspondingly.

## How did you test this code?

Manually:

Run:

`git config core.hooksPath hooks`

Then make changes and commit to see both pre-commit tools running in api and frontend folders.
