### PR TITLE
chore(release-please): add component to tags for sub packages

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -3,7 +3,7 @@ name: API Deploy to Production ECS
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
       - api/**
       - .github/**

--- a/.github/workflows/api-docker-publish-image.yml
+++ b/.github/workflows/api-docker-publish-image.yml
@@ -3,7 +3,7 @@ name: API Publish Docker Images
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
       - api/**
       - .github/**

--- a/.github/workflows/frontend-docker-publish-image.yml
+++ b/.github/workflows/frontend-docker-publish-image.yml
@@ -3,7 +3,7 @@ name: Frontend Publish Docker Images
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
       - frontend/**
       - .github/**

--- a/.github/workflows/frontend-e2e-docker-publish-image.yml
+++ b/.github/workflows/frontend-e2e-docker-publish-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     paths:
       - frontend/**
       - .github/**

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -3,7 +3,7 @@ name: Publish Flagsmith Private Cloud Image
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   FLAGSMITH_SAML_REVISION: v1.1.0

--- a/.github/workflows/platform-docker-publish-image.yml
+++ b/.github/workflows/platform-docker-publish-image.yml
@@ -3,7 +3,7 @@ name: Platform Publish Docker Images
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-dockerhub:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,7 @@
             "bump-minor-pre-major": false,
             "bump-patch-for-minor-pre-major": false,
             "draft": false,
-            "include-component-in-tag": false
+            "include-component-in-tag": true
         },
         "api": {
             "release-type": "python",
@@ -20,7 +20,7 @@
             "bump-minor-pre-major": false,
             "bump-patch-for-minor-pre-major": false,
             "draft": false,
-            "include-component-in-tag": false
+            "include-component-in-tag": true
         },
         "docs": {
             "release-type": "node",
@@ -28,7 +28,7 @@
             "bump-minor-pre-major": false,
             "bump-patch-for-minor-pre-major": false,
             "draft": false,
-            "include-component-in-tag": false
+            "include-component-in-tag": true
         }
     },
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",


### PR DESCRIPTION
## Changes

Adds the component to the tags for api, frontend and docs releases. This will fix the issue we have with the current open release please PR which is showing the wrong release notes due to the fact it is comparing api / frontend versions with main platform versions. 

As part of this, I have updated all the workflows that previously were triggered on `tags: - '*'` so that we do not trigger them multiple times when we merge a release please PR. We should perhaps change this in the future to use the individual tags (e.g. for deploying API to production) but I think there would be significant changes to achieve this as we use the tag number in the workflow itself for e.g. tagging the container image, etc. 

Note: once this is completed, we need to create tags for the previous release with the components in their names. 

## How did you test this code?

I don't think it's really possible to test it without merging. 
