### PR TITLE
fix: prevent error when addons is null

### DIFF
--- a/api/organisations/chargebee/chargebee.py
+++ b/api/organisations/chargebee/chargebee.py
@@ -190,8 +190,7 @@ def _convert_chargebee_subscription_to_dictionary(
 ) -> dict:
     chargebee_subscription_dict = vars(chargebee_subscription)
     # convert the addons into a list of dictionaries since vars don't do it recursively
-    chargebee_subscription_dict["addons"] = [
-        vars(addon) for addon in chargebee_subscription.addons
-    ]
+    addons = chargebee_subscription.addons or []
+    chargebee_subscription_dict["addons"] = [vars(addon) for addon in addons]
 
     return chargebee_subscription_dict

--- a/api/tests/unit/organisations/chargebee/conftest.py
+++ b/api/tests/unit/organisations/chargebee/conftest.py
@@ -86,10 +86,8 @@ def mock_subscription_response_with_addons(
 
 @pytest.fixture()
 def chargebee_cache_mocker(
-    mocker,
-) -> typing.Callable[
-    [dict[str, ChargebeeObjMetadata], dict[str, ChargebeeObjMetadata]], None
-]:
+    mocker: MockerFixture,
+) -> ChargebeeCacheMocker:
     def mock_chargebee_cache(
         plans_data: dict[str, ChargebeeObjMetadata] = None,
         addons_data: dict[str, ChargebeeObjMetadata] = None,

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -263,7 +263,8 @@ class ChargeBeeTestCase(TestCase):
 
 
 def test_extract_subscription_metadata(
-    mock_subscription_response, chargebee_object_metadata: ChargebeeObjMetadata
+    mock_subscription_response_with_addons,
+    chargebee_object_metadata: ChargebeeObjMetadata,
 ):
     # Given
     status = "status"
@@ -300,7 +301,8 @@ def test_extract_subscription_metadata(
 
 
 def test_extract_subscription_metadata_when_addon_list_is_empty(
-    mock_subscription_response, chargebee_object_metadata: ChargebeeObjMetadata
+    mock_subscription_response_with_addons,
+    chargebee_object_metadata: ChargebeeObjMetadata,
 ):
     # Given
     status = "status"
@@ -329,16 +331,19 @@ def test_extract_subscription_metadata_when_addon_list_is_empty(
 
 
 def test_get_subscription_metadata_from_id(
-    mock_subscription_response, chargebee_object_metadata: ChargebeeObjMetadata
+    mock_subscription_response_with_addons: MockChargeBeeSubscriptionResponse,
+    chargebee_object_metadata: ChargebeeObjMetadata,
 ):
     # Given
     customer_email = "test@example.com"
-    subscription_id = mock_subscription_response.subscription.id
+    subscription_id = mock_subscription_response_with_addons.subscription.id
 
     # When
     subscription_metadata = get_subscription_metadata_from_id(subscription_id)
 
     # Then
+    # Values here are multiplied by 2 because the both the plan and the addon included in
+    # the mock_subscription_response_with_addons fixture contain the same values.
     assert subscription_metadata.seats == chargebee_object_metadata.seats * 2
     assert subscription_metadata.api_calls == chargebee_object_metadata.api_calls * 2
     assert subscription_metadata.projects == chargebee_object_metadata.projects * 2
@@ -423,6 +428,23 @@ def test_get_subscription_metadata_from_id_returns_none_for_invalid_subscription
     # Then
     mocked_chargebee.Subscription.retrieve.assert_not_called()
     assert subscription_metadata is None
+
+
+def test_get_subscription_metadata_from_id_returns_valid_metadata_if_addons_is_none(
+    mock_subscription_response: MockChargeBeeSubscriptionResponse,
+    chargebee_object_metadata: ChargebeeObjMetadata,
+) -> None:
+    # Given
+    mock_subscription_response.addons = None
+    subscription_id = mock_subscription_response.subscription.id
+
+    # When
+    subscription_metadata = get_subscription_metadata_from_id(subscription_id)
+
+    # Then
+    assert subscription_metadata.seats == chargebee_object_metadata.seats
+    assert subscription_metadata.api_calls == chargebee_object_metadata.api_calls
+    assert subscription_metadata.projects == chargebee_object_metadata.projects
 
 
 def test_add_single_seat_with_existing_addon(mocker):

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -263,7 +263,7 @@ class ChargeBeeTestCase(TestCase):
 
 
 def test_extract_subscription_metadata(
-    mock_subscription_response_with_addons,
+    mock_subscription_response_with_addons: MockChargeBeeSubscriptionResponse,
     chargebee_object_metadata: ChargebeeObjMetadata,
 ):
     # Given
@@ -301,7 +301,7 @@ def test_extract_subscription_metadata(
 
 
 def test_extract_subscription_metadata_when_addon_list_is_empty(
-    mock_subscription_response_with_addons,
+    mock_subscription_response_with_addons: MockChargeBeeSubscriptionResponse,
     chargebee_object_metadata: ChargebeeObjMetadata,
 ):
     # Given


### PR DESCRIPTION
## Changes

Handle chargebee data when addons is null. 

## How did you test this code?

Added a new unit test. 
