### PR TITLE
fix: create initial versions logic and correct filters for get environment flags

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -23,6 +23,7 @@ from features.feature_types import MULTIVARIATE
 from features.models import Feature, FeatureSegment, FeatureState
 from features.multivariate.models import MultivariateFeatureOption
 from features.value_types import STRING
+from features.versioning.tasks import enable_v2_versioning
 from features.workflows.core.models import ChangeRequest
 from metadata.models import (
     Metadata,
@@ -158,8 +159,7 @@ def environment(project):
 
 @pytest.fixture()
 def environment_v2_versioning(environment):
-    environment.use_v2_feature_versioning = True
-    environment.save()
+    enable_v2_versioning(environment.id)
     return environment
 
 

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -43,7 +43,6 @@ from environments.exceptions import EnvironmentHeaderNotPresentError
 from environments.managers import EnvironmentManager
 from features.models import Feature, FeatureSegment, FeatureState
 from features.versioning.exceptions import FeatureVersioningError
-from features.versioning.tasks import create_initial_feature_versions
 from metadata.models import Metadata
 from segments.models import Segment
 from util.mappers import map_environment_to_environment_document
@@ -140,10 +139,6 @@ class Environment(
     def clear_environment_cache(self):
         # TODO: this could rebuild the cache itself (using an async task)
         environment_cache.delete(self.initial_value("api_key"))
-
-    @hook(AFTER_UPDATE, when="use_v2_feature_versioning", was=False, is_now=True)
-    def create_initial_versions(self):
-        create_initial_feature_versions.delay(kwargs={"environment_id": self.id})
 
     @hook(BEFORE_UPDATE, when="use_v2_feature_versioning", was=True, is_now=False)
     def validate_use_v2_feature_versioning(self):

--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -54,6 +54,7 @@ class EnvironmentSerializerLight(serializers.ModelSerializer):
             "hide_sensitive_data",
             "use_v2_feature_versioning",
         )
+        read_only_fields = ("use_v2_feature_versioning",)
 
     def get_use_mv_v2_evaluation(self, instance: Environment) -> bool:
         """

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -209,6 +209,11 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["POST"], url_path="enable-v2-versioning")
     def enable_v2_versioning(self, request: Request, api_key: str) -> Response:
         environment = self.get_object()
+        if environment.use_v2_feature_versioning is True:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"detail": "Environment already using v2 versioning."},
+            )
         enable_v2_versioning.delay(kwargs={"environment_id": environment.id})
         return Response(status=status.HTTP_202_ACCEPTED)
 

--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -1,24 +1,35 @@
 import logging
+import typing
 
 from django.utils import timezone
 
 from features.versioning.models import EnvironmentFeatureVersion
+from features.versioning.versioning_service import (
+    get_environment_flags_queryset,
+)
 from task_processor.decorators import register_task_handler
+
+if typing.TYPE_CHECKING:
+    from environments.models import Environment
+
 
 logger = logging.getLogger(__name__)
 
 
 @register_task_handler()
-def create_initial_feature_versions(environment_id: int):
+def enable_v2_versioning(environment_id: int):
     from environments.models import Environment
-    from features.models import Feature, FeatureState
 
     environment = Environment.objects.get(id=environment_id)
-    if not environment.use_v2_feature_versioning:
-        logger.warning(
-            "Cannot create initial versions for environment not using v2 versioning."
-        )
-        return
+
+    _create_initial_feature_versions(environment)
+
+    environment.use_v2_feature_versioning = True
+    environment.save()
+
+
+def _create_initial_feature_versions(environment: "Environment"):
+    from features.models import Feature
 
     for feature in Feature.objects.filter(project=environment.project_id):
         ef_version = EnvironmentFeatureVersion.objects.create(
@@ -27,6 +38,6 @@ def create_initial_feature_versions(environment_id: int):
             published=True,
             live_from=timezone.now(),
         )
-        FeatureState.objects.filter(
-            feature=feature, environment=environment, identity__isnull=True
+        get_environment_flags_queryset(environment=environment).filter(
+            identity__isnull=True, feature=feature
         ).update(environment_feature_version=ef_version)

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -75,11 +75,19 @@ def get_environment_flags_list(
 def _build_environment_flags_qs_filter(
     environment: "Environment", feature_name: str = None, additional_filters: Q = None
 ) -> Q:
+    now = timezone.now()
+
     qs_filter = Q(environment=environment, deleted_at__isnull=True)
-    if not environment.use_v2_feature_versioning:
+    if environment.use_v2_feature_versioning:
+        qs_filter &= Q(
+            environment_feature_version__isnull=False,
+            environment_feature_version__published=True,
+            environment_feature_version__live_from__lte=now,
+        )
+    else:
         qs_filter &= Q(
             live_from__isnull=False,
-            live_from__lte=timezone.now(),
+            live_from__lte=now,
             version__isnull=False,
             environment_feature_version__isnull=True,
         )

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -89,7 +89,6 @@ def _build_environment_flags_qs_filter(
             live_from__isnull=False,
             live_from__lte=now,
             version__isnull=False,
-            environment_feature_version__isnull=True,
         )
 
     if feature_name:

--- a/api/tests/integration/features/versioning/test_integration_v2_versioning.py
+++ b/api/tests/integration/features/versioning/test_integration_v2_versioning.py
@@ -1,4 +1,5 @@
 import json
+import time
 import typing
 
 import pytest
@@ -104,13 +105,14 @@ def test_v2_versioning(
 
     # Next, let's update the environment to use v2 versioning
     environment_update_url = reverse(
-        "api-v1:environments:environment-detail", args=[environment_api_key]
+        "api-v1:environments:environment-enable-v2-versioning",
+        args=[environment_api_key],
     )
-    data = {"use_v2_feature_versioning": True}
-    environment_update_response = admin_client.patch(
-        environment_update_url, data=json.dumps(data), content_type="application/json"
-    )
-    assert environment_update_response.status_code == status.HTTP_200_OK
+    environment_update_response = admin_client.post(environment_update_url)
+    assert environment_update_response.status_code == status.HTTP_202_ACCEPTED
+
+    # wait for the initial versions to have been created
+    time.sleep(0.5)
 
     # ... and let's verify that we get the same response on the flags / identities endpoints
     # before we change anything

--- a/api/tests/integration/features/versioning/test_integration_v2_versioning.py
+++ b/api/tests/integration/features/versioning/test_integration_v2_versioning.py
@@ -65,13 +65,11 @@ def environment_v2_versioning(
     admin_client: "APIClient", environment: int, environment_api_key: str
 ) -> int:
     environment_update_url = reverse(
-        "api-v1:environments:environment-detail", args=[environment_api_key]
+        "api-v1:environments:environment-enable-v2-versioning",
+        args=[environment_api_key],
     )
-    data = {"use_v2_feature_versioning": True}
-    environment_update_response = admin_client.patch(
-        environment_update_url, data=json.dumps(data), content_type="application/json"
-    )
-    assert environment_update_response.status_code == status.HTTP_200_OK
+    environment_update_response = admin_client.post(environment_update_url)
+    assert environment_update_response.status_code == status.HTTP_202_ACCEPTED
     return environment
 
 

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -417,38 +417,3 @@ def test_create_environment_creates_feature_states_in_all_environments_and_envir
         EnvironmentFeatureVersion.objects.filter(environment=environment).count() == 2
     )
     assert environment.feature_states.count() == 2
-
-
-def test_update_environment_to_v2_versioning_creates_initial_environment_feature_versions(
-    project: "Project", environment: Environment, feature: Feature
-) -> None:
-    """
-    Test which exercises the AFTER_UPDATE hook on the environment model and the
-    create_initial_versions task from features.versioning.tasks.
-    """
-
-    # Given
-    another_feature = Feature.objects.create(project=project, name="another_feature")
-
-    assert EnvironmentFeatureVersion.objects.count() == 0
-
-    # When
-    environment.use_v2_feature_versioning = True
-    environment.save()
-
-    # Then
-    assert (
-        EnvironmentFeatureVersion.objects.filter(environment=environment).count() == 2
-    )
-    assert (
-        EnvironmentFeatureVersion.objects.filter(
-            environment=environment, feature=feature
-        ).count()
-        == 1
-    )
-    assert (
-        EnvironmentFeatureVersion.objects.filter(
-            environment=environment, feature=another_feature
-        ).count()
-        == 1
-    )

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from pytest_mock import MockerFixture
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -65,3 +66,26 @@ def test_can_clone_environment_with_create_environment_permission(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_cannot_enable_v2_versioning_for_environment_already_enabled(
+    environment_v2_versioning: Environment,
+    admin_client: APIClient,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:environments:environment-enable-v2-versioning",
+        args=[environment_v2_versioning.api_key],
+    )
+
+    mock_enable_v2_versioning = mocker.patch("environments.views.enable_v2_versioning")
+
+    # When
+    response = admin_client.post(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Environment already using v2 versioning."}
+
+    mock_enable_v2_versioning.delay.assert_not_called()

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -2,17 +2,17 @@ import typing
 
 from environments.models import Environment
 from features.versioning.models import EnvironmentFeatureVersion
-from features.versioning.tasks import create_initial_feature_versions
+from features.versioning.tasks import enable_v2_versioning
 
 if typing.TYPE_CHECKING:
     from features.models import Feature
 
 
-def test_create_initial_feature_versions_does_nothing_if_environment_not_using_v2_versioning(
+def test_enable_v2_versioning_does_nothing_if_environment_not_using_v2_versioning(
     environment: "Environment", feature: "Feature"
 ) -> None:
     # When
-    create_initial_feature_versions(environment.id)
+    enable_v2_versioning(environment.id)
 
     # Then
     assert not EnvironmentFeatureVersion.objects.filter(

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -1,20 +1,22 @@
-import typing
-
 from environments.models import Environment
+from features.models import Feature
 from features.versioning.models import EnvironmentFeatureVersion
 from features.versioning.tasks import enable_v2_versioning
 
-if typing.TYPE_CHECKING:
-    from features.models import Feature
 
-
-def test_enable_v2_versioning_does_nothing_if_environment_not_using_v2_versioning(
-    environment: "Environment", feature: "Feature"
+def test_enable_v2_versioning(
+    environment: Environment, feature: Feature, multivariate_feature: Feature
 ) -> None:
     # When
     enable_v2_versioning(environment.id)
 
     # Then
-    assert not EnvironmentFeatureVersion.objects.filter(
+    assert EnvironmentFeatureVersion.objects.filter(
         environment=environment, feature=feature
     ).exists()
+    assert EnvironmentFeatureVersion.objects.filter(
+        environment=environment, feature=multivariate_feature
+    ).exists()
+
+    environment.refresh_from_db()
+    assert environment.use_v2_feature_versioning is True


### PR DESCRIPTION
## Changes

This PR addresses 3 things: 

 1. The logic to enable v2 versioning was flawed in that there would be a short window while the application was creating the initial versions in which the application would likely return incorrect values. I have resolved this by creating a new endpoint to enable v2 versioning and handling the process in a single task. 
 2. The logic to create initial versions previously didn't factor in the previous versioning logic. I have updated this now to only add the initial versions to the latest versions of flags. 
 3. Corrected the filters to get environment flags. Although this shouldn't have any material effect, it is cleaner to use the same filters between environment flags and identity flags. 

## How did you test this code?

Updated / added tests where necessary. 
