### PR TITLE
fix(SwaggerGenerationError): Remove filterset_field

### DIFF
--- a/api/audit/views.py
+++ b/api/audit/views.py
@@ -21,7 +21,6 @@ from organisations.models import OrganisationRole
 class _BaseAuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = AuditLogSerializer
     pagination_class = CustomPagination
-    filterset_fields = ["is_system_event"]
 
     def get_queryset(self) -> QuerySet[AuditLog]:
         q = self._get_base_filters()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Because we have the same field(`is_system_event`) as part of `filterset_fields` and `query_serializer` swagger fails with: `your query_serializer contains fields that conflict with the filter_backend or paginator_class on the view`

The fix is to remove `filterset_fields` because it is redundant.


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

 By loading the documentation while being logged into the admin panel
