### PR TITLE
feat: draft of new feature flag panel design

### DIFF
--- a/frontend/web/components/Actionables.tsx
+++ b/frontend/web/components/Actionables.tsx
@@ -1,0 +1,35 @@
+import React, { useState, type FC } from 'react'
+import { ellipsisVerticalCircleOutline } from 'ionicons/icons'
+import { IonIcon } from '@ionic/react'
+
+type ActionablesProps = {
+  children: React.ReactNode
+  width?: string
+}
+
+// Displays an icon that when hovered expands to the right to show a list of actionable children
+export const Actionables: FC<ActionablesProps> = ({ children, width }) => {
+  const [showList, setShowList] = useState(false)
+
+  // const onMouseLeave = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  //   e.stopPropagation()
+  //   setShowList(false)
+  // }
+
+  return (
+    <div
+      className='actionables'
+      style={{ width: width || 20 }}
+      onMouseEnter={() => setShowList(true)}
+      onTouchStart={() => setShowList(true)}
+      onMouseLeave={() => setShowList(false)}
+      onTouchEnd={() => setShowList(false)}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className='icon--new-tooltip mr-1'>
+        <IonIcon icon={ellipsisVerticalCircleOutline} />
+      </div>
+      <div className={`list ${showList ? 'showActions' : ''}`}>{children}</div>
+    </div>
+  )
+}

--- a/frontend/web/components/Actionables.tsx
+++ b/frontend/web/components/Actionables.tsx
@@ -3,33 +3,38 @@ import { ellipsisVerticalCircleOutline } from 'ionicons/icons'
 import { IonIcon } from '@ionic/react'
 
 type ActionablesProps = {
-  children: React.ReactNode
+  children: React.ReactNode[]
   width?: string
+  showActions?: boolean
 }
 
 // Displays an icon that when hovered expands to the right to show a list of actionable children
-export const Actionables: FC<ActionablesProps> = ({ children, width }) => {
-  const [showList, setShowList] = useState(false)
-
+export const Actionables: FC<ActionablesProps> = ({
+  children,
+  width,
+  showActions,
+}) => {
   // const onMouseLeave = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
   //   e.stopPropagation()
   //   setShowList(false)
   // }
-
+  console.log(children)
   return (
     <div
       className='actionables'
-      style={{ width: width || 20 }}
-      onMouseEnter={() => setShowList(true)}
-      onTouchStart={() => setShowList(true)}
-      onMouseLeave={() => setShowList(false)}
-      onTouchEnd={() => setShowList(false)}
+      style={{
+        width: showActions ? 48 * children.length - 20 : 20,
+      }}
       onClick={(e) => e.stopPropagation()}
     >
-      <div className='icon--new-tooltip mr-1'>
+      <div
+        className={`icon--new-tooltip mr-1 ${showActions ? 'hideIcon' : ''}`}
+      >
         <IonIcon icon={ellipsisVerticalCircleOutline} />
       </div>
-      <div className={`list ${showList ? 'showActions' : ''}`}>{children}</div>
+      <div className={`list ${showActions ? 'showActions' : ''}`}>
+        {children}
+      </div>
     </div>
   )
 }

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -20,7 +20,8 @@ class TheComponent extends Component {
   }
 
   state = {
-    features_compact_view: Utils.getFlagsmithValue('features_compact_view'),
+    features_compact_view: propTypes.compactView,
+    showActions: false,
   }
 
   confirmToggle = (projectFlag, environmentFlag, cb) => {
@@ -36,13 +37,28 @@ class TheComponent extends Component {
     )
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.compactView !== prevProps.compactView) {
+      this.setState({ features_compact_view: this.props.compactView })
+    }
+  }
+
   componentDidMount() {
     const { environmentFlags, projectFlag } = this.props
     const { feature, tab } = Utils.fromParam()
+    console.log(this.state)
     const { id } = projectFlag
     if (`${id}` === feature) {
       this.editFeature(projectFlag, environmentFlags[id], tab)
     }
+  }
+
+  showActions = () => {
+    this.setState({ showActions: true })
+  }
+
+  hideActions = () => {
+    this.setState({ showActions: false })
   }
 
   confirmRemove = (projectFlag, cb) => {
@@ -181,6 +197,10 @@ class TheComponent extends Component {
         onClick={() =>
           !readOnly && this.editFeature(projectFlag, environmentFlags[id])
         }
+        onMouseEnter={this.showActions}
+        onMouseLeave={this.hideActions}
+        onTouchStart={this.showActions}
+        onBlur={this.hideActions}
       >
         <Flex className='table-column'>
           <Row>
@@ -196,7 +216,7 @@ class TheComponent extends Component {
               >
                 <span className='me-2'>{name}</span>
 
-                <Actionables>
+                <Actionables showActions={this.state.showActions}>
                   {created_date && (
                     <Tooltip
                       place='top'
@@ -344,16 +364,14 @@ class TheComponent extends Component {
                   value={projectFlag.tags}
                 />
               </Row>
-              {description &&
-                !this.state.features_compact_view ===
-                  true(
-                    <div
-                      className='list-item-subtitle mt-1'
-                      style={{ lineHeight: '20px', width: width[4] }}
-                    >
-                      {description}
-                    </div>,
-                  )}
+              {description && !this.state.features_compact_view && (
+                <div
+                  className='list-item-subtitle mt-1'
+                  style={{ lineHeight: '20px', width: width[4] }}
+                >
+                  {description}
+                </div>
+              )}
             </Flex>
           </Row>
         </Flex>

--- a/frontend/web/components/PanelSearch.js
+++ b/frontend/web/components/PanelSearch.js
@@ -4,6 +4,7 @@ import Popover from './base/Popover'
 import Input from './base/forms/Input'
 import Icon from './Icon'
 import classNames from 'classnames'
+import Switch from './Switch'
 const PanelSearch = class extends Component {
   static displayName = 'PanelSearch'
 
@@ -35,6 +36,11 @@ const PanelSearch = class extends Component {
       sortBy: defaultSortingOption ? defaultSortingOption.value : null,
       sortOrder: defaultSortingOption ? defaultSortingOption.order : null,
     }
+  }
+
+  toggleFeatureViewMode = () => {
+    const newValue = !Utils.getFlagsmithHasFeature('features_compact_view')
+    flagsmith.setTrait('features_compact_view', newValue)
   }
 
   filter() {
@@ -155,7 +161,9 @@ const PanelSearch = class extends Component {
           this.props.actionButton ? (
             <Row>
               {!!this.props.filterElement && this.props.filterElement}
-
+              <Row>
+                <Switch onChange={this.toggleFeatureViewMode()} />
+              </Row>
               {!!this.props.sorting && (
                 <Row className='mr-3 relative'>
                   <Popover

--- a/frontend/web/components/PanelSearch.js
+++ b/frontend/web/components/PanelSearch.js
@@ -5,6 +5,7 @@ import Input from './base/forms/Input'
 import Icon from './Icon'
 import classNames from 'classnames'
 import Switch from './Switch'
+import { AsyncStorage } from 'polyfill-react-native'
 const PanelSearch = class extends Component {
   static displayName = 'PanelSearch'
 
@@ -25,6 +26,8 @@ const PanelSearch = class extends Component {
     searchPanel: OptionalNode,
     sorting: OptionalArray,
     title: propTypes.node,
+    toggleViewMode: OptionalFunc,
+    viewMode: OptionalBool,
   }
 
   constructor(props, context) {
@@ -32,15 +35,11 @@ const PanelSearch = class extends Component {
     const defaultSortingOption = _.find(_.get(props, 'sorting', []), {
       default: true,
     })
+
     this.state = {
       sortBy: defaultSortingOption ? defaultSortingOption.value : null,
       sortOrder: defaultSortingOption ? defaultSortingOption.order : null,
     }
-  }
-
-  toggleFeatureViewMode = () => {
-    const newValue = !Utils.getFlagsmithHasFeature('features_compact_view')
-    flagsmith.setTrait('features_compact_view', newValue)
   }
 
   filter() {
@@ -162,7 +161,12 @@ const PanelSearch = class extends Component {
             <Row>
               {!!this.props.filterElement && this.props.filterElement}
               <Row>
-                <Switch onChange={this.toggleFeatureViewMode()} />
+                {this.props.toggleViewMode && (
+                  <Switch
+                    onChange={() => this.props.toggleViewMode()}
+                    checked={this.props.viewMode}
+                  />
+                )}
               </Row>
               {!!this.props.sorting && (
                 <Row className='mr-3 relative'>

--- a/frontend/web/components/pages/FeaturesPage.js
+++ b/frontend/web/components/pages/FeaturesPage.js
@@ -26,6 +26,7 @@ const FeaturesPage = class extends Component {
   constructor(props, context) {
     super(props, context)
     this.state = {
+      compactView: false,
       search: null,
       showArchived: false,
       sort: { label: 'Name', sortBy: 'name', sortOrder: 'asc' },
@@ -82,6 +83,19 @@ const FeaturesPage = class extends Component {
         projectId: params.projectId,
       }),
     )
+  }
+
+  toggleFeatureViewMode = () => {
+    const newValue = !this.state.compactView
+    AsyncStorage.setItem(
+      'features_compact_view',
+      JSON.stringify({
+        enabled: newValue,
+      }),
+    )
+    this.setState({
+      compactView: newValue,
+    })
   }
 
   newFlag = () => {
@@ -268,6 +282,8 @@ const FeaturesPage = class extends Component {
                                 isLoading={FeatureListStore.isLoading}
                                 paging={FeatureListStore.paging}
                                 search={this.state.search}
+                                toggleViewMode={this.toggleFeatureViewMode}
+                                viewMode={this.state.compactView}
                                 header={
                                   <Row className='table-header'>
                                     <Flex className='table-column px-3'>
@@ -467,6 +483,7 @@ const FeaturesPage = class extends Component {
                                     toggleFlag={toggleFlag}
                                     removeFlag={removeFlag}
                                     projectFlag={projectFlag}
+                                    compactView={this.state.compactView}
                                   />
                                 )}
                                 filterRow={() => true}

--- a/frontend/web/components/pages/FeaturesPage.js
+++ b/frontend/web/components/pages/FeaturesPage.js
@@ -285,7 +285,7 @@ const FeaturesPage = class extends Component {
                                     >
                                       <Switch disabled />
                                     </div>
-                                    <div
+                                    {/* <div
                                       className='table-column'
                                       style={{ width: width[2] }}
                                     ></div>
@@ -294,7 +294,7 @@ const FeaturesPage = class extends Component {
                                       style={{ width: width[3] }}
                                     >
                                       Remove
-                                    </div>
+                                    </div> */}
                                   </Row>
                                 }
                                 onChange={(e) => {

--- a/frontend/web/styles/components/_actionables.scss
+++ b/frontend/web/styles/components/_actionables.scss
@@ -1,0 +1,44 @@
+.actionables {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: flex-start;
+    position: relative;
+    height: 100%;
+    margin-right: 0.5rem;
+
+    .list {
+        display: none;
+    }
+
+    .showActions {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        align-items:center;
+        justify-content: flex-start;
+        position: absolute;
+        top: -6px;
+        left: 20px;
+        width: 200px;
+        height: calc(100% + 8px);
+        gap: 8px;
+        padding-left: 8px;
+        padding-right: 8px;
+        background-color: $bg-light300;
+        border-radius: $border-radius-default;
+        cursor: default;
+    }
+
+    .showActions * {
+        display: block;
+        // height: inherit;
+        margin: 0 !important;
+    }
+}
+
+.dark .actionables {
+    .showActions {
+        background-color: $bg-dark200;
+    }
+}

--- a/frontend/web/styles/components/_actionables.scss
+++ b/frontend/web/styles/components/_actionables.scss
@@ -3,9 +3,10 @@
     flex-direction: row;
     align-items: flex-start;
     justify-content: flex-start;
-    position: relative;
     height: 100%;
     margin-right: 0.5rem;
+    width: 20px;
+    transition: width 0.6s cubic-bezier(0.5, 0, 0.2, 1);
 
     .list {
         display: none;
@@ -17,17 +18,14 @@
         flex-wrap: nowrap;
         align-items:center;
         justify-content: flex-start;
-        position: absolute;
-        top: -6px;
-        left: 20px;
-        width: 200px;
         height: calc(100% + 8px);
         gap: 8px;
         padding-left: 8px;
         padding-right: 8px;
+        cursor: default;
         background-color: $bg-light300;
         border-radius: $border-radius-default;
-        cursor: default;
+
     }
 
     .showActions * {
@@ -35,10 +33,17 @@
         // height: inherit;
         margin: 0 !important;
     }
+
+    .hideIcon {
+        display: none;
+    }
 }
 
 .dark .actionables {
-    .showActions {
+
+    .showActions{
         background-color: $bg-dark200;
+        border-radius: $border-radius-default;
+
     }
 }

--- a/frontend/web/styles/components/_index.scss
+++ b/frontend/web/styles/components/_index.scss
@@ -10,3 +10,4 @@
 @import 'feature-change';
 @import 'toast';
 @import 'color-block';
+@import 'actionables';


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Added a new component called "Actionables" which groups all actions represented as icons.
Modified PanelSearch component to receive "viewMode" and "toggleViewMode", so it shows a Switch on the left of the filters ta toggles the viewMode.

That's just a draft of what i understood about @kyle-ssg and @novakzaballa ideas. There's still a couple problems:

1. I'm not used to the codebase tools, so i'm probably using something that could be replaced by a already existing tool;
2. I couldn't make it initiate the view State from localStorage, and honestly, i don't really know why i couldn't grab the value calling the localStorage from componentDidMount. So it saves the state, but can't retrieve it.
3. The styling is more a POC than a real one.  

## How did you test this code?

I tested through my development environment at the features page.

Video for a quick peek:


https://github.com/Flagsmith/flagsmith/assets/77826309/dc3a8a05-fee2-4277-9a4d-1f248163ed9d

Related to: #2942 and #2981 
