### PR TITLE
fix: sales dashboard subscription metadata shows wrong data after starting trial

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -228,12 +228,12 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
 
     def get_subscription_metadata(self) -> BaseSubscriptionMetadata:
         metadata = None
+
         if self.is_in_trial():
             metadata = BaseSubscriptionMetadata(
                 seats=self.max_seats, api_calls=self.max_api_calls
             )
-
-        if self.payment_method == CHARGEBEE and self.subscription_id:
+        elif self.payment_method == CHARGEBEE and self.subscription_id:
             if self.organisation.has_subscription_information_cache():
                 # Getting the data from the subscription information cache because
                 # data is guaranteed to be up to date by using a Chargebee webhook.
@@ -247,17 +247,14 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
                 metadata = get_subscription_metadata_from_id(self.subscription_id)
         elif self.payment_method == XERO and self.subscription_id:
             metadata = XeroSubscriptionMetadata(
-                seats=self.max_seats, api_calls=self.max_api_calls, projects=None
+                seats=self.max_seats, api_calls=self.max_api_calls
             )
 
-        if not metadata:
-            metadata = BaseSubscriptionMetadata(
-                seats=self.max_seats,
-                api_calls=self.max_api_calls,
-                projects=MAX_PROJECTS_IN_FREE_PLAN,
-            )
-
-        return metadata
+        return metadata or BaseSubscriptionMetadata(
+            seats=self.max_seats,
+            api_calls=self.max_api_calls,
+            projects=MAX_PROJECTS_IN_FREE_PLAN,
+        )
 
     def add_single_seat(self):
         if not self.can_auto_upgrade_seats:

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -29,9 +29,6 @@ from organisations.models import (
     Organisation,
     OrganisationSubscriptionInformationCache,
 )
-from organisations.subscriptions.subscription_service import (
-    get_subscription_metadata,
-)
 from organisations.tasks import (
     update_organisation_subscription_information_cache,
     update_organisation_subscription_information_influx_cache,
@@ -123,7 +120,7 @@ def organisation_info(request, organisation_id):
         Organisation.objects.select_related("subscription"), pk=organisation_id
     )
     template = loader.get_template("sales_dashboard/organisation.html")
-    subscription_metadata = get_subscription_metadata(organisation)
+    subscription_metadata = organisation.subscription.get_subscription_metadata()
 
     identity_count_dict = {}
     identity_migration_status_dict = {}


### PR DESCRIPTION
## Changes

Updates the sales dashboard to use the correct method to retrieve the subscription metadata. 

## How did you test this code?

Rand the sales dashboard locally and tested the trial functionality. Also tested data from other sources. 
