### PR TITLE
feat: trial management in sales dashboard

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -217,7 +217,7 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
 
     def get_subscription_metadata(self) -> BaseSubscriptionMetadata:
         metadata = None
-        if self.subscription_id == TRIAL_SUBSCRIPTION_ID:
+        if self.is_in_trial():
             metadata = BaseSubscriptionMetadata(
                 seats=self.max_seats, api_calls=self.max_api_calls
             )
@@ -260,6 +260,9 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
             subscription_info.api_calls_30d - subscription_info.allowed_30d_api_calls
         )
         return overage if overage > 0 else 0
+
+    def is_in_trial(self):
+        return self.subscription_id == TRIAL_SUBSCRIPTION_ID
 
 
 class OrganisationWebhook(AbstractBaseExportableWebhookModel):

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -261,7 +261,7 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
         )
         return overage if overage > 0 else 0
 
-    def is_in_trial(self):
+    def is_in_trial(self) -> bool:
         return self.subscription_id == TRIAL_SUBSCRIPTION_ID
 
 

--- a/api/sales_dashboard/forms.py
+++ b/api/sales_dashboard/forms.py
@@ -7,7 +7,12 @@ from django.core.mail import send_mail
 
 from environments.models import Environment
 from features.models import Feature
-from organisations.models import Organisation
+from organisations.models import TRIAL_SUBSCRIPTION_ID, Organisation
+from organisations.subscriptions.constants import (
+    FREE_PLAN_ID,
+    MAX_API_CALLS_IN_FREE_PLAN,
+    MAX_SEATS_IN_FREE_PLAN,
+)
 from projects.models import Project
 from users.models import FFAdminUser
 
@@ -25,6 +30,29 @@ class MaxAPICallsForm(forms.Form):
 
     def save(self, organisation, commit=True):
         organisation.subscription.max_api_calls = self.cleaned_data["max_api_calls"]
+        organisation.subscription.save()
+
+
+class StartTrialForm(forms.Form):
+    max_seats = forms.IntegerField()
+    max_api_calls = forms.IntegerField()
+
+    def save(self, organisation, commit=True):
+        organisation.subscription.max_seats = self.cleaned_data["max_seats"]
+        organisation.subscription.max_api_calls = self.cleaned_data["max_api_calls"]
+        organisation.subscription.subscription_id = TRIAL_SUBSCRIPTION_ID
+        organisation.subscription.customer_id = TRIAL_SUBSCRIPTION_ID
+        organisation.subscription.plan = "enterprise-saas-monthly-v2"
+        organisation.subscription.save()
+
+
+class EndTrialForm(forms.Form):
+    def save(self, organisation, commit=True):
+        organisation.subscription.max_seats = MAX_SEATS_IN_FREE_PLAN
+        organisation.subscription.max_api_calls = MAX_API_CALLS_IN_FREE_PLAN
+        organisation.subscription.subscription_id = ""
+        organisation.subscription.customer_id = ""
+        organisation.subscription.plan = FREE_PLAN_ID
         organisation.subscription.save()
 
 

--- a/api/sales_dashboard/forms.py
+++ b/api/sales_dashboard/forms.py
@@ -47,7 +47,7 @@ class StartTrialForm(forms.Form):
 
 
 class EndTrialForm(forms.Form):
-    def save(self, organisation, commit=True):
+    def save(self, organisation: Organisation, commit: bool = True):
         organisation.subscription.max_seats = MAX_SEATS_IN_FREE_PLAN
         organisation.subscription.max_api_calls = MAX_API_CALLS_IN_FREE_PLAN
         organisation.subscription.subscription_id = ""

--- a/api/sales_dashboard/forms.py
+++ b/api/sales_dashboard/forms.py
@@ -37,23 +37,36 @@ class StartTrialForm(forms.Form):
     max_seats = forms.IntegerField()
     max_api_calls = forms.IntegerField()
 
-    def save(self, organisation: Organisation, commit: bool = True):
-        organisation.subscription.max_seats = self.cleaned_data["max_seats"]
-        organisation.subscription.max_api_calls = self.cleaned_data["max_api_calls"]
-        organisation.subscription.subscription_id = TRIAL_SUBSCRIPTION_ID
-        organisation.subscription.customer_id = TRIAL_SUBSCRIPTION_ID
-        organisation.subscription.plan = "enterprise-saas-monthly-v2"
-        organisation.subscription.save()
+    def save(self, organisation: Organisation, commit: bool = True) -> Organisation:
+        subscription = organisation.subscription
+
+        subscription.max_seats = self.cleaned_data["max_seats"]
+        subscription.max_api_calls = self.cleaned_data["max_api_calls"]
+        subscription.subscription_id = TRIAL_SUBSCRIPTION_ID
+        subscription.customer_id = TRIAL_SUBSCRIPTION_ID
+        subscription.plan = "enterprise-saas-monthly-v2"
+
+        if commit:
+            subscription.save()
+
+        return organisation
 
 
 class EndTrialForm(forms.Form):
-    def save(self, organisation: Organisation, commit: bool = True):
-        organisation.subscription.max_seats = MAX_SEATS_IN_FREE_PLAN
-        organisation.subscription.max_api_calls = MAX_API_CALLS_IN_FREE_PLAN
-        organisation.subscription.subscription_id = ""
-        organisation.subscription.customer_id = ""
-        organisation.subscription.plan = FREE_PLAN_ID
-        organisation.subscription.save()
+    def save(self, organisation: Organisation, commit: bool = True) -> Organisation:
+        subscription = organisation.subscription
+
+        subscription.max_seats = MAX_SEATS_IN_FREE_PLAN
+        subscription.max_api_calls = MAX_API_CALLS_IN_FREE_PLAN
+        subscription.subscription_id = ""
+        subscription.customer_id = ""
+        subscription.plan = FREE_PLAN_ID
+        subscription.save()
+
+        if commit:
+            subscription.save()
+
+        return organisation
 
 
 class EmailUsageForm(forms.Form):

--- a/api/sales_dashboard/forms.py
+++ b/api/sales_dashboard/forms.py
@@ -37,7 +37,7 @@ class StartTrialForm(forms.Form):
     max_seats = forms.IntegerField()
     max_api_calls = forms.IntegerField()
 
-    def save(self, organisation, commit=True):
+    def save(self, organisation: Organisation, commit: bool = True):
         organisation.subscription.max_seats = self.cleaned_data["max_seats"]
         organisation.subscription.max_api_calls = self.cleaned_data["max_api_calls"]
         organisation.subscription.subscription_id = TRIAL_SUBSCRIPTION_ID

--- a/api/sales_dashboard/templates/sales_dashboard/organisation.html
+++ b/api/sales_dashboard/templates/sales_dashboard/organisation.html
@@ -81,6 +81,21 @@
                         </tr>
                     </tbody>
                 </table>
+                {%if organisation.subscription.is_in_trial %}
+                    <form action="{% url 'sales_dashboard:organisation_end_trial' organisation.id %}" method="post" class="form-inline float-right">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-primary mb-2">End Trial</button>
+                    </form>
+                {% else %}
+                    <form action="{% url 'sales_dashboard:organisation_start_trial' organisation.id %}" method="post" class="form-inline float-right">
+                        {% csrf_token %}
+                        <label class="sr-only" for="trialSeats">Seats</label>
+                        <input type="text" class="form-control mb-2 mr-sm-2" id="max_seats" name="max_seats" placeholder="Seats">
+                        <label class="sr-only" for="trialApiCalls">API Calls</label>
+                        <input type="text" class="form-control mb-2 mr-sm-2" id="max_api_calls" name="max_api_calls" placeholder="API Calls">
+                        <button type="submit" class="btn btn-primary mb-2">Start Trial</button>
+                    </form>
+                {% endif %}
             </div>
 
             <h2>Projects</h2>

--- a/api/sales_dashboard/urls.py
+++ b/api/sales_dashboard/urls.py
@@ -19,6 +19,16 @@ urlpatterns = [
         name="update_seats",
     ),
     path(
+        "organisations/<int:organisation_id>/organisation_start_trial",
+        views.organisation_start_trial,
+        name="organisation_start_trial",
+    ),
+    path(
+        "organisations/<int:organisation_id>/organisation_end_trial",
+        views.organisation_end_trial,
+        name="organisation_end_trial",
+    ),
+    path(
         "organisations/<int:project_id>/migrate_identities",
         views.migrate_identities_to_edge,
         name="migrate_identities",

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -9,6 +9,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Count, F, Q
 from django.http import (
+    HttpRequest,
     HttpResponse,
     HttpResponseBadRequest,
     HttpResponseRedirect,
@@ -191,7 +192,9 @@ def update_max_api_calls(request, organisation_id):
 
 
 @staff_member_required
-def organisation_start_trial(request, organisation_id):
+def organisation_start_trial(
+    request: HttpRequest, organisation_id: int
+) -> HttpResponse:
     start_trial_form = StartTrialForm(request.POST)
     if start_trial_form.is_valid():
         organisation = get_object_or_404(Organisation, pk=organisation_id)
@@ -206,7 +209,7 @@ def organisation_start_trial(request, organisation_id):
 
 
 @staff_member_required
-def organisation_end_trial(request, organisation_id):
+def organisation_end_trial(request: HttpRequest, organisation_id: int) -> HttpResponse:
     end_trial_form = EndTrialForm(request.POST)
     if end_trial_form.is_valid():
         organisation = get_object_or_404(Organisation, pk=organisation_id)

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -36,7 +36,13 @@ from organisations.tasks import (
     update_organisation_subscription_information_influx_cache,
 )
 
-from .forms import EmailUsageForm, MaxAPICallsForm, MaxSeatsForm
+from .forms import (
+    EmailUsageForm,
+    EndTrialForm,
+    MaxAPICallsForm,
+    MaxSeatsForm,
+    StartTrialForm,
+)
 
 OBJECTS_PER_PAGE = 50
 DEFAULT_ORGANISATION_SORT = "subscription_information_cache__api_calls_30d"
@@ -182,6 +188,36 @@ def update_max_api_calls(request, organisation_id):
         max_api_calls_form.save(organisation)
 
     return HttpResponseRedirect(reverse("sales_dashboard:index"))
+
+
+@staff_member_required
+def organisation_start_trial(request, organisation_id):
+    start_trial_form = StartTrialForm(request.POST)
+    if start_trial_form.is_valid():
+        organisation = get_object_or_404(Organisation, pk=organisation_id)
+        start_trial_form.save(organisation)
+
+    return HttpResponseRedirect(
+        reverse(
+            "sales_dashboard:organisation_info",
+            kwargs={"organisation_id": organisation_id},
+        )
+    )
+
+
+@staff_member_required
+def organisation_end_trial(request, organisation_id):
+    end_trial_form = EndTrialForm(request.POST)
+    if end_trial_form.is_valid():
+        organisation = get_object_or_404(Organisation, pk=organisation_id)
+        end_trial_form.save(organisation)
+
+    return HttpResponseRedirect(
+        reverse(
+            "sales_dashboard:organisation_info",
+            kwargs={"organisation_id": organisation_id},
+        )
+    )
 
 
 @staff_member_required


### PR DESCRIPTION
This is so the sales team can manage folk going into and coming out of trials. 

We need to clear up how we manage this data as we currently have two areas of the database that store this data, and we need to figure out which to honour based on the subscription state. 