### PR TITLE
fix: Logic in segment overrides readonly with the manage_segment_overrides permission

### DIFF
--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -559,7 +559,7 @@ class TheComponent extends Component {
     const isLimitReached =
       segmentOverrideLimitAlert.percentage &&
       segmentOverrideLimitAlert.percentage >= 100
-    const manageSegmentsEnabled = Utils.getFlagsmithHasFeature(
+    const manageSegmentOverridesEnabled = Utils.getFlagsmithHasFeature(
       'manage_segment_overrides_env_role',
     )
     return (
@@ -603,7 +603,7 @@ class TheComponent extends Component {
                         theme='outline'
                         disabled={
                           !!isLimitReached ||
-                          (manageSegmentsEnabled && !manageSegments)
+                          (manageSegmentOverridesEnabled && !manageSegments)
                         }
                       >
                         Create Feature-Specific Segment

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -479,7 +479,7 @@ const CreateFlag = class extends Component {
     const existingChangeRequest = this.props.changeRequest
     const hideIdentityOverridesTab = Utils.getShouldHideIdentityOverridesTab()
     const noPermissions = this.props.noPermissions
-    const manageSegmentsEnabled = Utils.getFlagsmithHasFeature(
+    const manageSegmentOverridesEnabled = Utils.getFlagsmithHasFeature(
       'manage_segment_overrides_env_role',
     )
     let regexValid = true
@@ -1141,8 +1141,8 @@ const CreateFlag = class extends Component {
                                                   manageSegmentOverrides,
                                               }) => {
                                                 const isReadOnly =
-                                                  manageSegmentsEnabled
-                                                    ? manageSegmentOverrides
+                                                  manageSegmentOverridesEnabled
+                                                    ? !manageSegmentOverrides
                                                     : noPermissions
                                                 return (
                                                   <SegmentOverrides
@@ -1261,7 +1261,7 @@ const CreateFlag = class extends Component {
                                                                 !name ||
                                                                 invalid ||
                                                                 !savePermission ||
-                                                                (manageSegmentsEnabled &&
+                                                                (manageSegmentOverridesEnabled &&
                                                                   !manageSegmentsOverrides)
                                                               }
                                                             >

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -509,16 +509,19 @@ const CreateSegment: FC<CreateSegmentType> = ({
                 id={environmentId}
               >
                 {({ permission: manageSegmentOverrides }) => {
-                  const manageSegmentsEnabled = Utils.getFlagsmithHasFeature(
-                    'manage_segment_overrides_env_role',
-                  )
+                  const manageSegmentOverridesEnabled =
+                    Utils.getFlagsmithHasFeature(
+                      'manage_segment_overrides_env_role',
+                    )
                   const isReadOnly = !manageSegmentOverrides
                   return (
                     <AssociatedSegmentOverrides
                       feature={segment.feature}
                       projectId={projectId}
                       id={segment.id}
-                      readOnly={manageSegmentsEnabled ? isReadOnly : false}
+                      readOnly={
+                        manageSegmentOverridesEnabled ? isReadOnly : false
+                      }
                     />
                   )
                 }}


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Invert a boolean value when the user has manage_segment_overrides permission is not `readOnly`

## How did you test this code?
- Go to edit feature modal.
- Select the Segment Overrides Tab.
- If the user has manage_segment_overrides permission can create, update, and delete a segment override.
- if the user does not have permission Segment override component is `readOnly`