### PR TITLE
ci: Run only API tests affected by changes in PRs and Upgrade GHA runners

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -69,7 +69,7 @@ jobs:
         run: make django-make-migrations
 
       - name: Restore cached testmon data
-        if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' }}
         id: cache-testmon-restore
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -12,6 +12,8 @@ on:
       - .github/**
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 defaults:
   run:
@@ -19,7 +21,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: General-Purpose-8c-Runner
     name: API Unit Tests
 
     services:
@@ -33,7 +35,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     strategy:
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         python-version: ['3.10', '3.11']
 
@@ -66,10 +68,30 @@ jobs:
           opts: --no-input --dry-run --check
         run: make django-make-migrations
 
+      - name: Restore cached testmon data
+        if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+        id: cache-testmon-restore
+        uses: actions/cache/restore@v3
+        with:
+          enableCrossOsArchive: true
+          path: |
+            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
+          key: testmon-data-python${{ matrix.python-version }}-${{ github.event.pull_request.base.sha }}
+          restore-keys: testmon-data-python${{ matrix.python-version }}-
+
       - name: Run Tests
         env:
           DOTENV_OVERRIDE_FILE: .env-ci
         run: make test
+
+      - name: Save testmon data cache
+        id: cache-testmon-save
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
+          key: testmon-data-python${{ matrix.python-version }}-${{github.sha}}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ src/CI_COMMIT_SHA
 .DS_Store
 .idea
 *.iml
-api/.testmondata
-api/.testmondata-shm
-api/.testmondata-wal

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ src/CI_COMMIT_SHA
 .DS_Store
 .idea
 *.iml
+api/.testmondata
+api/.testmondata-shm
+api/.testmondata-wal

--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,3 +1,3 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
-PYTEST_ADDOPTS=--cov . --cov-report xml -n auto --dist worksteal
+PYTEST_ADDOPTS=--cov . --cov-report xml -n auto --dist worksteal --testmon

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -7,3 +7,6 @@ features/workflows/logic/
 
 # Unit test coverage
 .coverage
+
+# pytest-testmon files
+.testmondata*

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -211,8 +211,8 @@ files = [
 lazy-object-proxy = ">=1.4.0"
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
 ]
 
 [[package]]
@@ -825,8 +825,8 @@ openapi-spec-validator = ">=0.2.8,<=0.5.7"
 packaging = "*"
 prance = ">=0.18.2"
 pydantic = [
-    {version = ">=1.9.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.10.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"4.0\""},
+    {version = ">=1.9.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 PySnooper = ">=0.4.1,<2.0.0"
 toml = ">=0.10.0,<1.0.0"
@@ -2014,16 +2014,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2865,8 +2855,8 @@ files = [
 astroid = ">=2.14.2,<=2.16.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
 ]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
@@ -3143,6 +3133,21 @@ pytest = ">=5.0"
 
 [package.extras]
 dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.0.13"
+description = "selects tests affected by changed files and methods"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-testmon-2.0.13.tar.gz", hash = "sha256:9cf56021ccaa6c8c6bcaef07589fb6c872db1797f0f7ff1f104e93c96078d642"},
+    {file = "pytest_testmon-2.0.13-py3-none-any.whl", hash = "sha256:170872f2407e1eab431a266108229dbcde73513771a71ab77ed1e84ec94c816c"},
+]
+
+[package.dependencies]
+coverage = ">=6,<8"
+pytest = ">=5,<8"
 
 [[package]]
 name = "pytest-xdist"
@@ -4241,4 +4246,4 @@ requests = ">=2.7,<3.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "47b38ca471d9b731546899037f7084d4582517730abe3e0a0fc5243f4da0f49b"
+content-hash = "be73a0b143067476a8bff66e2d72b1a80c52c2a8084a53120cc77301c296dfa2"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -129,6 +129,7 @@ pip-tools = "~6.13.0"
 pytest-cov = "~4.1.0"
 datamodel-code-generator = "~0.22"
 requests-mock = "^1.11.0"
+pytest-testmon = "^2.0.13"
 
 [build-system]
 requires = ["poetry-core>=1.5.0"]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X ] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Use `pytest-testmon` to only execute API tests affected by changed files. Also upgrade GHA runners for this specific job.

## How did you test this code?

API Tests executed as expected. Also testing manually using this PR to ensure that only tests affected by changes are exectured.

## Implementation notes
Notice that for retrieving the cache we use `github.event.pull_request.base.sha` as the final part of the cache key, and when we save the tesmon database file to the cache we use `github.sha`. That is because we restore cache only on PR events while we save the cache only on the push to main event, and `github.event.pull_request.base.sha` on the PR event context should be the same as `github.sha` of the base branch on the push event context.

Also, notice that we are using absolute paths for storing/retrieving the tesmon database file to/from the cache. We do that because if we use a relative path it will not be relative to the working directory, but to the workspace directory, which can vary depending on the context, so in this particular case I think it is better to stick to the absolute path. For more details refer to the comments below.