### PR TITLE
fix: total api calls handling

### DIFF
--- a/frontend/common/services/useOrganisationUsage.ts
+++ b/frontend/common/services/useOrganisationUsage.ts
@@ -57,14 +57,11 @@ export async function getOrganisationUsage(
     typeof organisationUsageService.endpoints.getOrganisationUsage.initiate
   >[1],
 ) {
-  store.dispatch(
+  return store.dispatch(
     organisationUsageService.endpoints.getOrganisationUsage.initiate(
       data,
       options,
     ),
-  )
-  return Promise.all(
-    store.dispatch(organisationUsageService.util.getRunningQueriesThunk()),
   )
 }
 // END OF FUNCTION_EXPORTS

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -25,6 +25,7 @@ import Format from 'common/utils/format'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import Permission from 'common/providers/Permission'
 import { getOrganisationUsage } from 'common/services/useOrganisationUsage'
+import AccountStore from 'common/stores/account-store'
 const App = class extends Component {
   static propTypes = {
     children: propTypes.element.isRequired,
@@ -35,6 +36,7 @@ const App = class extends Component {
   }
 
   state = {
+    activeOrganisation: 0,
     asideIsVisible: !isMobile,
     pin: '',
     totalApiCalls: 0,
@@ -48,7 +50,25 @@ const App = class extends Component {
   componentDidMount = () => {
     getBuildVersion()
     this.listenTo(ProjectStore, 'change', () => this.forceUpdate())
+    this.listenTo(AccountStore, 'change', this.getOrganisationUsage)
+    this.getOrganisationUsage()
     window.addEventListener('scroll', this.handleScroll)
+  }
+
+  getOrganisationUsage = () => {
+    if (
+      AccountStore.getOrganisation()?.id &&
+      this.state.activeOrganisation !== AccountStore.getOrganisation().id
+    ) {
+      getOrganisationUsage(getStore(), {
+        organisationId: AccountStore.getOrganisation()?.id,
+      }).then((res) => {
+        this.setState({
+          activeOrganisation: AccountStore.getOrganisation().id,
+          totalApiCalls: res?.data?.totals.total,
+        })
+      })
+    }
   }
 
   toggleDarkMode = () => {
@@ -237,17 +257,7 @@ const App = class extends Component {
     if (document.location.href.includes('widget')) {
       return <div>{this.props.children}</div>
     }
-    if (
-      AccountStore.getOrganisation() &&
-      AccountStore.getOrganisation().id &&
-      this.state.totalApiCalls == 0
-    ) {
-      getOrganisationUsage(getStore(), {
-        organisationId: AccountStore.getOrganisation()?.id,
-      }).then((res) => {
-        this.setState({ totalApiCalls: res?.data?.totals.total })
-      })
-    }
+
     return (
       <Provider store={getStore()}>
         <AccountProvider

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -245,7 +245,7 @@ const App = class extends Component {
       getOrganisationUsage(getStore(), {
         organisationId: AccountStore.getOrganisation()?.id,
       }).then((res) => {
-        this.setState({ totalApiCalls: res[0]?.data?.totals.total })
+        this.setState({ totalApiCalls: res?.data?.totals.total })
       })
     }
     return (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

**Current problems**

- The promise to retrieve organisation usage was incorrect, this is causing the following error in production.

Currently in production the total api call detection does not work, this is because we are incorrectly parsing the response.
![image](https://github.com/Flagsmith/flagsmith/assets/8608314/66a872cf-b7da-41d8-9428-c62bf4be15a3)
- The action to get organisation usage is in the render function, this should never happen, side affects (especially API and set state calls) should never be there. This is causing the getOrganisation usage to be rapidly called in production. Luckily Redux RTK detects duplicate api call requests and only hits it once.
- The check to call get organisation usage included whether the total api calls state was 0, the problem with this is that it is infinitely called for new organisations and projects. The only reason why this is not breaking production is because of the first bullet point (It does call around 10 or so times but eventually fails and stops doing it).


**Changes**

- Fix the promise of getOrganisationUsage to return just the data of the API call
- Only call the organisation usage endpoint when we don't have the data for the active organisation (on mount, on organisation switch)

## How did you test this code?

Tested retrieving the initial usage and then switching organisations.