### PR TITLE
fix(frontend): Disabled loading indicator when getting featuers so screen doesn't flicker

### DIFF
--- a/frontend/common/stores/feature-list-store.js
+++ b/frontend/common/stores/feature-list-store.js
@@ -536,7 +536,6 @@ const controller = {
   },
   getFeatures: (projectId, environmentId, force, page, filter, pageSize) => {
     if (!store.model || store.envId !== environmentId || force) {
-      store.loading()
       store.envId = environmentId
       store.projectId = projectId
       store.environmentId = environmentId


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Removed the `store.load` line because that causes the entire page to not render while waiting on results. It also means that on a failed search, the input becomes unresponsive. It wasn't clear to me while looking through the code what the canonical way (in this code base) is to do local loading indicators, so I left it as a simple 1 line change.

## How did you test this code?
Manually:
1. Go to the features page
2. Search for a feature that doesn't exist
3. Notice that the whole screen doesn't flash, and the search box doesn't become unresponsive anymore

