### PR TITLE
chore: use EC2 runners for the Private Cloud build

### DIFF
--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -12,9 +12,22 @@ env:
   FLAGSMITH_AUTH_CONTROLLER_REVISION: v0.0.1
 
 jobs:
+  start-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.start.outputs.runner-label }}
+      instance-id: ${{ steps.start.outputs.instance-id }}
+    steps:
+      - uses: Flagsmith/actions/ec2-runner/start@v0.2.0
+        id: start
+        with:
+          github-access-token: ${{ secrets.GH_RUNNER_TOKEN }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_EC2_RUNNER }}
+
   build-dockerhub:
-    runs-on: self-hosted
     name: Platform Publish Docker Image
+    needs: [start-runner]
+    runs-on: ${{ needs.start-runner.outputs.runner-label }}
 
     steps:
       - name: Cloning repo
@@ -108,3 +121,16 @@ jobs:
           build-args: |
             SAML_INSTALLED=1
             POETRY_OPTS=--with saml,auth-controller
+
+  stop-runner:
+    needs: [start-runner, build-dockerhub]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Flagsmith/actions/ec2-runner/stop@v0.2.0
+        id: start
+        with:
+          github-access-token: ${{ secrets.GH_RUNNER_TOKEN }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_EC2_RUNNER }}
+          runner-label: ${{ needs.start-runner.outputs.runner-label }}
+          instance-id: ${{ needs.start-runner.outputs.instance-id }}

--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -128,7 +128,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Flagsmith/actions/ec2-runner/stop@v0.2.0
-        id: start
         with:
           github-access-token: ${{ secrets.GH_RUNNER_TOKEN }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_EC2_RUNNER }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR removes the need for me to have a GH runner running on my laptop to build the private cloud image.

## How did you test this code?

Run workflow in CI.

## Don't merge before...
- [x] `GH_RUNNER_TOKEN` is set to a GitHub token with full repo-level permissions to this repo.