### PR TITLE
feat(task-processor): validate arguments passed to task processor functions

### DIFF
--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -76,6 +76,9 @@ def register_task_handler(task_name: str = None):
         _wrapper.run_in_thread = run_in_thread
         _wrapper.task_identifier = task_identifier
 
+        # patch the original unwrapped function onto the wrapped version for testing
+        _wrapper.unwrapped = f
+
         return _wrapper
 
     return decorator

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -63,10 +63,6 @@ def register_task_handler(task_name: str = None):
             _validate_inputs(*args, **kwargs)
             Thread(target=f, args=args, kwargs=kwargs, daemon=True).start()
 
-        f.delay = delay
-        f.run_in_thread = run_in_thread
-        f.task_identifier = task_identifier
-
         def _wrapper(*args, **kwargs):
             """
             Execute the function after validating the arguments. Ensures that, in unit testing,
@@ -75,6 +71,10 @@ def register_task_handler(task_name: str = None):
             """
             _validate_inputs(*args, **kwargs)
             return f(*args, **kwargs)
+
+        _wrapper.delay = delay
+        _wrapper.run_in_thread = run_in_thread
+        _wrapper.task_identifier = task_identifier
 
         return _wrapper
 

--- a/api/task_processor/exceptions.py
+++ b/api/task_processor/exceptions.py
@@ -1,2 +1,6 @@
 class TaskProcessingError(Exception):
     pass
+
+
+class InvalidArgumentsError(TaskProcessingError):
+    pass

--- a/api/tests/unit/audit/test_unit_audit_tasks.py
+++ b/api/tests/unit/audit/test_unit_audit_tasks.py
@@ -178,7 +178,7 @@ def test_create_segment_priorities_changed_audit_log(
     create_segment_priorities_changed_audit_log(
         previous_id_priority_pairs=[
             (feature_segment.id, 0),
-            (another_feature_segment, 1),
+            (another_feature_segment.id, 1),
         ],
         feature_segment_ids=[feature_segment.id, another_feature_segment.id],
         user_id=admin_user.id,

--- a/api/tests/unit/task_processor/test_unit_task_processor_decorators.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_decorators.py
@@ -8,6 +8,7 @@ from task_processor.decorators import (
     register_recurring_task,
     register_task_handler,
 )
+from task_processor.exceptions import InvalidArgumentsError
 from task_processor.models import RecurringTask
 from task_processor.task_registry import get_task
 
@@ -93,3 +94,17 @@ def test_register_recurring_task_does_nothing_if_not_run_by_processor(mocker, db
     assert not RecurringTask.objects.filter(task_identifier=task_identifier).exists()
     with pytest.raises(KeyError):
         assert get_task(task_identifier)
+
+
+def test_register_task_handler_validates_inputs():
+    # Given
+    @register_task_handler()
+    def my_function(*args, **kwargs):
+        pass
+
+    class NonSerializableObj:
+        pass
+
+    # When
+    with pytest.raises(InvalidArgumentsError):
+        my_function(NonSerializableObj())

--- a/api/tests/unit/task_processor/test_unit_task_processor_decorators.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_decorators.py
@@ -44,7 +44,7 @@ def test_register_task_handler_run_in_thread(mocker, caplog):
 
     # Then
     mock_thread_class.assert_called_once_with(
-        target=my_function, args=args, kwargs=kwargs, daemon=True
+        target=my_function.unwrapped, args=args, kwargs=kwargs, daemon=True
     )
     mock_thread.start.assert_called_once()
 


### PR DESCRIPTION
## Changes

Validates the inputs to tasks when running synchronously or in a separate thread. Primary use case for this is to catch errors with serialization before going into production. 

## How did you test this code?

Added unit tests. Also, all existing calls to the task processor should subsequently be validated in the unit tests. 
