### PR TITLE
fix: Safely parse announcement Flag

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -203,6 +203,9 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   getFlagsmithHasFeature(key: string) {
     return flagsmith.hasFeature(key)
   },
+  getFlagsmithJSONValue(key: string, defaultValue: any) {
+    return flagsmith.getValue(key, { fallback: defaultValue, json: true })
+  },
   getFlagsmithValue(key: string) {
     return flagsmith.getValue(key)
   },

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -282,12 +282,13 @@ const App = class extends Component {
     if (document.location.href.includes('widget')) {
       return <div>{this.props.children}</div>
     }
-    const announcementValue = JSON.parse(
-      Utils.getFlagsmithValue('announcement'),
-    )
+    const announcementValue = Utils.getFlagsmithJSONValue('announcement', null)
     const dismissed = flagsmith.getTrait('dismissed_announcement')
     const showBanner =
-      announcementValue && (!dismissed || dismissed !== announcementValue.id)
+      announcementValue &&
+      (!dismissed || dismissed !== announcementValue.id) &&
+      Utils.getFlagsmithHasFeature('announcement') &&
+      this.state.showAnnouncement
 
     return (
       <Provider store={getStore()}>
@@ -489,27 +490,24 @@ const App = class extends Component {
                               id={AccountStore.getOrganisation()?.id}
                             />
                           )}
-                          {user &&
-                            showBanner &&
-                            Utils.getFlagsmithHasFeature('announcement') &&
-                            this.state.showAnnouncement && (
-                              <Row>
-                                <InfoMessage
-                                  title={announcementValue.title}
-                                  infoMessageClass={'announcement'}
-                                  isClosable={announcementValue.isClosable}
-                                  close={() =>
-                                    this.closeAnnouncement(announcementValue.id)
-                                  }
-                                  buttonText={announcementValue.buttonText}
-                                  url={announcementValue.url}
-                                >
-                                  <div>
-                                    <div>{announcementValue.description}</div>
-                                  </div>
-                                </InfoMessage>
-                              </Row>
-                            )}
+                          {user && showBanner && (
+                            <Row>
+                              <InfoMessage
+                                title={announcementValue.title}
+                                infoMessageClass={'announcement'}
+                                isClosable={announcementValue.isClosable}
+                                close={() =>
+                                  this.closeAnnouncement(announcementValue.id)
+                                }
+                                buttonText={announcementValue.buttonText}
+                                url={announcementValue.url}
+                              >
+                                <div>
+                                  <div>{announcementValue.description}</div>
+                                </div>
+                              </InfoMessage>
+                            </Row>
+                          )}
                           {this.props.children}
                         </Fragment>
                       )}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Instead of trying to JSON parse a feature flag without catching, the frontend will now safely handle the non-json type by providing a fallback.


_Please describe._

## How did you test this code?
Tried with / without a null, json and undefined announcement as well as dismissing the announcement.



<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
