### PR TITLE
fix: re-add EDGE_API_URL to api service task definition

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -170,6 +170,10 @@
                 {
                     "name": "PIPEDRIVE_IGNORE_DOMAINS",
                     "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io"
+                },
+                {
+                    "name":"EDGE_API_URL",
+                    "value":"https://edge.api.flagsmith.com/api/v1/"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Re-add the EDGE_API_URL environment variable to the API service to re-enable the edge forwarding logic. 

## How did you test this code?

N/a
