### PR TITLE
feat: Add seats to next invoice

### DIFF
--- a/api/organisations/chargebee/chargebee.py
+++ b/api/organisations/chargebee/chargebee.py
@@ -181,7 +181,7 @@ def add_single_seat(subscription_id: str):
                     {"id": ADDITIONAL_SEAT_ADDON_ID, "quantity": current_seats + 1}
                 ],
                 "prorate": True,
-                "invoice_immediately": True,
+                "invoice_immediately": False,
             },
         )
 

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -480,7 +480,7 @@ def test_add_single_seat_with_existing_addon(mocker):
                 {"id": ADDITIONAL_SEAT_ADDON_ID, "quantity": addon_quantity + 1}
             ],
             "prorate": True,
-            "invoice_immediately": True,
+            "invoice_immediately": False,
         },
     )
 
@@ -511,7 +511,7 @@ def test_add_single_seat_without_existing_addon(mocker):
         {
             "addons": [{"id": ADDITIONAL_SEAT_ADDON_ID, "quantity": 1}],
             "prorate": True,
-            "invoice_immediately": True,
+            "invoice_immediately": False,
         },
     )
 
@@ -555,7 +555,7 @@ def test_add_single_seat_throws_upgrade_seats_error_error_if_api_error(mocker, c
         {
             "addons": [{"id": ADDITIONAL_SEAT_ADDON_ID, "quantity": 1}],
             "prorate": True,
-            "invoice_immediately": True,
+            "invoice_immediately": False,
         },
     )
     assert len(caplog.records) == 1


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This simple fix of flipping a boolean pushes the invoice date for the new seat to the next billing period to satisfy [this ticket](https://github.com/orgs/Flagsmith/projects/2/views/11?pane=issue&itemId=44459438).

## How did you test this code?

I connected my local running code to the flagsmith-test chargebee account and manually added a seat then verified that the unbilled charges increased, see below:

<img width="440" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/222715/3eb282f5-b4b8-4a8f-8d29-6c058ef2770a">
