### PR TITLE
fix: Pagination icons disappeared

### DIFF
--- a/frontend/web/components/Paging.js
+++ b/frontend/web/components/Paging.js
@@ -2,6 +2,8 @@
 import React, { PureComponent } from 'react'
 import propTypes from 'prop-types'
 import cn from 'classnames'
+import { chevronBackOutline, chevronForwardOutline } from 'ionicons/icons'
+import { IonIcon } from '@ionic/react'
 
 export default class Paging extends PureComponent {
   static displayName = 'Paging'
@@ -36,9 +38,13 @@ export default class Paging extends PureComponent {
       <Row className=' paging py-0' style={isLoading ? { opacity: 0.5 } : {}}>
         <Button
           disabled={isLoading || !paging.previous}
-          className='icon btn-paging ion-ios-arrow-back'
+          className='icon btn-paging mt-1'
           onClick={() => prevPage()}
-        />
+        >
+          <div>
+            <IonIcon icon={chevronBackOutline} />
+          </div>
+        </Button>
         {paging.currentPage ? (
           <Row>
             {!range.includes(0) && !noPages && (
@@ -124,10 +130,14 @@ export default class Paging extends PureComponent {
           )
         )}
         <Button
-          className='icon btn-paging ion-ios-arrow-forward'
+          className='icon btn-paging mt-1'
           disabled={isLoading || !paging.next}
           onClick={() => nextPage()}
-        />
+        >
+          <div>
+            <IonIcon icon={chevronForwardOutline} />
+          </div>
+        </Button>
       </Row>
     )
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Added missing pagination icons
<img width="229" alt="Screen Shot 2023-11-16 at 09 42 21" src="https://github.com/Flagsmith/flagsmith/assets/41410593/a3302ad2-c439-4314-9867-8f67f11f1d60">

## How did you test this code?

1. Go to the Feature pages with over 100 features
3. Scroll down the page
4. See the Icons

