### PR TITLE
fix: Shows "Identities" nav element as disabled for users without relevant permission

### DIFF
--- a/frontend/web/components/Aside.js
+++ b/frontend/web/components/Aside.js
@@ -13,6 +13,7 @@ import Permission from 'common/providers/Permission'
 import Icon from './Icon'
 import ProjectSelect from './ProjectSelect'
 import AsideProjectButton from './AsideProjectButton'
+import Constants from 'common/constants'
 
 const Aside = class extends Component {
   static displayName = 'Aside'
@@ -484,21 +485,32 @@ const Aside = class extends Component {
                                                     </span>
                                                   ) : null}
                                                 </NavLink>
-                                                {manageIdentityPermission && (
+                                                {Utils.renderWithPermission(
+                                                  manageIdentityPermission,
+                                                  Constants.environmentPermissions(
+                                                    'View Identities',
+                                                  ),
                                                   <NavLink
                                                     id='users-link'
-                                                    className='aside__environment-list-item mt-1'
+                                                    className={`aside__environment-list-item ${
+                                                      !manageIdentityPermission &&
+                                                      'disabled'
+                                                    } mt-1`}
                                                     exact
                                                     to={`/project/${project.id}/environment/${environment.api_key}/users`}
                                                   >
                                                     <span className='mr-2'>
                                                       <Icon
                                                         name='people'
-                                                        fill='#9DA4AE'
+                                                        fill={
+                                                          manageIdentityPermission
+                                                            ? '#9DA4AE'
+                                                            : '#696969'
+                                                        }
                                                       />
                                                     </span>
                                                     Identities
-                                                  </NavLink>
+                                                  </NavLink>,
                                                 )}
 
                                                 {environmentAdmin && (

--- a/frontend/web/styles/project/_utils.scss
+++ b/frontend/web/styles/project/_utils.scss
@@ -144,6 +144,10 @@
         background-color: rgba(0,0,0,.2);
     }
 }
+.aside__environment-list-item.disabled {
+    color:#696969;
+    pointer-events: none;
+  }
 
 .justify-content-end {
     justify-content: flex-end;


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Show the 'Identities' nav element greyed out and disabled when the user haven't 'VIEW_IDENTITIES' permission.

<img width="1342" alt="Screen Shot 2023-09-28 at 16 38 19" src="https://github.com/Flagsmith/flagsmith/assets/41410593/a43335a7-0d5a-4df0-a47e-6a7a0060ff2b">


## How did you test this code?

- Remove 'VIEW_IDENTITIES' permission from a user.

