### PR TITLE
fix: Associated segment overrides

### DIFF
--- a/frontend/common/providers/withSegmentOverrides.js
+++ b/frontend/common/providers/withSegmentOverrides.js
@@ -19,6 +19,12 @@ export default (WrappedComponent) => {
       this.getOverrides()
     }
 
+    componentDidUpdate(prevProps, prevState, snapshot) {
+      if (prevProps.environmentId !== this.props.environmentId) {
+        this.getOverrides()
+      }
+    }
+
     getOverrides = () => {
       if (this.props.projectFlag) {
         Promise.all([

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -1,5 +1,5 @@
 // import propTypes from 'prop-types';
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react';
 import { SortableContainer, SortableElement } from 'react-sortable-hoc'
 import ProjectStore from 'common/stores/project-store'
 import ValueEditor from './ValueEditor'
@@ -183,7 +183,7 @@ const SegmentOverrideInner = class Override extends React.Component {
                             className='ml-2 dark-link'
                           >
                             Edit Segment
-                            <ion className={'ion ml-1 ion-md-open'} />
+                            <i className={'ion ml-1 ion-md-open'} />
                           </Button>
                         )}
                       </>,
@@ -333,7 +333,7 @@ const SegmentOverrideListInner = ({
   return (
     <div>
       {items.map((value, index) => (
-        <>
+        <Fragment key={value.segment.name}>
           <InnerComponent
             id={id}
             name={name}
@@ -344,7 +344,6 @@ const SegmentOverrideListInner = ({
             environmentId={environmentId}
             projectId={projectId}
             multivariateOptions={multivariateOptions}
-            key={value.segment.name}
             index={index}
             readOnly={readOnly}
             value={value}
@@ -372,7 +371,7 @@ const SegmentOverrideListInner = ({
               json={value}
             />
           </div>
-        </>
+        </Fragment>
       ))}
     </div>
   )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Associated segment overrides were not updating when switching environments
![image](https://github.com/Flagsmith/flagsmith/assets/8608314/3df49e5f-48cf-4115-9ad9-76a627048f3a)



## How did you test this code?

Segments > Segment > Feature > Adjust environment and see new overrides 