### PR TITLE
Bump flag engine version to fix Nan string validation

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -136,7 +136,7 @@ drf-yasg==1.21.6
     # via -r requirements.in
 environs==9.2.0
     # via -r requirements.in
-flagsmith-flag-engine==4.0.1
+flagsmith-flag-engine==4.0.3
     # via -r requirements.in
 google-api-core==1.23.0
     # via


### PR DESCRIPTION
## Changes

Bump flag engine version to fix issue with validation of "Nan" string.

Note: 4.0.3 not yet released. Workflows will fail until it is released.

## How did you test this code?

Tested in flag engine repository. 
