### PR TITLE
refactor: remove tag hack for version number

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -127,7 +127,6 @@ runs:
     - name: Write git info to Docker image
       run: |
         echo ${{ github.sha }} > api/CI_COMMIT_SHA
-        echo '${{ github.ref_name }}' > api/IMAGE_TAG
       shell: bash
 
     - name: Configure AWS Credentials

--- a/.github/actions/run-local-api/action.yml
+++ b/.github/actions/run-local-api/action.yml
@@ -36,7 +36,6 @@ runs:
 
     - name: Run the API
       id: run-api-container
-      working-directory: .
       env:
         E2E_TEST_AUTH_TOKEN: ${{ inputs.e2e_test_token }}
         DATABASE_URL: ${{ inputs.database_url }}

--- a/.github/actions/run-local-api/action.yml
+++ b/.github/actions/run-local-api/action.yml
@@ -30,12 +30,12 @@ runs:
 
   steps:
     - name: Build temporary Docker image for running the API
-      working-directory: api
-      run: docker build -t flagsmith/flagsmith-api:e2e-${{ github.sha }} .
+      run: docker build -t flagsmith/flagsmith-api:e2e-${{ github.sha }} -f api/Dockerfile .
       shell: bash
 
     - name: Run the API
       id: run-api-container
+      working-directory: api
       env:
         E2E_TEST_AUTH_TOKEN: ${{ inputs.e2e_test_token }}
         DATABASE_URL: ${{ inputs.database_url }}
@@ -54,7 +54,6 @@ runs:
         -e DJANGO_SETTINGS_MODULE=app.settings.test \
         -e FE_E2E_TEST_USER_EMAIL=nightwatch@solidstategroup.com \
         -e ACCESS_LOG_LOCATION=- \
-        -f api/Dockerfile \
         -d flagsmith/flagsmith-api:e2e-${{ github.sha }} )
         echo "containerId=$CONTAINER_ID" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/run-local-api/action.yml
+++ b/.github/actions/run-local-api/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Run the API
       id: run-api-container
-      working-directory: api
+      working-directory: .
       env:
         E2E_TEST_AUTH_TOKEN: ${{ inputs.e2e_test_token }}
         DATABASE_URL: ${{ inputs.database_url }}
@@ -55,6 +55,7 @@ runs:
         -e DJANGO_SETTINGS_MODULE=app.settings.test \
         -e FE_E2E_TEST_USER_EMAIL=nightwatch@solidstategroup.com \
         -e ACCESS_LOG_LOCATION=- \
+        -f api/Dockerfile \
         -d flagsmith/flagsmith-api:e2e-${{ github.sha }} )
         echo "containerId=$CONTAINER_ID" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/workflows/api-docker-publish-image.yml
+++ b/.github/workflows/api-docker-publish-image.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Write git info to Docker image
         run: |
           echo ${{ github.sha }} > api/CI_COMMIT_SHA
-          echo '${{ github.ref_name }}' > api/IMAGE_TAG
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -50,6 +49,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           file: api/Dockerfile
-          context: api/
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/frontend-docker-publish-image.yml
+++ b/.github/workflows/frontend-docker-publish-image.yml
@@ -31,7 +31,6 @@ jobs:
         run: |
           cd frontend
           echo ${{ github.sha }} > CI_COMMIT_SHA
-          echo '${{ github.ref_name }}' > IMAGE_TAG
 
       - name: Download features
         run: >

--- a/.github/workflows/frontend-docker-publish-image.yml
+++ b/.github/workflows/frontend-docker-publish-image.yml
@@ -55,6 +55,5 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           file: frontend/Dockerfile
-          context: frontend/
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/frontend-e2e-docker-publish-image.yml
+++ b/.github/workflows/frontend-e2e-docker-publish-image.yml
@@ -49,7 +49,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: frontend/Dockerfile.e2e
-          context: frontend/
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -71,7 +71,6 @@ jobs:
         run: |
           cd api
           echo ${{ github.sha }} > CI_COMMIT_SHA
-          echo '${{ steps.meta.outputs.tags }}' > IMAGE_TAG
           echo '' > ENTERPRISE_VERSION
 
       - name: Docker metadata

--- a/.github/workflows/platform-docker-publish-image.yml
+++ b/.github/workflows/platform-docker-publish-image.yml
@@ -46,6 +46,5 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
-          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/platform-docker-publish-image.yml
+++ b/.github/workflows/platform-docker-publish-image.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Write git info to Docker image
         run: |
           echo ${{ github.sha }} > api/CI_COMMIT_SHA
-          echo '${{ github.ref_name }}' > api/IMAGE_TAG
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -142,7 +142,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: api/Dockerfile
-          context: .
           push: false
           tags: flagsmith/flagsmith-api:testing
 
@@ -166,6 +165,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: frontend/Dockerfile
-          context: frontend/
           push: false
           tags: flagsmith/flagsmith-frontend:testing

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -142,7 +142,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: api/Dockerfile
-          context: api/
+          context: .
           push: false
           tags: flagsmith/flagsmith-api:testing
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ checkstyle.txt
 
 # These get baked into the docker container on build
 src/CI_COMMIT_SHA
-src/IMAGE_TAG
 
 
 # Web

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=build-python /usr/local/lib/python3.11/site-packages /usr/local/lib/
 COPY --from=build-python /usr/local/bin /usr/local/bin
 
 COPY api /app/
-COPY .release-please-manifest.json /app/.release-please-manifest.json
+COPY .release-please-manifest.json /app/.versions.json
 
 # Compile static Django assets
 RUN python /app/manage.py collectstatic --no-input

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY --from=build-python /usr/local/lib/python3.11/site-packages /usr/local/lib/
 COPY --from=build-python /usr/local/bin /usr/local/bin
 
 COPY api /app/
+COPY .release-please-manifest.json /app/.release-please-manifest.json
 
 # Compile static Django assets
 RUN python /app/manage.py collectstatic --no-input

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,7 @@
 FROM python:3.11 as build-python
 WORKDIR /app
 
-COPY pyproject.toml poetry.lock Makefile ./
+COPY api/pyproject.toml api/poetry.lock api/Makefile ./
 
 ARG POETRY_VIRTUALENVS_CREATE=false
 RUN make install-poetry
@@ -29,7 +29,8 @@ COPY --from=build-python /usr/local/lib/python3.11/site-packages /usr/local/lib/
 # Copy the bin folder as well to copy the executables created in package installation
 COPY --from=build-python /usr/local/bin /usr/local/bin
 
-COPY . .
+COPY api/ .
+COPY .release-please-manifest.json .
 
 # Compile static Django assets
 RUN python manage.py collectstatic --no-input

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build-python /usr/local/lib/python3.11/site-packages /usr/local/lib/
 COPY --from=build-python /usr/local/bin /usr/local/bin
 
 COPY api/ .
-COPY .release-please-manifest.json .
+COPY .release-please-manifest.json ./.versions.json
 
 # Compile static Django assets
 RUN python manage.py collectstatic --no-input

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -12,7 +12,7 @@ def create_hash():
 
 def get_version_info() -> dict:
     """Reads the version info baked into src folder of the docker container"""
-    release_please_manifest_location = "./.release-please-manifest.json"
+    release_please_manifest_location = "./.versions.json"
     manifest_versions = None
 
     if os.path.isfile(release_please_manifest_location):

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -1,3 +1,5 @@
+import json
+import os
 import pathlib
 
 import shortuuid
@@ -10,11 +12,25 @@ def create_hash():
 
 def get_version_info() -> dict:
     """Reads the version info baked into src folder of the docker container"""
+    release_please_manifest_location = "./.release-please-manifest.json"
+    manifest_versions = None
+
+    if os.path.isfile(release_please_manifest_location):
+        manifest_versions = json.loads(
+            _get_file_contents(release_please_manifest_location)
+        )
+        image_tag = manifest_versions["."]
+    else:
+        image_tag = "unknown"
+
     version_json = {
         "ci_commit_sha": _get_file_contents("./CI_COMMIT_SHA"),
-        "image_tag": _get_file_contents("./IMAGE_TAG"),
+        "image_tag": image_tag,
         "is_enterprise": pathlib.Path("./ENTERPRISE_VERSION").exists(),
     }
+
+    if manifest_versions:
+        version_json["package_versions"] = manifest_versions
 
     return version_json
 

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -39,4 +39,4 @@ def _get_file_contents(file_path: str) -> str:
         with open(file_path) as f:
             return f.read().replace("\n", "")
     except FileNotFoundError:
-        return "unknown"
+        return UNKNOWN

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -11,14 +11,14 @@ def create_hash():
 
 def get_version_info() -> dict:
     """Reads the version info baked into src folder of the docker container"""
-    release_please_manifest_location = "./.versions.json"
-    manifest_versions = None
+    release_please_manifest_location = ".versions.json"
     version_json = {}
     image_tag = "unknown"
 
-    manifest_versions = json.loads(_get_file_contents(release_please_manifest_location))
+    manifest_versions_string = _get_file_contents(release_please_manifest_location)
 
-    if manifest_versions:
+    if manifest_versions_string != "unknown":
+        manifest_versions = json.loads(manifest_versions_string)
         version_json["package_versions"] = manifest_versions
         image_tag = manifest_versions["."]
 

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -3,6 +3,9 @@ import pathlib
 
 import shortuuid
 
+UNKNOWN = "unknown"
+VERSIONS_INFO_FILE_LOCATION = ".versions.json"
+
 
 def create_hash():
     """Helper function to create a short hash"""
@@ -11,14 +14,13 @@ def create_hash():
 
 def get_version_info() -> dict:
     """Reads the version info baked into src folder of the docker container"""
-    release_please_manifest_location = ".versions.json"
     version_json = {}
-    image_tag = "unknown"
+    image_tag = UNKNOWN
 
-    manifest_versions_string = _get_file_contents(release_please_manifest_location)
+    manifest_versions_content: str = _get_file_contents(VERSIONS_INFO_FILE_LOCATION)
 
-    if manifest_versions_string != "unknown":
-        manifest_versions = json.loads(manifest_versions_string)
+    if manifest_versions_content != UNKNOWN:
+        manifest_versions = json.loads(manifest_versions_content)
         version_json["package_versions"] = manifest_versions
         image_tag = manifest_versions["."]
 

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -1,5 +1,4 @@
 import json
-import os
 import pathlib
 
 import shortuuid
@@ -14,23 +13,20 @@ def get_version_info() -> dict:
     """Reads the version info baked into src folder of the docker container"""
     release_please_manifest_location = "./.versions.json"
     manifest_versions = None
+    version_json = {}
+    image_tag = "unknown"
 
-    if os.path.isfile(release_please_manifest_location):
-        manifest_versions = json.loads(
-            _get_file_contents(release_please_manifest_location)
-        )
+    manifest_versions = json.loads(_get_file_contents(release_please_manifest_location))
+
+    if manifest_versions:
+        version_json["package_versions"] = manifest_versions
         image_tag = manifest_versions["."]
-    else:
-        image_tag = "unknown"
 
-    version_json = {
+    version_json = version_json | {
         "ci_commit_sha": _get_file_contents("./CI_COMMIT_SHA"),
         "image_tag": image_tag,
         "is_enterprise": pathlib.Path("./ENTERPRISE_VERSION").exists(),
     }
-
-    if manifest_versions:
-        version_json["package_versions"] = manifest_versions
 
     return version_json
 

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+from unittest import mock
 
 from pytest_mock import MockerFixture
 
@@ -26,8 +27,6 @@ def test_get_version_info(mocker: MockerFixture) -> None:
         "api": "2.66.2",
         "docs": "2.66.2",
     }
-    mock_is_file = mocker.patch("os.path.isfile")
-    mock_is_file.side_effect = (True,)
     mock_get_file_contents = mocker.patch("app.utils._get_file_contents")
     mock_get_file_contents.side_effect = (json.dumps(manifest_mocked_file), "some_sha")
 
@@ -45,4 +44,30 @@ def test_get_version_info(mocker: MockerFixture) -> None:
             "docs": "2.66.2",
             "frontend": "2.66.2",
         },
+    }
+
+
+def test_get_version_info_with_missing_files(mocker: MockerFixture) -> None:
+    # Given
+    mocked_pathlib = mocker.patch("app.utils.pathlib")
+
+    def path_side_effect(file_path: str) -> mocker.MagicMock:
+        mocked_path_object = mocker.MagicMock(spec=pathlib.Path)
+
+        if file_path == "./ENTERPRISE_VERSION":
+            mocked_path_object.exists.return_value = True
+
+        return mocked_path_object
+
+    mocked_pathlib.Path.side_effect = path_side_effect
+    mock.mock_open.side_effect = IOError
+
+    # When
+    result = get_version_info()
+
+    # Then
+    assert result == {
+        "ci_commit_sha": "unknown",
+        "image_tag": "unknown",
+        "is_enterprise": True,
     }

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 
 from pytest_mock import MockerFixture
@@ -19,8 +20,16 @@ def test_get_version_info(mocker: MockerFixture) -> None:
 
     mocked_pathlib.Path.side_effect = path_side_effect
 
+    manifest_mocked_file = {
+        ".": "2.66.2",
+        "frontend": "2.66.2",
+        "api": "2.66.2",
+        "docs": "2.66.2",
+    }
+    mock_is_file = mocker.patch("os.path.isfile")
+    mock_is_file.side_effect = (True,)
     mock_get_file_contents = mocker.patch("app.utils._get_file_contents")
-    mock_get_file_contents.side_effect = ("some_sha", "v1.0.0")
+    mock_get_file_contents.side_effect = (json.dumps(manifest_mocked_file), "some_sha")
 
     # When
     result = get_version_info()
@@ -28,6 +37,12 @@ def test_get_version_info(mocker: MockerFixture) -> None:
     # Then
     assert result == {
         "ci_commit_sha": "some_sha",
-        "image_tag": "v1.0.0",
+        "image_tag": "2.66.2",
         "is_enterprise": True,
+        "package_versions": {
+            ".": "2.66.2",
+            "api": "2.66.2",
+            "docs": "2.66.2",
+            "frontend": "2.66.2",
+        },
     }

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -23,9 +23,6 @@ def test_get_version_info(mocker: MockerFixture) -> None:
 
     manifest_mocked_file = {
         ".": "2.66.2",
-        "frontend": "2.66.2",
-        "api": "2.66.2",
-        "docs": "2.66.2",
     }
     mock_get_file_contents = mocker.patch("app.utils._get_file_contents")
     mock_get_file_contents.side_effect = (json.dumps(manifest_mocked_file), "some_sha")
@@ -38,12 +35,7 @@ def test_get_version_info(mocker: MockerFixture) -> None:
         "ci_commit_sha": "some_sha",
         "image_tag": "2.66.2",
         "is_enterprise": True,
-        "package_versions": {
-            ".": "2.66.2",
-            "api": "2.66.2",
-            "docs": "2.66.2",
-            "frontend": "2.66.2",
-        },
+        "package_versions": {".": "2.66.2"},
     }
 
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,8 @@ USER node
 
 WORKDIR /srv/bt
 
-COPY --chown=node:node . .
+COPY --chown=node:node frontend .
+COPY .release-please-manifest.json .
 
 RUN npm ci --quiet --production
 ENV ENV=prod

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -3,7 +3,7 @@ FROM ghcr.io/flagsmith/e2e-frontend-base:latest
 # Build Flagsmith
 WORKDIR /srv/flagsmith
 COPY frontend .
-COPY .release-please-manifest.json .
+COPY .release-please-manifest.json ./.versions.json
 
 RUN npm cache clean --force
 RUN npm ci

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -2,7 +2,9 @@ FROM ghcr.io/flagsmith/e2e-frontend-base:latest
 
 # Build Flagsmith
 WORKDIR /srv/flagsmith
-COPY . .
+COPY frontend .
+COPY .release-please-manifest.json .
+
 RUN npm cache clean --force
 RUN npm ci
 

--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -262,11 +262,11 @@ app.get('/version', (req, res) => {
   }
 
   try {
-    releasePleaseManifest = JSON.parse(fs.readFileSync('./.release-please-manifest.json', 'utf8'))
+    releasePleaseManifest = JSON.parse(fs.readFileSync('./.versions.json', 'utf8'))
     res.send({ 'ci_commit_sha': commitSha, 'image_tag': releasePleaseManifest["."], 'package_versions': releasePleaseManifest })
   } catch (err) {
     // eslint-disable-next-line
-    console.log('Unable to read release-please-manifest.json')
+    console.log('Unable to read .versions.json file')
     res.send({ 'ci_commit_sha': commitSha, 'image_tag': imageTag})
   }
 })

--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -263,8 +263,7 @@ app.get('/version', (req, res) => {
 
   try {
     imageTag = fs
-      .readFileSync('IMAGE_TAG', 'utf8')
-      .replace(/(\r\n|\n|\r)/gm, '')
+      .readFileSync('./.release-please-manifest.json', 'utf8')
   } catch (err) {
     // eslint-disable-next-line
     console.log('Unable to read IMAGE_TAG')

--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -262,14 +262,13 @@ app.get('/version', (req, res) => {
   }
 
   try {
-    imageTag = fs
-      .readFileSync('./.release-please-manifest.json', 'utf8')
+    releasePleaseManifest = JSON.parse(fs.readFileSync('./.release-please-manifest.json', 'utf8'))
+    res.send({ 'ci_commit_sha': commitSha, 'image_tag': releasePleaseManifest["."], 'package_versions': releasePleaseManifest })
   } catch (err) {
     // eslint-disable-next-line
-    console.log('Unable to read IMAGE_TAG')
+    console.log('Unable to read release-please-manifest.json')
+    res.send({ 'ci_commit_sha': commitSha, 'image_tag': imageTag})
   }
-
-  res.send({ 'ci_commit_sha': commitSha, 'image_tag': imageTag })
 })
 
 app.use(bodyParser.json())

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -33,7 +33,7 @@ services:
   frontend:
     build:
       context: ../
-      dockerfile: Dockerfile.e2e
+      dockerfile: frontend/Dockerfile.e2e
     platform: linux/amd64
     environment:
       E2E_TEST_TOKEN_DEV: some-token

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -32,7 +32,7 @@ services:
 
   frontend:
     build:
-      context: .
+      context: ../
       dockerfile: Dockerfile.e2e
     platform: linux/amd64
     environment:


### PR DESCRIPTION
Docker builds cant `COPY` from parent folders so all the Dockerfiles now need to be run in the root monorepo context so they can grab the `.release-please-manifest.json` file.

This also adds the suite of packages into the version json as can be seen in https://pr-2641-deployment-33281-flagsmith.app.uffizzi.com/version
