### PR TITLE
Use larger runners for E2E

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-e2e-tests:
-    runs-on: e2e-runner
+    runs-on: e2e-runner-8c
     name: Full E2E tests
 
     services:
@@ -50,7 +50,7 @@ jobs:
         run: docker logs $API_CONTAINER_ID
 
   run-e2e-tests-docker-unified:
-    runs-on: e2e-runner
+    runs-on: e2e-runner-8c
     name: Full E2E tests with unified image in Docker
 
     steps:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: e2e-runner
     name: Full E2E tests
 
     services:
@@ -50,7 +50,7 @@ jobs:
         run: docker logs $API_CONTAINER_ID
 
   run-e2e-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: e2e-runner
     name: Full E2E tests with unified image in Docker
 
     steps:


### PR DESCRIPTION
## Changes

Use 'larger runners' functionality for E2E tests.

## How did you test this code?

Ran E2E workflows multiple times (TODO)
