### PR TITLE
fix: remove call to update environment updated_at value

### DIFF
--- a/api/audit/models.py
+++ b/api/audit/models.py
@@ -114,7 +114,6 @@ class AuditLog(LifecycleModel):
         is_now=True,
     )
     def process_environment_update(self):
-        self.update_environments_updated_at()
         self.send_environments_to_dynamodb()
         self.send_environment_update_message()
 

--- a/api/environments/tests/test_models.py
+++ b/api/environments/tests/test_models.py
@@ -312,6 +312,7 @@ def test_get_from_cache_sets_the_cache_correctly_with_environment_api_key(
     assert environment == environment_cache.get(environment_api_key.key)
 
 
+@pytest.mark.skip("skipped because this is causing lock by task processor")
 def test_updated_at_gets_updated_when_environment_audit_log_created(environment):
     # When
     audit_log = AuditLog.objects.create(
@@ -323,6 +324,7 @@ def test_updated_at_gets_updated_when_environment_audit_log_created(environment)
     assert environment.updated_at == audit_log.created_date
 
 
+@pytest.mark.skip("skipped because this is causing lock by task processor")
 def test_updated_at_gets_updated_when_project_audit_log_created(environment):
     # When
     audit_log = AuditLog.objects.create(


### PR DESCRIPTION
## Changes

Remove logic to update environment `updated_at` attribute when AuditLog is written. This is only used by SSE logic. This is a temporary solution to resolve issue with task processor table locking. 

## How did you test this code?

Skipped broken tests. 
