### PR TITLE
chore: e2e tests with firefox

### DIFF
--- a/.github/workflows/frontend-e2e-docker-publish-image.yml
+++ b/.github/workflows/frontend-e2e-docker-publish-image.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -23,5 +23,5 @@ jobs:
       - name: 'Build E2E Frontend Image'
         run: |
           cd frontend
-          docker build -f Dockerfile.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest .
+          docker build -f Dockerfile-base.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest .
           docker push ghcr.io/flagsmith/e2e-frontend:latest

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -1,6 +1,8 @@
-name: Build E2E Frontend Image
+name: Build E2E Frontend Base Image
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Update the E2E Firefox testcafe version on the first of every month
     - cron: 0 0 1 * *

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -23,5 +23,5 @@ jobs:
       - name: 'Build E2E Frontend Image'
         run: |
           cd frontend
-          docker build Dockerfile.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest
+          docker build Dockerfile.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest .
           docker push ghcr.io/flagsmith/e2e-frontend:latest

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -1,0 +1,27 @@
+name: Build E2E Frontend Image
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  build-dockerhub:
+    runs-on: ubuntu-latest
+    name: Platform Publish Docker Image
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v3
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: 'Build E2E Frontend Image'
+        run: |
+          cd frontend
+          docker build Dockerfile.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest
+          docker push ghcr.io/flagsmith/e2e-frontend:latest

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -7,13 +7,13 @@ on:
 jobs:
   build-dockerhub:
     runs-on: ubuntu-latest
-    name: Platform Publish Docker Image
+    name: Publish E2E Frontend Image
 
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
 
-      - name: 'Login to GitHub Container Registry'
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -1,11 +1,12 @@
 name: Build E2E Frontend Image
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Update the E2E Firefox testcafe version on the first of every month
+    - cron: 0 0 1 * *
 
 jobs:
-  build-dockerhub:
+  build-e2e-docker-image:
     runs-on: ubuntu-latest
     name: Publish E2E Frontend Image
 
@@ -20,7 +21,7 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
-      - name: 'Build E2E Frontend Image'
+      - name: Build E2E Frontend Image
         run: |
           cd frontend
           docker build -f Dockerfile-base.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest .

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Build E2E Frontend Image
         run: |
           cd frontend
-          docker build -f Dockerfile-base.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest .
-          docker push ghcr.io/flagsmith/e2e-frontend:latest
+          docker build -f Dockerfile-base.e2e --tag ghcr.io/flagsmith/e2e-frontend-base:latest .
+          docker push ghcr.io/flagsmith/e2e-frontend-base:latest

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/.github/workflows/platform-docker-build-e2e-image.yml
+++ b/.github/workflows/platform-docker-build-e2e-image.yml
@@ -23,5 +23,5 @@ jobs:
       - name: 'Build E2E Frontend Image'
         run: |
           cd frontend
-          docker build Dockerfile.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest .
+          docker build -f Dockerfile.e2e --tag ghcr.io/flagsmith/e2e-frontend:latest .
           docker push ghcr.io/flagsmith/e2e-frontend:latest

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -80,6 +80,13 @@ jobs:
       - name: Cloning repo
         uses: actions/checkout@v3
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
       - name: Run docker-compose with unified-image
         working-directory: frontend
         env:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/frontend/.testcaferc.js
+++ b/frontend/.testcaferc.js
@@ -1,6 +1,6 @@
 const isDev = process.env.E2E_DEV;
 module.exports = {
-    "browsers": "chrome:headless",
+    "browsers": "firefox:headless",
     "port1": 8080,
     "port2": 8081,
     "hostname": "localhost",

--- a/frontend/Dockerfile-base.e2e
+++ b/frontend/Dockerfile-base.e2e
@@ -1,5 +1,8 @@
 FROM debian:latest
 
+# Set node version
+ENV NODE_VERSION 16.20.1
+
 # replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
@@ -9,7 +12,6 @@ RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 fire
 
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 16.20.1
 
 # install nvm
 # https://github.com/creationix/nvm#install-script

--- a/frontend/Dockerfile-base.e2e
+++ b/frontend/Dockerfile-base.e2e
@@ -1,0 +1,32 @@
+FROM debian:latest
+
+# replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Bring in firefox into debian sources
+#RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
+#RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
+#
+## nvm environment variables
+#ENV NVM_DIR /usr/local/nvm
+#ENV NODE_VERSION 16.14.0
+#
+## install nvm
+## https://github.com/creationix/nvm#install-script
+#RUN mkdir /usr/local/nvm && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.4/install.sh | bash
+#
+## install node and npm LTS
+#RUN source $NVM_DIR/nvm.sh \
+#    && nvm install $NODE_VERSION \
+#    && nvm alias default $NODE_VERSION \
+#    && nvm use default
+#
+## add node and npm to path so the commands are available
+#ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+#ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+#
+## confirm installation of node
+#RUN node -v
+#RUN npm -v
+
+CMD ["bash", "-l"]

--- a/frontend/Dockerfile-base.e2e
+++ b/frontend/Dockerfile-base.e2e
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 fire
 
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 16.14.0
+ENV NODE_VERSION 16.20.1
 
 # install nvm
 # https://github.com/creationix/nvm#install-script

--- a/frontend/Dockerfile-base.e2e
+++ b/frontend/Dockerfile-base.e2e
@@ -4,29 +4,29 @@ FROM debian:latest
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # Bring in firefox into debian sources
-#RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-#RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
-#
-## nvm environment variables
-#ENV NVM_DIR /usr/local/nvm
-#ENV NODE_VERSION 16.14.0
-#
-## install nvm
-## https://github.com/creationix/nvm#install-script
-#RUN mkdir /usr/local/nvm && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.4/install.sh | bash
-#
-## install node and npm LTS
-#RUN source $NVM_DIR/nvm.sh \
-#    && nvm install $NODE_VERSION \
-#    && nvm alias default $NODE_VERSION \
-#    && nvm use default
-#
-## add node and npm to path so the commands are available
-#ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-#ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-#
-## confirm installation of node
-#RUN node -v
-#RUN npm -v
+RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
+RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 16.14.0
+
+# install nvm
+# https://github.com/creationix/nvm#install-script
+RUN mkdir /usr/local/nvm && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.4/install.sh | bash
+
+# install node and npm LTS
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# confirm installation of node
+RUN node -v
+RUN npm -v
 
 CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,21 +1,47 @@
-FROM debian
+FROM debian:latest
 
-SHELL [ "/bin/bash", "-l", "-c" ]
-RUN apt-get update && apt-get install -y curl python3 make gcc g++
-RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
-RUN nvm install 16.14.0
+# replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
+# update the repository sources list
+# and install dependencies
+RUN apt-get update \
+    && apt-get install -y curl \
+    && apt-get -y autoclean
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 16.14.0
+
+# Bring in firefox into debian sources
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends firefox
+RUN apt-get update && apt-get install -y build-essential libssl-dev  python3 gnupg2 firefox
+
+# install nvm
+# https://github.com/creationix/nvm#install-script
+RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+
+# install node and npm LTS
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# confirm installation of node
+RUN node -v
+RUN npm -v
 
 WORKDIR /srv/flagsmith
 COPY . .
 RUN npm cache clean --force
 RUN npm ci
 
-ENV ENV=e2e
-RUN npm run env
 
-EXPOSE 8080
-CMD ["npm",  "run", "test"]
+# Force bash as shell
+# RUN ["/bin/bash", "-c", "echo hello all in one string"]
+
+CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,20 +1,20 @@
-# From https://hub.docker.com/r/mkfarrow/docker-nvm/dockerfile as a start
 FROM debian:latest
 
 # replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
+
+# Bring in firefox into debian sources
+RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
+RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
+
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 16.14.0
 
-# Bring in firefox into debian sources
-RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update && apt-get install -y build-essential libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
-
 # install nvm
 # https://github.com/creationix/nvm#install-script
-RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.4/install.sh | bash
+RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
 
 # install node and npm LTS
 RUN source $NVM_DIR/nvm.sh \
@@ -30,10 +30,15 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN node -v
 RUN npm -v
 
-# build Flagsmith front end
+
+
 WORKDIR /srv/flagsmith
 COPY . .
 RUN npm cache clean --force
 RUN npm ci
+
+
+# Force bash as shell
+# RUN ["/bin/bash", "-c", "echo hello all in one string"]
 
 CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM ghcr.io/flagsmith/e2e-frontend:latest
+FROM ghcr.io/flagsmith/e2e-frontend-base:latest
 
 # Build Flagsmith
 WORKDIR /srv/flagsmith

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -3,7 +3,6 @@ FROM debian:latest
 # replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-
 # Bring in firefox into debian sources
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
 RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
@@ -14,7 +13,7 @@ ENV NODE_VERSION 16.14.0
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
-RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+RUN mkdir /usr/local/nvm && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.4/install.sh | bash
 
 # install node and npm LTS
 RUN source $NVM_DIR/nvm.sh \
@@ -30,15 +29,13 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN node -v
 RUN npm -v
 
-
-
+# Build Flagsmith
 WORKDIR /srv/flagsmith
 COPY . .
 RUN npm cache clean --force
 RUN npm ci
 
-
-# Force bash as shell
-# RUN ["/bin/bash", "-c", "echo hello all in one string"]
+ENV ENV=e2e
+RUN npm run env
 
 CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,22 +1,17 @@
-FROM node:16
+FROM debian
 
-RUN mkdir /srv/flagsmith && chown node:node /srv/flagsmith
+SHELL [ "/bin/bash", "-l", "-c" ]
+RUN apt-get update && apt-get install -y curl python3 make gcc g++
+RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
+RUN nvm install 16.14.0
 
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
 RUN apt-get update
-#ARG CHROME_URL='https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/google-chrome-stable_107.0.5304.121-1_amd64.deb'
-#RUN wget -q $CHROME_URL
-RUN apt install -y firefox -f
-RUN apt-get clean
+RUN apt-get install -y --no-install-recommends firefox
 
 WORKDIR /srv/flagsmith
-
-COPY --chown=node:node . .
-
-USER node
-
+COPY . .
 RUN npm cache clean --force
-
 RUN npm ci
 
 ENV ENV=e2e

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -3,23 +3,17 @@ FROM debian:latest
 # replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-# update the repository sources list
-# and install dependencies
-RUN apt-get update \
-    && apt-get install -y curl \
-    && apt-get -y autoclean
-
 # nvm environment variables
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 16.14.0
 
 # Bring in firefox into debian sources
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update && apt-get install -y build-essential libssl-dev  python3 gnupg2 firefox
+RUN apt-get update && apt-get install -y build-essential libssl-dev python3 gnupg2 firefox && apt-get -y autoclean
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
-RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.4/install.sh | bash
 
 # install node and npm LTS
 RUN source $NVM_DIR/nvm.sh \

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,34 +1,5 @@
 FROM debian:latest
 
-# replace shell with bash so we can source files
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-
-# Bring in firefox into debian sources
-RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update && apt-get install -y g++ make libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
-
-# nvm environment variables
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 16.14.0
-
-# install nvm
-# https://github.com/creationix/nvm#install-script
-RUN mkdir /usr/local/nvm && curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.4/install.sh | bash
-
-# install node and npm LTS
-RUN source $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default
-
-# add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-# confirm installation of node
-RUN node -v
-RUN npm -v
-
 # Build Flagsmith
 WORKDIR /srv/flagsmith
 COPY . .

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,3 +1,4 @@
+# From https://hub.docker.com/r/mkfarrow/docker-nvm/dockerfile as a start
 FROM debian:latest
 
 # replace shell with bash so we can source files
@@ -9,7 +10,7 @@ ENV NODE_VERSION 16.14.0
 
 # Bring in firefox into debian sources
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update && apt-get install -y build-essential libssl-dev python3 gnupg2 firefox && apt-get -y autoclean
+RUN apt-get update && apt-get install -y build-essential libssl-dev python3 gnupg2 firefox curl && apt-get -y autoclean
 
 # install nvm
 # https://github.com/creationix/nvm#install-script
@@ -29,13 +30,10 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN node -v
 RUN npm -v
 
+# build Flagsmith front end
 WORKDIR /srv/flagsmith
 COPY . .
 RUN npm cache clean --force
 RUN npm ci
-
-
-# Force bash as shell
-# RUN ["/bin/bash", "-c", "echo hello all in one string"]
 
 CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM ghcr.io/flagsmith/e2e-frontend:latest
 
 # Build Flagsmith
 WORKDIR /srv/flagsmith

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -2,10 +2,11 @@ FROM node:16
 
 RUN mkdir /srv/flagsmith && chown node:node /srv/flagsmith
 
+RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
 RUN apt-get update
-ARG CHROME_URL='https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/google-chrome-stable_107.0.5304.121-1_amd64.deb'
-RUN wget -q $CHROME_URL
-RUN apt install -y ./google-chrome*.deb -f
+#ARG CHROME_URL='https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/google-chrome-stable_107.0.5304.121-1_amd64.deb'
+#RUN wget -q $CHROME_URL
+RUN apt install -y firefox -f
 RUN apt-get clean
 
 WORKDIR /srv/flagsmith

--- a/frontend/e2e/index.cafe.js
+++ b/frontend/e2e/index.cafe.js
@@ -6,7 +6,7 @@ const _options = require("../.testcaferc")
 const upload = require('../bin/upload-file');
 const options = {
     ..._options,
-    browsers: process.env.E2E_DEV ? ['chrome'] : ['chrome:headless'],
+    browsers: process.env.E2E_DEV ? ['firefox'] : ['firefox:headless'],
     debugOnFail: !!process.env.E2E_DEV
 }
 let testcafe;


### PR DESCRIPTION
Moving E2E tests from chrome to firefox. Pain to get the docker images working. 

Using GHCR to host a test runner image that reduces test time.