### PR TITLE
fix: Button to go to the link doesnt close the announcement

### DIFF
--- a/frontend/web/components/InfoMessage.js
+++ b/frontend/web/components/InfoMessage.js
@@ -7,9 +7,6 @@ export default class InfoMessage extends PureComponent {
 
   handleOpenNewWindow = () => {
     window.open(this.props.url, '_blank')
-    if (this.props.isClosable) {
-     this.props.close()
-    }
   }
 
   render() {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Button to go to the link doesn't close the announcement.


