### PR TITLE
feat: Click Segment Overrides icon doesnt open the segment override tab

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -60,9 +60,7 @@ class TheComponent extends Component {
     history.replaceState(
       {},
       null,
-      `${document.location.pathname}?feature=${projectFlag.id}${
-        tab ? `&tab=${tab}` : ''
-      }`,
+      `${document.location.pathname}?feature=${projectFlag.id}`,
     )
     openModal(
       `${this.props.permission ? 'Edit Feature' : 'Feature'}: ${
@@ -75,6 +73,7 @@ class TheComponent extends Component {
         projectFlag={projectFlag}
         noPermissions={!this.props.permission}
         environmentFlag={environmentFlag}
+        tab={tab}
         flagId={environmentFlag.id}
       />,
       'side-modal create-feature-modal',
@@ -222,22 +221,29 @@ class TheComponent extends Component {
                 </span>
 
                 {!!projectFlag.num_segment_overrides && (
-                  <Tooltip
-                    title={
-                      <span
-                        className='chip me-2 chip--xs bg-primary text-white'
-                        style={{ border: 'none' }}
-                      >
-                        <SegmentsIcon className='chip-svg-icon' />
-                        <span>{projectFlag.num_segment_overrides}</span>
-                      </span>
-                    }
-                    place='top'
+                  <div
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      this.editFeature(projectFlag, environmentFlags[id], 1)
+                    }}
                   >
-                    {`${projectFlag.num_segment_overrides} Segment Override${
-                      projectFlag.num_segment_overrides !== 1 ? 's' : ''
-                    }`}
-                  </Tooltip>
+                    <Tooltip
+                      title={
+                        <span
+                          className='chip me-2 chip--xs bg-primary text-white'
+                          style={{ border: 'none' }}
+                        >
+                          <SegmentsIcon className='chip-svg-icon' />
+                          <span>{projectFlag.num_segment_overrides}</span>
+                        </span>
+                      }
+                      place='top'
+                    >
+                      {`${projectFlag.num_segment_overrides} Segment Override${
+                        projectFlag.num_segment_overrides !== 1 ? 's' : ''
+                      }`}
+                    </Tooltip>
+                  </div>
                 )}
                 {!!projectFlag.num_identity_overrides && (
                   <Tooltip

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -56,7 +56,7 @@ const CreateFlag = class extends Component {
       : {
           multivariate_options: [],
         }
-    const { allowEditDescription } = this.props
+    const { allowEditDescription, tab } = this.props
     if (this.props.projectFlag) {
       this.userOverridesPage(1)
     }
@@ -84,7 +84,7 @@ const CreateFlag = class extends Component {
       name,
       period: 30,
       selectedIdentity: null,
-      tab: Utils.fromParam().tab || 0,
+      tab: tab || 0,
       tags: tags || [],
     }
     AppActions.getGroups(AccountStore.getOrganisation().id)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- When clicking the Segment Overrides Icon in a feature row this opens the segment override tab

<img width="1033" alt="Screen Shot 2023-10-24 at 18 14 35" src="https://github.com/Flagsmith/flagsmith/assets/41410593/6b2373ed-8a31-47d9-adcb-6d0696a1814d">

<img width="1038" alt="Screen Shot 2023-10-24 at 18 15 49" src="https://github.com/Flagsmith/flagsmith/assets/41410593/e9e238ff-7b17-43da-b515-1fbe4a649ff1">

## How did you test this code?

- Go to Features page
- Click Segment overrides Icon
