### PR TITLE
docs(core): better swagger auth info

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -428,13 +428,13 @@ SWAGGER_SETTINGS = {
             "type": "apiKey",
             "in": "header",
             "name": "Authorization",
-            "description": "Every time you create a new Project Environment, an environment API key is automatically generated for you. This is all you need to pass in to get access to Flags etc. <br />Example value: <br />Token 884b1b4c6b4ddd112e7a0a139f09eb85e8c254ff",  # noqa
+            "description": "For Private Endpoints. <a href='https://docs.flagsmith.com/clients/rest#private-api-endpoints'>Find out more</a>.",  # noqa
         },
         "Public": {
             "type": "apiKey",
             "in": "header",
             "name": "X-Environment-Key",
-            "description": "Things like creating new flags, environments, toggle flags or indeed anything that is possible from the administrative front end. <br />Example value: <br />FFnVjhp7xvkT5oTLq4q788",  # noqa
+            "description": "For Public Endpoints. <a href='https://docs.flagsmith.com/clients/rest#public-api-endpoints'>Find out more</a>.",  # noqa
         },
     },
 }


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith/issues/2595

<img width="564" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/173290/2adf5b76-629c-42d8-bc4f-6cb7c2614c55">

Which links to https://docs.flagsmith.com/clients/rest#private-api-endpoints and https://docs.flagsmith.com/clients/rest#public-api-endpoints