### PR TITLE
fix: Update endpoint getEnvironment RTK response

### DIFF
--- a/frontend/common/services/useEnvironment.ts
+++ b/frontend/common/services/useEnvironment.ts
@@ -46,11 +46,8 @@ export async function getEnvironment(
     typeof environmentService.endpoints.getEnvironment.initiate
   >[1],
 ) {
-  store.dispatch(
+  return store.dispatch(
     environmentService.endpoints.getEnvironment.initiate(data, options),
-  )
-  return Promise.all(
-    store.dispatch(environmentService.util.getRunningQueriesThunk()),
   )
 }
 // END OF FUNCTION_EXPORTS

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -434,7 +434,7 @@ class TheComponent extends Component {
       id: this.props.environmentId,
     }).then((res) => {
       this.setState({
-        totalSegmentOverrides: res[0].data.total_segment_overrides,
+        totalSegmentOverrides: res.data.total_segment_overrides,
       })
     })
   }

--- a/frontend/web/components/modals/AssociatedSegmentOverrides.js
+++ b/frontend/web/components/modals/AssociatedSegmentOverrides.js
@@ -401,7 +401,7 @@ class SegmentOverridesInnerAdd extends Component {
 
     getEnvironment(getStore(), { id }).then((res) => {
       this.setState({
-        totalSegmentOverrides: res[1].data.total_segment_overrides,
+        totalSegmentOverrides: res.data.total_segment_overrides,
       })
     })
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Update endpoint getEnvironment RTK response

## How did you test this code?

- Go to the Segments page
- Click any segments
- Open the Console in your browser
- the error `TypeError: Cannot read properties of undefined (reading: data) at AssociatedSegmentOverrides` is no longer seen
