### PR TITLE
chore(fe): add admin route to frontend proxy

### DIFF
--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -201,7 +201,7 @@ window.enableDynatrace = true;
 if (process.env.FLAGSMITH_PROXY_API_URL) {
   const { createProxyMiddleware } = require('http-proxy-middleware')
   app.use(
-    '/api/v1/',
+    ['/api/v1/', '/admin/', '/admin'],
     createProxyMiddleware({
       changeOrigin: true,
       target: process.env.FLAGSMITH_PROXY_API_URL,


### PR DESCRIPTION
## Changes

Adds django admin to the proxy middleware. 

There's a slight question about whether we actually do want to do this. The reason to do it is that it means that people using the proxy don't have to add an ingress route to their API servers just to access the admin. The reason not to do it, is that the django admin is quite powerful and maybe people wouldn't want it exposed. 

## How did you test this code?

I have not yet been able to. Running the FE locally with the API running on localhost:8000 and setting `FLAGSMITH_PROXY_API_URL=http://localhost:8000/` doesn't seem to work (even before these changes). I need to determine _how_ to test this but this was meant to be a quick change based on customer feedback and I don't want to spend more time on it right now. If anyone else has time to pick this up and test it, that would be great!
