### PR TITLE
feat: add copy tooltip to feature flag names

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -198,6 +198,7 @@ class TheComponent extends Component {
                   rowGap: 4,
                   wordBreak: 'break-all',
                 }}
+                
               >
                 <span className='me-2'>
                   {created_date ? (
@@ -219,6 +220,24 @@ class TheComponent extends Component {
                     name
                   )}
                 </span>
+                <Tooltip
+                  html
+                  title={
+                    <div
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        navigator.clipboard.writeText(
+                          projectFlag.name,
+                        )
+                        toast('Copied')
+                      }}
+                    >
+                      <Icon name='copy' width={20} fill='#9DA4AE' />
+                    </div>
+                  }
+                >
+                  Copy feature name
+                </Tooltip>
 
                 {!!projectFlag.num_segment_overrides && (
                   <div


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Adding a button to the right side of the feature name, after the tooltip with the create date.

## How did you test this code?
Running on my local environment the page renders correctly, the button is there and clicking on the button it copies the feature flag name.

![image](https://github.com/Flagsmith/flagsmith/assets/7240118/26a0dcfe-23c7-40ea-a2de-d41c1cbe6b76)

