### PR TITLE
fix(tasks): Create a different task to update environment document 

### DIFF
--- a/api/audit/models.py
+++ b/api/audit/models.py
@@ -110,6 +110,8 @@ class AuditLog(LifecycleModel):
         is_now=True,
     )
     def update_environments_updated_at(self):
+        from environments.tasks import process_environment_update
+
         environments_filter = Q()
         if self.environment_id:
             environments_filter = Q(id=self.environment_id)
@@ -119,6 +121,5 @@ class AuditLog(LifecycleModel):
         self.project.environments.filter(environments_filter).update(
             updated_at=self.created_date
         )
-        from .tasks import process_environment_update
 
-        process_environment_update.delay(args=(self.id))
+        process_environment_update.delay(args=(self.id,))

--- a/api/audit/models.py
+++ b/api/audit/models.py
@@ -14,10 +14,6 @@ from django_lifecycle import (
 from api_keys.models import MasterAPIKey
 from audit.related_object_type import RelatedObjectType
 from projects.models import Project
-from sse import (
-    send_environment_update_message_for_environment,
-    send_environment_update_message_for_project,
-)
 
 RELATED_OBJECT_TYPES = ((tag.name, tag.value) for tag in RelatedObjectType)
 
@@ -113,11 +109,6 @@ class AuditLog(LifecycleModel):
         when="environment_document_updated",
         is_now=True,
     )
-    def process_environment_update(self):
-        self.update_environments_updated_at()
-        self.send_environments_to_dynamodb()
-        self.send_environment_update_message()
-
     def update_environments_updated_at(self):
         environments_filter = Q()
         if self.environment_id:
@@ -128,20 +119,6 @@ class AuditLog(LifecycleModel):
         self.project.environments.filter(environments_filter).update(
             updated_at=self.created_date
         )
+        from .tasks import process_environment_update
 
-    def send_environments_to_dynamodb(self):
-        from environments.models import Environment
-
-        Environment.write_environments_to_dynamodb(
-            environment_id=self.environment_id, project_id=self.project_id
-        )
-
-    def send_environment_update_message(self):
-        if self.environment_id:
-            environment = self.environment
-            # Because we updated the environment `updated_at` in the previous hook in bulk
-            # update it manually here to save a `refresh_from_db` call
-            environment.updated_at = self.created_date
-            send_environment_update_message_for_environment(environment)
-        else:
-            send_environment_update_message_for_project(self.project)
+        process_environment_update.delay(args=(self.id))

--- a/api/audit/models.py
+++ b/api/audit/models.py
@@ -109,7 +109,7 @@ class AuditLog(LifecycleModel):
         when="environment_document_updated",
         is_now=True,
     )
-    def update_environments_updated_at(self):
+    def process_environment_update(self):
         from environments.tasks import process_environment_update
 
         environments_filter = Q()

--- a/api/audit/tasks.py
+++ b/api/audit/tasks.py
@@ -8,11 +8,6 @@ from audit.constants import (
     FEATURE_STATE_WENT_LIVE_MESSAGE,
 )
 from audit.models import AuditLog, RelatedObjectType
-from environments.models import Environment
-from sse import (
-    send_environment_update_message_for_environment,
-    send_environment_update_message_for_project,
-)
 from task_processor.decorators import register_task_handler
 
 logger = logging.getLogger(__name__)
@@ -168,19 +163,3 @@ def create_segment_priorities_changed_audit_log(
         related_object_type=RelatedObjectType.FEATURE.name,
         master_api_key_id=master_api_key_id,
     )
-
-
-@register_task_handler()
-def process_environment_update(audit_log_id: int):
-    audit_log = AuditLog.objects.get(id=audit_log_id)
-
-    # Send environment document to dynamodb
-    Environment.write_environments_to_dynamodb(
-        environment_id=audit_log.environment_id, project_id=audit_log.project_id
-    )
-
-    # send environment update message
-    if audit_log.environment_id:
-        send_environment_update_message_for_environment(audit_log.environment)
-    else:
-        send_environment_update_message_for_project(audit_log.project)

--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -1,5 +1,10 @@
+from audit.models import AuditLog
 from environments.dynamodb import DynamoEnvironmentWrapper
 from environments.models import Environment
+from sse import (
+    send_environment_update_message_for_environment,
+    send_environment_update_message_for_project,
+)
 from task_processor.decorators import register_task_handler
 
 
@@ -9,3 +14,19 @@ def rebuild_environment_document(environment_id: int):
     if wrapper.is_enabled:
         environment = Environment.objects.get(id=environment_id)
         wrapper.write_environment(environment)
+
+
+@register_task_handler()
+def process_environment_update(audit_log_id: int):
+    audit_log = AuditLog.objects.get(id=audit_log_id)
+
+    # Send environment document to dynamodb
+    Environment.write_environments_to_dynamodb(
+        environment_id=audit_log.environment_id, project_id=audit_log.project_id
+    )
+
+    # send environment update message
+    if audit_log.environment_id:
+        send_environment_update_message_for_environment(audit_log.environment)
+    else:
+        send_environment_update_message_for_project(audit_log.project)

--- a/api/tests/unit/audit/test_unit_audit_models.py
+++ b/api/tests/unit/audit/test_unit_audit_models.py
@@ -160,67 +160,33 @@ def test_audit_log_save_project_is_added_if_not_set(environment):
     assert audit_log.project == environment.project
 
 
-def test_creating_audit_logs_triggers_environment_update_message(environment, mocker):
+def test_creating_audit_logs_creates_process_environment_update_task(
+    environment, mocker
+):
     # Given
-    send_environment_update_message_for_environment = mocker.patch(
-        "audit.models.send_environment_update_message_for_environment"
+    process_environment_update = mocker.patch(
+        "environments.tasks.process_environment_update"
     )
 
     # When
     audit_log = AuditLog.objects.create(environment=environment)
 
     # Then
-    send_environment_update_message_for_environment.assert_called_once_with(environment)
+    process_environment_update.delay.assert_called_once_with(args=(audit_log.id,))
+
+    # and
+    environment.refresh_from_db()
     assert environment.updated_at == audit_log.created_date
 
 
-def test_creating_audit_logs_triggers_environment_update_message_for_environment_if_environment_is_present(
+def test_creating_audit_logs_for_change_request_does_not_trigger_process_environment_update(
     environment, mocker, project
 ):
     # Given
-    send_environment_update_message_for_environment = mocker.patch(
-        "audit.models.send_environment_update_message_for_environment"
+    process_environment_update = mocker.patch(
+        "environments.tasks.process_environment_update"
     )
-    send_environment_update_message_for_project = mocker.patch(
-        "audit.models.send_environment_update_message_for_project"
-    )
-    # When
-    audit_log = AuditLog.objects.create(environment=environment, project=project)
 
-    # Then
-    send_environment_update_message_for_environment.assert_called_once_with(environment)
-    send_environment_update_message_for_project.assert_not_called()
-    assert environment.updated_at == audit_log.created_date
-
-
-def test_creating_audit_logs_triggers_environment_update_message_for_project_if_environment_is_not_present(
-    environment, mocker, project
-):
-    # Given
-    send_environment_update_message_for_environment = mocker.patch(
-        "audit.models.send_environment_update_message_for_environment"
-    )
-    send_environment_update_message_for_project = mocker.patch(
-        "audit.models.send_environment_update_message_for_project"
-    )
-    # When
-    AuditLog.objects.create(project=project)
-
-    # Then
-    send_environment_update_message_for_project.assert_called_once_with(project)
-    send_environment_update_message_for_environment.assert_not_called()
-
-
-def test_creating_audit_logs_for_change_request_does_not_trigger_environment_update_message(
-    environment, mocker, project
-):
-    # Given
-    send_environment_update_message_for_environment = mocker.patch(
-        "audit.models.send_environment_update_message_for_environment"
-    )
-    send_environment_update_message_for_project = mocker.patch(
-        "audit.models.send_environment_update_message_for_project"
-    )
     # When
     audit_log = AuditLog.objects.create(
         project=project,
@@ -228,6 +194,5 @@ def test_creating_audit_logs_for_change_request_does_not_trigger_environment_upd
     )
 
     # Then
-    send_environment_update_message_for_environment.assert_not_called()
-    send_environment_update_message_for_project.assert_not_called()
+    process_environment_update.delay.assert_not_called()
     assert audit_log.created_date != environment.updated_at

--- a/api/tests/unit/environments/test_unit_environment_tasks.py
+++ b/api/tests/unit/environments/test_unit_environment_tasks.py
@@ -1,4 +1,8 @@
-from environments.tasks import rebuild_environment_document
+from audit.models import AuditLog
+from environments.tasks import (
+    process_environment_update,
+    rebuild_environment_document,
+)
 
 
 def test_rebuild_environment_document(environment, mocker):
@@ -13,3 +17,61 @@ def test_rebuild_environment_document(environment, mocker):
 
     # Then
     mock_dynamo_wrapper.write_environment.assert_called_once_with(environment)
+
+
+def test_process_update_with_environment_audit_log(environment, mocker):
+    # Given
+    audit_log = AuditLog.objects.create(
+        project=environment.project, environment=environment
+    )
+    mock_environment_model_class = mocker.patch(
+        "environments.tasks.Environment", autospec=True
+    )
+    mock_send_environment_update_message_for_environment = mocker.patch(
+        "environments.tasks.send_environment_update_message_for_environment",
+        autospec=True,
+    )
+    mock_send_environment_update_message_for_project = mocker.patch(
+        "environments.tasks.send_environment_update_message_for_project",
+        autospec=True,
+    )
+
+    # When
+    process_environment_update(audit_log_id=audit_log.id)
+
+    # Then
+    mock_environment_model_class.write_environments_to_dynamodb.assert_called_once_with(
+        environment_id=environment.id, project_id=environment.project.id
+    )
+    mock_send_environment_update_message_for_environment.assert_called_once_with(
+        environment
+    )
+    mock_send_environment_update_message_for_project.assert_not_called()
+
+
+def test_process_update_with_project_audit_log(environment, mocker):
+    # Given
+    audit_log = AuditLog.objects.create(project=environment.project)
+    mock_environment_model_class = mocker.patch(
+        "environments.tasks.Environment", autospec=True
+    )
+    mock_send_environment_update_message_for_environment = mocker.patch(
+        "environments.tasks.send_environment_update_message_for_environment",
+        autospec=True,
+    )
+    mock_send_environment_update_message_for_project = mocker.patch(
+        "environments.tasks.send_environment_update_message_for_project",
+        autospec=True,
+    )
+
+    # When
+    process_environment_update(audit_log_id=audit_log.id)
+
+    # Then
+    mock_environment_model_class.write_environments_to_dynamodb.assert_called_once_with(
+        environment_id=None, project_id=environment.project.id
+    )
+    mock_send_environment_update_message_for_environment.assert_not_called()
+    mock_send_environment_update_message_for_project.assert_called_once_with(
+        environment.project
+    )

--- a/api/tests/unit/environments/test_unit_environment_tasks.py
+++ b/api/tests/unit/environments/test_unit_environment_tasks.py
@@ -19,7 +19,7 @@ def test_rebuild_environment_document(environment, mocker):
     mock_dynamo_wrapper.write_environment.assert_called_once_with(environment)
 
 
-def test_process_update_with_environment_audit_log(environment, mocker):
+def test_process_environment_update_with_environment_audit_log(environment, mocker):
     # Given
     audit_log = AuditLog.objects.create(
         project=environment.project, environment=environment
@@ -49,7 +49,7 @@ def test_process_update_with_environment_audit_log(environment, mocker):
     mock_send_environment_update_message_for_project.assert_not_called()
 
 
-def test_process_update_with_project_audit_log(environment, mocker):
+def test_process_environment_update_with_project_audit_log(environment, mocker):
     # Given
     audit_log = AuditLog.objects.create(project=environment.project)
     mock_environment_model_class = mocker.patch(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Create a different task for updating environment document and sending SSE message in order to reduce the transaction length (earlier it was doing all of the above as well in the same transaction)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds unit tests