### PR TITLE
fix: Failure to import LD project other than `default`

### DIFF
--- a/docs/docs/integrations/importers/launchdarkly.md
+++ b/docs/docs/integrations/importers/launchdarkly.md
@@ -9,7 +9,7 @@ You can import your Flags and Segments from LaunchDarkly into Flagsmith.
 
 :::caution
 
-Flagsmith and Launch Darkly do have differences in their product design and underlying data model. Our importer makes
+Flagsmith and LaunchDarkly do have differences in their product design and underlying data model. Our importer makes
 sane decisions around how to migrate data but we strongly recommend you check the results of the import by hand once the
 import has finished.
 

--- a/frontend/web/components/pages/ImportPage.tsx
+++ b/frontend/web/components/pages/ImportPage.tsx
@@ -122,7 +122,7 @@ const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
                   id='projects-list'
                   className='no-pad panel-projects'
                   listClassName='row mt-n2 gy-4'
-                  title='Launch Darkly Projects'
+                  title='LaunchDarkly Projects'
                   items={projects}
                   renderRow={({ name, key }, i) => {
                     return (

--- a/frontend/web/components/pages/ImportPage.tsx
+++ b/frontend/web/components/pages/ImportPage.tsx
@@ -68,9 +68,9 @@ const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
       })
   }
 
-  const createImportLDProjects = (LDKey: string, projectId: string) => {
+  const createImportLDProjects = (LDKey: string, key: string, projectId: string) => {
     createLaunchDarklyProjectImport({
-      body: { project_key: 'default', token: LDKey },
+      body: { project_key: key, token: LDKey },
       project_id: projectId,
     })
   }
@@ -124,7 +124,7 @@ const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
                   listClassName='row mt-n2 gy-4'
                   title='Launch Darkly Projects'
                   items={projects}
-                  renderRow={({ name }, i) => {
+                  renderRow={({ name, key }, i) => {
                     return (
                       <>
                         <Button
@@ -132,11 +132,13 @@ const ImportPage: FC<ImportPageType> = ({ projectId, projectName }) => {
                           onClick={() =>
                             openConfirm(
                               'Import LaunchDarkly project',
-                              <div>
-                                {`Are you sure you want import ${name} to ${projectName}`}
-                              </div>,
+                              <span>
+                                Flagsmith will import{' '}
+                                {<strong>{name}</strong>} to {<strong>{projectName}</strong>}.
+                                Are you sure?
+                              </span>,
                               () => {
-                                createImportLDProjects(LDKey, projectId)
+                                createImportLDProjects(LDKey, key, projectId)
                               },
                               () => {
                                 return


### PR DESCRIPTION
Closes https://github.com/Flagsmith/flagsmith/issues/2978.

- Fix the bug
- Better wording

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This uses the project key retrieved from LD api rather than the hardcoded `default` when creating an import request.

## How did you test this code?

`npm run dev` locally.
