### PR TITLE
chore: Remove fetch-depth which is redundant and slower

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Deploy API to Production
         id: deploy-api
@@ -65,8 +63,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Run E2E tests against production
         uses: ./.github/actions/e2e-tests

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Deploy API to Staging
         id: deploy-api
@@ -65,8 +63,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Run E2E tests against staging
         uses: ./.github/actions/e2e-tests

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -40,8 +40,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/frontend-audit.yml
+++ b/.github/workflows/frontend-audit.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Audit
         working-directory: frontend

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Run E2E tests against production
         uses: ./.github/actions/e2e-tests
@@ -43,8 +41,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
@@ -79,8 +75,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v3

--- a/.github/workflows/frontend-e2e-docker-publish-image.yml
+++ b/.github/workflows/frontend-e2e-docker-publish-image.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/frontend-test-staging.yml
+++ b/.github/workflows/frontend-test-staging.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Run Staging E2E Tests
         working-directory: frontend

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Checkout SAML package
         uses: actions/checkout@v3

--- a/.github/workflows/platform-test-merge-to-main.yml
+++ b/.github/workflows/platform-test-merge-to-main.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Run Local API
         id: run-local-api


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Remove `fetch-depth:0` as its slow and redundant:

https://github.com/actions/checkout#checkout-v3
> Set fetch-depth: 0 to fetch all history for all branches and tags

## How did you test this code?

Ran the GH actions as part of this PR
