### PR TITLE
fix: ensure SimpleFeatureStateViewSet uses correct permissions for segment overrides

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -181,14 +181,14 @@ def environment(project):
 @pytest.fixture()
 def with_environment_permissions(
     environment: Environment, staff_user: FFAdminUser
-) -> typing.Callable[[list[str], int], None]:
+) -> typing.Callable[[list[str], int | None], UserEnvironmentPermission]:
     """
     Add environment permissions to the staff_user fixture.
     Defaults to associating to the environment fixture.
     """
 
     def _with_environment_permissions(
-        permission_keys: list[str], environment_id: typing.Optional[int] = None
+        permission_keys: list[str], environment_id: int | None = None
     ) -> UserEnvironmentPermission:
         environment_id = environment_id or environment.id
         uep, __ = UserEnvironmentPermission.objects.get_or_create(

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -17,6 +17,7 @@ from environments.permissions.constants import (
     MANAGE_SEGMENT_OVERRIDES,
     UPDATE_FEATURE_STATE,
 )
+from environments.permissions.models import UserEnvironmentPermission
 from features.feature_types import MULTIVARIATE
 from features.models import Feature, FeatureSegment, FeatureState
 from features.multivariate.models import MultivariateFeatureOption
@@ -1274,12 +1275,14 @@ def test_cannot_update_feature_of_a_feature_state(
 
 def test_create_segment_override__using_simple_feature_state_viewset__allows_manage_segment_overrides(
     staff_client: APIClient,
-    with_environment_permissions: Callable[[list[str], int], None],
+    with_environment_permissions: Callable[
+        [list[str], int | None], UserEnvironmentPermission
+    ],
     environment: Environment,
     feature: Feature,
     segment: Segment,
     feature_segment: FeatureSegment,
-):
+) -> None:
     # Given
     with_environment_permissions([MANAGE_SEGMENT_OVERRIDES])
 
@@ -1311,12 +1314,14 @@ def test_create_segment_override__using_simple_feature_state_viewset__allows_man
 
 def test_create_segment_override__using_simple_feature_state_viewset__denies_update_feature_state(
     staff_client: APIClient,
-    with_environment_permissions: Callable[[list[str], int], None],
+    with_environment_permissions: Callable[
+        [list[str], int | None], UserEnvironmentPermission
+    ],
     environment: Environment,
     feature: Feature,
     segment: Segment,
     feature_segment: FeatureSegment,
-):
+) -> None:
     # Given
     with_environment_permissions([UPDATE_FEATURE_STATE])
 
@@ -1344,13 +1349,15 @@ def test_create_segment_override__using_simple_feature_state_viewset__denies_upd
 
 def test_update_segment_override__using_simple_feature_state_viewset__allows_manage_segment_overrides(
     staff_client: APIClient,
-    with_environment_permissions: Callable[[list[str], int], None],
+    with_environment_permissions: Callable[
+        [list[str], int | None], UserEnvironmentPermission
+    ],
     environment: Environment,
     feature: Feature,
     segment: Segment,
     feature_segment: FeatureSegment,
     segment_featurestate: FeatureState,
-):
+) -> None:
     # Given
     with_environment_permissions([MANAGE_SEGMENT_OVERRIDES])
 
@@ -1388,13 +1395,15 @@ def test_update_segment_override__using_simple_feature_state_viewset__allows_man
 
 def test_update_segment_override__using_simple_feature_state_viewset__denies_update_feature_state(
     staff_client: APIClient,
-    with_environment_permissions: Callable[[list[str], int], None],
+    with_environment_permissions: Callable[
+        [list[str], int | None], UserEnvironmentPermission
+    ],
     environment: Environment,
     feature: Feature,
     segment: Segment,
     feature_segment: FeatureSegment,
     segment_featurestate: FeatureState,
-):
+) -> None:
     # Given
     with_environment_permissions([UPDATE_FEATURE_STATE])
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes an issue found when testing the new MANAGE_SEGMENTS permission functionality. The FE uses the SimpleFeatureStateViewSet for updating segment overrides, which the new permission didn't cover. This PR ensures that this endpoint is correctly covered by the new permission for creating (although this is not used by the FE) and updating segment overrides via this API route. 

## How did you test this code?

Added new unit tests. 
