### PR TITLE
fix: ensure recurring tasks are unlocked after being picked up (but not executed)

### DIFF
--- a/api/task_processor/models.py
+++ b/api/task_processor/models.py
@@ -44,9 +44,12 @@ class AbstractBaseTask(models.Model):
         return json.loads(data)
 
     def mark_failure(self):
-        self.is_locked = False
+        self.unlock()
 
     def mark_success(self):
+        self.unlock()
+
+    def unlock(self):
         self.is_locked = False
 
     def run(self):
@@ -119,7 +122,7 @@ class Task(AbstractBaseTask):
         self.num_failures += 1
 
     def mark_success(self):
-        super().mark_failure()
+        super().mark_success()
         self.completed = True
 
 

--- a/api/task_processor/processor.py
+++ b/api/task_processor/processor.py
@@ -45,7 +45,7 @@ def run_tasks(num_tasks: int = 1) -> typing.List[TaskRun]:
     return []
 
 
-def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTask]:
+def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTaskRun]:
     if num_tasks < 1:
         raise ValueError("Number of tasks to process must be at least one")
 
@@ -81,7 +81,7 @@ def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTask]:
     return []
 
 
-def _run_task(task: Task) -> typing.Optional[typing.Tuple[Task, TaskRun]]:
+def _run_task(task: typing.Union[Task, RecurringTask]) -> typing.Tuple[Task, TaskRun]:
     task_run = task.task_runs.model(started_at=timezone.now(), task=task)
 
     try:

--- a/api/task_processor/processor.py
+++ b/api/task_processor/processor.py
@@ -55,7 +55,6 @@ def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTask]:
     tasks = RecurringTask.objects.get_tasks_to_process(num_tasks)
     if tasks:
         task_runs = []
-        executed_tasks = []
 
         for task in tasks:
             # Remove the task if it's not registered anymore
@@ -65,11 +64,13 @@ def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTask]:
 
             if task.should_execute:
                 task, task_run = _run_task(task)
-                executed_tasks.append(task)
                 task_runs.append(task_run)
+            else:
+                task.unlock()
 
-        if executed_tasks:
-            RecurringTask.objects.bulk_update(executed_tasks, fields=["is_locked"])
+        # update all tasks that were not deleted
+        to_update = [task for task in tasks if task.id]
+        RecurringTask.objects.bulk_update(to_update, fields=["is_locked"])
 
         if task_runs:
             RecurringTaskRun.objects.bulk_create(task_runs)


### PR DESCRIPTION
## Changes

Ensures that recurring tasks are unlocked after being picked up (but not executed) by the task processor. 

## How did you test this code?

Updated existing unit test. 
