### PR TITLE
fix: prevent environment document generation if size limits exceeded

### DIFF
--- a/api/util/mappers/exceptions.py
+++ b/api/util/mappers/exceptions.py
@@ -1,0 +1,2 @@
+class MappingError(Exception):
+    pass


### PR DESCRIPTION
## Changes

Adds a final line of defence to prevent environment documents being generated that exceed maximum limits. 

Notes: 
 - This relies on PR #2480 
 - We should not merge this until we have increased the limits for existing customers that have already exceeded the limits defined in #2480 

## How did you test this code?

TODO
