### PR TITLE
fix: Price is missing in dark mode

### DIFF
--- a/frontend/web/styles/project/_PricingPage.scss
+++ b/frontend/web/styles/project/_PricingPage.scss
@@ -43,6 +43,11 @@
 		}
 	}
 }
+.dark {
+	.pricing-type {
+		color: #d8d8d8;
+	}
+}
 .pricing-type {
 	color: #22354a;
 	margin-bottom: 0;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Updated price text color.
<img width="1327" alt="Screen Shot 2023-09-21 at 15 59 50" src="https://github.com/Flagsmith/flagsmith/assets/41410593/439a0a1a-0697-49f6-ac51-3d97e16499c7">


## How did you test this code?
- Open payment modal.
