### PR TITLE
refactor: linting tweaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,23 +4,30 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3
         exclude: migrations
+
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
         name: flake8
         args: [--config, api/.flake8]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: check-yaml
+      - id: check-json
+      - id: check-toml
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0
     hooks:
       - id: prettier
+        exclude: ^(frontend/|CHANGELOG.md)

--- a/api/.flake8
+++ b/api/.flake8
@@ -5,6 +5,6 @@ exclude = .git,.venv,.direnv,__pycache__,*/migrations/*
 
 per-file-ignores =
     # Need the * prefix to work with pre-commit which runs from the root of the repo
-    */app/settings/local.py: F403, F405
-    */app/settings/production.py: F403, F405
-    */app/settings/saas.py: F403, F405
+    *app/settings/local.py: F403, F405
+    *app/settings/production.py: F403, F405
+    *app/settings/saas.py: F403, F405

--- a/api/.flake8
+++ b/api/.flake8
@@ -4,6 +4,7 @@ max-complexity = 10
 exclude = .git,.venv,.direnv,__pycache__,*/migrations/*
 
 per-file-ignores =
-    app/settings/local.py: F403, F405
-    app/settings/production.py: F403, F405
-    app/settings/saas.py: F403, F405
+    # Need the * prefix to work with pre-commit which runs from the root of the repo
+    */app/settings/local.py: F403, F405
+    */app/settings/production.py: F403, F405
+    */app/settings/saas.py: F403, F405

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -52,6 +52,6 @@ Check out our [Server Side SDK architecture first!](clients/overview.md)
 - [Go](/clients/server-side)
 - [Elixir](/clients/server-side)
 
-## Open Source vs SaaS vs Enterprise
+#### Open Source vs SaaS vs Enterprise
 
 Learn more about the [different ways you can run Flagsmith](version-comparison.md).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -52,6 +52,6 @@ Check out our [Server Side SDK architecture first!](clients/overview.md)
 - [Go](/clients/server-side)
 - [Elixir](/clients/server-side)
 
-#### Open Source vs SaaS vs Enterprise
+## Open Source vs SaaS vs Enterprise
 
 Learn more about the [different ways you can run Flagsmith](version-comparison.md).

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -29,7 +29,7 @@
     }
   },
   "exclude": [
-    "node_modules",
+    "node_modules"
   ],
   "include": [
     "global.d.ts",


### PR DESCRIPTION
- Updates flake8 config so you can run `cd api && flake8` as well as `pre-commit run --all-files`
- Remove frontend and changelog.md from prettier to avoid clobbering husky and deal with release-please markdown format
- Fix a broken json file
- Include validation of other structured data formats