### PR TITLE
fix: ensure that migrate command exits with non zero error code

### DIFF
--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -7,7 +7,6 @@ set -e
 
 function migrate () {
     python manage.py waitfordb && python manage.py migrate && python manage.py createcachetable
-    migrate_analytics_db
 }
 function serve() {
     # configuration parameters for statsd. Docs can be found here:
@@ -65,6 +64,7 @@ function go_to_sleep(){
 if [ "$1" == "migrate" ]; then
     if [ $# -eq 2 ]; then go_to_sleep "$2"; fi
     migrate
+    migrate_analytics_db
 elif [ "$1" == "serve" ]; then
     if [ $# -eq 2 ]; then go_to_sleep "$2"; fi
     serve
@@ -73,6 +73,7 @@ elif [ "$1" == "run-task-processor" ]; then
 elif [ "$1" == "migrate-and-serve" ]; then
     if [ $# -eq 2 ]; then go_to_sleep "$2"; fi
     migrate
+    migrate_analytics_db
     serve
 elif [ "$1" == "migrate-identities" ]; then
     migrate_identities "$2"


### PR DESCRIPTION
## Changes

Ensures that calling `./run-docker.sh migrate` returns a non-zero exit code if one of the chained commands does. Previously, the bash script would continue onto the `migrate_analytics_db` function, which would (in most cases) return 0 because it doesn't have to do anything. 

## How did you test this code?

Verified that the following commands exit with `0` and `1` return codes respectively. 

```
DATABASE_URL=<valid db url> ./run-docker.sh
DATABASE_URL=<invalid db url> ./run-docker.sh
```
