### PR TITLE
fix: resolve environment N+1 caused by feature versioning v2

### DIFF
--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -97,6 +97,7 @@ class Identity(models.Model):
             full_query &= additional_filters
 
         select_related_args = [
+            "environment",
             "feature",
             "feature_state_value",
             "feature_segment",


### PR DESCRIPTION
## Changes

Caused by the addition of [this line](https://github.com/Flagsmith/flagsmith/blob/main/api/features/models.py#L474) in the feature versioning V2, this PR resolves an N+1 query issue retrieving the environment. 

Note, this adds a test to the old location to keep things grouped for now but should be moved to the new location asap. 

## How did you test this code?

Added a test to reproduce the N+1 error before resolving. 
