### PR TITLE
Only enable dynatrace if dtrum is defined

### DIFF
--- a/frontend/common/stores/config-store.js
+++ b/frontend/common/stores/config-store.js
@@ -39,7 +39,7 @@ store.dispatcherIndex = Dispatcher.register(store, (payload) => {
   }
 })
 
-const enableDynatrace = !!window.enableDynatrace
+const enableDynatrace = !!window.enableDynatrace && typeof dtrum !== 'undefined'
 
 flagsmith
   .init({

--- a/frontend/web/project/api.js
+++ b/frontend/web/project/api.js
@@ -1,7 +1,6 @@
 import amplitude from 'amplitude-js'
 import data from 'common/data/base/_data'
-
-const enableDynatrace = !!window.enableDynatrace
+const enableDynatrace = !!window.enableDynatrace && typeof dtrum !== 'undefined'
 
 global.API = {
   ajaxHandler(store, res) {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Dtrum is loaded in the head, however there's a possibility that it doesn't get loaded due to adblockers / firewalls. This will safely check that dtrum is defined before interacting with it.

## How did you test this code?

Ran and tested dtrum events were still being sent.