### PR TITLE
chore: improve UPDATE_FEATURE_STATE permission in UI

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -104,11 +104,7 @@ class TheComponent extends Component {
     )
 
     if (this.props.condensed) {
-      return Utils.renderWithPermission(
-        permission,
-        Constants.environmentPermissions(
-          Utils.getManageFeaturePermissionDescription(changeRequestsEnabled),
-        ),
+      return (
         <Flex
           onClick={() =>
             !readOnly && this.editFeature(projectFlag, environmentFlags[id])
@@ -168,14 +164,10 @@ class TheComponent extends Component {
               data-test={`feature-value-${this.props.index}`}
             />
           </Flex>
-        </Flex>,
+        </Flex>
       )
     }
-    return Utils.renderWithPermission(
-      permission,
-      Constants.environmentPermissions(
-        Utils.getManageFeaturePermissionDescription(changeRequestsEnabled),
-      ),
+    return (
       <Row
         className={`list-item ${readOnly ? '' : 'clickable'} ${
           this.props.widget ? 'py-1' : 'py-2'
@@ -415,7 +407,7 @@ class TheComponent extends Component {
             </Permission>
           )}
         </div>
-      </Row>,
+      </Row>
     )
   }
 }

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1214,68 +1214,47 @@ const CreateFlag = class extends Component {
                                                   }
                                                 </strong>
                                               </p>
-                                              <Permission
-                                                level='environment'
-                                                permission={Utils.getManageFeaturePermission(
-                                                  is4Eyes,
-                                                  identity,
-                                                )}
-                                                id={this.props.environmentId}
-                                              >
-                                                {({
-                                                  permission: savePermission,
-                                                }) =>
-                                                  Utils.renderWithPermission(
-                                                    savePermission,
-                                                    Constants.environmentPermissions(
-                                                      Utils.getManageFeaturePermissionDescription(
-                                                        is4Eyes,
-                                                        identity,
+                                              <div className='text-right'>
+                                                <Permission
+                                                  level='environment'
+                                                  permission={
+                                                    'MANAGE_SEGMENT_OVERRIDES'
+                                                  }
+                                                  id={this.props.environmentId}
+                                                >
+                                                  {({
+                                                    permission:
+                                                      manageSegmentsOverrides,
+                                                  }) => {
+                                                    return Utils.renderWithPermission(
+                                                      manageSegmentsOverrides,
+                                                      Constants.environmentPermissions(
+                                                        'Manage segment overrides',
                                                       ),
-                                                    ),
-                                                    <div className='text-right'>
-                                                      <Permission
-                                                        level='environment'
-                                                        permission={
-                                                          'MANAGE_SEGMENT_OVERRIDES'
+                                                      <Button
+                                                        onClick={
+                                                          saveFeatureSegments
                                                         }
-                                                        id={
-                                                          this.props
-                                                            .environmentId
+                                                        type='button'
+                                                        data-test='update-feature-segments-btn'
+                                                        id='update-feature-segments-btn'
+                                                        disabled={
+                                                          isSaving ||
+                                                          !name ||
+                                                          invalid ||
+                                                          (manageSegmentOverridesEnabled &&
+                                                            !manageSegmentsOverrides)
                                                         }
                                                       >
-                                                        {({
-                                                          permission:
-                                                            manageSegmentsOverrides,
-                                                        }) => {
-                                                          return (
-                                                            <Button
-                                                              onClick={
-                                                                saveFeatureSegments
-                                                              }
-                                                              type='button'
-                                                              data-test='update-feature-segments-btn'
-                                                              id='update-feature-segments-btn'
-                                                              disabled={
-                                                                isSaving ||
-                                                                !name ||
-                                                                invalid ||
-                                                                !savePermission ||
-                                                                (manageSegmentOverridesEnabled &&
-                                                                  !manageSegmentsOverrides)
-                                                              }
-                                                            >
-                                                              {isSaving
-                                                                ? 'Updating'
-                                                                : 'Update Segment Overrides'}
-                                                            </Button>
-                                                          )
-                                                        }}
-                                                      </Permission>
-                                                    </div>,
-                                                  )
-                                                }
-                                              </Permission>
+                                                        {isSaving
+                                                          ? 'Updating'
+                                                          : 'Update Segment Overrides'}
+                                                      </Button>,
+                                                    )
+                                                  }}
+                                                </Permission>
+                                              </div>
+                                              ,
                                             </div>
                                           )}
                                         </div>

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1217,41 +1217,65 @@ const CreateFlag = class extends Component {
                                               <div className='text-right'>
                                                 <Permission
                                                   level='environment'
-                                                  permission={
-                                                    'MANAGE_SEGMENT_OVERRIDES'
-                                                  }
+                                                  permission={Utils.getManageFeaturePermission(
+                                                    is4Eyes,
+                                                    identity,
+                                                  )}
                                                   id={this.props.environmentId}
                                                 >
                                                   {({
-                                                    permission:
-                                                      manageSegmentsOverrides,
-                                                  }) => {
-                                                    return Utils.renderWithPermission(
-                                                      manageSegmentsOverrides,
-                                                      Constants.environmentPermissions(
-                                                        'Manage segment overrides',
-                                                      ),
-                                                      <Button
-                                                        onClick={
-                                                          saveFeatureSegments
-                                                        }
-                                                        type='button'
-                                                        data-test='update-feature-segments-btn'
-                                                        id='update-feature-segments-btn'
-                                                        disabled={
-                                                          isSaving ||
-                                                          !name ||
-                                                          invalid ||
-                                                          (manageSegmentOverridesEnabled &&
-                                                            !manageSegmentsOverrides)
-                                                        }
-                                                      >
-                                                        {isSaving
-                                                          ? 'Updating'
-                                                          : 'Update Segment Overrides'}
-                                                      </Button>,
-                                                    )
-                                                  }}
+                                                    permission: savePermission,
+                                                  }) => (
+                                                    <Permission
+                                                      level='environment'
+                                                      permission={
+                                                        'MANAGE_SEGMENT_OVERRIDES'
+                                                      }
+                                                      id={
+                                                        this.props.environmentId
+                                                      }
+                                                    >
+                                                      {({
+                                                        permission:
+                                                          manageSegmentsOverrides,
+                                                      }) => {
+                                                        return Utils.renderWithPermission(
+                                                          manageSegmentOverridesEnabled
+                                                            ? manageSegmentsOverrides
+                                                            : savePermission,
+                                                          Constants.environmentPermissions(
+                                                            manageSegmentOverridesEnabled
+                                                              ? 'Manage segment overrides'
+                                                              : Utils.getManageFeaturePermissionDescription(
+                                                                  is4Eyes,
+                                                                  identity,
+                                                                ),
+                                                          ),
+                                                          <Button
+                                                            onClick={
+                                                              saveFeatureSegments
+                                                            }
+                                                            type='button'
+                                                            data-test='update-feature-segments-btn'
+                                                            id='update-feature-segments-btn'
+                                                            disabled={
+                                                              isSaving ||
+                                                              !name ||
+                                                              invalid ||
+                                                              (!manageSegmentOverridesEnabled &&
+                                                                !savePermission) ||
+                                                              (manageSegmentOverridesEnabled &&
+                                                                !manageSegmentsOverrides)
+                                                            }
+                                                          >
+                                                            {isSaving
+                                                              ? 'Updating'
+                                                              : 'Update Segment Overrides'}
+                                                          </Button>,
+                                                        )
+                                                      }}
+                                                    </Permission>
+                                                  )}
                                                 </Permission>
                                               </div>
                                               ,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- The "Update segment override" button is no longer affected by UPDATE_FEATURE_STATE permission
## How did you test this code?

- Give and remove UPDATE_FEATURE_STATE permission in the environment setting page
- If you have permission you can modify the feature flag.
- Having or not having permission does not affect the "segment" overrides tab
