### PR TITLE
fix: pre-commit docs link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thanks for submitting a PR! Please check the boxes below:
 
-- [ ] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
+- [ ] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
 - [ ] I have filled in the "Changes" section below?
 - [ ] I have filled in the "How did you test this code" section below?
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?

## Changes

Fix the link in the PR template.

## How did you test this code?

n/a