### PR TITLE
chore(tests): move coverage from pyproject.toml

### DIFF
--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,3 +1,3 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
-PYTEST_ADDOPTS=--cov-report xml -n auto
+PYTEST_ADDOPTS=--cov . --cov-report xml -n auto

--- a/api/.env-local
+++ b/api/.env-local
@@ -1,3 +1,3 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
 DJANGO_SETTINGS_MODULE=app.settings.local
-PYTEST_ADDOPTS=--cov-report html -n auto
+PYTEST_ADDOPTS=--cov . --cov-report html -n auto

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -34,4 +34,4 @@ known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','cor
 skip = ['migrations','.venv','.direnv']
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings', '--cov', '.']
+addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings']


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR removes an option to enable coverage from pyproject.toml which prevents pytest-cov from slowing down e.g. individual test runs initiated in IDE.

The coverage-related options are moved to the dotenv files used by `make test`. As expected, `PYTEST_ADDOPTS` defined in the user `.env` takes precedence.
 
## How did you test this code?

Ran `make test` and `pytest` locally and compared the output.