### PR TITLE
chore: re-enable task clean up logic

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -129,11 +129,7 @@
                 },
                 {
                     "name": "TASK_DELETE_RETENTION_DAYS",
-                    "value": "280"
-                },
-                {
-                    "name": "ENABLE_CLEAN_UP_OLD_TASKS",
-                    "value": "False"
+                    "value": "45"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Enables task clean up logic which is run using a recurring task. @gagantrivedi and I have been cleaning up the task and taskrun tables in preparation for this but this should not be released until the data in those tables is inline with the retention period. 

## How did you test this code?

Tests already exist in code, this PR is just changing environment variables. Logic has also been running successfully in staging. 
