### PR TITLE
fix: reduce queue pop size to 1

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -15,7 +15,9 @@
                 "--numthreads",
                 "25",
                 "--graceperiodms",
-                "20000"
+                "20000",
+                "--queuepopsize",
+                "1"
             ],
             "essential": true,
             "environment": [


### PR DESCRIPTION
## Changes

Reduce queue pop size to 1 to alleviate issues with table locking on environment updates. 

## How did you test this code?

N/a
