### PR TITLE
fix: Don't show archived flags by default on identity page

### DIFF
--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -36,6 +36,7 @@ const UserPage = class extends Component {
   constructor(props, context) {
     super(props, context)
     this.state = {
+      showArchived: false,
       preselect: Utils.fromParam().flag,
       tags: [],
     }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Prior to this change, viewing an identity would show archived flags by default.

## How did you test this code?

Viewed an identity page