### PR TITLE
fix: Cannot see the assigned users in the changes request section

### DIFF
--- a/frontend/web/components/pages/ChangeRequestPage.js
+++ b/frontend/web/components/pages/ChangeRequestPage.js
@@ -30,7 +30,7 @@ const ChangeRequestsPage = class extends Component {
   }
 
   getApprovals = (users, approvals) =>
-    users?.filter((v) => approvals?.includes(v.group))
+    users?.filter((v) => approvals?.includes(v.id))
 
   getGroupApprovals = (groups, approvals) =>
     groups.filter((v) => approvals.find((a) => a.group === v.id))


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Can interact and see the list of assigned users

## How did you test this code?

1. Go to the "Changes Request" section
2. Select a change request (If they have already been assigned, the list will be seen)
3. Click "Assigned Users" to display the drop-down list of users and assign users

