### PR TITLE
fix(webhooks): fix skipping webhooks calls on timeouts

### DIFF
--- a/api/webhooks/tests/test_webhooks.py
+++ b/api/webhooks/tests/test_webhooks.py
@@ -1,10 +1,13 @@
 import hashlib
 import hmac
 import json
+from typing import Type
 from unittest import TestCase, mock
 
 import pytest
 from core.constants import FLAGSMITH_SIGNATURE_HEADER
+from pytest_mock import MockerFixture
+from requests.exceptions import ConnectionError, Timeout
 
 from environments.models import Environment, Webhook
 from organisations.models import Organisation, OrganisationWebhook
@@ -149,3 +152,62 @@ class WebhooksTestCase(TestCase):
         # Then
         _, kwargs = mock_requests.post.call_args_list[0]
         assert FLAGSMITH_SIGNATURE_HEADER not in kwargs["headers"]
+
+
+@pytest.mark.parametrize("expected_error", [ConnectionError, Timeout])
+def test_call_environment_webhooks__multiple_webhooks__failure__calls_expected(
+    mocker: MockerFixture,
+    expected_error: Type[Exception],
+    environment: Environment,
+) -> None:
+    # Given
+    requests_post_mock = mocker.patch("webhooks.webhooks.requests.post")
+    requests_post_mock.side_effect = expected_error()
+    send_failure_email_mock: mock.Mock = mocker.patch(
+        "webhooks.webhooks.send_failure_email"
+    )
+
+    webhook_1 = Webhook.objects.create(
+        url="http://url.1.com",
+        enabled=True,
+        environment=environment,
+    )
+    webhook_2 = Webhook.objects.create(
+        url="http://url.2.com",
+        enabled=True,
+        environment=environment,
+    )
+
+    expected_data = {}
+    expected_event_type = WebhookEventType.FLAG_UPDATED
+    expected_send_failure_email_data = {
+        "event_type": expected_event_type.value,
+        "data": expected_data,
+    }
+    expected_send_failure_status_code = f"N/A ({expected_error.__name__})"
+
+    # When
+    call_environment_webhooks(
+        environment=environment,
+        data=expected_data,
+        event_type=expected_event_type,
+    )
+
+    # Then
+    assert send_failure_email_mock.call_count == 2
+    send_failure_email_mock.assert_has_calls(
+        [
+            mocker.call(
+                webhook_2,
+                expected_send_failure_email_data,
+                WebhookType.ENVIRONMENT,
+                expected_send_failure_status_code,
+            ),
+            mocker.call(
+                webhook_1,
+                expected_send_failure_email_data,
+                WebhookType.ENVIRONMENT,
+                expected_send_failure_status_code,
+            ),
+        ]
+    )

--- a/api/webhooks/webhooks.py
+++ b/api/webhooks/webhooks.py
@@ -106,8 +106,13 @@ def _call_webhook_email_on_error(
 ):
     try:
         res = _call_webhook(webhook, data)
-    except requests.exceptions.ConnectionError:
-        send_failure_email(webhook, data, webhook_type)
+    except requests.exceptions.RequestException as exc:
+        send_failure_email(
+            webhook,
+            data,
+            webhook_type,
+            f"N/A ({exc.__class__.__name__})",
+        )
         return
 
     if res.status_code != 200:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #2500.

- Handle all HTTP errors, including timeouts
- Send the error name as part of failure email

## How did you test this code?

Added a unit test.
