### PR TITLE
Ensure that project admins are considered as environment admins

### DIFF
--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -188,7 +188,7 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
         environment = self.get_object()
 
         permission_data = get_environment_permission_data(
-            environment.id, user_id=request.user.id
+            environment=environment, user=request.user
         )
         serializer = UserObjectPermissionsSerializer(instance=permission_data)
         return Response(serializer.data)

--- a/api/tests/unit/permissions/test_unit_permissions_calculator.py
+++ b/api/tests/unit/permissions/test_unit_permissions_calculator.py
@@ -195,12 +195,30 @@ def test_environment_permissions_calculator_get_permission_data(
 
     # When
     user_permission_data = get_environment_permission_data(
-        environment.id, user_id=user.id
+        environment=environment, user=user
     )
 
     # Then
     assert user_permission_data.admin == expected_admin
     assert user_permission_data.permissions == expected_permissions
+
+
+def test_environment_permissions_calculator_returns_admin_for_project_admin(
+    environment, project, organisation, django_user_model
+):
+    # Given
+    user = django_user_model.objects.create(email="test@example.com")
+    user.add_organisation(organisation, OrganisationRole.USER)
+
+    UserProjectPermission.objects.create(user=user, project=project, admin=True)
+
+    # When
+    user_permission_data = get_environment_permission_data(
+        environment=environment, user=user
+    )
+
+    # Then
+    assert user_permission_data.admin is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes

This is a somewhat temporary fix to ensure that project admins are evaluated as environment admins. It is considered to be temporary as it is not an efficient solution to the problem, likely resulting in more database queries than are strictly necessary. 

We (@gagantrivedi and I) need to discuss a more permanent solution for inherited admin permissions. 

## How did you test this code?

Added a new unit test. 
