### PR TITLE
fix: percentage allocation display

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -111,9 +111,9 @@ const CreateFlag = class extends Component {
               return {
                 ...v,
                 default_percentage_allocation:
-                  v.default_percentage_allocation ||
                   (matchingVariation &&
                     matchingVariation.percentage_allocation) ||
+                  v.default_percentage_allocation ||
                   0,
               }
             }),


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the display of multivariate values where the default percentage is non 0.

## How did you test this code?

Viewed problem feature, MV E2E