### PR TITLE
fix(revert):  feat: Add backoff to webhooks, and call multiple webhooks async

### DIFF
--- a/api/audit/signals.py
+++ b/api/audit/signals.py
@@ -27,9 +27,7 @@ def call_webhooks(sender, instance, **kwargs):
         if instance.project
         else instance.environment.project.organisation
     )
-    call_organisation_webhooks.delay(
-        args=(organisation.id, data, WebhookEventType.AUDIT_LOG_CREATED.value)
-    )
+    call_organisation_webhooks(organisation, data, WebhookEventType.AUDIT_LOG_CREATED)
 
 
 def _get_integration_config(instance, integration_name):

--- a/api/edge_api/identities/tasks.py
+++ b/api/edge_api/identities/tasks.py
@@ -68,7 +68,7 @@ def call_environment_webhook_for_feature_state_change(
         else WebhookEventType.FLAG_UPDATED
     )
 
-    call_environment_webhooks(environment.id, data, event_type=event_type.value)
+    call_environment_webhooks(environment, data, event_type=event_type)
 
 
 @register_task_handler()

--- a/api/features/tasks.py
+++ b/api/features/tasks.py
@@ -1,3 +1,5 @@
+from threading import Thread
+
 from environments.models import Webhook
 from features.models import FeatureState
 from webhooks.constants import WEBHOOK_DATETIME_FORMAT
@@ -36,18 +38,19 @@ def trigger_feature_state_change_webhooks(
     previous_state = _get_previous_state(history_instance, event_type)
     if previous_state:
         data.update(previous_state=previous_state)
+    Thread(
+        target=call_environment_webhooks,
+        args=(instance.environment, data, event_type),
+    ).start()
 
-    call_environment_webhooks.delay(
-        args=(instance.environment.id, data, event_type.value)
-    )
-
-    call_organisation_webhooks.delay(
+    Thread(
+        target=call_organisation_webhooks,
         args=(
-            instance.environment.project.organisation.id,
+            instance.environment.project.organisation,
             data,
-            event_type.value,
-        )
-    )
+            event_type,
+        ),
+    ).start()
 
 
 def _get_previous_state(

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -42,7 +42,6 @@ def register_task_handler(task_name: str = None):
                 return
 
             if settings.TASK_RUN_METHOD == TaskRunMethod.SYNCHRONOUSLY:
-                logger.debug("Running task %s synchronously", task_identifier)
                 _validate_inputs(*args, **kwargs)
                 f(*args, **kwargs)
             elif settings.TASK_RUN_METHOD == TaskRunMethod.SEPARATE_THREAD:

--- a/api/tests/unit/audit/test_unit_audit_models.py
+++ b/api/tests/unit/audit/test_unit_audit_models.py
@@ -1,13 +1,11 @@
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
-from audit.serializers import AuditLogSerializer
 from integrations.datadog.models import DataDogConfiguration
-from webhooks.webhooks import WebhookEventType
 
 
 def test_organisation_webhooks_are_called_when_audit_log_saved(project, mocker):
     # Given
-    mock_call_webhooks = mocker.patch("audit.signals.call_organisation_webhooks.delay")
+    mock_call_webhooks = mocker.patch("audit.signals.call_organisation_webhooks")
 
     audit_log = AuditLog(project=project, log="Some audit log")
 
@@ -15,13 +13,7 @@ def test_organisation_webhooks_are_called_when_audit_log_saved(project, mocker):
     audit_log.save()
 
     # Then
-    mock_call_webhooks.assert_called_once_with(
-        args=(
-            project.organisation.id,
-            AuditLogSerializer(instance=audit_log).data,
-            WebhookEventType.AUDIT_LOG_CREATED.value,
-        )
-    )
+    mock_call_webhooks.assert_called()
 
 
 def test_data_dog_track_event_not_called_on_audit_log_saved_when_not_configured(

--- a/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
+++ b/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
@@ -52,8 +52,8 @@ def test_call_environment_webhook_for_feature_state_change_with_new_state_only(
     mock_call_environment_webhooks.assert_called_once()
     call_args = mock_call_environment_webhooks.call_args
 
-    assert call_args[0][0] == environment.id
-    assert call_args[1]["event_type"] == WebhookEventType.FLAG_UPDATED.value
+    assert call_args[0][0] == environment
+    assert call_args[1]["event_type"] == WebhookEventType.FLAG_UPDATED
 
     mock_generate_webhook_feature_state_data.assert_called_once_with(
         feature=feature,
@@ -105,8 +105,8 @@ def test_call_environment_webhook_for_feature_state_change_with_previous_state_o
     mock_call_environment_webhooks.assert_called_once()
     call_args = mock_call_environment_webhooks.call_args
 
-    assert call_args[0][0] == environment.id
-    assert call_args[1]["event_type"] == WebhookEventType.FLAG_DELETED.value
+    assert call_args[0][0] == environment
+    assert call_args[1]["event_type"] == WebhookEventType.FLAG_DELETED
 
     mock_generate_webhook_feature_state_data.assert_called_once_with(
         feature=feature,
@@ -176,8 +176,8 @@ def test_call_environment_webhook_for_feature_state_change_with_both_states(
     mock_call_environment_webhooks.assert_called_once()
     call_args = mock_call_environment_webhooks.call_args
 
-    assert call_args[0][0] == environment.id
-    assert call_args[1]["event_type"] == WebhookEventType.FLAG_UPDATED.value
+    assert call_args[0][0] == environment
+    assert call_args[1]["event_type"] == WebhookEventType.FLAG_UPDATED
 
     assert mock_generate_webhook_feature_state_data.call_count == 2
     mock_generate_data_calls = mock_generate_webhook_feature_state_data.call_args_list

--- a/api/webhooks/tests/test_webhooks.py
+++ b/api/webhooks/tests/test_webhooks.py
@@ -45,9 +45,9 @@ class WebhooksTestCase(TestCase):
 
         # When
         call_environment_webhooks(
-            environment_id=self.environment.id,
+            environment=self.environment,
             data={},
-            event_type=WebhookEventType.FLAG_UPDATED.value,
+            event_type=WebhookEventType.FLAG_UPDATED,
         )
 
         # Then
@@ -70,9 +70,9 @@ class WebhooksTestCase(TestCase):
 
         # When
         call_environment_webhooks(
-            environment_id=self.environment.id,
+            environment=self.environment,
             data={},
-            event_type=WebhookEventType.FLAG_UPDATED.value,
+            event_type=WebhookEventType.FLAG_UPDATED,
         )
 
         # Then
@@ -124,9 +124,9 @@ class WebhooksTestCase(TestCase):
         ).hexdigest()
 
         call_environment_webhooks(
-            environment_id=self.environment.id,
+            environment=self.environment,
             data={},
-            event_type=WebhookEventType.FLAG_UPDATED.value,
+            event_type=WebhookEventType.FLAG_UPDATED,
         )
         # When
         _, kwargs = mock_requests.post.call_args_list[0]
@@ -144,9 +144,9 @@ class WebhooksTestCase(TestCase):
         )
         # When
         call_environment_webhooks(
-            environment_id=self.environment.id,
+            environment=self.environment,
             data={},
-            event_type=WebhookEventType.FLAG_UPDATED.value,
+            event_type=WebhookEventType.FLAG_UPDATED,
         )
 
         # Then
@@ -179,16 +179,16 @@ def test_call_environment_webhooks__multiple_webhooks__failure__calls_expected(
     )
 
     expected_data = {}
-    expected_event_type = WebhookEventType.FLAG_UPDATED.value
+    expected_event_type = WebhookEventType.FLAG_UPDATED
     expected_send_failure_email_data = {
-        "event_type": expected_event_type,
+        "event_type": expected_event_type.value,
         "data": expected_data,
     }
     expected_send_failure_status_code = f"N/A ({expected_error.__name__})"
 
     # When
     call_environment_webhooks(
-        environment_id=environment.id,
+        environment=environment,
         data=expected_data,
         event_type=expected_event_type,
     )
@@ -200,13 +200,13 @@ def test_call_environment_webhooks__multiple_webhooks__failure__calls_expected(
             mocker.call(
                 webhook_2,
                 expected_send_failure_email_data,
-                WebhookType.ENVIRONMENT.value,
+                WebhookType.ENVIRONMENT,
                 expected_send_failure_status_code,
             ),
             mocker.call(
                 webhook_1,
                 expected_send_failure_email_data,
-                WebhookType.ENVIRONMENT.value,
+                WebhookType.ENVIRONMENT,
                 expected_send_failure_status_code,
             ),
         ],


### PR DESCRIPTION
Reverts Flagsmith/flagsmith#2559

Revert this pull request because max_time of 2 seconds is quite low. This should be done by creating another task to retry the webhook 