### PR TITLE
fix: ensure relevant email domains are not sent to Pipedrive

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -120,10 +120,6 @@
                     "value": "f001193d9249bb49d631d7c2c516ab72f9ebd204"
                 },
                 {
-                    "name": "PIPEDRIVE_IGNORE_DOMAINS",
-                    "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io"
-                },
-                {
                     "name": "PIPEDRIVE_LEAD_LABEL_EXISTING_CUSTOMER_ID",
                     "value": "d828a3a0-bf34-11ed-b08d-b12d3497f5c4"
                 }

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -170,6 +170,10 @@
                 {
                     "name": "AUTO_SEAT_UPGRADE_PLANS",
                     "value": "scale-up,scale-up-v2,scale-up-annual-v2"
+                },
+                {
+                    "name": "PIPEDRIVE_IGNORE_DOMAINS",
+                    "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Moves the `PIPEDRIVE_IGNORE_DOMAINS` environment variable to the web service. The check to see if a user should be tracked in pipedrive is performed in the API to avoid creating unnecessary tasks for the processor so we need this env var there instead of the task processor. 

## How did you test this code?

Unit tests cover the functionality. This is just moving an environment variable. Needs testing in production environment. 
