### PR TITLE
fix: rendering recurring task admin times out

### DIFF
--- a/api/task_processor/admin.py
+++ b/api/task_processor/admin.py
@@ -1,16 +1,17 @@
 from django.contrib import admin
 
-from task_processor.models import (
-    RecurringTask,
-    RecurringTaskRun,
-    Task,
-    TaskRun,
-)
+from task_processor.models import RecurringTask
 
 
 @admin.register(RecurringTask)
 class RecurringTaskAdmin(admin.ModelAdmin):
-    list_display = ("uuid", "task_identifier", "run_every", "last_run_status", "is_locked")
+    list_display = (
+        "uuid",
+        "task_identifier",
+        "run_every",
+        "last_run_status",
+        "is_locked",
+    )
     readonly_fields = ("args", "kwargs")
 
     def last_run_status(self, instance: RecurringTask) -> str:

--- a/api/task_processor/admin.py
+++ b/api/task_processor/admin.py
@@ -8,24 +8,10 @@ from task_processor.models import (
 )
 
 
-class TaskRunInline(admin.StackedInline):
-    model = TaskRun
-    extra = 0
-    show_change_link = False
-
-
-class RecurringTaskRunInline(admin.StackedInline):
-    model = RecurringTaskRun
-    extra = 0
-    show_change_link = False
-    max_num = 5
-
-
 @admin.register(RecurringTask)
 class RecurringTaskAdmin(admin.ModelAdmin):
-    inlines = (RecurringTaskRunInline,)
     list_display = ("uuid", "task_identifier", "run_every", "last_run_status", "is_locked")
     readonly_fields = ("args", "kwargs")
 
-    def last_run_status(self, instance: Task) -> str:
+    def last_run_status(self, instance: RecurringTask) -> str:
         return instance.task_runs.order_by("-started_at").first().result

--- a/api/task_processor/admin.py
+++ b/api/task_processor/admin.py
@@ -18,12 +18,13 @@ class RecurringTaskRunInline(admin.StackedInline):
     model = RecurringTaskRun
     extra = 0
     show_change_link = False
+    max_num = 5
 
 
 @admin.register(RecurringTask)
 class RecurringTaskAdmin(admin.ModelAdmin):
     inlines = (RecurringTaskRunInline,)
-    list_display = ("uuid", "task_identifier", "run_every", "last_run_status")
+    list_display = ("uuid", "task_identifier", "run_every", "last_run_status", "is_locked")
     readonly_fields = ("args", "kwargs")
 
     def last_run_status(self, instance: Task) -> str:


### PR DESCRIPTION
## Changes

Limit number of task run objects in inline.

## How did you test this code?

N/a - needs testing in staging. 
