### PR TITLE
test: Split E2E test into different jobs

### DIFF
--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -11,6 +11,9 @@ inputs:
   environment:
     description: The value of the ENV environment variable to use for npm run env.
     required: true
+  tests:
+    description: The space separated list of E2E tests to be executed.
+    required: false
 
 runs:
   using: composite
@@ -41,5 +44,5 @@ runs:
       run: |
         node -v
         npm run env
-        npm run test
+        npm run test -- ${{ inputs.tests }}
       shell: bash

--- a/.github/actions/local-e2e-tests/action.yml
+++ b/.github/actions/local-e2e-tests/action.yml
@@ -1,0 +1,55 @@
+name: Run E2E tests in local environment
+description: Run the E2E tests against local environment
+
+inputs:
+  sentry_sdk_dsn:
+    description: The sentry SDK DSN
+    required: true
+  sendgrid_api_key:
+    description: The sendgrid API key to use for email sending
+    required: true
+  slack_token:
+    description: The slack authentication token.
+    required: true
+  tests:
+    description: The space separated list of E2E tests to be executed.
+    required: false
+    default: ''
+  concurrency:
+    description: The concurrent number of browsers to be used on testing.
+    required: false
+    default: 3
+
+runs:
+  using: composite
+
+  steps:
+    - name: Run Local API
+      id: run-local-api
+      uses: ./.github/actions/run-local-api
+      with:
+        e2e_test_token: some-token
+        # As per https://stackoverflow.com/q/65497331/421808 172.17.0.1 seems like the only way to resolve host DB
+        database_url: postgres://postgres:postgres@172.17.0.1:5432/flagsmith
+        sentry_sdk_dsn: ${{ inputs.sentry_sdk_dsn }}
+        sendgrid_api_key: ${{ inputs.sendgrid_api_key }}
+        disable_analytics_features: true
+
+    - name: Run E2E tests against local
+      uses: ./.github/actions/e2e-tests
+      env:
+        E2E_CONCURRENCY: ${{ inputs.concurrency }}
+      with:
+        e2e_test_token: some-token
+        slack_token: ${{ inputs.slack_token }}
+        environment: local
+        tests: ${{ inputs.tests }}
+
+    - name: Output API container status and logs
+      if: failure()
+      env:
+        API_CONTAINER_ID: ${{ steps.run-local-api.outputs.containerId }}
+      run: |
+        docker inspect $API_CONTAINER_ID | jq '.[0].State'
+        docker logs $API_CONTAINER_ID
+      shell: bash

--- a/.github/actions/local-e2e-tests/action.yml
+++ b/.github/actions/local-e2e-tests/action.yml
@@ -2,12 +2,6 @@ name: Run E2E tests in local environment
 description: Run the E2E tests against local environment
 
 inputs:
-  sentry_sdk_dsn:
-    description: The sentry SDK DSN
-    required: true
-  sendgrid_api_key:
-    description: The sendgrid API key to use for email sending
-    required: true
   slack_token:
     description: The slack authentication token.
     required: true
@@ -31,8 +25,6 @@ runs:
         e2e_test_token: some-token
         # As per https://stackoverflow.com/q/65497331/421808 172.17.0.1 seems like the only way to resolve host DB
         database_url: postgres://postgres:postgres@172.17.0.1:5432/flagsmith
-        sentry_sdk_dsn: ${{ inputs.sentry_sdk_dsn }}
-        sendgrid_api_key: ${{ inputs.sendgrid_api_key }}
         disable_analytics_features: true
 
     - name: Run E2E tests against local

--- a/.github/actions/run-local-api/action.yml
+++ b/.github/actions/run-local-api/action.yml
@@ -53,7 +53,7 @@ runs:
         -e DISABLE_ANALYTICS_FEATURES=$DISABLE_ANALYTICS_FEATURES \
         -e DJANGO_ALLOWED_HOSTS="*" \
         -e DJANGO_SETTINGS_MODULE=app.settings.test \
-        -e FE_E2E_TEST_USER_EMAIL=nightwatch@solidstategroup.com \
+        -e ENABLE_FE_E2E=True \
         -e ACCESS_LOG_LOCATION=- \
         -d flagsmith/flagsmith-api:e2e-${{ github.sha }} )
         echo "containerId=$CONTAINER_ID" >> "$GITHUB_OUTPUT"

--- a/.github/actions/run-local-api/action.yml
+++ b/.github/actions/run-local-api/action.yml
@@ -5,12 +5,6 @@ inputs:
   database_url:
     description: The database URL to connect the API to
     required: true
-  sendgrid_api_key:
-    description: The sendgrid API key to use for email sending
-    required: true
-  sentry_sdk_dsn:
-    description: The sentry SDK DSN
-    required: true
   e2e_test_token:
     description: The token to use for authenticating the E2E test process
     required: false
@@ -40,16 +34,12 @@ runs:
       env:
         E2E_TEST_AUTH_TOKEN: ${{ inputs.e2e_test_token }}
         DATABASE_URL: ${{ inputs.database_url }}
-        SENDGRID_API_KEY: ${{ inputs.sendgrid_api_key }}
-        SENTRY_SDK_DSN: ${{ inputs.sentry_sdk_dsn }}
         DISABLE_ANALYTICS_FEATURES: ${{ inputs.disable_analytics_features }}
       run: |
         CONTAINER_ID=$( docker run \
         -p 8000:8000 \
         -e DATABASE_URL=$DATABASE_URL \
         -e E2E_TEST_AUTH_TOKEN=$E2E_TEST_AUTH_TOKEN \
-        -e SENDGRID_API_KEY=$SENDGRID_API_KEY \
-        -e SENTRY_SDK_DSN=$SENTRY_SDK_DSN \
         -e DISABLE_ANALYTICS_FEATURES=$DISABLE_ANALYTICS_FEATURES \
         -e DJANGO_ALLOWED_HOSTS="*" \
         -e DJANGO_SETTINGS_MODULE=app.settings.test \

--- a/.github/actions/unified-e2e-tests/action.yml
+++ b/.github/actions/unified-e2e-tests/action.yml
@@ -1,0 +1,40 @@
+name: Run E2E tests in docker unified environment
+description: Run the E2E tests against docker unified environment
+
+inputs:
+  github_actor:
+    description: Github actor
+    required: true
+  github_token:
+    description: Github token
+    required: true
+  e2e_test_token_staging:
+    description: The staging test token.
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v2
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.github_actor }}
+        password: ${{ inputs.github_token }}
+
+    - name: Build docker-compose with unified-image
+      working-directory: frontend
+      env:
+        E2E_TEST_TOKEN_STAGING: ${{ inputs.e2e_test_token_staging }}
+        ENV: staging
+        STATIC_ASSET_CDN_URL: /
+      run: |
+        docker buildx bake -f docker-compose-e2e-tests.yml --load
+      shell: bash

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: e2e-runner
     name: API Unit Tests
 
     services:

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: e2e-runner
+    runs-on: ubuntu-latest
     name: API Unit Tests
 
     services:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -29,9 +29,9 @@ jobs:
             style
             test
 
-  run-e2e-tests:
-    runs-on: e2e-runner-8c
-    name: Full E2E tests
+  run-e2e-tests-1:
+    runs-on: ubuntu-latest
+    name: E2E Segment Part 1 and environment tests
 
     services:
       postgres:
@@ -47,129 +47,136 @@ jobs:
       - name: Cloning repo
         uses: actions/checkout@v3
 
-      - name: Run Local API
-        id: run-local-api
-        uses: ./.github/actions/run-local-api
+      - name: Run E2E tests against local
+        uses: ./.github/actions/local-e2e-tests
         with:
-          e2e_test_token: some-token
-          # As per https://stackoverflow.com/q/65497331/421808 172.17.0.1 seems like the only way to resolve host DB
-          database_url: postgres://postgres:postgres@172.17.0.1:5432/flagsmith
           sentry_sdk_dsn: ${{ secrets.SENTRY_SDK_DSN }}
           sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
-          disable_analytics_features: true
-
-      - name: Run E2E tests against local
-        uses: ./.github/actions/e2e-tests
-        with:
-          e2e_test_token: some-token
           slack_token: ${{ secrets.SLACK_TOKEN }}
-          environment: local
+          tests: segment-part-1 environment
+          concurrency: 1
 
-      - name: Output API container status and logs
-        if: failure()
+  run-e2e-tests-2:
+    runs-on: ubuntu-latest
+    name: E2E Segment Part 2
+
+    services:
+      postgres:
+        image: postgres:11.12-alpine
         env:
-          API_CONTAINER_ID: ${{ steps.run-local-api.outputs.containerId }}
-        run: |
-          docker inspect $API_CONTAINER_ID | jq '.[0].State'
-          docker logs $API_CONTAINER_ID
-
-  run-e2e-segments-1-tests-docker-unified:
-    runs-on: e2e-runner
-    name: E2E Segment Part 1 and environment tests with unified image in Docker
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: flagsmith
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Run E2E tests against local
+        uses: ./.github/actions/local-e2e-tests
         with:
-          registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          sentry_sdk_dsn: ${{ secrets.SENTRY_SDK_DSN }}
+          sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          tests: segment-part-2
+          concurrency: 1
 
-      - name: Run docker-compose with unified-image
+  run-e2e-tests-3:
+    runs-on: ubuntu-latest
+    name: E2E segments-3, signup,flag, invite, project tests on local
+
+    services:
+      postgres:
+        image: postgres:11.12-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: flagsmith
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v3
+
+      - name: Run E2E tests against local
+        uses: ./.github/actions/local-e2e-tests
+        with:
+          sentry_sdk_dsn: ${{ secrets.SENTRY_SDK_DSN }}
+          sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          tests: segment-part-3 signup flag invite project
+          concurrency: 2
+
+  run-e2e-segments-1-tests-docker-unified:
+    runs-on: ubuntu-latest
+    name: Unified E2E Segment Part 1, environment
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v3
+
+      - name: Build unified docker container
+        uses: ./.github/actions/unified-e2e-tests
+        with:
+          github_actor: ${{github.actor}}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          e2e_test_token_staging: ${{ secrets.E2E_TEST_TOKEN }}
+
+      - name: Run tests on unified docker image
         working-directory: frontend
         env:
-          E2E_TEST_TOKEN_STAGING: ${{ secrets.E2E_TEST_TOKEN }}
-          ENV: staging
-          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          STATIC_ASSET_CDN_URL: /
+          SLACK_TOKEN: ${{ inputs.slack_token }}
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          docker buildx bake -f docker-compose-e2e-tests.yml --load |
           docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-1 environment
 
   run-e2e-segments-2-tests-docker-unified:
-    runs-on: e2e-runner
-    name: E2E Segment Part 2 tests with unified image in Docker
+    runs-on: ubuntu-latest
+    name: Unified E2E Segment Part 2
 
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Build unified docker container
+        uses: ./.github/actions/unified-e2e-tests
         with:
-          registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          github_actor: ${{github.actor}}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          e2e_test_token_staging: ${{ secrets.E2E_TEST_TOKEN }}
 
-      - name: Run docker-compose with unified-image
+      - name: Run tests on unified docker image
         working-directory: frontend
         env:
-          E2E_TEST_TOKEN_STAGING: ${{ secrets.E2E_TEST_TOKEN }}
-          ENV: staging
-          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          STATIC_ASSET_CDN_URL: /
+          SLACK_TOKEN: ${{ inputs.slack_token }}
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          docker buildx bake -f docker-compose-e2e-tests.yml --load |
           docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-2
 
   run-e2e-other-tests-docker-unified:
-    runs-on: e2e-runner
-    name: E2E segments-3, signup,flag, invite, project tests with in Docker
+    runs-on: ubuntu-latest
+    name: Unified E2E segments-3, signup,flag, invite, project
 
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Build unified docker container
+        uses: ./.github/actions/unified-e2e-tests
         with:
-          registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          github_actor: ${{github.actor}}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          e2e_test_token_staging: ${{ secrets.E2E_TEST_TOKEN }}
 
-      - name: Build docker-compose with unified-image
+      - name: Run tests on unified docker image
         working-directory: frontend
         env:
-          E2E_TEST_TOKEN_STAGING: ${{ secrets.E2E_TEST_TOKEN }}
-          ENV: staging
-          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          STATIC_ASSET_CDN_URL: /
+          SLACK_TOKEN: ${{ inputs.slack_token }}
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          docker buildx bake -f docker-compose-e2e-tests.yml --load |
           docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=2 npm run test -- segment-part-3 signup flag invite project
 
   docker-build-unified:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -98,7 +98,7 @@ jobs:
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npm run test -- segment-part-1 environment
+          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-1 environment
 
   run-e2e-segments-2-tests-docker-unified:
     runs-on: ubuntu-latest
@@ -125,7 +125,7 @@ jobs:
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npm run test -- segment-part-2
+          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-2
 
   run-e2e-other-tests-docker-unified:
     runs-on: ubuntu-latest
@@ -152,7 +152,7 @@ jobs:
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npm run test -- signup flag invite project
+          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- signup flag invite project
 
   docker-build-unified:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -73,9 +73,9 @@ jobs:
           docker inspect $API_CONTAINER_ID | jq '.[0].State'
           docker logs $API_CONTAINER_ID
 
-  run-e2e-tests-docker-unified:
+  run-e2e-segments-1-tests-docker-unified:
     runs-on: ubuntu-latest
-    name: Full E2E tests with unified image in Docker
+    name: E2E Segment Part 1 and environment tests with unified image in Docker
 
     steps:
       - name: Cloning repo
@@ -98,7 +98,61 @@ jobs:
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npm run test
+          docker-compose -f docker-compose-e2e-tests.yml run frontend npm run test -- segment-part-1 environment
+
+  run-e2e-segments-2-tests-docker-unified:
+    runs-on: ubuntu-latest
+    name: E2E Segment Part 2 tests with unified image in Docker
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Run docker-compose with unified-image
+        working-directory: frontend
+        env:
+          E2E_TEST_TOKEN_STAGING: ${{ secrets.E2E_TEST_TOKEN }}
+          ENV: staging
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          STATIC_ASSET_CDN_URL: /
+          GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          docker-compose -f docker-compose-e2e-tests.yml build
+          docker-compose -f docker-compose-e2e-tests.yml run frontend npm run test -- segment-part-2
+
+  run-e2e-other-tests-docker-unified:
+    runs-on: ubuntu-latest
+    name: E2E signup,flag, invite, and project tests with unified image in Docker
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Run docker-compose with unified-image
+        working-directory: frontend
+        env:
+          E2E_TEST_TOKEN_STAGING: ${{ secrets.E2E_TEST_TOKEN }}
+          ENV: staging
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          STATIC_ASSET_CDN_URL: /
+          GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          docker-compose -f docker-compose-e2e-tests.yml build
+          docker-compose -f docker-compose-e2e-tests.yml run frontend npm run test -- signup flag invite project
 
   docker-build-unified:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -152,7 +152,7 @@ jobs:
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- signup flag invite project
+          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=4 npm run test -- signup flag invite project
 
   docker-build-unified:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -31,7 +31,7 @@ jobs:
 
   run-e2e-tests-1:
     runs-on: ubuntu-latest
-    name: E2E Segment Part 1 and environment tests
+    name: E2E Local - Segments-1, Environment
 
     services:
       postgres:
@@ -58,7 +58,7 @@ jobs:
 
   run-e2e-tests-2:
     runs-on: ubuntu-latest
-    name: E2E Segment Part 2
+    name: E2E Local - Segments-2
 
     services:
       postgres:
@@ -85,7 +85,7 @@ jobs:
 
   run-e2e-tests-3:
     runs-on: ubuntu-latest
-    name: E2E segments-3, signup,flag, invite, project tests on local
+    name: E2E Local - Segments-3, Signup, Flag, Invite, Project
 
     services:
       postgres:
@@ -112,7 +112,7 @@ jobs:
 
   run-e2e-segments-1-tests-docker-unified:
     runs-on: ubuntu-latest
-    name: Unified E2E Segment Part 1, environment
+    name: Unified E2E - Segments-1, Environment
 
     steps:
       - name: Cloning repo
@@ -135,7 +135,7 @@ jobs:
 
   run-e2e-segments-2-tests-docker-unified:
     runs-on: ubuntu-latest
-    name: Unified E2E Segment Part 2
+    name: Unified E2E - Segments-2
 
     steps:
       - name: Cloning repo
@@ -158,7 +158,7 @@ jobs:
 
   run-e2e-other-tests-docker-unified:
     runs-on: ubuntu-latest
-    name: Unified E2E segments-3, signup,flag, invite, project
+    name: Unified E2E - Segments-3, Signup, Flag, Invite, Project
 
     steps:
       - name: Cloning repo

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Run E2E tests against local
         uses: ./.github/actions/local-e2e-tests
         with:
-          sentry_sdk_dsn: ${{ secrets.SENTRY_SDK_DSN }}
-          sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
           tests: segment-part-1 environment
           concurrency: 1
@@ -77,8 +75,6 @@ jobs:
       - name: Run E2E tests against local
         uses: ./.github/actions/local-e2e-tests
         with:
-          sentry_sdk_dsn: ${{ secrets.SENTRY_SDK_DSN }}
-          sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
           tests: segment-part-2
           concurrency: 1
@@ -104,8 +100,6 @@ jobs:
       - name: Run E2E tests against local
         uses: ./.github/actions/local-e2e-tests
         with:
-          sentry_sdk_dsn: ${{ secrets.SENTRY_SDK_DSN }}
-          sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
           tests: segment-part-3 signup flag invite project
           concurrency: 2

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -170,7 +170,7 @@ jobs:
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           docker buildx bake -f docker-compose-e2e-tests.yml --load |
-          docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=2 npm run test -- signup flag invite project
+          docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=2 npm run test -- segment-part-3 signup flag invite project
 
   docker-build-unified:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -106,7 +106,7 @@ jobs:
 
   run-e2e-segments-1-tests-docker-unified:
     runs-on: ubuntu-latest
-    name: Unified E2E - Segments-1, Environment
+    name: E2E Unified - Segments-1, Environment
 
     steps:
       - name: Cloning repo
@@ -129,7 +129,7 @@ jobs:
 
   run-e2e-segments-2-tests-docker-unified:
     runs-on: ubuntu-latest
-    name: Unified E2E - Segments-2
+    name: E2E Unified - Segments-2
 
     steps:
       - name: Cloning repo
@@ -152,7 +152,7 @@ jobs:
 
   run-e2e-other-tests-docker-unified:
     runs-on: ubuntu-latest
-    name: Unified E2E - Segments-3, Signup, Flag, Invite, Project
+    name: E2E Unified - Segments-3, Signup, Flag, Invite, Project
 
     steps:
       - name: Cloning repo

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -192,8 +192,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=image-unified-fb
+          cache-to: type=gha,mode=max,scope=image-unified-fb
           tags: flagsmith/flagsmith:testing
 
   docker-build-api:
@@ -218,8 +218,8 @@ jobs:
           file: api/Dockerfile
           context: api/
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=image-api-fb
+          cache-to: type=gha,mode=max,scope=image-api-fb
           tags: flagsmith/flagsmith-api:testing
 
   docker-build-frontend:
@@ -244,6 +244,6 @@ jobs:
           file: frontend/Dockerfile
           context: frontend/
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=image-frontend-fb
+          cache-to: type=gha,mode=max,scope=image-frontend-fb
           tags: flagsmith/flagsmith-frontend:testing

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -141,7 +141,7 @@ jobs:
 
   run-e2e-other-tests-docker-unified:
     runs-on: e2e-runner
-    name: E2E signup,flag, invite, and project tests with unified image in Docker
+    name: E2E segments-3, signup,flag, invite, project tests with in Docker
 
     steps:
       - name: Cloning repo

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
             test
 
   run-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: e2e-runner-8c
     name: Full E2E tests
 
     services:
@@ -74,13 +74,19 @@ jobs:
           docker logs $API_CONTAINER_ID
 
   run-e2e-segments-1-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: e2e-runner
     name: E2E Segment Part 1 and environment tests with unified image in Docker
 
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -97,17 +103,23 @@ jobs:
           STATIC_ASSET_CDN_URL: /
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-1 environment
+          docker buildx bake -f docker-compose-e2e-tests.yml --load |
+          docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-1 environment
 
   run-e2e-segments-2-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: e2e-runner
     name: E2E Segment Part 2 tests with unified image in Docker
 
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -124,17 +136,23 @@ jobs:
           STATIC_ASSET_CDN_URL: /
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-2
+          docker buildx bake -f docker-compose-e2e-tests.yml --load |
+          docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-2
 
   run-e2e-other-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: e2e-runner
     name: E2E signup,flag, invite, and project tests with unified image in Docker
 
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -142,7 +160,7 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Run docker-compose with unified-image
+      - name: Build docker-compose with unified-image
         working-directory: frontend
         env:
           E2E_TEST_TOKEN_STAGING: ${{ secrets.E2E_TEST_TOKEN }}
@@ -151,8 +169,8 @@ jobs:
           STATIC_ASSET_CDN_URL: /
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          docker-compose -f docker-compose-e2e-tests.yml build
-          docker-compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=4 npm run test -- signup flag invite project
+          docker buildx bake -f docker-compose-e2e-tests.yml --load |
+          docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=2 npm run test -- signup flag invite project
 
   docker-build-unified:
     if: github.event.pull_request.draft == false
@@ -171,9 +189,11 @@ jobs:
 
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: flagsmith/flagsmith:testing
 
   docker-build-api:
@@ -193,11 +213,13 @@ jobs:
 
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           file: api/Dockerfile
           context: api/
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: flagsmith/flagsmith-api:testing
 
   docker-build-frontend:
@@ -217,9 +239,11 @@ jobs:
 
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           file: frontend/Dockerfile
           context: frontend/
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: flagsmith/flagsmith-frontend:testing

--- a/.github/workflows/platform-test-merge-to-main.yml
+++ b/.github/workflows/platform-test-merge-to-main.yml
@@ -31,8 +31,6 @@ jobs:
           e2e_test_token: some-token
           # As per https://stackoverflow.com/q/65497331/421808 172.17.0.1 seems like the only way to resolve host DB
           database_url: postgres://postgres:postgres@172.17.0.1:5432/flagsmith
-          sentry_sdk_dsn: ${{ secrets.SENTRY_SDK_DSN }}
-          sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
           disable_analytics_features: true
 
       - name: Run E2E tests against local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 # Step 1 - Build Front End Application
 FROM node:16 AS build-frontend
 
-# Copy the entire project - Webpack puts compiled assets into the Django folder
+# Copy the files required to install npm packages
 WORKDIR /app
-COPY . .
+COPY frontend/package.json frontend/package-lock.json frontend/.npmrc ./frontend/.nvmrc ./frontend/
+COPY frontend/bin/ ./frontend/bin/
+COPY frontend/env/ ./frontend/env/
 
 RUN cd frontend && npm ci --quiet --production
+
+# Copy the entire project - Webpack puts compiled assets into the Django folder
+COPY . .
 ENV ENV=prod
 ENV STATIC_ASSET_CDN_URL=/static/
 RUN cd frontend && npm run bundledjango

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -445,8 +445,11 @@ LOGOUT_URL = "/admin/logout/"
 
 # Email associated with user that is used by front end for end to end testing purposes
 E2E_TEST_EMAIL_DOMAIN = "flagsmithe2etestdomain.io"
+# User email address used for E2E Signup test
 E2E_SIGNUP_USER = f"e2e_signup_user@{E2E_TEST_EMAIL_DOMAIN}"
+# User email address used for Change email E2E test which is part of invite tests
 E2E_CHANGE_EMAIL_USER = f"e2e_change_email@{E2E_TEST_EMAIL_DOMAIN}"
+# User email address used for the rest of the E2E tests
 E2E_USER = f"e2e_user@{E2E_TEST_EMAIL_DOMAIN}"
 
 # SSL handling in Django

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -443,6 +443,8 @@ SWAGGER_SETTINGS = {
 LOGIN_URL = "/admin/login/"
 LOGOUT_URL = "/admin/logout/"
 
+# Enable E2E tests
+ENABLE_FE_E2E = env.bool("ENABLE_FE_E2E", default=False)
 # Email associated with user that is used by front end for end to end testing purposes
 E2E_TEST_EMAIL_DOMAIN = "flagsmithe2etestdomain.io"
 # User email address used for E2E Signup test

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -444,7 +444,10 @@ LOGIN_URL = "/admin/login/"
 LOGOUT_URL = "/admin/logout/"
 
 # Email associated with user that is used by front end for end to end testing purposes
-FE_E2E_TEST_USER_EMAIL = "nightwatch@solidstategroup.com"
+E2E_TEST_EMAIL_DOMAIN = "flagsmithe2etestdomain.io"
+E2E_SIGNUP_USER = f"e2e_signup_user@{E2E_TEST_EMAIL_DOMAIN}"
+E2E_CHANGE_EMAIL_USER = f"e2e_change_email@{E2E_TEST_EMAIL_DOMAIN}"
+E2E_USER = f"e2e_user@{E2E_TEST_EMAIL_DOMAIN}"
 
 # SSL handling in Django
 SECURE_PROXY_SSL_HEADER_NAME = env.str(

--- a/api/e2etests/e2e_seed_data.py
+++ b/api/e2etests/e2e_seed_data.py
@@ -12,11 +12,21 @@ from users.models import FFAdminUser
 PASSWORD = "str0ngp4ssw0rd!"
 
 
+def delete_user_and_its_organisations(user_email: str) -> None:
+    user = FFAdminUser.objects.filter(email=user_email).first()
+    if user:
+        for organisation in Organisation.objects.filter(
+            id__in=user.organisations.all()
+        ):
+            organisation.delete()
+        user.delete()
+
+
 def teardown() -> None:
-    # delete users created for e2e test by front end
-    FFAdminUser.objects.filter(email=E2E_SIGNUP_USER).delete()
-    FFAdminUser.objects.filter(email=E2E_USER).delete()
-    FFAdminUser.objects.filter(email=E2E_CHANGE_EMAIL_USER).delete()
+    # delete users and their orgs created for e2e test by front end
+    delete_user_and_its_organisations(user_email=E2E_SIGNUP_USER)
+    delete_user_and_its_organisations(user_email=E2E_USER)
+    delete_user_and_its_organisations(user_email=E2E_CHANGE_EMAIL_USER)
 
 
 def seed_data() -> None:

--- a/api/e2etests/e2e_seed_data.py
+++ b/api/e2etests/e2e_seed_data.py
@@ -1,0 +1,43 @@
+import os
+
+from environments.models import Environment
+from organisations.models import Organisation, OrganisationRole
+from projects.models import Project
+from users.models import FFAdminUser
+
+
+class E2ESeedData:
+    fe_e2e_test_user_email = (
+        os.environ["FE_E2E_TEST_USER_EMAIL"]
+        if "FE_E2E_TEST_USER_EMAIL" in os.environ
+        else None
+    )
+    password = "str0ngp4ssw0rd!"
+
+    def teardown(self):
+        # delete users created for e2e test by front end
+        if self.fe_e2e_test_user_email:
+            FFAdminUser.objects.filter(email=self.fe_e2e_test_user_email).delete()
+            FFAdminUser.objects.filter(
+                email=self.fe_e2e_test_user_email + ".io"
+            ).delete()
+            FFAdminUser.objects.filter(email="changeMail@test.com").delete()
+
+    def seed_data(self):
+        # create user and organisation for e2e test by front end
+        if self.fe_e2e_test_user_email:
+            organisation = Organisation.objects.create(name="Bullet Train Ltd")
+            org_admin = FFAdminUser.objects.create_user(
+                email=self.fe_e2e_test_user_email,
+                password=self.password,
+                username=self.fe_e2e_test_user_email,
+            )
+            org_admin.add_organisation(organisation, OrganisationRole.ADMIN)
+
+            project = Project.objects.create(
+                name="My Test Project", organisation=organisation
+            )
+
+            Environment.objects.create(name="Development", project=project)
+
+            Environment.objects.create(name="Production", project=project)

--- a/api/e2etests/e2e_seed_data.py
+++ b/api/e2etests/e2e_seed_data.py
@@ -1,8 +1,5 @@
-from app.settings.common import (
-    E2E_CHANGE_EMAIL_USER,
-    E2E_SIGNUP_USER,
-    E2E_USER,
-)
+from django.conf import settings
+
 from environments.models import Environment
 from organisations.models import Organisation, OrganisationRole, Subscription
 from projects.models import Project
@@ -13,29 +10,27 @@ PASSWORD = "str0ngp4ssw0rd!"
 
 
 def delete_user_and_its_organisations(user_email: str) -> None:
-    user = FFAdminUser.objects.filter(email=user_email).first()
+    user: FFAdminUser | None = FFAdminUser.objects.filter(email=user_email).first()
+
     if user:
-        for organisation in Organisation.objects.filter(
-            id__in=user.organisations.all()
-        ):
-            organisation.delete()
+        user.organisations.all().delete()
         user.delete()
 
 
 def teardown() -> None:
     # delete users and their orgs created for e2e test by front end
-    delete_user_and_its_organisations(user_email=E2E_SIGNUP_USER)
-    delete_user_and_its_organisations(user_email=E2E_USER)
-    delete_user_and_its_organisations(user_email=E2E_CHANGE_EMAIL_USER)
+    delete_user_and_its_organisations(user_email=settings.E2E_SIGNUP_USER)
+    delete_user_and_its_organisations(user_email=settings.E2E_USER)
+    delete_user_and_its_organisations(user_email=settings.E2E_CHANGE_EMAIL_USER)
 
 
 def seed_data() -> None:
     # create user and organisation for e2e test by front end
     organisation: Organisation = Organisation.objects.create(name="Bullet Train Ltd")
     org_admin: FFAdminUser = FFAdminUser.objects.create_user(
-        email=E2E_USER,
+        email=settings.E2E_USER,
         password=PASSWORD,
-        username=E2E_USER,
+        username=settings.E2E_USER,
     )
     org_admin.add_organisation(organisation, OrganisationRole.ADMIN)
 

--- a/api/e2etests/e2e_seed_data.py
+++ b/api/e2etests/e2e_seed_data.py
@@ -1,43 +1,53 @@
-import os
-
+from app.settings.common import (
+    E2E_CHANGE_EMAIL_USER,
+    E2E_SIGNUP_USER,
+    E2E_USER,
+)
 from environments.models import Environment
-from organisations.models import Organisation, OrganisationRole
+from organisations.models import Organisation, OrganisationRole, Subscription
 from projects.models import Project
 from users.models import FFAdminUser
 
 
 class E2ESeedData:
-    fe_e2e_test_user_email = (
-        os.environ["FE_E2E_TEST_USER_EMAIL"]
-        if "FE_E2E_TEST_USER_EMAIL" in os.environ
-        else None
-    )
-    password = "str0ngp4ssw0rd!"
+    def __init__(self) -> None:
+        # User email address used for E2E Signup test
+        self.signup_user: str = E2E_SIGNUP_USER
 
-    def teardown(self):
+        # User email address used for Change email E2E test which is part of invite tests
+        self.change_email_user: str = E2E_CHANGE_EMAIL_USER
+
+        # User email address used for the rest of the E2E tests
+        self.e2e_user: str = E2E_USER
+
+        # Password used by all the test users
+        self.password = "str0ngp4ssw0rd!"
+
+    def teardown(self) -> None:
         # delete users created for e2e test by front end
-        if self.fe_e2e_test_user_email:
-            FFAdminUser.objects.filter(email=self.fe_e2e_test_user_email).delete()
-            FFAdminUser.objects.filter(
-                email=self.fe_e2e_test_user_email + ".io"
-            ).delete()
-            FFAdminUser.objects.filter(email="changeMail@test.com").delete()
+        FFAdminUser.objects.filter(email=self.signup_user).delete()
+        FFAdminUser.objects.filter(email=self.e2e_user).delete()
+        FFAdminUser.objects.filter(email=self.change_email_user).delete()
 
-    def seed_data(self):
+    def seed_data(self) -> None:
         # create user and organisation for e2e test by front end
-        if self.fe_e2e_test_user_email:
-            organisation = Organisation.objects.create(name="Bullet Train Ltd")
-            org_admin = FFAdminUser.objects.create_user(
-                email=self.fe_e2e_test_user_email,
-                password=self.password,
-                username=self.fe_e2e_test_user_email,
-            )
-            org_admin.add_organisation(organisation, OrganisationRole.ADMIN)
+        organisation: Organisation = Organisation.objects.create(
+            name="Bullet Train Ltd"
+        )
+        org_admin: FFAdminUser = FFAdminUser.objects.create_user(
+            email=self.e2e_user,
+            password=self.password,
+            username=self.e2e_user,
+        )
+        org_admin.add_organisation(organisation, OrganisationRole.ADMIN)
 
-            project = Project.objects.create(
-                name="My Test Project", organisation=organisation
-            )
+        project: Project = Project.objects.create(
+            name="My Test Project", organisation=organisation
+        )
+        Environment.objects.create(name="Development", project=project)
+        Environment.objects.create(name="Production", project=project)
 
-            Environment.objects.create(name="Development", project=project)
-
-            Environment.objects.create(name="Production", project=project)
+        # Upgrade organisation seats
+        Subscription.objects.filter(
+            organisation__in=org_admin.organisations.all()
+        ).update(max_seats=2)

--- a/api/e2etests/e2e_seed_data.py
+++ b/api/e2etests/e2e_seed_data.py
@@ -8,46 +8,34 @@ from organisations.models import Organisation, OrganisationRole, Subscription
 from projects.models import Project
 from users.models import FFAdminUser
 
+# Password used by all the test users
+PASSWORD = "str0ngp4ssw0rd!"
 
-class E2ESeedData:
-    def __init__(self) -> None:
-        # User email address used for E2E Signup test
-        self.signup_user: str = E2E_SIGNUP_USER
 
-        # User email address used for Change email E2E test which is part of invite tests
-        self.change_email_user: str = E2E_CHANGE_EMAIL_USER
+def teardown() -> None:
+    # delete users created for e2e test by front end
+    FFAdminUser.objects.filter(email=E2E_SIGNUP_USER).delete()
+    FFAdminUser.objects.filter(email=E2E_USER).delete()
+    FFAdminUser.objects.filter(email=E2E_CHANGE_EMAIL_USER).delete()
 
-        # User email address used for the rest of the E2E tests
-        self.e2e_user: str = E2E_USER
 
-        # Password used by all the test users
-        self.password = "str0ngp4ssw0rd!"
+def seed_data() -> None:
+    # create user and organisation for e2e test by front end
+    organisation: Organisation = Organisation.objects.create(name="Bullet Train Ltd")
+    org_admin: FFAdminUser = FFAdminUser.objects.create_user(
+        email=E2E_USER,
+        password=PASSWORD,
+        username=E2E_USER,
+    )
+    org_admin.add_organisation(organisation, OrganisationRole.ADMIN)
 
-    def teardown(self) -> None:
-        # delete users created for e2e test by front end
-        FFAdminUser.objects.filter(email=self.signup_user).delete()
-        FFAdminUser.objects.filter(email=self.e2e_user).delete()
-        FFAdminUser.objects.filter(email=self.change_email_user).delete()
+    project: Project = Project.objects.create(
+        name="My Test Project", organisation=organisation
+    )
+    Environment.objects.create(name="Development", project=project)
+    Environment.objects.create(name="Production", project=project)
 
-    def seed_data(self) -> None:
-        # create user and organisation for e2e test by front end
-        organisation: Organisation = Organisation.objects.create(
-            name="Bullet Train Ltd"
-        )
-        org_admin: FFAdminUser = FFAdminUser.objects.create_user(
-            email=self.e2e_user,
-            password=self.password,
-            username=self.e2e_user,
-        )
-        org_admin.add_organisation(organisation, OrganisationRole.ADMIN)
-
-        project: Project = Project.objects.create(
-            name="My Test Project", organisation=organisation
-        )
-        Environment.objects.create(name="Development", project=project)
-        Environment.objects.create(name="Production", project=project)
-
-        # Upgrade organisation seats
-        Subscription.objects.filter(
-            organisation__in=org_admin.organisations.all()
-        ).update(max_seats=2)
+    # Upgrade organisation seats
+    Subscription.objects.filter(organisation__in=org_admin.organisations.all()).update(
+        max_seats=2
+    )

--- a/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
+++ b/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from app.settings.common import E2E_SIGNUP_USER, E2E_USER
 from organisations.models import Subscription
 from users.models import FFAdminUser
 
@@ -13,10 +12,11 @@ def test_e2e_teardown(settings, db) -> None:
     # TODO: tidy up this hack to fix throttle rates
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["signup"] = "1000/min"
     token = "test-token"
-    e2e_user_email = E2E_USER
-    e2e_user2_email = E2E_SIGNUP_USER
     register_url = "/api/v1/auth/users/"
 
+    print(
+        f"settings.E2E_SIGNUP_USER: {settings.E2E_USER},settings.E2E_SIGNUP_USER: {settings.E2E_SIGNUP_USER}"
+    )
     os.environ["E2E_TEST_AUTH_TOKEN"] = token
     os.environ["ENABLE_FE_E2E"] = "True"
 
@@ -25,7 +25,7 @@ def test_e2e_teardown(settings, db) -> None:
     # Register a user with the e2e test user email address
     test_password = FFAdminUser.objects.make_random_password()
     register_data = {
-        "email": e2e_user2_email,
+        "email": settings.E2E_SIGNUP_USER,
         "first_name": "test",
         "last_name": "test",
         "password": test_password,
@@ -37,10 +37,10 @@ def test_e2e_teardown(settings, db) -> None:
     # then test that we can teardown that user
     url = reverse(viewname="api-v1:e2etests:teardown")
     teardown_response = client.post(url)
-    e2e_user: FFAdminUser = FFAdminUser.objects.get(email=e2e_user_email)
+    e2e_user: FFAdminUser = FFAdminUser.objects.get(email=settings.E2E_USER)
     assert teardown_response.status_code == status.HTTP_204_NO_CONTENT
     assert e2e_user is not None
-    assert not FFAdminUser.objects.filter(email=e2e_user2_email).exists()
+    assert not FFAdminUser.objects.filter(email=settings.E2E_SIGNUP_USER).exists()
     for subscription in Subscription.objects.filter(
         organisation__in=e2e_user.organisations.all()
     ):

--- a/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
+++ b/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
@@ -1,31 +1,32 @@
-import json
 import os
+from typing import LiteralString
 
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from app.settings.common import E2E_SIGNUP_USER, E2E_USER
 from organisations.models import Subscription
 from users.models import FFAdminUser
 
 
-def test_e2e_teardown(settings, db):
+def test_e2e_teardown(settings, db) -> None:
     # TODO: tidy up this hack to fix throttle rates
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["signup"] = "1000/min"
     token = "test-token"
-    e2e_user_email = "test@example.com"
-    e2e_user2_email = e2e_user_email + ".io"
+    e2e_user_email: LiteralString = E2E_USER
+    e2e_user2_email: LiteralString = E2E_SIGNUP_USER
     register_url = "/api/v1/auth/users/"
 
     os.environ["E2E_TEST_AUTH_TOKEN"] = token
-    os.environ["FE_E2E_TEST_USER_EMAIL"] = e2e_user_email
+    os.environ["ENABLE_FE_E2E"] = "True"
 
     client = APIClient(HTTP_X_E2E_TEST_AUTH_TOKEN=token)
 
     # Register a user with the e2e test user email address
     test_password = FFAdminUser.objects.make_random_password()
     register_data = {
-        "email": os.environ["FE_E2E_TEST_USER_EMAIL"],
+        "email": e2e_user2_email,
         "first_name": "test",
         "last_name": "test",
         "password": test_password,
@@ -35,11 +36,16 @@ def test_e2e_teardown(settings, db):
     assert register_response.status_code == status.HTTP_201_CREATED
 
     # then test that we can teardown that user
-    url = reverse("api-v1:e2etests:teardown")
+    url = reverse(viewname="api-v1:e2etests:teardown")
     teardown_response = client.post(url)
+    e2e_user: FFAdminUser = FFAdminUser.objects.get(email=e2e_user_email)
     assert teardown_response.status_code == status.HTTP_204_NO_CONTENT
-    assert FFAdminUser.objects.filter(email=e2e_user_email).exists()
+    assert e2e_user is not None
     assert not FFAdminUser.objects.filter(email=e2e_user2_email).exists()
+    for subscription in Subscription.objects.filter(
+        organisation__in=e2e_user.organisations.all()
+    ):
+        assert subscription.max_seats == 2
 
 
 def test_e2e_teardown_with_incorrect_token(settings, db):
@@ -54,24 +60,3 @@ def test_e2e_teardown_with_incorrect_token(settings, db):
 
     # Then
     assert teardown_response.status_code == status.HTTP_401_UNAUTHORIZED
-
-
-def test_e2e_add_seats(settings, db, admin_user, organisation):
-    # Given
-    token = "test-token"
-    os.environ["E2E_TEST_AUTH_TOKEN"] = token
-    os.environ["FE_E2E_TEST_USER_EMAIL"] = admin_user.email
-
-    url = reverse("api-v1:e2etests:update-seats")
-    seats = 10
-
-    client = APIClient(HTTP_X_E2E_TEST_AUTH_TOKEN=token)
-
-    # When
-    update_seats_response = client.put(
-        url, data=json.dumps({"seats": seats}), content_type="application/json"
-    )
-
-    # Then
-    assert update_seats_response.status_code == status.HTTP_204_NO_CONTENT
-    assert Subscription.objects.get(organisation=organisation).max_seats == seats

--- a/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
+++ b/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
@@ -1,5 +1,4 @@
 import os
-from typing import LiteralString
 
 from django.urls import reverse
 from rest_framework import status
@@ -14,8 +13,8 @@ def test_e2e_teardown(settings, db) -> None:
     # TODO: tidy up this hack to fix throttle rates
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["signup"] = "1000/min"
     token = "test-token"
-    e2e_user_email: LiteralString = E2E_USER
-    e2e_user2_email: LiteralString = E2E_SIGNUP_USER
+    e2e_user_email = E2E_USER
+    e2e_user2_email = E2E_SIGNUP_USER
     register_url = "/api/v1/auth/users/"
 
     os.environ["E2E_TEST_AUTH_TOKEN"] = token

--- a/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
+++ b/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
@@ -14,6 +14,7 @@ def test_e2e_teardown(settings, db):
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["signup"] = "1000/min"
     token = "test-token"
     e2e_user_email = "test@example.com"
+    e2e_user2_email = e2e_user_email + ".io"
     register_url = "/api/v1/auth/users/"
 
     os.environ["E2E_TEST_AUTH_TOKEN"] = token
@@ -37,7 +38,8 @@ def test_e2e_teardown(settings, db):
     url = reverse("api-v1:e2etests:teardown")
     teardown_response = client.post(url)
     assert teardown_response.status_code == status.HTTP_204_NO_CONTENT
-    assert not FFAdminUser.objects.filter(email=e2e_user_email).exists()
+    assert FFAdminUser.objects.filter(email=e2e_user_email).exists()
+    assert not FFAdminUser.objects.filter(email=e2e_user2_email).exists()
 
 
 def test_e2e_teardown_with_incorrect_token(settings, db):

--- a/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
+++ b/api/e2etests/tests/end_to_end/test_integration_e2e_tests.py
@@ -13,12 +13,9 @@ def test_e2e_teardown(settings, db) -> None:
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["signup"] = "1000/min"
     token = "test-token"
     register_url = "/api/v1/auth/users/"
+    settings.ENABLE_FE_E2E = True
 
-    print(
-        f"settings.E2E_SIGNUP_USER: {settings.E2E_USER},settings.E2E_SIGNUP_USER: {settings.E2E_SIGNUP_USER}"
-    )
     os.environ["E2E_TEST_AUTH_TOKEN"] = token
-    os.environ["ENABLE_FE_E2E"] = "True"
 
     client = APIClient(HTTP_X_E2E_TEST_AUTH_TOKEN=token)
 
@@ -37,8 +34,8 @@ def test_e2e_teardown(settings, db) -> None:
     # then test that we can teardown that user
     url = reverse(viewname="api-v1:e2etests:teardown")
     teardown_response = client.post(url)
-    e2e_user: FFAdminUser = FFAdminUser.objects.get(email=settings.E2E_USER)
     assert teardown_response.status_code == status.HTTP_204_NO_CONTENT
+    e2e_user: FFAdminUser = FFAdminUser.objects.get(email=settings.E2E_USER)
     assert e2e_user is not None
     assert not FFAdminUser.objects.filter(email=settings.E2E_SIGNUP_USER).exists()
     for subscription in Subscription.objects.filter(

--- a/api/e2etests/urls.py
+++ b/api/e2etests/urls.py
@@ -1,11 +1,10 @@
 from django.conf.urls import url
 
-from .views import Teardown, UpdateSeats
+from .views import Teardown
 
 app_name = "e2etests"
 
 
 urlpatterns = [
     url(r"teardown/", Teardown.as_view(), name="teardown"),
-    url(r"update-seats/", UpdateSeats.as_view(), name="update-seats"),
 ]

--- a/api/e2etests/views.py
+++ b/api/e2etests/views.py
@@ -5,11 +5,10 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from environments.models import Environment
-from organisations.models import Organisation, OrganisationRole, Subscription
-from projects.models import Project
+from organisations.models import Subscription
 from users.models import FFAdminUser
 
+from .e2e_seed_data import E2ESeedData
 from .permissions import E2ETestPermission
 
 
@@ -19,31 +18,9 @@ class Teardown(APIView):
     authentication_classes = (TokenAuthentication,)
 
     def post(self, request):
-        # delete users created for e2e test by front end
-        fe_e2e_test_user_email = os.environ["FE_E2E_TEST_USER_EMAIL"]
-        password = "pbkdf2_sha256$260000$RuWdd52KA8sgO7taxBtRH1$N81RojtN9tVUp9vd8nyBthp7EJZ+NYFrjn2QCm76QME="
-        if fe_e2e_test_user_email:
-            FFAdminUser.objects.filter(email=fe_e2e_test_user_email).delete()
-            FFAdminUser.objects.filter(email=fe_e2e_test_user_email + ".io").delete()
-            FFAdminUser.objects.filter(email="changeMail@test.com").delete()
-
-        # create user and organisation for e2e test by front end
-        organisation = Organisation.objects.create(name="Bullet Train Ltd")
-        org_admin = FFAdminUser.objects.create(
-            email=fe_e2e_test_user_email,
-            password=password,
-            username=fe_e2e_test_user_email,
-        )
-        org_admin.add_organisation(organisation, OrganisationRole.ADMIN)
-
-        project = Project.objects.create(
-            name="My Test Project", organisation=organisation
-        )
-
-        Environment.objects.create(name="Development", project=project)
-
-        Environment.objects.create(name="Production", project=project)
-
+        e2e_seed_data = E2ESeedData()
+        e2e_seed_data.teardown()  # Llama al método teardown de E2ESeedData
+        e2e_seed_data.seed_data()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/api/e2etests/views.py
+++ b/api/e2etests/views.py
@@ -5,9 +5,6 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from organisations.models import Subscription
-from users.models import FFAdminUser
-
 from .e2e_seed_data import E2ESeedData
 from .permissions import E2ETestPermission
 
@@ -16,21 +13,12 @@ class Teardown(APIView):
     schema = None
     permission_classes = (E2ETestPermission,)
     authentication_classes = (TokenAuthentication,)
+    e2e_seed_data = E2ESeedData()
 
     def post(self, request):
-        e2e_seed_data = E2ESeedData()
-        e2e_seed_data.teardown()  # Llama al método teardown de E2ESeedData
-        e2e_seed_data.seed_data()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        if "ENABLE_FE_E2E" not in os.environ:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
-
-class UpdateSeats(APIView):
-    permission_classes = (E2ETestPermission,)
-    authentication_classes = (TokenAuthentication,)
-
-    def put(self, request):
-        user = FFAdminUser.objects.get(email=os.environ["FE_E2E_TEST_USER_EMAIL"])
-        Subscription.objects.filter(organisation__in=user.organisations.all()).update(
-            max_seats=request.data.get("seats", 3)
-        )
+        self.e2e_seed_data.teardown()
+        self.e2e_seed_data.seed_data()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/api/e2etests/views.py
+++ b/api/e2etests/views.py
@@ -5,7 +5,7 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .e2e_seed_data import E2ESeedData
+from .e2e_seed_data import seed_data, teardown
 from .permissions import E2ETestPermission
 
 
@@ -13,12 +13,11 @@ class Teardown(APIView):
     schema = None
     permission_classes = (E2ETestPermission,)
     authentication_classes = (TokenAuthentication,)
-    e2e_seed_data = E2ESeedData()
 
     def post(self, request):
         if "ENABLE_FE_E2E" not in os.environ:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        self.e2e_seed_data.teardown()
-        self.e2e_seed_data.seed_data()
+        teardown()
+        seed_data()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/api/e2etests/views.py
+++ b/api/e2etests/views.py
@@ -1,5 +1,4 @@
-import os
-
+from django.conf import settings
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
@@ -15,7 +14,7 @@ class Teardown(APIView):
     authentication_classes = (TokenAuthentication,)
 
     def post(self, request):
-        if "ENABLE_FE_E2E" not in os.environ:
+        if not settings.ENABLE_FE_E2E:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         teardown()

--- a/frontend/.testcaferc.js
+++ b/frontend/.testcaferc.js
@@ -1,7 +1,6 @@
 const isDev = process.env.E2E_DEV;
 module.exports = {
     "browsers": "firefox:headless",
-    "concurrency": 3,
     "port1": 8080,
     "port2": 8081,
     "hostname": "localhost",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,9 +7,13 @@ USER node
 
 WORKDIR /srv/bt
 
-COPY --chown=node:node . .
+COPY --chown=node:node package.json package-lock.json .npmrc .nvmrc ./
+COPY --chown=node:node bin/ ./bin/
+COPY --chown=node:node env/ ./env/
 
 RUN npm ci --quiet --production
+
+COPY --chown=node:node . .
 ENV ENV=prod
 RUN npm run bundle
 

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -3,7 +3,7 @@ FROM ghcr.io/flagsmith/e2e-frontend-base:latest
 # Build Flagsmith
 WORKDIR /srv/flagsmith
 COPY . .
-RUN npm cache clean --force
+# RUN npm cache clean --force
 RUN npm ci
 
 ENV ENV=e2e

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -12,5 +12,6 @@ RUN npm ci
 
 
 COPY . .
+RUN npm run env
 
 CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -6,14 +6,11 @@ COPY package.json package-lock.json .npmrc .nvmrc ./
 COPY bin/ ./bin/
 COPY env/ ./env/
 
-# Run npm ci before copying source code to improve caching of layers. Cache clean no needed?
-# RUN npm cache clean --force
+# Run npm ci before copying source code to improve caching of layers. No need to clean cache.
 ENV ENV=e2e
 RUN npm ci
 
 
 COPY . .
-# Commented because it is already executed on the postinstall hook of npm ci
-# RUN npm run env
 
 CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -2,11 +2,18 @@ FROM ghcr.io/flagsmith/e2e-frontend-base:latest
 
 # Build Flagsmith
 WORKDIR /srv/flagsmith
-COPY . .
+COPY package.json package-lock.json .npmrc .nvmrc ./
+COPY bin/ ./bin/
+COPY env/ ./env/
+
+# Run npm ci before copying source code to improve caching of layers. Cache clean no needed?
 # RUN npm cache clean --force
+ENV ENV=e2e
 RUN npm ci
 
-ENV ENV=e2e
-RUN npm run env
+
+COPY . .
+# Commented because it is already executed on the postinstall hook of npm ci
+# RUN npm run env
 
 CMD ["bash", "-l"]

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -6,7 +6,7 @@ COPY package.json package-lock.json .npmrc .nvmrc ./
 COPY bin/ ./bin/
 COPY env/ ./env/
 
-# Run npm ci before copying source code to improve caching of layers. No need to clean cache.
+# Run npm ci before copying source code to improve caching of layers.
 ENV ENV=e2e
 RUN npm ci
 

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -28,9 +28,9 @@ services:
       dockerfile: Dockerfile
       x-bake:
         cache-from:
-          - type=gha
+          - type=gha,scope=image-e2e-unified-api
         cache-to:
-          - type=gha,mode=max
+          - type=gha,mode=max,scope=image-e2e-unified-api
         tags:
           - frontend_flagsmith-api
     environment:
@@ -54,9 +54,9 @@ services:
       dockerfile: Dockerfile.e2e
       x-bake:
         cache-from:
-          - type=gha,scope=unified-fe-$GITHUB_BASE_REF-$GITHUB_REF_NAME
+          - type=gha,scope=image-e2e-unified-fe
         cache-to:
-          - type=gha,mode=max,scope=unified-fe-$GITHUB_BASE_REF-$GITHUB_REF_NAME
+          - type=gha,mode=max,scope=image-e2e-unified-fe
         tags:
           - frontend_frontend
     platform: linux/amd64

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -11,16 +11,6 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: flagsmith
     container_name: flagsmith_postgres
-    # build:
-    #   context: ../
-    #   dockerfile: Dockerfile
-    #   x-bake:
-    #     cache-from:
-    #       - type=gha
-    #     cache-to:
-    #       - type=gha,mode=max
-    #     tags:
-    #       - postgres:11.12-alpine
 
   flagsmith-api:
     build:

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -30,13 +30,19 @@ services:
       DATABASE_URL: postgresql://postgres:password@db:5432/flagsmith
       DISABLE_ANALYTICS_FEATURES: 'true'
       EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+      ACCESS_LOG_LOCATION: /dev/shm/log.txt
     ports:
       - 8000:8000
     depends_on:
-      db:
-        condition: service_started
+      - db
     links:
       - db:db
+    healthcheck:
+      test: "[ -e /dev/shm/log.txt ] && exit 0 || exit 1"
+      start_period: 60s
+      interval: 10s
+      timeout: 3s
+      retries: 30
 
   frontend:
     build:
@@ -59,7 +65,7 @@ services:
       - 8080:8080
     depends_on:
       flagsmith-api:
-        condition: service_started
+        condition: service_healthy
 
     links:
       - flagsmith-api:flagsmith-api

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -11,11 +11,28 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: flagsmith
     container_name: flagsmith_postgres
+    # build:
+    #   context: ../
+    #   dockerfile: Dockerfile
+    #   x-bake:
+    #     cache-from:
+    #       - type=gha
+    #     cache-to:
+    #       - type=gha,mode=max
+    #     tags:
+    #       - postgres:11.12-alpine
 
   flagsmith-api:
     build:
       context: ../
       dockerfile: Dockerfile
+      x-bake:
+        cache-from:
+          - type=gha
+        cache-to:
+          - type=gha,mode=max
+        tags:
+          - frontend_flagsmith-api
     environment:
       E2E_TEST_AUTH_TOKEN: some-token
       FE_E2E_TEST_USER_EMAIL: nightwatch@solidstategroup.com
@@ -26,7 +43,8 @@ services:
     ports:
       - 8000:8000
     depends_on:
-      - db
+      db:
+        condition: service_started
     links:
       - db:db
 
@@ -34,6 +52,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.e2e
+      x-bake:
+        cache-from:
+          - type=gha,scope=unified-fe-$GITHUB_BASE_REF-$GITHUB_REF_NAME
+        cache-to:
+          - type=gha,mode=max,scope=unified-fe-$GITHUB_BASE_REF-$GITHUB_REF_NAME
+        tags:
+          - frontend_frontend
     platform: linux/amd64
     environment:
       E2E_TEST_TOKEN_DEV: some-token
@@ -43,7 +68,9 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      - flagsmith-api
+      flagsmith-api:
+        condition: service_started
+
     links:
       - flagsmith-api:flagsmith-api
     command: [npm, run, test]

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -25,7 +25,7 @@ services:
           - frontend_flagsmith-api
     environment:
       E2E_TEST_AUTH_TOKEN: some-token
-      FE_E2E_TEST_USER_EMAIL: nightwatch@solidstategroup.com
+      ENABLE_FE_E2E: 'True'
       DJANGO_ALLOWED_HOSTS: '*'
       DATABASE_URL: postgresql://postgres:password@db:5432/flagsmith
       DISABLE_ANALYTICS_FEATURES: 'true'

--- a/frontend/e2e/config.ts
+++ b/frontend/e2e/config.ts
@@ -1,0 +1,5 @@
+const E2E_EMAIL_DOMAIN = 'flagsmithe2etestdomain.io'
+export const E2E_SIGN_UP_USER = `e2e_signup_user@${E2E_EMAIL_DOMAIN}`
+export const E2E_USER = `e2e_user@${E2E_EMAIL_DOMAIN}`
+export const E2E_CHANGE_MAIL = `e2e_change_email@${E2E_EMAIL_DOMAIN}`
+export const PASSWORD = 'str0ngp4ssw0rd!'

--- a/frontend/e2e/helpers.cafe.ts
+++ b/frontend/e2e/helpers.cafe.ts
@@ -27,8 +27,10 @@ export const waitForElementVisible = async (selector:string) => {
 
 export const logResults = async (requests:LoggedRequest[], t)=> {
     if(!t.testRun?.errs?.length) {
+        log('Finished without errors')
         return // do not log anything for passed tests
     }
+    log('Start of Requests')
     log(undefined, undefined, JSON.stringify(requests.filter((v)=>{
         if(v.request?.url?.includes("get-subscription-metadata") || v.request?.url?.includes("analytics/flags")) {
             return false
@@ -40,6 +42,7 @@ export const logResults = async (requests:LoggedRequest[], t)=> {
     }), null, 2));
     log(undefined, undefined, "Session JavaScript Errors")
     log(undefined, undefined, JSON.stringify((await t.getBrowserConsoleMessages())));
+    log('End of Requests')
 }
 
 export const waitForElementNotExist = async (selector:string) => {

--- a/frontend/e2e/index.cafe.js
+++ b/frontend/e2e/index.cafe.js
@@ -29,6 +29,8 @@ createTestCafe()
         const runner = testcafe.createRunner()
         const args = process.argv.splice(2).map(value => value.toLowerCase());
         console.log('Filter tests:', args)
+        const concurrentInstances = process.env.E2E_CONCURRENCY ?? 3
+        console.log('E2E Concurrency:', concurrentInstances)
 
         return runner
             .clientScripts('e2e/add-error-logs.js')
@@ -40,6 +42,7 @@ createTestCafe()
                 return args.includes(testName.toLowerCase())
                 }
             })
+            .concurrency(parseInt(concurrentInstances))
             .run(options)
     })
     .then(async (v) => {

--- a/frontend/e2e/index.cafe.js
+++ b/frontend/e2e/index.cafe.js
@@ -36,7 +36,7 @@ createTestCafe()
             .clientScripts('e2e/add-error-logs.js')
             .src(['./e2e/init.cafe.js'])
             .filter(testName => {
-                if (!args.length || testName.toLowerCase() === 'signup') {
+                if (!args.length) {
                     return true
                 } else {
                 return args.includes(testName.toLowerCase())

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -14,7 +14,16 @@ import flagTests from './tests/flag-tests'
 require('dotenv').config()
 
 const url = `http://localhost:${process.env.PORT || 8080}/`
+const e2eTestApi = `${Project.api}e2etests/teardown/`
 const logger = getLogger()
+
+console.log(
+  '\n',
+  '\x1b[32m',
+  `E2E using API: ${e2eTestApi}. E2E URL: ${url}`,
+  '\x1b[0m',
+  '\n',
+)
 
 fixture`E2E Tests`.requestHooks(logger).before(async () => {
   const token = process.env.E2E_TEST_TOKEN
@@ -22,7 +31,7 @@ fixture`E2E Tests`.requestHooks(logger).before(async () => {
     : process.env[`E2E_TEST_TOKEN_${Project.env.toUpperCase()}`]
 
   if (token) {
-    await fetch(`${Project.api}e2etests/teardown/`, {
+    await fetch(e2eTestApi, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -7,7 +7,7 @@ import { getLogger, logout, logResults } from './helpers.cafe'
 import environmentTest from './tests/environment-test'
 import inviteTest from './tests/invite-test'
 import projectTest from './tests/project-test'
-import {testSegment1, testSegment2} from './tests/segment-test'
+import { testSegment1, testSegment2, testSegment3 } from './tests/segment-test'
 import initialiseTests from './tests/initialise-tests'
 import flagTests from './tests/flag-tests'
 
@@ -80,6 +80,11 @@ test('Segment-part-1', async () => {
 
 test('Segment-part-2', async () => {
   await testSegment2()
+  await logout()
+})
+
+test('Segment-part-3', async () => {
+  await testSegment3()
   await logout()
 })
 

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -67,10 +67,8 @@ fixture`E2E Tests`.requestHooks(logger).before(async () => {
   .beforeEach(async () => {
     await waitForReact()
   })
-  .after(async (t) => {
-    console.log('Start of Initialise Requests')
+  .afterEach(async (t) => {
     await logResults(logger.requests, t)
-    console.log('End of Initialise Requests')
   })
 
 test('Segment-part-1', async () => {

--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -1,9 +1,9 @@
 import fetch from 'node-fetch'
-import { t, test, fixture } from 'testcafe'
+import { test, fixture } from 'testcafe'
 import { waitForReact } from 'testcafe-react-selectors'
 
 import Project from '../common/project'
-import { getLogger, log, logout, logResults } from './helpers.cafe'
+import { getLogger, logout, logResults } from './helpers.cafe'
 import environmentTest from './tests/environment-test'
 import inviteTest from './tests/invite-test'
 import projectTest from './tests/project-test'

--- a/frontend/e2e/tests/environment-test.ts
+++ b/frontend/e2e/tests/environment-test.ts
@@ -1,24 +1,30 @@
-import { byId, click, log, login, setText, waitForElementVisible } from '../helpers.cafe';
+import {
+  byId,
+  click,
+  log,
+  login,
+  setText,
+  waitForElementVisible,
+} from '../helpers.cafe'
+import { PASSWORD, E2E_USER } from '../config'
 
-const email = 'nightwatch@solidstategroup.com';
-const password = 'str0ngp4ssw0rd!';
-export default async function() {
-    log('Login');
-    await login(email, password);
-    await click('#project-select-0');
-    log('Create environment');
-    await click('#create-env-link');
-    await setText('[name="envName"]', 'Staging');
-    await click('#create-env-btn');
-    await waitForElementVisible(byId('switch-environment-staging-active'));
-    log('Edit Environment');
-    await click('#env-settings-link');
-    await setText("[name='env-name']", 'Internal');
-    await click('#save-env-btn');
-    await waitForElementVisible(byId('switch-environment-internal-active'));
-    log('Delete environment');
-    await click('#delete-env-btn');
-    await setText("[name='confirm-env-name']", 'Internal');
-    await click('#confirm-delete-env-btn');
-    await waitForElementVisible(byId('features-page'));
+export default async function () {
+  log('Login')
+  await login(E2E_USER, PASSWORD)
+  await click('#project-select-0')
+  log('Create environment')
+  await click('#create-env-link')
+  await setText('[name="envName"]', 'Staging')
+  await click('#create-env-btn')
+  await waitForElementVisible(byId('switch-environment-staging-active'))
+  log('Edit Environment')
+  await click('#env-settings-link')
+  await setText("[name='env-name']", 'Internal')
+  await click('#save-env-btn')
+  await waitForElementVisible(byId('switch-environment-internal-active'))
+  log('Delete environment')
+  await click('#delete-env-btn')
+  await setText("[name='confirm-env-name']", 'Internal')
+  await click('#confirm-delete-env-btn')
+  await waitForElementVisible(byId('features-page'))
 }

--- a/frontend/e2e/tests/flag-tests.ts
+++ b/frontend/e2e/tests/flag-tests.ts
@@ -14,14 +14,12 @@ import {
   waitForElementVisible,
 } from '../helpers.cafe'
 import { t } from 'testcafe'
-
-const email = 'nightwatch@solidstategroup.com'
-const password = 'str0ngp4ssw0rd!'
+import { E2E_USER, PASSWORD } from '../config'
 
 export default async function () {
-  log('Login');
-  await login(email, password);
-  await click('#project-select-0');
+  log('Login')
+  await login(E2E_USER, PASSWORD)
+  await click('#project-select-0')
 
   log('Create Features')
   await click('#features-link')
@@ -104,5 +102,4 @@ export default async function () {
   log('Clear down features')
   await deleteFeature(1, 'header_size')
   await deleteFeature(0, 'header_enabled')
-
 }

--- a/frontend/e2e/tests/initialise-tests.ts
+++ b/frontend/e2e/tests/initialise-tests.ts
@@ -1,37 +1,34 @@
 import {
-    byId,
-    click,
-    log,
-    setText,
-    waitForElementVisible,
-} from '../helpers.cafe';
+  byId,
+  click,
+  log,
+  setText,
+  waitForElementVisible,
+} from '../helpers.cafe'
+import { E2E_SIGN_UP_USER, PASSWORD } from '../config'
 
-const email = 'nightwatch@solidstategroup.com';
-const password = 'str0ngp4ssw0rd!';
+export default async function () {
+  log('Create Organisation')
+  await click(byId('jsSignup'))
+  await setText(byId('firstName'), 'Bullet') // visit the url
+  await setText(byId('lastName'), 'Train') // visit the url
+  await setText(byId('email'), E2E_SIGN_UP_USER) // visit the url
+  await setText(byId('password'), PASSWORD) // visit the url
+  await click(byId('signup-btn'))
+  await setText('[name="orgName"]', 'Bullet Train Ltd 0')
+  await click('#create-org-btn')
+  await waitForElementVisible(byId('project-select-page'))
 
-export default async function() {
-    log('Create Organisation');
-    await click(byId('jsSignup'));
-    await setText(byId('firstName'), 'Bullet'); // visit the url
-    await setText(byId('lastName'), 'Train'); // visit the url
-    await setText(byId('email'), email + '.io'); // visit the url
-    await setText(byId('password'), password); // visit the url
-    await click(byId('signup-btn'));
-    await setText('[name="orgName"]', 'Bullet Train Ltd 0');
-    await click('#create-org-btn');
-    await waitForElementVisible(byId('project-select-page'));
+  log('Create Project')
+  await click(byId('create-first-project-btn'))
+  await setText(byId('projectName'), 'My Test Project')
+  await click(byId('create-project-btn'))
+  await waitForElementVisible(byId('features-page'))
 
-    log('Create Project');
-    await click(byId('create-first-project-btn'));
-    await setText(byId('projectName'), 'My Test Project');
-    await click(byId('create-project-btn'));
-    await waitForElementVisible((byId('features-page')));
-
-    log('Hide disabled flags');
-    await click('#project-settings-link');
-    await click(byId('js-sdk-settings'));
-    await click(byId('js-hide-disabled-flags'));
-    await setText(byId('js-project-name'), 'My Test Project');
-    await click(byId('js-confirm'));
-
+  log('Hide disabled flags')
+  await click('#project-settings-link')
+  await click(byId('js-sdk-settings'))
+  await click(byId('js-hide-disabled-flags'))
+  await setText(byId('js-project-name'), 'My Test Project')
+  await click(byId('js-confirm'))
 }

--- a/frontend/e2e/tests/invite-test.ts
+++ b/frontend/e2e/tests/invite-test.ts
@@ -7,53 +7,14 @@ import {
   setText,
   waitForElementVisible,
 } from '../helpers.cafe'
-import Project from '../../common/project'
-import fetch from 'node-fetch'
 import { Selector, t } from 'testcafe'
+import { E2E_CHANGE_MAIL, E2E_USER, PASSWORD } from '../config'
 
 const invitePrefix = `flagsmith${new Date().valueOf()}`
 const inviteEmail = `${invitePrefix}@restmail.net`
-const email = 'nightwatch@solidstategroup.com'
-const newEmail = 'changeMail@test.com'
-const password = 'str0ngp4ssw0rd!'
 export default async function () {
   log('Login')
-  await login(email, password)
-  const token = process.env.E2E_TEST_TOKEN
-    ? process.env.E2E_TEST_TOKEN
-    : process.env[`E2E_TEST_TOKEN_${Project.env.toUpperCase()}`]
-  if (token) {
-    await fetch(`${Project.api}e2etests/update-seats/`, {
-      method: 'PUT',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'X-E2E-Test-Auth-Token': token.trim(),
-      },
-      body: JSON.stringify({ seats: 2 }),
-    }).then((res) => {
-      if (res.ok) {
-        // eslint-disable-next-line no-console
-        console.log(
-          '\n',
-          '\x1b[32m',
-          'update-seats successful',
-          '\x1b[0m',
-          '\n',
-        )
-      } else {
-        // eslint-disable-next-line no-console
-        console.error(
-          '\n',
-          '\x1b[31m',
-          'update-seats failed',
-          res.status,
-          '\x1b[0m',
-          '\n',
-        )
-      }
-    })
-  }
+  await login(E2E_USER, PASSWORD)
   log('Get Invite url')
   await t.navigateTo('http://localhost:3000/organisation-settings')
   await Selector(byId('organisation-name')).value
@@ -64,20 +25,20 @@ export default async function () {
   await setText(byId('firstName'), 'Bullet') // visit the url
   await setText(byId('lastName'), 'Train')
   await setText(byId('email'), inviteEmail)
-  await setText(byId('password'), password)
+  await setText(byId('password'), PASSWORD)
   await waitForElementVisible(byId('signup-btn'))
   await click(byId('signup-btn'))
   log('Change email')
   await click(byId('account-settings-link'))
   await click(byId('change-email-button'))
-  await setText("[name='EmailAddress']", newEmail)
-  await setText("[name='newPassword']", password)
+  await setText("[name='EmailAddress']", E2E_CHANGE_MAIL)
+  await setText("[name='newPassword']", PASSWORD)
   await click('#save-changes')
-  await login(newEmail, password)
+  await login(E2E_CHANGE_MAIL, PASSWORD)
   log('Delete invite user')
   await assertTextContent('[id=account-settings-link]', 'Account')
   await click(byId('account-settings-link'))
   await click(byId('delete-user-btn'))
-  await setText("[name='currentPassword']", password)
+  await setText("[name='currentPassword']", PASSWORD)
   await click(byId('delete-account'))
 }

--- a/frontend/e2e/tests/project-test.ts
+++ b/frontend/e2e/tests/project-test.ts
@@ -1,15 +1,20 @@
-import { byId, click, log, login, setText, waitForElementVisible } from '../helpers.cafe';
+import {
+  byId,
+  click,
+  log,
+  login,
+  setText,
+  waitForElementVisible,
+} from '../helpers.cafe'
+import { E2E_USER, PASSWORD } from '../config'
 
-const email = 'nightwatch@solidstategroup.com';
-const password = 'str0ngp4ssw0rd!';
-export default async function() {
-    log('Login', 'Project Test');
-    await login(email, password);
-    await click('#project-select-0');
-    log('Edit Project', 'Project Test');
-    await click('#project-settings-link');
-    await setText("[name='proj-name']", 'Test Project');
-    await click('#save-proj-btn');
-    await waitForElementVisible(byId('switch-project-test-project'));
-
+export default async function () {
+  log('Login', 'Project Test')
+  await login(E2E_USER, PASSWORD)
+  await click('#project-select-0')
+  log('Edit Project', 'Project Test')
+  await click('#project-settings-link')
+  await setText("[name='proj-name']", 'Test Project')
+  await click('#save-proj-btn')
+  await waitForElementVisible(byId('switch-project-test-project'))
 }

--- a/frontend/e2e/tests/segment-test.ts
+++ b/frontend/e2e/tests/segment-test.ts
@@ -240,6 +240,24 @@ export const testSegment2 = async () => {
   await gotoFeatures()
   await deleteFeature(1, 'flag')
   await deleteFeature(0, 'config')
+}
+
+export const testSegment3 = async () => {
+  log('Login')
+  await login(email, password)
+
+  log('Create Organisation')
+  await click(byId('create-organisation-btn'))
+  await setText('[name="orgName"]', 'Bullet Train Ltd 4')
+  await click('#create-org-btn')
+  await waitForElementVisible(byId('project-select-page'))
+
+  log('Create Project')
+
+  await click('.btn-project-create')
+  await setText(byId('projectName'), 'My Segment Test Project 3')
+  await click(byId('create-project-btn'))
+  await waitForElementVisible(byId('features-page'))
 
   log('Create features')
   await gotoFeatures()

--- a/frontend/e2e/tests/segment-test.ts
+++ b/frontend/e2e/tests/segment-test.ts
@@ -26,13 +26,11 @@ import {
   waitAndRefresh,
   waitForElementVisible,
 } from '../helpers.cafe'
-
-const email = 'nightwatch@solidstategroup.com'
-const password = 'str0ngp4ssw0rd!'
+import { E2E_USER, PASSWORD } from '../config'
 
 export const testSegment1 = async () => {
   log('Login')
-  await login(email, password)
+  await login(E2E_USER, PASSWORD)
 
   log('Create Organisation')
   await click(byId('create-organisation-btn'))
@@ -147,7 +145,7 @@ export const testSegment1 = async () => {
 
 export const testSegment2 = async () => {
   log('Login')
-  await login(email, password)
+  await login(E2E_USER, PASSWORD)
 
   log('Create Organisation')
   await click(byId('create-organisation-btn'))
@@ -244,7 +242,7 @@ export const testSegment2 = async () => {
 
 export const testSegment3 = async () => {
   log('Login')
-  await login(email, password)
+  await login(E2E_USER, PASSWORD)
 
   log('Create Organisation')
   await click(byId('create-organisation-btn'))

--- a/frontend/env/project_prod.js
+++ b/frontend/env/project_prod.js
@@ -1,3 +1,5 @@
+import { E2E_CHANGE_MAIL, E2E_SIGN_UP_USER, E2E_USER } from '../e2e/config'
+
 const globalThis = typeof window === 'undefined' ? global : window
 module.exports = global.Project = {
   api: 'https://api.flagsmith.com/api/v1/',
@@ -10,7 +12,7 @@ module.exports = global.Project = {
 
   env: 'prod',
 
-  excludeAnalytics: 'nightwatch@solidstategroup.com',
+  excludeAnalytics: [E2E_SIGN_UP_USER, E2E_USER, E2E_CHANGE_MAIL],
 
   // This is our Bullet Train API key - Bullet Train runs on Bullet Train!
   flagsmith: '4vfqhypYjcPoGGu8ByrBaj',

--- a/frontend/web/project/api.js
+++ b/frontend/web/project/api.js
@@ -40,7 +40,7 @@ global.API = {
       })
   },
   alias(id, user = {}) {
-    if (id === Project.excludeAnalytics) return
+    if (Project.excludeAnalytics?.includes(id)) return
     if (Project.mixpanel) {
       mixpanel.alias(id)
     }
@@ -114,7 +114,7 @@ global.API = {
     }
   },
   identify(id, user = {}) {
-    if (id === Project.excludeAnalytics) return
+    if (Project.excludeAnalytics?.includes(id)) return
     try {
       const orgs =
         (user &&
@@ -205,7 +205,7 @@ global.API = {
     })
   },
   register(email, firstName, lastName) {
-    if (email === Project.excludeAnalytics) return
+    if (Project.excludeAnalytics?.includes(email)) return
     if (Project.mixpanel) {
       mixpanel.register({
         'Email': email,

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -68,8 +68,8 @@
                     "value": "flagsmith_environments"
                 },
                 {
-                    "name": "FE_E2E_TEST_USER_EMAIL",
-                    "value": "nightwatch@solidstategroup.com"
+                    "name": "ENABLE_FE_E2E",
+                    "value": "True"
                 },
                 {
                     "name": "GITHUB_CLIENT_ID",
@@ -169,7 +169,7 @@
                 },
                 {
                     "name": "PIPEDRIVE_IGNORE_DOMAINS",
-                    "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io"
+                    "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io,flagsmithe2etestdomain.io"
                 },
                 {
                     "name":"EDGE_API_URL",

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -72,8 +72,8 @@
                     "value": "flagsmith_environments"
                 },
                 {
-                    "name": "FE_E2E_TEST_USER_EMAIL",
-                    "value": "nightwatch@solidstategroup.com"
+                    "name": "ENABLE_FE_E2E",
+                    "value": "True"
                 },
                 {
                     "name": "GITHUB_CLIENT_ID",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Tests are now split into:
- Segment-part-1
- Segment-part-2
- Segment-part-3
- Flag
- Signup
- Invite
- Project

### Improvements

- Tests can now be executed in concurrent (multiple browsers) mode locally and in Github Actions, and in parallel mode (multiple jobs) in Github Actions.
- Since tests are now split, it is easier to find the error in the video and the logs.
- Now you need to re-run only the tests failing not the whole set of E2E tests
- The total time of execution is about half of the prior version.
- We are using Docker BuildX in every job and step and we are caching layers to speedup the process.

### Concurrency
By default, the E2E tests are executed in concurrent mode with **3** browsers.

### Usage
#### Running all tests in the local dev environment:
In order to run all the E2E tests set the necessary environment variables:
For the API:
```
export E2E_TEST_AUTH_TOKEN='some-token'
export ENABLE_FE_E2E='True'
export FLAGSMITH_API_URL=http://127.0.0.1:8000/api/v1/
```
For the Frontend:
```
export FLAGSMITH_API_URL=http://127.0.0.1:8000/api/v1/
export E2E_TEST_TOKEN='some-token' # Only if it is a different environment from API
export ENV=local
npm run env (execute only once with ENV=local)
```
and execute:
```
npm run test:devBundle
```
#### Running only `Invite `and `Environment` E2E tests with two browsers, notice that you can use lowercased test names:
`ENV=local npx cross-env E2E_CONCURRENCY=2 npm run test:devBundle -- invite environment
`

### Running E2E tests in a container (no need to have node installed)
In the frontend folder:
```
docker buildx bake -f docker-compose-e2e-tests.yml
docker compose -f docker-compose-e2e-tests.yml run frontend npm run test
```
### Notes

- While the most common sources of flaky tests were solved, React node not being completely rendered, and button not being hit, and some events results not being verified before moving to the next test action, there could still be some flaky tests, however, now should be easier to detect them as well as simply re-run flaky tests.
- Segment-part-2, Segment-part-1, and Flags are long-lasting E2E tests, although the two segments take much more than Flags. Because of that, 3 browsers are configured by default, since Segments-part-2 last almost the same as Segment-part-1, which takes almost the same time as the rest of the tests.

## How did you test this code?

Tested during Github Actions CI/CD execution
