### PR TITLE
chore: update error message for non unique email address

### DIFF
--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from djoser.conf import settings as djoser_settings
 from djoser.serializers import UserCreateSerializer, UserDeleteSerializer
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
@@ -36,7 +35,7 @@ class CustomUserCreateSerializer(UserCreateSerializer):
                     UniqueValidator(
                         queryset=FFAdminUser.objects.all(),
                         lookup="iexact",
-                        message=djoser_settings.CONSTANTS.messages.CANNOT_CREATE_USER_ERROR,
+                        message="Invalid email address.",
                     )
                 ]
             }

--- a/api/custom_auth/tests/test_serializer.py
+++ b/api/custom_auth/tests/test_serializer.py
@@ -25,7 +25,7 @@ def test_CustomUserCreateSerializer_does_case_insensitive_lookup_with_email(db):
 
     # When
     assert serializer.is_valid() is False
-    assert serializer.errors["email"][0].title() == "Unable To Create Account."
+    assert serializer.errors["email"][0] == "Invalid email address."
 
 
 def test_CustomUserCreateSerializer_calls_is_authentication_method_valid_correctly_if_auth_controller_is_installed(


### PR DESCRIPTION
## Changes

Updates the error message given when an already-used email address is provided on registration. This is done to ensure that the error message displayed next to the email address field on registration is more contextually valid. 

See [this PR](https://github.com/Flagsmith/flagsmith/pull/2622) and the following screenshots for context. 

Before:

<img width="300" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/e526ec5f-7345-4719-a244-d27ecef39e58">

After:

<img width="300" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/e678f9aa-1fcd-437a-b373-b428a4da001f">


## How did you test this code?

Updated the unit test. 
