### PR TITLE
docs(api): document usage of endpoint_url on import/export

### DIFF
--- a/docs/docs/deployment/configuration/importing-and-exporting.md
+++ b/docs/docs/deployment/configuration/importing-and-exporting.md
@@ -141,12 +141,13 @@ make sure whichever role you are using to run you container has access to read f
 Alternatively, you can provide the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to refer to an
 IAM user that has access to the S3 bucket.
 
-> Using localstack to achieve local/test exports with s3 can be done using
-> [localstack](https://github.com/localstack/localstack) and the
-> [service-specific endpoint](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) strategy.
->
-> Once running you are able to set a specific url for the s3 service `AWS_ENDPOINT_URL_S3` or for all services
-> `AWS_ENDPOINT_URL`.
+#### Using localstack to achieve local/test exports with s3 can be done using
+
+[localstack](https://github.com/localstack/localstack) and the
+[service-specific endpoint](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) strategy.
+
+Once running you are able to set a specific url for the s3 service `AWS_ENDPOINT_URL_S3` or for all services
+`AWS_ENDPOINT_URL`.
 
 ## Importing
 
@@ -166,9 +167,10 @@ e.g.
 python manage.py import-organisation-from-s3 my-export-bucket exports/organisation-1.json
 ```
 
-> Using localstack to achieve local/test imports with s3 can be done using
-> [localstack](https://github.com/localstack/localstack) and the
-> [service-specific endpoint](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) strategy.
->
-> Once running you are able to set a specific url for the s3 service `AWS_ENDPOINT_URL_S3` or for all services
-> `AWS_ENDPOINT_URL`.
+#### Using localstack to achieve local/test imports with s3 can be done using
+
+[localstack](https://github.com/localstack/localstack) and the
+[service-specific endpoint](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) strategy.
+
+Once running you are able to set a specific url for the s3 service `AWS_ENDPOINT_URL_S3` or for all services
+`AWS_ENDPOINT_URL`.

--- a/docs/docs/deployment/configuration/importing-and-exporting.md
+++ b/docs/docs/deployment/configuration/importing-and-exporting.md
@@ -141,6 +141,13 @@ make sure whichever role you are using to run you container has access to read f
 Alternatively, you can provide the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to refer to an
 IAM user that has access to the S3 bucket.
 
+> Using localstack to achieve local/test exports with s3 can be done using
+> [localstack](https://github.com/localstack/localstack) and the
+> [service-specific endpoint](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) strategy.
+>
+> Once running you are able to set a specific url for the s3 service `AWS_ENDPOINT_URL_S3` or for all services
+> `AWS_ENDPOINT_URL`.
+
 ## Importing
 
 ### Option 1 - Local File System
@@ -158,3 +165,10 @@ e.g.
 ```bash
 python manage.py import-organisation-from-s3 my-export-bucket exports/organisation-1.json
 ```
+
+> Using localstack to achieve local/test imports with s3 can be done using
+> [localstack](https://github.com/localstack/localstack) and the
+> [service-specific endpoint](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) strategy.
+>
+> Once running you are able to set a specific url for the s3 service `AWS_ENDPOINT_URL_S3` or for all services
+> `AWS_ENDPOINT_URL`.


### PR DESCRIPTION
- [x] I have run [pre-commit](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Updated documentation to include a pattern where using env vars for AWS endpoint URLs will allow users to import/export locally using localstack or similar.

## How did you test this code?

Docs change, no testing required
