### PR TITLE
chore: bump vercel version

### DIFF
--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -104,5 +104,5 @@ jobs:
           npm run env
           npm run bundle
           echo ${{ github.sha }} > CI_COMMIT_SHA
-          npm install --global vercel@31.1.0
+          npm install --global vercel@31.2.0
           vercel --prod --token ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Removes `vm2` dependency