### PR TITLE
feat: Use isEnterprise from endpoint version response to determine permissions

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -242,15 +242,15 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     if (plan && plan.includes('start-up')) {
       return planNames.startup
     }
-    if (plan && plan.includes('enterprise')) {
+    if (
+      global.flagsmithVersion?.backend.is_enterprise ||
+      (plan && plan.includes('enterprise'))
+    ) {
       return planNames.enterprise
     }
     return planNames.free
   },
   getPlanPermission: (plan: string, permission: string) => {
-    if (global.flagsmithVersion?.backend.is_enterprise) {
-      return true
-    }
     let valid = true
     const planName = Utils.getPlanName(plan)
 
@@ -307,9 +307,6 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   },
 
   getPlansPermission: (permission: string) => {
-    if (global.flagsmithVersion?.backend.is_enterprise) {
-      return true
-    }
     const isOrgPermission = permission !== '2FA'
     const plans = isOrgPermission
       ? AccountStore.getActiveOrgPlan()

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -248,11 +248,12 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     return planNames.free
   },
   getPlanPermission: (plan: string, permission: string) => {
-    let valid = true
-    const planName = Utils.getPlanName(plan)
-    if (!Utils.getFlagsmithHasFeature('plan_based_access')) {
+    if (global.flagsmithVersion?.backend.is_enterprise) {
       return true
     }
+    let valid = true
+    const planName = Utils.getPlanName(plan)
+
     if (!plan || planName === planNames.free) {
       return false
     }
@@ -306,7 +307,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   },
 
   getPlansPermission: (permission: string) => {
-    if (!Utils.getFlagsmithHasFeature('plan_based_access')) {
+    if (global.flagsmithVersion?.backend.is_enterprise) {
       return true
     }
     const isOrgPermission = permission !== '2FA'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?

## Changes
Use `isEnterprise` attribute from API `/version` endpoint response to determine permissions.

## How did you test this code?

Tested with both self-hosted version
