### PR TITLE
fix(env-clone/permission): allow clone using CREATE_ENVIRONMENT

### DIFF
--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -48,7 +48,7 @@ class EnvironmentPermissions(IsAuthenticated):
             return False
 
         if view.action == "clone":
-            return request.user.is_project_admin(obj.project)
+            return request.user.has_project_permission(CREATE_ENVIRONMENT, obj.project)
 
         return request.user.is_environment_admin(obj) or view.action in [
             "user_permissions"

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from environments.models import Environment
+from projects.permissions import CREATE_ENVIRONMENT
 
 
 def test_retrieve_environment(
@@ -45,3 +46,22 @@ def test_retrieve_environment(
         response_json["use_mv_v2_evaluation"]
         == environment.use_identity_composite_key_for_hashing
     )
+
+
+def test_can_clone_environment_with_create_environment_permission(
+    test_user,
+    test_user_client,
+    environment,
+    user_project_permission,
+):
+    # Given
+    env_name = "Cloned env"
+    user_project_permission.permissions.add(CREATE_ENVIRONMENT)
+
+    url = reverse("api-v1:environments:environment-clone", args=[environment.api_key])
+
+    # When
+    response = test_user_client.post(url, {"name": env_name})
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Use CREATE_ENIVIRONMENT permission instead of project admin for environment clone 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds unit test case to cover the change 