### PR TITLE
feat(ui): hide API keys from integrations list

### DIFF
--- a/frontend/web/components/modals/CreateEditIntegrationModal.js
+++ b/frontend/web/components/modals/CreateEditIntegrationModal.js
@@ -184,7 +184,9 @@ const CreateEditIntegration = class extends Component {
                   </label>
                 </div>
                 {this.props.readOnly ? (
-                  <div className='mb-3'>{this.state.data[field.key]}</div>
+                  <div className='mb-3'>
+                    {field.hidden ? this.state.data[field.key].replace(/./g, '*') : this.state.data[field.key]}
+                  </div>
                 ) : field.options ? (
                   <div className='full-width mb-2'>
                     <Select
@@ -216,7 +218,7 @@ const CreateEditIntegration = class extends Component {
                     value={this.state.data[field.key]}
                     onChange={(e) => this.update(field.key, e)}
                     isValid={!!this.state.data[field.key]}
-                    type='text'
+                    type={field.hidden ? 'password' : 'text'}
                     className='full-width mb-2'
                   />
                 )}


### PR DESCRIPTION
## Changes

Fixes #3018. 

Note: requires the addition of the attribute `"hidden": true` to each field that should be hidden in each integration. I have done this in staging already. 

## How did you test this code?

Ran the FE locally and verified that the relevant fields were hidden / not hidden. 
