### PR TITLE
fix: metadata validation causes AttributeError for patch requests

### DIFF
--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from environments.models import Environment, EnvironmentAPIKey, Webhook
 from features.serializers import FeatureStateSerializerFull
 from metadata.serializers import MetadataSerializer, SerializerWithMetadata
-from organisations.models import Organisation, Subscription
+from organisations.models import Subscription
 from organisations.subscriptions.serializers.mixins import (
     ReadOnlyIfNotValidPlanMixin,
 )
@@ -75,11 +75,15 @@ class EnvironmentSerializerWithMetadata(
     class Meta(EnvironmentSerializerLight.Meta):
         fields = EnvironmentSerializerLight.Meta.fields + ("metadata",)
 
-    def get_organisation_from_validated_data(self, validated_data) -> Organisation:
-        return validated_data.get("project").organisation
+    def get_project(self, validated_data: dict = None) -> Project:
+        if self.instance:
+            return self.instance.project
+        elif "project" in validated_data:
+            return validated_data["project"]
 
-    def get_project_from_validated_data(self, validated_data) -> Project:
-        return validated_data.get("project")
+        raise serializers.ValidationError(
+            "Unable to retrieve project for metadata validation."
+        )
 
 
 class CreateUpdateEnvironmentSerializer(

--- a/api/environments/tests/test_views.py
+++ b/api/environments/tests/test_views.py
@@ -820,3 +820,19 @@ def test_environment_my_permissions_reruns_400_for_master_api_key(
         response.json()["detail"]
         == "This endpoint can only be used with a user and not Master API Key"
     )
+
+
+def test_partial_environment_update(
+    admin_client: APIClient, environment: "Environment"
+) -> None:
+    # Given
+    url = reverse("api-v1:environments:environment-detail", args=[environment.api_key])
+    new_name = "updated!"
+
+    # When
+    response = admin_client.patch(
+        url, data=json.dumps({"name": new_name}), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK

--- a/api/metadata/serializers.py
+++ b/api/metadata/serializers.py
@@ -98,10 +98,10 @@ class MetadataSerializer(serializers.ModelSerializer):
 
 
 class SerializerWithMetadata(serializers.BaseSerializer):
-    def get_organisation_from_validated_data(self, validated_data) -> Organisation:
-        raise NotImplementedError()
+    def get_organisation(self, validated_data: dict = None) -> Organisation:
+        return self.get_project(validated_data).organisation
 
-    def get_project_from_validated_data(self, validated_data) -> Project:
+    def get_project(self, validated_data: dict = None) -> Project:
         raise NotImplementedError()
 
     def get_required_for_object(
@@ -109,7 +109,7 @@ class SerializerWithMetadata(serializers.BaseSerializer):
     ) -> Model:
         model_name = requirement.content_type.model
         try:
-            return getattr(self, f"get_{model_name}_from_validated_data")(data)
+            return getattr(self, f"get_{model_name}")(data)
         except AttributeError:
             raise ValueError(
                 f"`get_{model_name}_from_validated_data` method does not exist"
@@ -120,7 +120,7 @@ class SerializerWithMetadata(serializers.BaseSerializer):
 
         content_type = ContentType.objects.get_for_model(self.Meta.model)
 
-        organisation = self.get_organisation_from_validated_data(data)
+        organisation = self.get_organisation(data)
 
         requirements = MetadataModelFieldRequirement.objects.filter(
             model_field__content_type=content_type,


### PR DESCRIPTION
## Changes

Fixes AttributeError raised by metadata validation logic when using patch request on environments viewset. 

## How did you test this code?

Added a new unit test to verify that the issue is resolved. 
