### PR TITLE
fix: Infinite loop 404 after leaving the organisation

### DIFF
--- a/frontend/common/stores/project-store.js
+++ b/frontend/common/stores/project-store.js
@@ -146,6 +146,7 @@ const controller = {
         })
         .catch(() => {
           if (!getIsWidget()) {
+            AsyncStorage.removeItem('lastEnv')
             document.location.href = '/404?entity=project'
           }
         })

--- a/frontend/web/components/pages/NotFoundErrorPage.js
+++ b/frontend/web/components/pages/NotFoundErrorPage.js
@@ -14,8 +14,8 @@ const ComingSoon = class extends Component {
         <h3 className='pt-5'>Oops!</h3>
         <p>
           It looks like you do not have permission to view this{' '}
-          {Utils.fromParam().entity || 'page'}. Please contact a member with
-          administrator privileges.
+          {Utils.fromParam().entity || 'page'} or you are not a member of the
+          organisation . Please contact a member with administrator privileges.
         </p>
       </div>
     )

--- a/frontend/web/components/pages/NotFoundErrorPage.js
+++ b/frontend/web/components/pages/NotFoundErrorPage.js
@@ -14,8 +14,8 @@ const ComingSoon = class extends Component {
         <h3 className='pt-5'>Oops!</h3>
         <p>
           It looks like you do not have permission to view this{' '}
-          {Utils.fromParam().entity || 'page'} or you are not a member of the
-          organisation . Please contact a member with administrator privileges.
+          {Utils.fromParam().entity || 'page'}. Please contact a member with
+          administrator privileges.
         </p>
       </div>
     )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Removed the item 'lastEnv' from AsyncStorage the user is no longer a member of the organization.

## How did you test this code?

1. At app.flagsmith.com log in as a user with access to organisations A & B and navigate to a project in Organisation B.
2. In the Django admin, remove access for that user to organisation B.
3. At app.flagsmith.com, refresh the page.
4. The app no longer enters an infinite loop.

