### PR TITLE
ci: move audit to poetry

### DIFF
--- a/.github/workflows/api-audit.yml
+++ b/.github/workflows/api-audit.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: 0 8 * * *
 
+defaults:
+  run:
+    working-directory: api
+
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -12,8 +16,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
@@ -21,15 +23,7 @@ jobs:
           python-version: '3.11'
 
       - name: Run Audit
-        # todo:
-        #  - remove the hack to upgrade `packaging` as drf-yasg2 has an old version dependency
-        #  - remove the setuptools upgrade (caused by the fact that actions/setup-python seems
-        #    to come packaged with setuptools 65.5.0)
         run: |
-          cd api
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
-          pip install -r requirements-all.txt
-          pip install packaging==21.3
-          python -m pip install pip-audit
-          pip-audit
+          make install
+          poetry self add poetry-audit-plugin
+          poetry audit


### PR DESCRIPTION
Move `pip-audit` to poetry