### PR TITLE
fix: try self-hosted runner for the private cloud image

### DIFF
--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-dockerhub:
-    runs-on: self-image
+    runs-on: self-hosted
     name: Platform Publish Docker Image
 
     steps:

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-dockerhub:
-    runs-on: ubuntu-latest
+    runs-on: self-image
     name: Platform Publish Docker Image
 
     steps:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Enable a self-hosted runner to test the (currently failing on GH runners) multi-platform Docker build for flagsmith-private-cloud.
This is meant to be a temporary change.

## How did you test this code?

In CI.