### PR TITLE
fix: incorrect default_percentage_allocation on import, binary flags imported as multivariate

### DIFF
--- a/api/features/feature_types.py
+++ b/api/features/feature_types.py
@@ -1,5 +1,9 @@
-MULTIVARIATE = "MULTIVARIATE"
-STANDARD = "STANDARD"
+from typing import Literal
+
+FeatureType = Literal["STANDARD", "MULTIVARIATE"]
+
+MULTIVARIATE: FeatureType = "MULTIVARIATE"
+STANDARD: FeatureType = "STANDARD"
 
 # the following two types have been merged in terms of functionality
 # but kept for now until the FE is updated

--- a/api/tests/unit/integrations/launch_darkly/test_services.py
+++ b/api/tests/unit/integrations/launch_darkly/test_services.py
@@ -137,19 +137,45 @@ def test_process_import_request__success__expected_status(
     boolean_standard_feature_states_by_env_name["Test"].enabled is True
     boolean_standard_feature_states_by_env_name["Production"].enabled is False
 
-    value_standard_feature = Feature.objects.get(project=project, name="flag2_value")
-    value_standard_feature_states_by_env_name = {
+    string_standard_feature = Feature.objects.get(project=project, name="flag2_value")
+    string_standard_feature_states_by_env_name = {
         fs.environment.name: fs
-        for fs in FeatureState.objects.filter(feature=value_standard_feature)
+        for fs in FeatureState.objects.filter(feature=string_standard_feature)
     }
-    value_standard_feature_states_by_env_name["Test"].enabled is True
-    value_standard_feature_states_by_env_name[
-        "Test"
-    ].get_feature_state_value() == "123123"
-    value_standard_feature_states_by_env_name["Production"].enabled is False
-    value_standard_feature_states_by_env_name[
-        "Production"
-    ].get_feature_state_value() == ""
+    assert string_standard_feature_states_by_env_name["Test"].enabled is True
+    assert (
+        string_standard_feature_states_by_env_name["Test"].get_feature_state_value()
+        == "123123"
+    )
+    assert (
+        string_standard_feature_states_by_env_name["Test"].feature_state_value.type
+        == "unicode"
+    )
+    assert (
+        string_standard_feature_states_by_env_name[
+            "Test"
+        ].feature_state_value.string_value
+        == "123123"
+    )
+    assert string_standard_feature_states_by_env_name["Production"].enabled is False
+    assert (
+        string_standard_feature_states_by_env_name[
+            "Production"
+        ].get_feature_state_value()
+        == ""
+    )
+    assert (
+        string_standard_feature_states_by_env_name[
+            "Production"
+        ].feature_state_value.type
+        == "unicode"
+    )
+    assert (
+        string_standard_feature_states_by_env_name[
+            "Production"
+        ].feature_state_value.string_value
+        == ""
+    )
 
     # Multivariate feature states with percentage rollout have expected values.
     percentage_mv_feature = Feature.objects.get(
@@ -168,7 +194,7 @@ def test_process_import_request__success__expected_status(
             "multivariate_feature_option__string_value",
             "percentage_allocation",
         )
-    ) == [("variation1", 100), ("variation2", 0)]
+    ) == [("variation1", 100), ("variation2", 0), ("variation3", 0)]
 
     assert percentage_mv_feature_states_by_env_name["Production"].enabled is True
     assert list(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes two issues with LD importer:

- multivariate options created with 100% default percentage, should be 0
- standard valued features treated as multivariate with 100/0 variations

## How did you test this code?

Extended unit tests.