### PR TITLE
feat: Home page announcement

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -212,8 +212,9 @@ const App = class extends Component {
     this.context.router.history.replace('/')
   }
 
-  closeAnnouncement = () => {
-    this.setState({ showAnnouncement: !this.state.showAnnouncement })
+  closeAnnouncement = (announcementId) => {
+    this.setState({ showAnnouncement: false })
+    flagsmith.setTrait(`dismissed_announcement`, announcementId)
   }
 
   render() {
@@ -283,8 +284,10 @@ const App = class extends Component {
       return <div>{this.props.children}</div>
     }
     const announcementValue = JSON.parse(
-      Utils.getFlagsmithValue('announcement_manage'),
+      Utils.getFlagsmithValue('announcement'),
     )
+    const dismissed = flagsmith.getTrait('dismissed_announcement')
+    const showBanner = !dismissed || dismissed !== announcementValue.id
 
     return (
       <Provider store={getStore()}>
@@ -481,17 +484,19 @@ const App = class extends Component {
                         </div>
                       ) : (
                         <Fragment>
-                          {Utils.getFlagsmithHasFeature(
-                            'announcement_manage',
-                          ) &&
+                          {showBanner &&
+                            Utils.getFlagsmithHasFeature('announcement') &&
                             this.state.showAnnouncement && (
                               <Row>
                                 <InfoMessage
                                   title={announcementValue.title}
-                                  infoMessageClass={'announcement '}
-                                  isClosable
-                                  close={this.closeAnnouncement}
+                                  infoMessageClass={'announcement'}
+                                  isClosable={announcementValue.isClosable}
+                                  close={() =>
+                                    this.closeAnnouncement(announcementValue.id)
+                                  }
                                   buttonText={announcementValue.buttonText}
+                                  url={announcementValue.url}
                                 >
                                   <div>
                                     <div>{announcementValue.description}</div>

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { matchPath } from 'react-router'
 import { withRouter } from 'react-router-dom'
 import amplitude from 'amplitude-js'
@@ -22,6 +22,7 @@ import { getOrganisationUsage } from 'common/services/useOrganisationUsage'
 import Button from './base/forms/Button'
 import Icon from 'components/Icon'
 import AccountStore from 'common/stores/account-store'
+import InfoMessage from './InfoMessage'
 
 const App = class extends Component {
   static propTypes = {
@@ -38,6 +39,7 @@ const App = class extends Component {
     lastEnvironmentId: '',
     lastProjectId: '',
     pin: '',
+    showAnnouncement: true,
     totalApiCalls: 0,
   }
 
@@ -210,6 +212,10 @@ const App = class extends Component {
     this.context.router.history.replace('/')
   }
 
+  closeAnnouncement = () => {
+    this.setState({ showAnnouncement: !this.state.showAnnouncement })
+  }
+
   render() {
     if (
       Utils.getFlagsmithHasFeature('dark_mode') &&
@@ -276,6 +282,9 @@ const App = class extends Component {
     if (document.location.href.includes('widget')) {
       return <div>{this.props.children}</div>
     }
+    const announcementValue = JSON.parse(
+      Utils.getFlagsmithValue('announcement_manage'),
+    )
 
     return (
       <Provider store={getStore()}>
@@ -471,7 +480,27 @@ const App = class extends Component {
                           <Loader />
                         </div>
                       ) : (
-                        this.props.children
+                        <Fragment>
+                          {Utils.getFlagsmithHasFeature(
+                            'announcement_manage',
+                          ) &&
+                            this.state.showAnnouncement && (
+                              <Row>
+                                <InfoMessage
+                                  title={announcementValue.title}
+                                  infoMessageClass={'announcement '}
+                                  isClosable
+                                  close={this.closeAnnouncement}
+                                  buttonText={announcementValue.buttonText}
+                                >
+                                  <div>
+                                    <div>{announcementValue.description}</div>
+                                  </div>
+                                </InfoMessage>
+                              </Row>
+                            )}
+                          {this.props.children}
+                        </Fragment>
                       )}
                     </div>
                   )}

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -484,7 +484,8 @@ const App = class extends Component {
                         </div>
                       ) : (
                         <Fragment>
-                          {showBanner &&
+                          {user &&
+                            showBanner &&
                             Utils.getFlagsmithHasFeature('announcement') &&
                             this.state.showAnnouncement && (
                               <Row>

--- a/frontend/web/components/InfoMessage.js
+++ b/frontend/web/components/InfoMessage.js
@@ -6,15 +6,26 @@ export default class InfoMessage extends PureComponent {
   static displayName = 'InfoMessage'
 
   render() {
+    const infoMessageClass = `alert alert-info ${
+      this.props.infoMessageClass || 'flex-1'
+    }`
     return (
-      <div className='alert alert-info flex-1'>
+      <div className={infoMessageClass}>
         <span className='icon-alert'>
           <Icon name='info' />
         </span>
         <div>
           <div className='title'>{this.props.title || 'NOTE'}</div>
-          {this.props.children}
+          <div className={`${this.props.infoMessageClass} body`}>
+            {this.props.children}
+          </div>
         </div>
+        <Button className='my-2'>{this.props.buttonText}</Button>
+        {this.props.isClosable && (
+          <a onClick={this.props.close} className='mt-n2 mr-n2'>
+            <span className='icon ion-md-close' />
+          </a>
+        )}
       </div>
     )
   }

--- a/frontend/web/components/InfoMessage.js
+++ b/frontend/web/components/InfoMessage.js
@@ -5,24 +5,37 @@ import Icon from './Icon'
 export default class InfoMessage extends PureComponent {
   static displayName = 'InfoMessage'
 
+  handleOpenNewWindow = () => {
+    window.open(this.props.url, '_blank')
+    if (this.props.isClosable) {
+     this.props.close()
+    }
+  }
+
   render() {
     const infoMessageClass = `alert alert-info ${
       this.props.infoMessageClass || 'flex-1'
     }`
+    const titleDescClass = this.props.infoMessageClass
+      ? `${this.props.infoMessageClass} body mr-2`
+      : ''
+
     return (
       <div className={infoMessageClass}>
         <span className='icon-alert'>
           <Icon name='info' />
         </span>
-        <div>
+        <div className={titleDescClass}>
           <div className='title'>{this.props.title || 'NOTE'}</div>
-          <div className={`${this.props.infoMessageClass} body`}>
-            {this.props.children}
-          </div>
+          {this.props.children}
         </div>
-        <Button className='my-2'>{this.props.buttonText}</Button>
+        {this.props.url && (
+          <Button className='btn my-2' onClick={this.handleOpenNewWindow}>
+            {this.props.buttonText}
+          </Button>
+        )}
         {this.props.isClosable && (
-          <a onClick={this.props.close} className='mt-n2 mr-n2'>
+          <a onClick={this.props.close} className='mt-n2 mr-n2 pl-2'>
             <span className='icon ion-md-close' />
           </a>
         )}

--- a/frontend/web/project/toast.js
+++ b/frontend/web/project/toast.js
@@ -22,6 +22,7 @@ const Message = class extends React.Component {
       },
       themeClassNames[this.props.theme],
     )
+    console.log('DEBUG: className:', className)
 
     return (
       <div className={className}>

--- a/frontend/web/project/toast.js
+++ b/frontend/web/project/toast.js
@@ -22,7 +22,6 @@ const Message = class extends React.Component {
       },
       themeClassNames[this.props.theme],
     )
-    console.log('DEBUG: className:', className)
 
     return (
       <div className={className}>

--- a/frontend/web/styles/project/_alert.scss
+++ b/frontend/web/styles/project/_alert.scss
@@ -56,6 +56,18 @@
     color: $text-icon-dark;
   }
 }
+
+.announcement {
+  margin: auto;
+  margin-top: 10px;
+  display: flex;
+  flex-direction: row;
+  .body {
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+}
+
 .dark {
   .alert {
     color: $alert-color-dark;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Show an announcement at the top of the home page.
The title, body and link of the annouoncement are provided in the value attribute of the `announcement`  feature flag on our production environment of the Flagsmith Website project.
Example value:
```
{ 
"id":"announcement-1",
"title":"Master Feature Flags & Progressive Delivery!",
"description":"Join us in London for a hands-on workshop with Dynatrace on feature flags and observability-driven progressive delivery.",
"buttonText":"Save My Seat!",
"url":"https://info.dynatrace.com/emea-uk-dh-progressive-delivery-workshop-flagsmith-22371-registration.html",
"isClosable":true
}
```
## How did you test this code?

This code has been manually tested by setting a JSON value for the  `announcement`  feature flag, and verifying that:

- The banner is shown with the correct content
- The button has the right label and when clicked opens a new tab with the right URL
- When dismissed is not being shown anymore to the same user
