### PR TITLE
test: Seed E2E tests data to make tests independant from signup

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
             test
 
   run-e2e-tests:
-    runs-on: e2e-runner-8c
+    runs-on: ubuntu-latest
     name: Full E2E tests
 
     services:
@@ -74,7 +74,7 @@ jobs:
           docker logs $API_CONTAINER_ID
 
   run-e2e-tests-docker-unified:
-    runs-on: e2e-runner-8c
+    runs-on: ubuntu-latest
     name: Full E2E tests with unified image in Docker
 
     steps:

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -15,7 +15,6 @@ require('dotenv').config()
 
 const url = `http://localhost:${process.env.PORT || 8080}/`
 const logger = getLogger()
-let e2eInitDone = undefined
 
 fixture`E2E Tests`.requestHooks(logger).before(async () => {
   const token = process.env.E2E_TEST_TOKEN
@@ -52,6 +51,7 @@ fixture`E2E Tests`.requestHooks(logger).before(async () => {
           '\n',
         )
       }
+      console.log('Starting E2E tests')
     })
   } else {
     // eslint-disable-next-line no-console
@@ -73,56 +73,36 @@ fixture`E2E Tests`.requestHooks(logger).before(async () => {
     console.log('End of Initialise Requests')
   })
 
-const waitForInitTests = async () => {
-  log('Waiting for the initialization')
-  while (e2eInitDone === undefined) {
-    await t.wait(100)
-  }
-}
-
-test('Signup', async () => {
-  console.log('Init')
-  await initialiseTests()
-  await logout()
-  e2eInitDone = true
-}).after(async () => {
-  if (!e2eInitDone) {
-    e2eInitDone = false
-    throw new Error('not passed')
-  }
-})
-
-test('Flag', async () => {
-  await waitForInitTests()
-  await flagTests()
-  await logout()
-})
-
 test('Segment-part-1', async () => {
-  await waitForInitTests()
   await testSegment1()
   await logout()
 })
 
 test('Segment-part-2', async () => {
-  await waitForInitTests()
   await testSegment2()
   await logout()
 })
 
-test('Environment', async () => {
-  await waitForInitTests()
-  await environmentTest()
+test('Flag', async () => {
+  await flagTests()
+  await logout()
+})
+
+test('Signup', async () => {
+  await initialiseTests()
   await logout()
 })
 
 test('Invite', async () => {
-  await waitForInitTests()
   await inviteTest()
 })
 
+test('Environment', async () => {
+  await environmentTest()
+  await logout()
+})
+
 test('Project', async () => {
-  await waitForInitTests()
   await projectTest()
   await logout()
 })

--- a/frontend/e2e/tests/initialise-tests.ts
+++ b/frontend/e2e/tests/initialise-tests.ts
@@ -14,10 +14,10 @@ export default async function() {
     await click(byId('jsSignup'));
     await setText(byId('firstName'), 'Bullet'); // visit the url
     await setText(byId('lastName'), 'Train'); // visit the url
-    await setText(byId('email'), email); // visit the url
+    await setText(byId('email'), email + '.io'); // visit the url
     await setText(byId('password'), password); // visit the url
     await click(byId('signup-btn'));
-    await setText('[name="orgName"]', 'Bullet Train Ltd');
+    await setText('[name="orgName"]', 'Bullet Train Ltd 0');
     await click('#create-org-btn');
     await waitForElementVisible(byId('project-select-page'));
 

--- a/frontend/e2e/tests/invite-test.ts
+++ b/frontend/e2e/tests/invite-test.ts
@@ -56,7 +56,7 @@ export default async function () {
   }
   log('Get Invite url')
   await t.navigateTo('http://localhost:3000/organisation-settings')
-  const organisationName = await Selector(byId('organisation-name')).value
+  await Selector(byId('organisation-name')).value
   const inviteLink = await Selector(byId('invite-link')).value
   log('Accept invite')
   await t.navigateTo(inviteLink)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Add seed data to the E2E teardown process to make tests independant from signup so any test can start without waiting for signup.

That allows running tests in concurrent mode, in paralllel, and running only one or some of the tests.

## How did you test this code?

Pushing to test in Github Actions. **Please do not merge!**