### PR TITLE
feat: re-add totals and limits

### DIFF
--- a/api/audit/serializers.py
+++ b/api/audit/serializers.py
@@ -2,14 +2,14 @@ from rest_framework import serializers
 
 from audit.models import AuditLog
 from environments.serializers import EnvironmentSerializerLight
-from projects.serializers import ProjectSerializer
+from projects.serializers import ProjectListSerializer
 from users.serializers import UserListSerializer
 
 
 class AuditLogSerializer(serializers.ModelSerializer):
     author = UserListSerializer()
     environment = EnvironmentSerializerLight()
-    project = ProjectSerializer()
+    project = ProjectListSerializer()
 
     class Meta:
         model = AuditLog

--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -10,7 +10,7 @@ from organisations.subscriptions.serializers.mixins import (
     ReadOnlyIfNotValidPlanMixin,
 )
 from projects.models import Project
-from projects.serializers import ProjectSerializer
+from projects.serializers import ProjectListSerializer
 from util.drf_writable_nested.serializers import (
     DeleteBeforeUpdateWritableNestedModelSerializer,
 )
@@ -18,7 +18,7 @@ from util.drf_writable_nested.serializers import (
 
 class EnvironmentSerializerFull(serializers.ModelSerializer):
     feature_states = FeatureStateSerializerFull(many=True)
-    project = ProjectSerializer()
+    project = ProjectListSerializer()
 
     class Meta:
         model = Environment
@@ -84,6 +84,16 @@ class EnvironmentSerializerWithMetadata(
         raise serializers.ValidationError(
             "Unable to retrieve project for metadata validation."
         )
+
+
+class EnvironmentRetrieveSerializerWithMetadata(EnvironmentSerializerWithMetadata):
+    total_segment_overrides = serializers.IntegerField()
+
+    class Meta(EnvironmentSerializerWithMetadata.Meta):
+        fields = EnvironmentSerializerWithMetadata.Meta.fields + (
+            "total_segment_overrides",
+        )
+        read_only_fields = ("total_segment_overrides",)
 
 
 class CreateUpdateEnvironmentSerializer(

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import logging
 
+from django.db.models import Count
 from django.utils.decorators import method_decorator
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -41,6 +42,7 @@ from .serializers import (
     CloneEnvironmentSerializer,
     CreateUpdateEnvironmentSerializer,
     EnvironmentAPIKeySerializer,
+    EnvironmentRetrieveSerializerWithMetadata,
     EnvironmentSerializerWithMetadata,
     WebhookSerializer,
 )
@@ -73,6 +75,8 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
             return DeleteAllTraitKeysSerializer
         if self.action == "clone":
             return CloneEnvironmentSerializer
+        if self.action == "retrieve":
+            return EnvironmentRetrieveSerializerWithMetadata
         elif self.action in ("create", "update", "partial_update"):
             return CreateUpdateEnvironmentSerializer
         return EnvironmentSerializerWithMetadata
@@ -98,12 +102,20 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
                 return (
                     self.request.master_api_key.organisation.projects.environments.all()
                 )
+
             return self.request.user.get_permitted_environments(
                 "VIEW_ENVIRONMENT", project=project
             )
 
         # Permission class handles validation of permissions for other actions
-        return Environment.objects.all()
+        queryset = Environment.objects.all()
+
+        if self.action == "retrieve":
+            queryset = queryset.annotate(
+                total_segment_overrides=Count("feature_segments")
+            )
+
+        return queryset
 
     def perform_create(self, serializer):
         environment = serializer.save()

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -49,7 +49,7 @@ from permissions.serializers import (
     PermissionModelSerializer,
     UserObjectPermissionsSerializer,
 )
-from projects.serializers import ProjectSerializer
+from projects.serializers import ProjectListSerializer
 from users.serializers import UserIdSerializer
 from webhooks.mixins import TriggerSampleWebhookMixin
 from webhooks.webhooks import WebhookType
@@ -118,7 +118,7 @@ class OrganisationViewSet(viewsets.ModelViewSet):
     def projects(self, request, pk):
         organisation = self.get_object()
         projects = organisation.projects.all()
-        return Response(ProjectSerializer(projects, many=True).data)
+        return Response(ProjectListSerializer(projects, many=True).data)
 
     @action(detail=True, methods=["POST"])
     def invite(self, request, pk):

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -57,8 +57,8 @@ class ProjectListSerializer(serializers.ModelSerializer):
 
 
 class ProjectRetrieveSerializer(ProjectListSerializer):
-    total_features = serializers.IntegerField()
-    total_segments = serializers.IntegerField()
+    total_features = serializers.SerializerMethodField()
+    total_segments = serializers.SerializerMethodField()
 
     class Meta(ProjectListSerializer.Meta):
         fields = ProjectListSerializer.Meta.fields + (
@@ -76,6 +76,16 @@ class ProjectRetrieveSerializer(ProjectListSerializer):
             "total_features",
             "total_segments",
         )
+
+    def get_total_features(self, instance: Project) -> int:
+        # added here to prevent need for annotate(Count("features", distinct=True))
+        # which causes performance issues.
+        return instance.features.count()
+
+    def get_total_segments(self, instance: Project) -> int:
+        # added here to prevent need for annotate(Count("segments", distinct=True))
+        # which causes performance issues.
+        return instance.segments.count()
 
 
 class CreateUpdateUserProjectPermissionSerializer(

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -12,7 +12,7 @@ from projects.models import (
 from users.serializers import UserListSerializer, UserPermissionGroupSerializer
 
 
-class ProjectSerializer(serializers.ModelSerializer):
+class ProjectListSerializer(serializers.ModelSerializer):
     migration_status = serializers.SerializerMethodField(
         help_text="Edge migration status of the project; can be one of: "
         + ", ".join([k.value for k in ProjectIdentityMigrationStatus])
@@ -39,10 +39,8 @@ class ProjectSerializer(serializers.ModelSerializer):
     def get_migration_status(self, obj: Project) -> str:
         if not settings.PROJECT_METADATA_TABLE_NAME_DYNAMO:
             migration_status = ProjectIdentityMigrationStatus.NOT_APPLICABLE.value
-
         elif obj.is_edge_project_by_default:
             migration_status = ProjectIdentityMigrationStatus.MIGRATION_COMPLETED.value
-
         else:
             migration_status = IdentityMigrator(obj.id).migration_status.value
 
@@ -55,6 +53,28 @@ class ProjectSerializer(serializers.ModelSerializer):
         return (
             self.context["migration_status"]
             == ProjectIdentityMigrationStatus.MIGRATION_COMPLETED.value
+        )
+
+
+class ProjectRetrieveSerializer(ProjectListSerializer):
+    total_features = serializers.IntegerField()
+    total_segments = serializers.IntegerField()
+
+    class Meta(ProjectListSerializer.Meta):
+        fields = ProjectListSerializer.Meta.fields + (
+            "max_segments_allowed",
+            "max_features_allowed",
+            "max_segment_overrides_allowed",
+            "total_features",
+            "total_segments",
+        )
+
+        read_only_fields = (
+            "max_segments_allowed",
+            "max_features_allowed",
+            "max_segment_overrides_allowed",
+            "total_features",
+            "total_segments",
         )
 
 

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.db.models import Count, Q
 from django.utils.decorators import method_decorator
 from drf_yasg import openapi
 from drf_yasg.utils import no_body, swagger_auto_schema
@@ -98,16 +97,6 @@ class ProjectViewSet(viewsets.ModelViewSet):
         project_uuid = self.request.query_params.get("uuid")
         if project_uuid:
             queryset = queryset.filter(uuid=project_uuid)
-
-        if self.action == "retrieve":
-            queryset = queryset.annotate(
-                total_features=Count(
-                    "features", filter=Q(features__deleted_at__isnull=True)
-                ),
-                total_segments=Count(
-                    "segments", filter=Q(segments__deleted_at__isnull=True)
-                ),
-            )
 
         return queryset
 

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -1,0 +1,82 @@
+import pytest
+from django.urls import reverse
+from pytest_lazyfixture import lazy_fixture
+from rest_framework import status
+
+from features.models import Feature
+from projects.models import Project
+from segments.models import Segment
+
+
+@pytest.mark.parametrize(
+    "client", (lazy_fixture("admin_client"), lazy_fixture("master_api_key_client"))
+)
+def test_get_project_list_data(client, organisation):
+    # Given
+    list_url = reverse("api-v1:projects:project-list")
+
+    project_name = "Test project"
+    hide_disabled_flags = False
+    enable_dynamo_db = False
+    prevent_flag_defaults = True
+    enable_realtime_updates = False
+    only_allow_lower_case_feature_names = True
+
+    Project.objects.create(
+        name=project_name,
+        organisation=organisation,
+        hide_disabled_flags=hide_disabled_flags,
+        enable_dynamo_db=enable_dynamo_db,
+        prevent_flag_defaults=prevent_flag_defaults,
+        enable_realtime_updates=enable_realtime_updates,
+        only_allow_lower_case_feature_names=only_allow_lower_case_feature_names,
+    )
+
+    # When
+    response = client.get(list_url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()[0]["name"] == project_name
+    assert response.json()[0]["hide_disabled_flags"] is hide_disabled_flags
+    assert response.json()[0]["enable_dynamo_db"] is enable_dynamo_db
+    assert response.json()[0]["prevent_flag_defaults"] is prevent_flag_defaults
+    assert response.json()[0]["enable_realtime_updates"] is enable_realtime_updates
+    assert (
+        response.json()[0]["only_allow_lower_case_feature_names"]
+        is only_allow_lower_case_feature_names
+    )
+    assert "max_segments_allowed" not in response.json()[0].keys()
+    assert "max_features_allowed" not in response.json()[0].keys()
+    assert "max_segment_overrides_allowed" not in response.json()[0].keys()
+    assert "total_features" not in response.json()[0].keys()
+    assert "total_segments" not in response.json()[0].keys()
+
+
+@pytest.mark.parametrize(
+    "client", (lazy_fixture("admin_client"), lazy_fixture("master_api_key_client"))
+)
+def test_get_project_data_by_id(client, organisation, project):
+    # Given
+    url = reverse("api-v1:projects:project-detail", args=[project.id])
+
+    num_features = 5
+    num_segments = 7
+
+    for i in range(num_features):
+        Feature.objects.create(name=f"feature_{i}", project=project)
+
+    for i in range(num_segments):
+        Segment.objects.create(name=f"feature_{i}", project=project)
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["name"] == project.name
+    assert response.json()["max_segments_allowed"] == 100
+    assert response.json()["max_features_allowed"] == 400
+    assert response.json()["max_segment_overrides_allowed"] == 100
+    assert response.json()["total_features"] == num_features
+    assert response.json()["total_segments"] == num_segments


### PR DESCRIPTION
## Changes

Re-add totals and limits removed in #2625 due to performance issues. 

Uses separate queries instead of `annotate(Count(..., distinct=True))` to avoid further performance issues.

## How did you test this code?

Updated the test from the previous iteration to ensure its verifying that the numbers are correct. I've been unable to really reproduce the performance issues we saw in production, but there is a lot less black magic going on with this approach. The additional queries should have a negligible impact on performance. 
