### PR TITLE
fix: Handle payment errors during user flow

### DIFF
--- a/api/organisations/chargebee/chargebee.py
+++ b/api/organisations/chargebee/chargebee.py
@@ -189,8 +189,9 @@ def add_single_seat(subscription_id: str):
         api_error_code = e.json_obj["api_error_code"]
         if api_error_code in CHARGEBEE_PAYMENT_ERROR_CODES:
             logger.warning(
-                "Payment declined during additional seat upgrade to a "
-                f"CB subscription for subscription_id {subscription_id}"
+                f"Payment declined ({api_error_code}) during additional "
+                f"seat upgrade to a CB subscription for subscription_id "
+                f"{subscription_id}"
             )
             raise UpgradeSeatsPaymentFailure() from e
 

--- a/api/organisations/invites/tests/test_views.py
+++ b/api/organisations/invites/tests/test_views.py
@@ -1,16 +1,20 @@
 import json
+import typing
 from datetime import timedelta
 
 import pytest
+from chargebee import APIError as ChargebeeAPIError
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
+from pytest_django.fixtures import SettingsWrapper
 from pytest_lazyfixture import lazy_fixture
+from pytest_mock.plugin import MockerFixture
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APIClient, APITestCase
 
 from organisations.invites.models import Invite, InviteLink
-from organisations.models import Organisation, OrganisationRole
+from organisations.models import Organisation, OrganisationRole, Subscription
 from users.models import FFAdminUser
 
 
@@ -282,7 +286,6 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit(
     settings.ENABLE_CHARGEBEE = True
     settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
     url = reverse(url, args=[invite_object.hash])
-
     # When
     response = test_user_client.post(url)
 
@@ -291,6 +294,61 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit(
     assert (
         response.json()["detail"]
         == "Please Upgrade your plan to add additional seats/users"
+    )
+
+
+@pytest.mark.parametrize(
+    "invite_object, url",
+    [
+        (lazy_fixture("invite"), "api-v1:users:user-join-organisation"),
+        (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
+    ],
+)
+def test_join_organisation_returns_400_if_payment_fails(
+    test_user_client: APIClient,
+    organisation: Organisation,
+    admin_user: FFAdminUser,
+    invite_object: typing.Union[Invite, InviteLink],
+    url: str,
+    subscription: Subscription,
+    settings: SettingsWrapper,
+    mocker: MockerFixture,
+):
+    # Given
+    settings.ENABLE_CHARGEBEE = True
+    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
+
+    url = reverse(url, args=[invite_object.hash])
+
+    subscription.plan = "scale-up"
+    subscription.subscription_id = "chargemepls"
+    subscription.save()
+
+    mocked_cb_subscription = mocker.MagicMock(addons=[])
+
+    mocked_chargebee = mocker.patch("organisations.chargebee.chargebee.chargebee")
+    mocked_chargebee.Subscription.retrieve.return_value = mocked_cb_subscription
+
+    chargebee_response_data = {
+        "message": "Subscription cannot be created as the payment collection failed. Gateway Error: Card declined.",
+        "type": "payment",
+        "api_error_code": "payment_processing_failed",
+        "param": "item_id",
+        "error_code": "DeprecatedField",
+    }
+
+    mocked_chargebee.Subscription.update.side_effect = ChargebeeAPIError(
+        http_code=200, json_obj=chargebee_response_data
+    )
+
+    # When
+    response = test_user_client.post(url)
+
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.json()["detail"]
+        == "Joining the organisation has failed due to a payment issue. Please contact your organisation's admin."
     )
 
 

--- a/api/organisations/invites/tests/test_views.py
+++ b/api/organisations/invites/tests/test_views.py
@@ -338,7 +338,7 @@ def test_join_organisation_returns_400_if_payment_fails(
     }
 
     mocked_chargebee.Subscription.update.side_effect = ChargebeeAPIError(
-        http_code=200, json_obj=chargebee_response_data
+        http_code=400, json_obj=chargebee_response_data
     )
 
     # When

--- a/api/organisations/subscriptions/exceptions.py
+++ b/api/organisations/subscriptions/exceptions.py
@@ -14,6 +14,14 @@ class UpgradeSeatsError(APIException):
     default_detail = "Failed to upgrade seats in Chargebee"
 
 
+class UpgradeSeatsPaymentFailure(APIException):
+    status_code = 400
+    default_detail = (
+        "Joining the organisation has failed due to a payment issue. "
+        "Please contact your organisation's admin."
+    )
+
+
 class SubscriptionDoesNotSupportSeatUpgrade(APIException):
     status_code = 400
     default_detail = "Please Upgrade your plan to add additional seats/users"

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -518,17 +518,19 @@ def test_add_single_seat_without_existing_addon(mocker):
 
 def test_add_single_seat_throws_upgrade_seats_error_error_if_api_error(mocker, caplog):
     # Given
-
-    # Chargebee's APIError requires additional arguments to instantiate it so instead
-    # we mock it with our own exception here to test that it is caught correctly
-    class MockException(Exception):
-        pass
-
     mocked_chargebee = mocker.patch("organisations.chargebee.chargebee.chargebee")
 
-    mocker.patch("organisations.chargebee.chargebee.ChargebeeAPIError", MockException)
-
-    mocked_chargebee.Subscription.update.side_effect = MockException
+    # Typical non-payment related error from Chargebee.
+    chargebee_response_data = {
+        "message": "82sa2Sqa5 not found",
+        "type": "invalid_request",
+        "api_error_code": "resource_not_found",
+        "param": "item_id",
+        "error_code": "DeprecatedField",
+    }
+    mocked_chargebee.Subscription.update.side_effect = APIError(
+        http_code=404, json_obj=chargebee_response_data
+    )
 
     # Let's create a (mocked) subscription object
     subscription_id = "sub-id"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

[Ticket reference](https://github.com/orgs/Flagsmith/projects/2/views/11?pane=issue&itemId=35443590)

Before this PR we were treating all errors from the chargebee client as one thing and we responded to a user that was in the process of signing up by issuing a 500 error, we were also logging all the chargebee errors as exceptions even though a declined credit card shouldn't be. Now, if the error is payment related, a `400` error gets sent to the client with a message to contact their administrator. 

## How did you test this code?

A combination of manual probing through the code with the test suite on and two new tests. 

## Remaining TODOs
- [x] Figure out what other callsites there are that will be impacted by this change, if any.
- [x] See if there are any other other areas of the codebase with invite-related code need to handle payment failures.
- [x] Manually test this somehow. I have access to flagsmith-test.chargebee.com but I'm not sure what server it is connected to. Is that staging?
- ~[ ] Team up with @novakzaballa and get the frontend hooked up so the change will actually matter.~