### PR TITLE
fix: opening the flag panel shifts the main table slightly

### DIFF
--- a/frontend/web/styles/project/_modals.scss
+++ b/frontend/web/styles/project/_modals.scss
@@ -189,7 +189,7 @@ $side-width: 660px;
 
 .modal-open {
   position: relative;
-  padding-right: 0 !important;
+  padding-right: 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Removed the "!important" from padding-right on class "modal-open", which was forcing the browser to increase the page width when the scrollbar disappears.

The issue was that every time the page had a scroll-bar, opening a modal causes a layout shift, since it makes the scroll-bar disappears. So it was not only on the feature flag modal, but all of them.
Fixes #2984 

## How did you test this code?

1. Go to any page that has a modal;
2. Get vertical space so the scrollbar appears;
3. Open modal.
