### PR TITLE
fix: Tighten ACL for user routes

### DIFF
--- a/api/organisations/tests/test_views.py
+++ b/api/organisations/tests/test_views.py
@@ -1158,7 +1158,7 @@ def test_make_user_group_admin_success(
 
 
 def test_make_user_group_admin_forbidden(
-    test_user_client, organisation, user_permission_group
+    staff_client, organisation, user_permission_group
 ):
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
@@ -1170,7 +1170,7 @@ def test_make_user_group_admin_forbidden(
     )
 
     # When
-    response = test_user_client.post(url)
+    response = staff_client.post(url)
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -1222,7 +1222,7 @@ def test_remove_user_as_group_admin_success(
 
 
 def test_remove_user_as_group_admin_forbidden(
-    test_user_client, organisation, user_permission_group
+    staff_client, organisation, user_permission_group
 ):
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
@@ -1235,7 +1235,7 @@ def test_remove_user_as_group_admin_forbidden(
     )
 
     # When
-    response = test_user_client.post(url)
+    response = staff_client.post(url)
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
 

--- a/api/organisations/tests/test_views.py
+++ b/api/organisations/tests/test_views.py
@@ -1157,6 +1157,25 @@ def test_make_user_group_admin_success(
     )
 
 
+def test_make_user_group_admin_forbidden(
+    test_user_client, organisation, user_permission_group
+):
+    # Given
+    another_user = FFAdminUser.objects.create(email="another_user@example.com")
+    another_user.add_organisation(organisation)
+    another_user.permission_groups.add(user_permission_group)
+    url = reverse(
+        "api-v1:organisations:make-user-group-admin",
+        args=[organisation.id, user_permission_group.id, another_user.id],
+    )
+
+    # When
+    response = test_user_client.post(url)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
 def test_remove_user_as_group_admin_user_does_not_belong_to_group(
     admin_client, admin_user, organisation, user_permission_group
 ):
@@ -1200,6 +1219,25 @@ def test_remove_user_as_group_admin_success(
         ).group_admin
         is False
     )
+
+
+def test_remove_user_as_group_admin_forbidden(
+    test_user_client, organisation, user_permission_group
+):
+    # Given
+    another_user = FFAdminUser.objects.create(email="another_user@example.com")
+    another_user.add_organisation(organisation)
+    another_user.permission_groups.add(user_permission_group)
+    another_user.make_group_admin(user_permission_group.id)
+    url = reverse(
+        "api-v1:organisations:remove-user-group-admin",
+        args=[organisation.id, user_permission_group.id, another_user.id],
+    )
+
+    # When
+    response = test_user_client.post(url)
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_list_user_groups_as_group_admin(organisation, api_client):

--- a/api/organisations/tests/test_views.py
+++ b/api/organisations/tests/test_views.py
@@ -1158,7 +1158,9 @@ def test_make_user_group_admin_success(
 
 
 def test_make_user_group_admin_forbidden(
-    staff_client, organisation, user_permission_group
+    staff_client: FFAdminUser,
+    organisation: Organisation,
+    user_permission_group: UserPermissionGroup,
 ):
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
@@ -1222,7 +1224,9 @@ def test_remove_user_as_group_admin_success(
 
 
 def test_remove_user_as_group_admin_forbidden(
-    staff_client, organisation, user_permission_group
+    staff_client: FFAdminUser,
+    organisation: Organisation,
+    user_permission_group: UserPermissionGroup,
 ):
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -249,7 +249,7 @@ class UserPermissionGroupViewSet(viewsets.ModelViewSet):
 @permission_classes([IsAuthenticated, NestedIsOrganisationAdminPermission])
 def make_user_group_admin(
     request: Request, organisation_pk: int, group_pk: int, user_pk: int
-):
+) -> Response:
     user = get_object_or_404(
         FFAdminUser,
         userorganisation__organisation_id=organisation_pk,
@@ -264,7 +264,7 @@ def make_user_group_admin(
 @permission_classes([IsAuthenticated, NestedIsOrganisationAdminPermission])
 def remove_user_as_group_admin(
     request: Request, organisation_pk: int, group_pk: int, user_pk: int
-):
+) -> Response:
     user = get_object_or_404(
         FFAdminUser,
         userorganisation__organisation_id=organisation_pk,

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -245,8 +245,8 @@ class UserPermissionGroupViewSet(viewsets.ModelViewSet):
         return self.list(request, organisation_pk)
 
 
-@permission_classes([IsAuthenticated(), NestedIsOrganisationAdminPermission()])
 @api_view(["POST"])
+@permission_classes([IsAuthenticated, NestedIsOrganisationAdminPermission])
 def make_user_group_admin(
     request: Request, organisation_pk: int, group_pk: int, user_pk: int
 ):
@@ -260,8 +260,8 @@ def make_user_group_admin(
     return Response()
 
 
-@permission_classes([IsAuthenticated(), NestedIsOrganisationAdminPermission()])
 @api_view(["POST"])
+@permission_classes([IsAuthenticated, NestedIsOrganisationAdminPermission])
 def remove_user_as_group_admin(
     request: Request, organisation_pk: int, group_pk: int, user_pk: int
 ):


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I found these routes were wide open while working on a separate PR that had an endpoint with the same issue. The changes simply fix the order of the decorators and stop the incorrect instantiation of the permission classes into instances. 

## How did you test this code?

I wrote two tests that verified that the code was broken then watched them pass. 