### PR TITLE
feat: add copy button to server keys

### DIFF
--- a/frontend/web/components/ServerSideSDKKeys.js
+++ b/frontend/web/components/ServerSideSDKKeys.js
@@ -194,6 +194,17 @@ class ServerSideSDKKeys extends Component {
                 <div className='table-column'>
                   <Token style={{ width: 280 }} token={key} />
                 </div>
+                  <Button
+                    onClick={() => {
+                      navigator.clipboard.writeText(
+                        key,
+                      )
+                      toast('Copied')
+                    }}
+                    className='ml-2 btn-with-icon'
+                  >
+                    <Icon name='copy' width={20} fill='#656D7B' />
+                  </Button>
                 <div className='table-column'>
                   <Button
                     onClick={() => this.remove(id, name)}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Under Project Settings, under the Keys tab. Added the ability to copy the server side keys (we already had that for client side key)

## How did you test this code?

Locally in my browser.
