### PR TITLE
fix: Avoid N+1 queries in deprecated identities SDK endpoint

### DIFF
--- a/api/environments/identities/managers.py
+++ b/api/environments/identities/managers.py
@@ -1,6 +1,32 @@
+from typing import TYPE_CHECKING, Iterable
+
 from django.db.models import Manager
+
+if TYPE_CHECKING:
+    from environments.identities.models import Identity
+    from environments.models import Environment
+    from integrations.integration import IntegrationConfig
 
 
 class IdentityManager(Manager):
     def get_by_natural_key(self, identifier, environment_api_key):
         return self.get(identifier=identifier, environment__api_key=environment_api_key)
+
+    def get_or_create_for_sdk(
+        self,
+        identifier: str,
+        environment: "Environment",
+        integrations: Iterable["IntegrationConfig"],
+    ) -> tuple["Identity", bool]:
+        return (
+            self.select_related(
+                "environment",
+                "environment__project",
+                *[
+                    f"environment__{integration['relation_name']}"
+                    for integration in integrations
+                ],
+            )
+            .prefetch_related("identity_traits")
+            .get_or_create(identifier=identifier, environment=environment)
+        )

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -112,11 +112,11 @@ class SDKIdentitiesDeprecated(SDKAPIView):
     def get(self, request, identifier, *args, **kwargs):
         # if we have identifier fetch, or create if does not exist
         if identifier:
-            identity, _ = Identity.objects.get_or_create(
+            identity, _ = Identity.objects.get_or_create_for_sdk(
                 identifier=identifier,
                 environment=request.environment,
+                integrations=IDENTITY_INTEGRATIONS,
             )
-
         else:
             return Response(
                 {"detail": "Missing identifier"}, status=status.HTTP_400_BAD_REQUEST
@@ -172,17 +172,10 @@ class SDKIdentities(SDKAPIView):
                 {"detail": "Missing identifier"}
             )  # TODO: add 400 status - will this break the clients?
 
-        identity, _ = (
-            Identity.objects.select_related(
-                "environment",
-                "environment__project",
-                *[
-                    f"environment__{integration['relation_name']}"
-                    for integration in IDENTITY_INTEGRATIONS
-                ],
-            )
-            .prefetch_related("identity_traits")
-            .get_or_create(identifier=identifier, environment=request.environment)
+        identity, _ = Identity.objects.get_or_create_for_sdk(
+            identifier=identifier,
+            environment=request.environment,
+            integrations=IDENTITY_INTEGRATIONS,
         )
         self.identity = identity
 

--- a/api/integrations/integration.py
+++ b/api/integrations/integration.py
@@ -1,11 +1,20 @@
+from typing import Type, TypedDict
+
 from integrations.amplitude.amplitude import AmplitudeWrapper
+from integrations.common.wrapper import AbstractBaseIdentityIntegrationWrapper
 from integrations.heap.heap import HeapWrapper
 from integrations.mixpanel.mixpanel import MixpanelWrapper
 from integrations.rudderstack.rudderstack import RudderstackWrapper
 from integrations.segment.segment import SegmentWrapper
 from integrations.webhook.webhook import WebhookWrapper
 
-IDENTITY_INTEGRATIONS = [
+
+class IntegrationConfig(TypedDict):
+    relation_name: str
+    wrapper: Type[AbstractBaseIdentityIntegrationWrapper]
+
+
+IDENTITY_INTEGRATIONS: list[IntegrationConfig] = [
     {"relation_name": "amplitude_config", "wrapper": AmplitudeWrapper},
     {"relation_name": "segment_config", "wrapper": SegmentWrapper},
     {"relation_name": "heap_config", "wrapper": HeapWrapper},


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds prefetches to the legacy SDK identities endpoint, hopefully avoiding the environment-related N+1 queries.

## How did you test this code?

We'll test in production as we can not write an isolated test in a timely manner.