### PR TITLE
feat: Create staff fixture

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -80,9 +80,9 @@ def test_user_client(api_client, test_user):
 def staff_user(django_user_model):
     """
     A non-admin user fixture.
-    To add to an environment with permissions use:
-    uep = UserEnvironmentPermission.objects.create ...
-    uep.permissions.add ...
+    To add to an environment with permissions use the fixture
+    with_environment_permissions.
+
     This fixture is attached to the organisation fixture.
     """
     return django_user_model.objects.create(email="staff@example.com")
@@ -180,6 +180,11 @@ def environment(project):
 def with_environment_permissions(
     environment: Environment, staff_user: FFAdminUser
 ) -> typing.Callable:
+    """
+    Add environment permissions to the staff_user fixture.
+    Defaults to associating to the environment fixture.
+    """
+
     def _with_environment_permissions(
         permission_keys: list[str], environment_id: typing.Optional[int] = None
     ) -> UserEnvironmentPermission:

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -77,9 +77,29 @@ def test_user_client(api_client, test_user):
 
 
 @pytest.fixture()
-def organisation(db, admin_user):
+def staff_user(django_user_model):
+    """
+    A non-admin user fixture.
+    To add to an environment with permissions use:
+    uep = UserEnvironmentPermission.objects.create ...
+    uep.permissions.add ...
+    This fixture is attached to the organisation fixture.
+    """
+    return django_user_model.objects.create(email="staff@example.com")
+
+
+@pytest.fixture()
+def staff_client(staff_user):
+    client = APIClient()
+    client.force_authenticate(user=staff_user)
+    return client
+
+
+@pytest.fixture()
+def organisation(db, admin_user, staff_user):
     org = Organisation.objects.create(name="Test Org")
     admin_user.add_organisation(org, role=OrganisationRole.ADMIN)
+    staff_user.add_organisation(org, role=OrganisationRole.USER)
     return org
 
 

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -177,6 +177,24 @@ def environment(project):
 
 
 @pytest.fixture()
+def with_environment_permissions(
+    environment: Environment, staff_user: FFAdminUser
+) -> typing.Callable:
+    def _with_environment_permissions(
+        permission_keys: list[str], environment_id: typing.Optional[int] = None
+    ) -> UserEnvironmentPermission:
+        environment_id = environment_id or environment.id
+        uep, __ = UserEnvironmentPermission.objects.get_or_create(
+            environment_id=environment_id, user=staff_user
+        )
+        uep.permissions.add(*permission_keys)
+
+        return uep
+
+    return _with_environment_permissions
+
+
+@pytest.fixture()
 def identity(environment):
     return Identity.objects.create(identifier="test_identity", environment=environment)
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add a new fixture to transition to testing more routes by default at a lower level of access to ensure staff members are:

1. Able to do stuff they're supposed to do.
2. Not able to do stuff they're not supposed to do.

Essentially, start by default by using the staff fixture since the resulting tests are more robust since admin users are automatically able to sail through most permissions classes.

## How did you test this code?

By using the same code in [this PR](https://github.com/Flagsmith/flagsmith/pull/2919/files)
