### PR TITLE
fix: Manage members layout is broken

### DIFF
--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -26,7 +26,7 @@ import PageTitle from 'components/PageTitle'
 import { getStore } from 'common/store'
 import { getRoles } from 'common/services/useRole'
 
-const widths = [450, 150, 100, 250, 235, 255]
+const widths = [450, 255, 250, 235, 150, 100]
 const rolesWidths = [250, 600, 100]
 const OrganisationSettingsPage = class extends Component {
   static contextTypes = {
@@ -958,25 +958,25 @@ const OrganisationSettingsPage = class extends Component {
                                                   <Flex
                                                     className='table-column'
                                                     style={{
-                                                      minWidth: widths[5],
+                                                      minWidth: widths[1],
                                                     }}
                                                   >
                                                     Role
                                                   </Flex>
                                                   <div
-                                                    style={{ width: widths[3] }}
+                                                    style={{ width: widths[2] }}
                                                     className='table-column'
                                                   >
                                                     Action
                                                   </div>
                                                   <div
-                                                    style={{ width: widths[1] }}
+                                                    style={{ width: widths[4] }}
                                                     className='table-column'
                                                   >
                                                     Last logged in
                                                   </div>
                                                   <div
-                                                    style={{ width: widths[2] }}
+                                                    style={{ width: widths[5] }}
                                                     className='table-column text-center'
                                                   >
                                                     Remove
@@ -1028,7 +1028,7 @@ const OrganisationSettingsPage = class extends Component {
                                                     <Flex className='table-column'>
                                                       <div
                                                         style={{
-                                                          minWidth: widths[4],
+                                                          minWidth: widths[3],
                                                         }}
                                                       >
                                                         {organisation.role ===
@@ -1104,7 +1104,7 @@ const OrganisationSettingsPage = class extends Component {
                                                     {role !== 'ADMIN' ? (
                                                       <div
                                                         style={{
-                                                          width: widths[3],
+                                                          width: widths[2],
                                                         }}
                                                         onClick={onEditClick}
                                                         className='table-column'
@@ -1124,13 +1124,13 @@ const OrganisationSettingsPage = class extends Component {
                                                     ) : (
                                                       <div
                                                         style={{
-                                                          width: widths[3],
+                                                          width: widths[2],
                                                         }}
                                                       ></div>
                                                     )}
                                                     <div
                                                       style={{
-                                                        width: widths[1],
+                                                        width: widths[4],
                                                       }}
                                                       className='table-column'
                                                     >
@@ -1142,7 +1142,7 @@ const OrganisationSettingsPage = class extends Component {
                                                     </div>
                                                     <div
                                                       style={{
-                                                        width: widths[2],
+                                                        width: widths[5],
                                                       }}
                                                       className='table-column text-center'
                                                     >
@@ -1222,7 +1222,7 @@ const OrganisationSettingsPage = class extends Component {
                                                     </div>
                                                     <div
                                                       style={{
-                                                        width: widths[2],
+                                                        width: widths[5],
                                                       }}
                                                       className='table-column text-center'
                                                     >
@@ -1289,7 +1289,7 @@ const OrganisationSettingsPage = class extends Component {
                                                     <div
                                                       className='table-column text-center'
                                                       style={{
-                                                        width: widths[2],
+                                                        width: widths[5],
                                                       }}
                                                     >
                                                       <Button

--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -26,7 +26,7 @@ import PageTitle from 'components/PageTitle'
 import { getStore } from 'common/store'
 import { getRoles } from 'common/services/useRole'
 
-const widths = [450, 150, 100]
+const widths = [450, 150, 100, 250, 235, 255]
 const rolesWidths = [250, 600, 100]
 const OrganisationSettingsPage = class extends Component {
   static contextTypes = {
@@ -955,11 +955,16 @@ const OrganisationSettingsPage = class extends Component {
                                                   <Flex className='table-column px-3'>
                                                     User
                                                   </Flex>
-                                                  <Flex className='table-column'>
+                                                  <Flex
+                                                    className='table-column'
+                                                    style={{
+                                                      minWidth: widths[5],
+                                                    }}
+                                                  >
                                                     Role
                                                   </Flex>
                                                   <div
-                                                    style={{ width: widths[0] }}
+                                                    style={{ width: widths[3] }}
                                                     className='table-column'
                                                   >
                                                     Action
@@ -1021,7 +1026,11 @@ const OrganisationSettingsPage = class extends Component {
                                                     </Flex>
 
                                                     <Flex className='table-column'>
-                                                      <div>
+                                                      <div
+                                                        style={{
+                                                          minWidth: widths[4],
+                                                        }}
+                                                      >
                                                         {organisation.role ===
                                                           'ADMIN' &&
                                                         id !==
@@ -1095,7 +1104,7 @@ const OrganisationSettingsPage = class extends Component {
                                                     {role !== 'ADMIN' ? (
                                                       <div
                                                         style={{
-                                                          width: widths[0],
+                                                          width: widths[3],
                                                         }}
                                                         onClick={onEditClick}
                                                         className='table-column'
@@ -1115,7 +1124,7 @@ const OrganisationSettingsPage = class extends Component {
                                                     ) : (
                                                       <div
                                                         style={{
-                                                          width: widths[0],
+                                                          width: widths[3],
                                                         }}
                                                       ></div>
                                                     )}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Manage members layout is fixed

Before:
<img width="994" alt="Screen Shot 2023-11-28 at 14 53 43" src="https://github.com/Flagsmith/flagsmith/assets/41410593/ac65c24e-c5b4-409e-944f-445aaf29bcbb">

Now:
<img width="1045" alt="Screen Shot 2023-11-28 at 14 45 48" src="https://github.com/Flagsmith/flagsmith/assets/41410593/83012297-585d-4211-bc55-7e0a633675a6">


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- Go to manage -> Members -> Members
