### PR TITLE
feat: Add a pill for server side only flags

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -257,6 +257,23 @@ class TheComponent extends Component {
                     }`}
                   </Tooltip>
                 )}
+                {projectFlag.is_server_key_only && (
+                  <Tooltip
+                    title={
+                      <span
+                        className='chip me-2 chip--xs bg-primary text-white'
+                        style={{ border: 'none' }}
+                      >
+                        <span>{'Server side Only'}</span>
+                      </span>
+                    }
+                    place='top'
+                  >
+                    {
+                      'Prevent this feature from being accessed with client-side SDKs.'
+                    }
+                  </Tooltip>
+                )}
                 <TagValues
                   inline
                   projectId={`${projectId}`}

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -264,7 +264,7 @@ class TheComponent extends Component {
                         className='chip me-2 chip--xs bg-primary text-white'
                         style={{ border: 'none' }}
                       >
-                        <span>{'Server side Only'}</span>
+                        <span>{'Server-side only'}</span>
                       </span>
                     }
                     place='top'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Added a pill for server-side only flags in the feature rows.

<img width="1341" alt="Screen Shot 2023-09-14 at 10 16 03" src="https://github.com/Flagsmith/flagsmith/assets/41410593/9be27401-588b-44b5-81ab-f71a111cf656">


## How did you test this code?

- Create or update a flag and enable the "Server-side Only" option.
