### PR TITLE
refactor(get_environment_from_cache): Optimize SQL  query

### DIFF
--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -191,6 +191,7 @@ class Environment(
 
             if cls.is_bad_key(api_key):
                 return None
+
             environment = environment_cache.get(api_key)
             if not environment:
                 select_related_args = (

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -203,13 +203,13 @@ class Environment(
                     "heap_config",
                     "dynatrace_config",
                 )
-                environment = (
-                    cls.objects.select_related(*select_related_args)
-                    .filter(Q(api_key=api_key) | Q(api_keys__key=api_key))
-                    .distinct()
-                    .defer("description")
-                    .get()
+                base_qs = cls.objects.select_related(*select_related_args).defer(
+                    "description"
                 )
+                qs_one = base_qs.filter(api_key=api_key)
+                qs_two = base_qs.filter(api_keys__key=api_key)
+
+                environment = qs_one.union(qs_two).get()
                 environment_cache.set(
                     api_key, environment, timeout=settings.ENVIRONMENT_CACHE_SECONDS
                 )

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -191,7 +191,6 @@ class Environment(
 
             if cls.is_bad_key(api_key):
                 return None
-
             environment = environment_cache.get(api_key)
             if not environment:
                 select_related_args = (
@@ -206,10 +205,10 @@ class Environment(
                 base_qs = cls.objects.select_related(*select_related_args).defer(
                     "description"
                 )
-                qs_one = base_qs.filter(api_key=api_key)
-                qs_two = base_qs.filter(api_keys__key=api_key)
+                qs_for_embedded_api_key = base_qs.filter(api_key=api_key)
+                qs_for_fk_api_key = base_qs.filter(api_keys__key=api_key)
 
-                environment = qs_one.union(qs_two).get()
+                environment = qs_for_embedded_api_key.union(qs_for_fk_api_key).get()
                 environment_cache.set(
                     api_key, environment, timeout=settings.ENVIRONMENT_CACHE_SECONDS
                 )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Use union to utitlize index instead of doing a sequential scan 

Old SQL query:

```
SELECT 
  DISTINCT "environments_environment"."id", 
  "environments_environment"."deleted_at", 
  "environments_environment"."name", 
  "environments_environment"."created_date", 
  "environments_environment"."project_id", 
  "environments_environment"."api_key", 
  "environments_environment"."minimum_change_request_approvals", 
  "environments_environment"."webhooks_enabled", 
  "environments_environment"."webhook_url", 
  "environments_environment"."allow_client_traits", 
  "environments_environment"."updated_at", 
  "environments_environment"."banner_text", 
  "environments_environment"."banner_colour", 
  "environments_environment"."hide_disabled_flags", 
  "environments_environment"."use_mv_v2_evaluation", 
  "environments_environment"."hide_sensitive_data", 
  "projects_project"."id", 
  "projects_project"."deleted_at", 
  "projects_project"."uuid", 
  "projects_project"."name", 
  "projects_project"."created_date", 
  "projects_project"."organisation_id", 
  "projects_project"."hide_disabled_flags", 
  "projects_project"."enable_dynamo_db", 
  "projects_project"."prevent_flag_defaults", 
  "projects_project"."enable_realtime_updates", 
  "projects_project"."only_allow_lower_case_feature_names", 
  "projects_project"."feature_name_regex", 
  "projects_project"."max_segments_allowed", 
  "projects_project"."max_features_allowed", 
  "projects_project"."max_segment_overrides_allowed", 
  "organisations_organisation"."id", 
  "organisations_organisation"."deleted_at", 
  "organisations_organisation"."uuid", 
  "organisations_organisation"."name", 
  "organisations_organisation"."has_requested_features", 
  "organisations_organisation"."webhook_notification_email", 
  "organisations_organisation"."created_date", 
  "organisations_organisation"."alerted_over_plan_limit", 
  "organisations_organisation"."stop_serving_flags", 
  "organisations_organisation"."restrict_project_create_to_admin", 
  "organisations_organisation"."persist_trait_data", 
  "organisations_organisation"."block_access_to_admin", 
  "organisations_organisation"."feature_analytics", 
  "amplitude_amplitudeconfiguration"."id", 
  "amplitude_amplitudeconfiguration"."deleted_at", 
  "amplitude_amplitudeconfiguration"."uuid", 
  "amplitude_amplitudeconfiguration"."api_key", 
  "amplitude_amplitudeconfiguration"."base_url", 
  "amplitude_amplitudeconfiguration"."environment_id", 
  "segment_segmentconfiguration"."id", 
  "segment_segmentconfiguration"."deleted_at", 
  "segment_segmentconfiguration"."uuid", 
  "segment_segmentconfiguration"."base_url", 
  "segment_segmentconfiguration"."api_key", 
  "segment_segmentconfiguration"."environment_id", 
  "heap_heapconfiguration"."id", 
  "heap_heapconfiguration"."deleted_at", 
  "heap_heapconfiguration"."uuid", 
  "heap_heapconfiguration"."base_url", 
  "heap_heapconfiguration"."api_key", 
  "heap_heapconfiguration"."environment_id", 
  "mixpanel_mixpanelconfiguration"."id", 
  "mixpanel_mixpanelconfiguration"."deleted_at", 
  "mixpanel_mixpanelconfiguration"."uuid", 
  "mixpanel_mixpanelconfiguration"."base_url", 
  "mixpanel_mixpanelconfiguration"."api_key", 
  "mixpanel_mixpanelconfiguration"."environment_id", 
  "dynatrace_dynatraceconfiguration"."id", 
  "dynatrace_dynatraceconfiguration"."deleted_at", 
  "dynatrace_dynatraceconfiguration"."uuid", 
  "dynatrace_dynatraceconfiguration"."base_url", 
  "dynatrace_dynatraceconfiguration"."api_key", 
  "dynatrace_dynatraceconfiguration"."environment_id", 
  "dynatrace_dynatraceconfiguration"."entity_selector" 
FROM 
  "environments_environment" 
  LEFT OUTER JOIN "environments_environmentapikey" ON (
    "environments_environment"."id" = "environments_environmentapikey"."environment_id"
  ) 
  INNER JOIN "projects_project" ON (
    "environments_environment"."project_id" = "projects_project"."id"
  ) 
  INNER JOIN "organisations_organisation" ON (
    "projects_project"."organisation_id" = "organisations_organisation"."id"
  ) 
  LEFT OUTER JOIN "amplitude_amplitudeconfiguration" ON (
    "environments_environment"."id" = "amplitude_amplitudeconfiguration"."environment_id"
  ) 
  LEFT OUTER JOIN "segment_segmentconfiguration" ON (
    "environments_environment"."id" = "segment_segmentconfiguration"."environment_id"
  ) 
  LEFT OUTER JOIN "heap_heapconfiguration" ON (
    "environments_environment"."id" = "heap_heapconfiguration"."environment_id"
  ) 
  LEFT OUTER JOIN "mixpanel_mixpanelconfiguration" ON (
    "environments_environment"."id" = "mixpanel_mixpanelconfiguration"."environment_id"
  ) 
  LEFT OUTER JOIN "dynatrace_dynatraceconfiguration" ON (
    "environments_environment"."id" = "dynatrace_dynatraceconfiguration"."environment_id"
  ) 
WHERE 
  (
    "environments_environment"."deleted_at" IS NULL 
    AND (
      "environments_environment"."api_key" = '<api_Key>' 
      OR "environments_environmentapikey"."key" = '<api_Key>'
    )
  ) 
LIMIT 
  21

```

Generated plan:

```
Limit  (cost=1050.42..1054.31 rows=21 width=2552) (actual time=15.146..15.149 rows=0 loops=1)
   Buffers: shared hit=8084
   ->  Unique  (cost=1050.42..1054.68 rows=23 width=2552) (actual time=15.145..15.148 rows=0 loops=1)
         Buffers: shared hit=8084
         ->  Sort  (cost=1050.42..1050.48 rows=23 width=2552) (actual time=15.144..15.147 rows=0 loops=1)
               Sort Key: environments_environment.id, environments_environment.deleted_at, environments_environment.name, environments_environment.created_date, environments_environment.project_id, environments_environment.api_key, environments_environment.minimum_change_request_approvals, environments_environment.
webhooks_enabled, environments_environment.webhook_url, environments_environment.allow_client_traits, environments_environment.updated_at, environments_environment.banner_text, environments_environment.banner_colour, environments_environment.hide_disabled_flags, environments_environment.use_mv_v2_evaluation, enviro
nments_environment.hide_sensitive_data, projects_project.deleted_at, projects_project.uuid, projects_project.name, projects_project.created_date, projects_project.organisation_id, projects_project.hide_disabled_flags, projects_project.enable_dynamo_db, projects_project.prevent_flag_defaults, projects_project.enable
_realtime_updates, projects_project.only_allow_lower_case_feature_names, projects_project.feature_name_regex, projects_project.max_segments_allowed, projects_project.max_features_allowed, projects_project.max_segment_overrides_allowed, organisations_organisation.deleted_at, organisations_organisation.uuid, organisa
tions_organisation.name, organisations_organisation.has_requested_features, organisations_organisation.webhook_notification_email, organisations_organisation.created_date, organisations_organisation.alerted_over_plan_limit, organisations_organisation.stop_serving_flags, organisations_organisation.restrict_project_c
reate_to_admin, organisations_organisation.persist_trait_data, organisations_organisation.block_access_to_admin, organisations_organisation.feature_analytics, amplitude_amplitudeconfiguration.id, amplitude_amplitudeconfiguration.deleted_at, amplitude_amplitudeconfiguration.uuid, amplitude_amplitudeconfiguration.api
_key, amplitude_amplitudeconfiguration.base_url, amplitude_amplitudeconfiguration.environment_id, segment_segmentconfiguration.id, segment_segmentconfiguration.deleted_at, segment_segmentconfiguration.uuid, segment_segmentconfiguration.base_url, segment_segmentconfiguration.api_key, segment_segmentconfiguration.env
ironment_id, heap_heapconfiguration.id, heap_heapconfiguration.deleted_at, heap_heapconfiguration.uuid, heap_heapconfiguration.base_url, heap_heapconfiguration.api_key, heap_heapconfiguration.environment_id, mixpanel_mixpanelconfiguration.id, mixpanel_mixpanelconfiguration.deleted_at, mixpanel_mixpanelconfiguration
.uuid, mixpanel_mixpanelconfiguration.base_url, mixpanel_mixpanelconfiguration.api_key, mixpanel_mixpanelconfiguration.environment_id, dynatrace_dynatraceconfiguration.id, dynatrace_dynatraceconfiguration.deleted_at, dynatrace_dynatraceconfiguration.uuid, dynatrace_dynatraceconfiguration.base_url, dynatrace_dynatra
ceconfiguration.api_key, dynatrace_dynatraceconfiguration.environment_id, dynatrace_dynatraceconfiguration.entity_selector
               Sort Method: quicksort  Memory: 25kB
               Buffers: shared hit=8084
               ->  Nested Loop Left Join  (cost=1.42..1049.90 rows=23 width=2552) (actual time=15.108..15.112 rows=0 loops=1)
                     Join Filter: (environments_environment.id = dynatrace_dynatraceconfiguration.environment_id)
                     Buffers: shared hit=8084
                     ->  Nested Loop Left Join  (cost=1.42..1046.76 rows=23 width=1368) (actual time=15.108..15.111 rows=0 loops=1)
                           Join Filter: (environments_environment.id = mixpanel_mixpanelconfiguration.environment_id)
                           Buffers: shared hit=8084
                           ->  Nested Loop Left Join  (cost=1.42..1036.89 rows=23 width=1306) (actual time=15.107..15.110 rows=0 loops=1)
                                 Join Filter: (environments_environment.id = heap_heapconfiguration.environment_id)
                                 Buffers: shared hit=8084
                                 ->  Nested Loop Left Join  (cost=1.42..1026.96 rows=23 width=844) (actual time=15.107..15.109 rows=0 loops=1)
                                       Buffers: shared hit=8084
                                       ->  Nested Loop Left Join  (cost=1.27..1023.33 rows=23 width=778) (actual time=15.106..15.108 rows=0 loops=1)
                                             Buffers: shared hit=8084
                                             ->  Nested Loop  (cost=1.14..1019.70 rows=23 width=691) (actual time=15.105..15.107 rows=0 loops=1)
                                                   Buffers: shared hit=8084
                                                   ->  Nested Loop  (cost=0.85..1012.31 rows=23 width=608) (actual time=15.105..15.106 rows=0 loops=1)
                                                         Buffers: shared hit=8084
                                                         ->  Merge Left Join  (cost=0.56..1005.16 rows=23 width=524) (actual time=15.104..15.105 rows=0 loops=1)
                                                               Merge Cond: (environments_environment.id = environments_environmentapikey.environment_id)
                                                               Filter: (((environments_environment.api_key)::text = '<api_key>'::text) OR ((environments_environmentapikey.key)::text = '<api_key>'::text))
                                                               Rows Removed by Filter: 23294
                                                               Buffers: shared hit=8084
                                                               ->  Index Scan using environments_environment_pkey on environments_environment  (cost=0.29..896.12 rows=23153 width=524) (actual time=0.045..11.901 rows=23180 loops=1)
                                                                     Filter: (deleted_at IS NULL)
                                                                     Rows Removed by Filter: 3881
                                                                     Buffers: shared hit=7656
                                                               ->  Index Scan using environments_environmentapikey_environment_id_bae78ba1 on environments_environmentapikey  (cost=0.28..35.10 rows=1046 width=31) (actual time=0.024..0.370 rows=1075 loops=1)
                                                                     Buffers: shared hit=428
                                                         ->  Index Scan using projects_project_pkey on projects_project  (cost=0.29..0.31 rows=1 width=84) (never executed)
                                                               Index Cond: (id = environments_environment.project_id)
                                                   ->  Index Scan using organisations_organisation_pkey on organisations_organisation  (cost=0.29..0.32 rows=1 width=83) (never executed)
                                                         Index Cond: (id = projects_project.organisation_id)
                                             ->  Index Scan using amplitude_amplitudeconfiguration_environment_id_key on amplitude_amplitudeconfiguration  (cost=0.14..0.16 rows=1 width=87) (never executed)
                                                   Index Cond: (environments_environment.id = environment_id)
                                       ->  Index Scan using segment_segmentconfiguration_environment_id_key on segment_segmentconfiguration  (cost=0.14..0.16 rows=1 width=66) (never executed)
                                             Index Cond: (environments_environment.id = environment_id)
                                 ->  Materialize  (cost=0.00..1.38 rows=25 width=462) (never executed)
                                       ->  Seq Scan on heap_heapconfiguration  (cost=0.00..1.25 rows=25 width=462) (never executed)
                           ->  Materialize  (cost=0.00..2.33 rows=22 width=62) (never executed)
                                 ->  Seq Scan on mixpanel_mixpanelconfiguration  (cost=0.00..2.22 rows=22 width=62) (never executed)
                     ->  Materialize  (cost=0.00..1.09 rows=6 width=1184) (never executed)
                           ->  Seq Scan on dynatrace_dynatraceconfiguration  (cost=0.00..1.06 rows=6 width=1184) (never executed)
 Planning Time: 8.182 ms
 Execution Time: 15.534 ms


```
Query generated by this PR
```
(
  SELECT 
    "environments_environment"."id", 
    "environments_environment"."deleted_at", 
    "environments_environment"."name", 
    "environments_environment"."created_date", 
    "environments_environment"."project_id", 
    "environments_environment"."api_key", 
    "environments_environment"."minimum_change_request_approvals", 
    "environments_environment"."webhooks_enabled", 
    "environments_environment"."webhook_url", 
    "environments_environment"."allow_client_traits", 
    "environments_environment"."updated_at", 
    "environments_environment"."banner_text", 
    "environments_environment"."banner_colour", 
    "environments_environment"."hide_disabled_flags", 
    "environments_environment"."use_mv_v2_evaluation", 
    "environments_environment"."hide_sensitive_data", 
    "projects_project"."id", 
    "projects_project"."deleted_at", 
    "projects_project"."uuid", 
    "projects_project"."name", 
    "projects_project"."created_date", 
    "projects_project"."organisation_id", 
    "projects_project"."hide_disabled_flags", 
    "projects_project"."enable_dynamo_db", 
    "projects_project"."prevent_flag_defaults", 
    "projects_project"."enable_realtime_updates", 
    "projects_project"."only_allow_lower_case_feature_names", 
    "projects_project"."feature_name_regex", 
    "projects_project"."max_segments_allowed", 
    "projects_project"."max_features_allowed", 
    "projects_project"."max_segment_overrides_allowed", 
    "organisations_organisation"."id", 
    "organisations_organisation"."deleted_at", 
    "organisations_organisation"."uuid", 
    "organisations_organisation"."name", 
    "organisations_organisation"."has_requested_features", 
    "organisations_organisation"."webhook_notification_email", 
    "organisations_organisation"."created_date", 
    "organisations_organisation"."alerted_over_plan_limit", 
    "organisations_organisation"."stop_serving_flags", 
    "organisations_organisation"."restrict_project_create_to_admin", 
    "organisations_organisation"."persist_trait_data", 
    "organisations_organisation"."block_access_to_admin", 
    "organisations_organisation"."feature_analytics", 
    "amplitude_amplitudeconfiguration"."id", 
    "amplitude_amplitudeconfiguration"."deleted_at", 
    "amplitude_amplitudeconfiguration"."uuid", 
    "amplitude_amplitudeconfiguration"."api_key", 
    "amplitude_amplitudeconfiguration"."base_url", 
    "amplitude_amplitudeconfiguration"."environment_id", 
    "segment_segmentconfiguration"."id", 
    "segment_segmentconfiguration"."deleted_at", 
    "segment_segmentconfiguration"."uuid", 
    "segment_segmentconfiguration"."base_url", 
    "segment_segmentconfiguration"."api_key", 
    "segment_segmentconfiguration"."environment_id", 
    "heap_heapconfiguration"."id", 
    "heap_heapconfiguration"."deleted_at", 
    "heap_heapconfiguration"."uuid", 
    "heap_heapconfiguration"."base_url", 
    "heap_heapconfiguration"."api_key", 
    "heap_heapconfiguration"."environment_id", 
    "mixpanel_mixpanelconfiguration"."id", 
    "mixpanel_mixpanelconfiguration"."deleted_at", 
    "mixpanel_mixpanelconfiguration"."uuid", 
    "mixpanel_mixpanelconfiguration"."base_url", 
    "mixpanel_mixpanelconfiguration"."api_key", 
    "mixpanel_mixpanelconfiguration"."environment_id", 
    "dynatrace_dynatraceconfiguration"."id", 
    "dynatrace_dynatraceconfiguration"."deleted_at", 
    "dynatrace_dynatraceconfiguration"."uuid", 
    "dynatrace_dynatraceconfiguration"."base_url", 
    "dynatrace_dynatraceconfiguration"."api_key", 
    "dynatrace_dynatraceconfiguration"."environment_id", 
    "dynatrace_dynatraceconfiguration"."entity_selector" 
  FROM 
    "environments_environment" 
    INNER JOIN "projects_project" ON (
      "environments_environment"."project_id" = "projects_project"."id"
    ) 
    INNER JOIN "organisations_organisation" ON (
      "projects_project"."organisation_id" = "organisations_organisation"."id"
    ) 
    LEFT OUTER JOIN "amplitude_amplitudeconfiguration" ON (
      "environments_environment"."id" = "amplitude_amplitudeconfiguration"."environment_id"
    ) 
    LEFT OUTER JOIN "segment_segmentconfiguration" ON (
      "environments_environment"."id" = "segment_segmentconfiguration"."environment_id"
    ) 
    LEFT OUTER JOIN "heap_heapconfiguration" ON (
      "environments_environment"."id" = "heap_heapconfiguration"."environment_id"
    ) 
    LEFT OUTER JOIN "mixpanel_mixpanelconfiguration" ON (
      "environments_environment"."id" = "mixpanel_mixpanelconfiguration"."environment_id"
    ) 
    LEFT OUTER JOIN "dynatrace_dynatraceconfiguration" ON (
      "environments_environment"."id" = "dynatrace_dynatraceconfiguration"."environment_id"
    ) 
  WHERE 
    (
      "environments_environment"."deleted_at" IS NULL 
      AND "environments_environment"."api_key" = '<api_key>'
    ) 
  ORDER BY 
    "environments_environment"."id" ASC
) 
UNION 
  (
    SELECT 
      "environments_environment"."id", 
      "environments_environment"."deleted_at", 
      "environments_environment"."name", 
      "environments_environment"."created_date", 
      "environments_environment"."project_id", 
      "environments_environment"."api_key", 
      "environments_environment"."minimum_change_request_approvals", 
      "environments_environment"."webhooks_enabled", 
      "environments_environment"."webhook_url", 
      "environments_environment"."allow_client_traits", 
      "environments_environment"."updated_at", 
      "environments_environment"."banner_text", 
      "environments_environment"."banner_colour", 
      "environments_environment"."hide_disabled_flags", 
      "environments_environment"."use_mv_v2_evaluation", 
      "environments_environment"."hide_sensitive_data", 
      "projects_project"."id", 
      "projects_project"."deleted_at", 
      "projects_project"."uuid", 
      "projects_project"."name", 
      "projects_project"."created_date", 
      "projects_project"."organisation_id", 
      "projects_project"."hide_disabled_flags", 
      "projects_project"."enable_dynamo_db", 
      "projects_project"."prevent_flag_defaults", 
      "projects_project"."enable_realtime_updates", 
      "projects_project"."only_allow_lower_case_feature_names", 
      "projects_project"."feature_name_regex", 
      "projects_project"."max_segments_allowed", 
      "projects_project"."max_features_allowed", 
      "projects_project"."max_segment_overrides_allowed", 
      "organisations_organisation"."id", 
      "organisations_organisation"."deleted_at", 
      "organisations_organisation"."uuid", 
      "organisations_organisation"."name", 
      "organisations_organisation"."has_requested_features", 
      "organisations_organisation"."webhook_notification_email", 
      "organisations_organisation"."created_date", 
      "organisations_organisation"."alerted_over_plan_limit", 
      "organisations_organisation"."stop_serving_flags", 
      "organisations_organisation"."restrict_project_create_to_admin", 
      "organisations_organisation"."persist_trait_data", 
      "organisations_organisation"."block_access_to_admin", 
      "organisations_organisation"."feature_analytics", 
      "amplitude_amplitudeconfiguration"."id", 
      "amplitude_amplitudeconfiguration"."deleted_at", 
      "amplitude_amplitudeconfiguration"."uuid", 
      "amplitude_amplitudeconfiguration"."api_key", 
      "amplitude_amplitudeconfiguration"."base_url", 
      "amplitude_amplitudeconfiguration"."environment_id", 
      "segment_segmentconfiguration"."id", 
      "segment_segmentconfiguration"."deleted_at", 
      "segment_segmentconfiguration"."uuid", 
      "segment_segmentconfiguration"."base_url", 
      "segment_segmentconfiguration"."api_key", 
      "segment_segmentconfiguration"."environment_id", 
      "heap_heapconfiguration"."id", 
      "heap_heapconfiguration"."deleted_at", 
      "heap_heapconfiguration"."uuid", 
      "heap_heapconfiguration"."base_url", 
      "heap_heapconfiguration"."api_key", 
      "heap_heapconfiguration"."environment_id", 
      "mixpanel_mixpanelconfiguration"."id", 
      "mixpanel_mixpanelconfiguration"."deleted_at", 
      "mixpanel_mixpanelconfiguration"."uuid", 
      "mixpanel_mixpanelconfiguration"."base_url", 
      "mixpanel_mixpanelconfiguration"."api_key", 
      "mixpanel_mixpanelconfiguration"."environment_id", 
      "dynatrace_dynatraceconfiguration"."id", 
      "dynatrace_dynatraceconfiguration"."deleted_at", 
      "dynatrace_dynatraceconfiguration"."uuid", 
      "dynatrace_dynatraceconfiguration"."base_url", 
      "dynatrace_dynatraceconfiguration"."api_key", 
      "dynatrace_dynatraceconfiguration"."environment_id", 
      "dynatrace_dynatraceconfiguration"."entity_selector" 
    FROM 
      "environments_environment" 
      INNER JOIN "environments_environmentapikey" ON (
        "environments_environment"."id" = "environments_environmentapikey"."environment_id"
      ) 
      INNER JOIN "projects_project" ON (
        "environments_environment"."project_id" = "projects_project"."id"
      ) 
      INNER JOIN "organisations_organisation" ON (
        "projects_project"."organisation_id" = "organisations_organisation"."id"
      ) 
      LEFT OUTER JOIN "amplitude_amplitudeconfiguration" ON (
        "environments_environment"."id" = "amplitude_amplitudeconfiguration"."environment_id"
      ) 
      LEFT OUTER JOIN "segment_segmentconfiguration" ON (
        "environments_environment"."id" = "segment_segmentconfiguration"."environment_id"
      ) 
      LEFT OUTER JOIN "heap_heapconfiguration" ON (
        "environments_environment"."id" = "heap_heapconfiguration"."environment_id"
      ) 
      LEFT OUTER JOIN "mixpanel_mixpanelconfiguration" ON (
        "environments_environment"."id" = "mixpanel_mixpanelconfiguration"."environment_id"
      ) 
      LEFT OUTER JOIN "dynatrace_dynatraceconfiguration" ON (
        "environments_environment"."id" = "dynatrace_dynatraceconfiguration"."environment_id"
      ) 
    WHERE 
      (
        "environments_environment"."deleted_at" IS NULL 
        AND "environments_environmentapikey"."key" = '<api_key>'
      ) 
    ORDER BY 
      "environments_environment"."id" ASC
  ) 
LIMIT 
  21


```

Query plan:

```
 Limit  (cost=20.69..21.07 rows=2 width=7761) (actual time=0.063..0.067 rows=0 loops=1)
   ->  Unique  (cost=20.69..21.07 rows=2 width=7761) (actual time=0.063..0.066 rows=0 loops=1)
         ->  Sort  (cost=20.69..20.69 rows=2 width=7761) (actual time=0.063..0.066 rows=0 loops=1)
               Sort Key: environments_environment.id, environments_environment.deleted_at, environments_environment.name, environments_environment.created_date, environments_environment.project_id, environments_environment.api_key, environments_environment.minimum_change_request_approvals, environments_environment.
webhooks_enabled, environments_environment.webhook_url, environments_environment.allow_client_traits, environments_environment.updated_at, environments_environment.banner_text, environments_environment.banner_colour, environments_environment.hide_disabled_flags, environments_environment.use_mv_v2_evaluation, enviro
nments_environment.hide_sensitive_data, projects_project.id, projects_project.deleted_at, projects_project.uuid, projects_project.name, projects_project.created_date, projects_project.organisation_id, projects_project.hide_disabled_flags, projects_project.enable_dynamo_db, projects_project.prevent_flag_defaults, pr
ojects_project.enable_realtime_updates, projects_project.only_allow_lower_case_feature_names, projects_project.feature_name_regex, projects_project.max_segments_allowed, projects_project.max_features_allowed, projects_project.max_segment_overrides_allowed, organisations_organisation.id, organisations_organisation.d
eleted_at, organisations_organisation.uuid, organisations_organisation.name, organisations_organisation.has_requested_features, organisations_organisation.webhook_notification_email, organisations_organisation.created_date, organisations_organisation.alerted_over_plan_limit, organisations_organisation.stop_serving_
flags, organisations_organisation.restrict_project_create_to_admin, organisations_organisation.persist_trait_data, organisations_organisation.block_access_to_admin, organisations_organisation.feature_analytics, amplitude_amplitudeconfiguration.id, amplitude_amplitudeconfiguration.deleted_at, amplitude_amplitudeconf
iguration.uuid, amplitude_amplitudeconfiguration.api_key, amplitude_amplitudeconfiguration.base_url, amplitude_amplitudeconfiguration.environment_id, segment_segmentconfiguration.id, segment_segmentconfiguration.deleted_at, segment_segmentconfiguration.uuid, segment_segmentconfiguration.base_url, segment_segmentcon
figuration.api_key, segment_segmentconfiguration.environment_id, heap_heapconfiguration.id, heap_heapconfiguration.deleted_at, heap_heapconfiguration.uuid, heap_heapconfiguration.base_url, heap_heapconfiguration.api_key, heap_heapconfiguration.environment_id, mixpanel_mixpanelconfiguration.id, mixpanel_mixpanelconf
iguration.deleted_at, mixpanel_mixpanelconfiguration.uuid, mixpanel_mixpanelconfiguration.base_url, mixpanel_mixpanelconfiguration.api_key, mixpanel_mixpanelconfiguration.environment_id, dynatrace_dynatraceconfiguration.id, dynatrace_dynatraceconfiguration.deleted_at, dynatrace_dynatraceconfiguration.uuid, dynatrac
e_dynatraceconfiguration.base_url, dynatrace_dynatraceconfiguration.api_key, dynatrace_dynatraceconfiguration.environment_id, dynatrace_dynatraceconfiguration.entity_selector
               Sort Method: quicksort  Memory: 25kB
               ->  Append  (cost=9.62..20.68 rows=2 width=7761) (actual time=0.040..0.043 rows=0 loops=1)
                     ->  Nested Loop Left Join  (cost=9.62..14.22 rows=1 width=2552) (actual time=0.027..0.028 rows=0 loops=1)
                           ->  Nested Loop  (cost=9.48..11.78 rows=1 width=2465) (actual time=0.026..0.028 rows=0 loops=1)
                                 ->  Nested Loop  (cost=9.19..11.46 rows=1 width=2382) (actual time=0.026..0.028 rows=0 loops=1)
                                       ->  Merge Left Join  (cost=8.91..8.95 rows=1 width=2298) (actual time=0.026..0.027 rows=0 loops=1)
                                             Merge Cond: (environments_environment.id = dynatrace_dynatraceconfiguration.environment_id)
                                             ->  Sort  (cost=7.77..7.77 rows=1 width=1114) (actual time=0.025..0.027 rows=0 loops=1)
                                                   Sort Key: environments_environment.id
                                                   Sort Method: quicksort  Memory: 25kB
                                                   ->  Hash Right Join  (cost=5.45..7.76 rows=1 width=1114) (actual time=0.024..0.025 rows=0 loops=1)
                                                         Hash Cond: (mixpanel_mixpanelconfiguration.environment_id = environments_environment.id)
                                                         ->  Seq Scan on mixpanel_mixpanelconfiguration  (cost=0.00..2.22 rows=22 width=62) (never executed)
                                                         ->  Hash  (cost=5.43..5.43 rows=1 width=1052) (actual time=0.020..0.021 rows=0 loops=1)
                                                               Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                                               ->  Hash Right Join  (cost=3.85..5.43 rows=1 width=1052) (actual time=0.020..0.021 rows=0 loops=1)
                                                                     Hash Cond: (segment_segmentconfiguration.environment_id = environments_environment.id)
                                                                     ->  Seq Scan on segment_segmentconfiguration  (cost=0.00..1.42 rows=42 width=66) (never executed)
                                                                     ->  Hash  (cost=3.83..3.83 rows=1 width=986) (actual time=0.017..0.018 rows=0 loops=1)
                                                                           Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                                                           ->  Hash Right Join  (cost=2.52..3.83 rows=1 width=986) (actual time=0.017..0.018 rows=0 loops=1)
                                                                                 Hash Cond: (heap_heapconfiguration.environment_id = environments_environment.id)
                                                                                 ->  Seq Scan on heap_heapconfiguration  (cost=0.00..1.25 rows=25 width=462) (never executed)
                                                                                 ->  Hash  (cost=2.51..2.51 rows=1 width=524) (actual time=0.013..0.013 rows=0 loops=1)
                                                                                       Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                                                                       ->  Index Scan using environments_environment_api_key_b1cbb73a_like on environments_environment  (cost=0.29..2.51 rows=1 width=524) (actual time=0.012..0.013 rows=0 loops=1)
                                                                                             Index Cond: ((api_key)::text = '<api_key>'::text)
                                                                                             Filter: (deleted_at IS NULL)
                                             ->  Sort  (cost=1.14..1.15 rows=6 width=1184) (never executed)
                                                   Sort Key: dynatrace_dynatraceconfiguration.environment_id
                                                   ->  Seq Scan on dynatrace_dynatraceconfiguration  (cost=0.00..1.06 rows=6 width=1184) (never executed)
                                       ->  Index Scan using projects_project_pkey on projects_project  (cost=0.29..2.50 rows=1 width=84) (never executed)
                                             Index Cond: (id = environments_environment.project_id)
                                 ->  Index Scan using organisations_organisation_pkey on organisations_organisation  (cost=0.29..0.32 rows=1 width=83) (never executed)
                                       Index Cond: (id = projects_project.organisation_id)
                           ->  Index Scan using amplitude_amplitudeconfiguration_environment_id_key on amplitude_amplitudeconfiguration  (cost=0.14..2.36 rows=1 width=87) (never executed)
                                 Index Cond: (environments_environment.id = environment_id)
                     ->  Sort  (cost=6.43..6.43 rows=1 width=2552) (actual time=0.013..0.014 rows=0 loops=1)
                           Sort Key: environments_environment_1.id
                           Sort Method: quicksort  Memory: 25kB
                           ->  Nested Loop Left Join  (cost=1.82..6.42 rows=1 width=2552) (actual time=0.012..0.012 rows=0 loops=1)
                                 ->  Nested Loop Left Join  (cost=1.69..6.26 rows=1 width=1368) (actual time=0.011..0.012 rows=0 loops=1)
                                       ->  Nested Loop Left Join  (cost=1.55..6.11 rows=1 width=1306) (actual time=0.011..0.012 rows=0 loops=1)
                                             ->  Nested Loop Left Join  (cost=1.42..5.95 rows=1 width=844) (actual time=0.011..0.012 rows=0 loops=1)
                                                   ->  Nested Loop Left Join  (cost=1.27..5.79 rows=1 width=778) (actual time=0.011..0.011 rows=0 loops=1)
                                                         ->  Nested Loop  (cost=1.14..5.63 rows=1 width=691) (actual time=0.011..0.011 rows=0 loops=1)
                                                               ->  Nested Loop  (cost=0.85..5.31 rows=1 width=608) (actual time=0.011..0.011 rows=0 loops=1)
                                                                     ->  Nested Loop  (cost=0.56..5.00 rows=1 width=524) (actual time=0.011..0.011 rows=0 loops=1)
                                                                           ->  Index Scan using environments_environmentapikey_key_cb39852c_like on environments_environmentapikey  (cost=0.28..2.50 rows=1 width=4) (actual time=0.010..0.010 rows=0 loops=1)
                                                                                 Index Cond: ((key)::text = '<api_key>'::text)
                                                                           ->  Index Scan using environments_environment_pkey on environments_environment environments_environment_1  (cost=0.29..2.51 rows=1 width=524) (never executed)
                                                                                 Index Cond: (id = environments_environmentapikey.environment_id)
                                                                                 Filter: (deleted_at IS NULL)
                                                                     ->  Index Scan using projects_project_pkey on projects_project projects_project_1  (cost=0.29..0.31 rows=1 width=84) (never executed)
                                                                           Index Cond: (id = environments_environment_1.project_id)
                                                               ->  Index Scan using organisations_organisation_pkey on organisations_organisation organisations_organisation_1  (cost=0.29..0.32 rows=1 width=83) (never executed)
                                                                     Index Cond: (id = projects_project_1.organisation_id)
                                                         ->  Index Scan using amplitude_amplitudeconfiguration_environment_id_key on amplitude_amplitudeconfiguration amplitude_amplitudeconfiguration_1  (cost=0.14..0.16 rows=1 width=87) (never executed)
                                                               Index Cond: (environments_environment_1.id = environment_id)
                                                   ->  Index Scan using segment_segmentconfiguration_environment_id_key on segment_segmentconfiguration segment_segmentconfiguration_1  (cost=0.14..0.16 rows=1 width=66) (never executed)
                                                         Index Cond: (environments_environment_1.id = environment_id)
                                             ->  Index Scan using heap_heapconfiguration_environment_id_key on heap_heapconfiguration heap_heapconfiguration_1  (cost=0.14..0.16 rows=1 width=462) (never executed)
                                                   Index Cond: (environments_environment_1.id = environment_id)
                                       ->  Index Scan using mixpanel_mixpanelconfiguration_environment_id_key on mixpanel_mixpanelconfiguration mixpanel_mixpanelconfiguration_1  (cost=0.14..0.16 rows=1 width=62) (never executed)
                                             Index Cond: (environments_environment_1.id = environment_id)
                                 ->  Index Scan using dynatrace_dynatraceconfiguration_environment_id_key on dynatrace_dynatraceconfiguration dynatrace_dynatraceconfiguration_1  (cost=0.13..0.15 rows=1 width=1184) (never executed)
                                       Index Cond: (environments_environment_1.id = environment_id)
 Planning Time: 6.373 ms
 Execution Time: 0.538 ms

```


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Correctness is covered by unit test cases. Plans are generate on prodcution database 