### PR TITLE
feat: Add Payment component in the blocked page

### DIFF
--- a/frontend/web/components/Blocked.js
+++ b/frontend/web/components/Blocked.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ConfigProvider from 'common/providers/ConfigProvider'
+import Payment from 'components/modals/Payment'
 
 const Blocked = class extends React.Component {
   static contextTypes = {
@@ -14,25 +15,50 @@ const Blocked = class extends React.Component {
   }
 
   render = () => (
-    <div className='fullscreen-container maintenance fullscreen-container__grey justify-content-center'>
-      <div className='col-md-6 mt-5' id='sign-up'>
-        <h1>Please get in touch</h1>
-        Your organisation has been disabled. Please get in touch so we can
-        discuss enabling your account.
-        {
-          <>
-            {' '}
-            <a
-              target='_blank'
-              href='mailto:support@flagsmith.com'
-              rel='noreferrer'
-            >
-              support@flagsmith.com
-            </a>
-            .
-          </>
-        }
-      </div>
+    <div className='fullscreen-container maintenance fullscreen-container__grey justify-content-center dark'>
+      {!Utils.getFlagsmithHasFeature('show_payment') ? (
+        <div className='col-md-6 mt-5' id='sign-up'>
+          <h1>Please get in touch</h1>
+          Your organisation has been disabled. Please get in touch so we can
+          discuss enabling your account.
+          {
+            <>
+              {' '}
+              <a
+                target='_blank'
+                href='mailto:support@flagsmith.com'
+                rel='noreferrer'
+              >
+                support@flagsmith.com
+              </a>
+              .
+            </>
+          }
+        </div>
+      ) : (
+        <div className='col-md-8 mt-5' id='sign-up'>
+          {
+            <>
+              <div>
+                <Button
+                  theme='text'
+                  onClick={() => {
+                    AppActions.logout()
+                    window.location.href = `/login`
+                  }}
+                >
+                  Return to Sign in/Sign up page
+                </Button>
+              </div>
+              <Payment
+                isDisableAccountText={
+                  'Your organisation has been disabled. Please upgrade your plan or get in touch so we can discuss enabling your account.'
+                }
+              />
+            </>
+          }
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/web/components/Blocked.js
+++ b/frontend/web/components/Blocked.js
@@ -16,7 +16,7 @@ const Blocked = class extends React.Component {
 
   render = () => (
     <div className='fullscreen-container maintenance fullscreen-container__grey justify-content-center dark'>
-      {!Utils.getFlagsmithHasFeature('show_payment') ? (
+      {!Utils.getFlagsmithHasFeature('payments_on_blocked_page') ? (
         <div className='col-md-6 mt-5' id='sign-up'>
           <h1>Please get in touch</h1>
           Your organisation has been disabled. Please get in touch so we can

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -31,6 +31,9 @@ const PaymentButton = (props) => {
             },
             success: (res) => {
               AppActions.updateSubscription(res)
+              if (this.props.isDisableAccount) {
+                window.location.href = `/projects`
+              }
             },
           })
         }}
@@ -99,6 +102,20 @@ const Payment = class extends Component {
               <div className='col-md-12'>
                 <Row space className='mb-4'>
                   <h5>Manage Payment Plan</h5>
+                  {this.props.isDisableAccountText && (
+                    <Row>
+                      <h7>
+                        {this.props.isDisableAccountText}{' '}
+                        <a
+                          target='_blank'
+                          href='mailto:support@flagsmith.com'
+                          rel='noreferrer'
+                        >
+                          support@flagsmith.com
+                        </a>
+                      </h7>
+                    </Row>
+                  )}
                 </Row>
                 <Row className='pricing-container align-start'>
                   <Flex className='pricing-panel p-2'>
@@ -122,6 +139,7 @@ const Payment = class extends Component {
                             <PaymentButton
                               data-cb-plan-id='startup-annual-v2'
                               className='btn btn-primary full-width mt-3'
+                              isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('startup') ? 'Purchased' : 'Buy'}
                             </PaymentButton>
@@ -129,6 +147,7 @@ const Payment = class extends Component {
                             <PaymentButton
                               data-cb-plan-id='startup-v2'
                               className='btn btn-primary full-width mt-3'
+                              isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('startup') ? 'Purchased' : 'Buy'}
                             </PaymentButton>
@@ -329,6 +348,7 @@ const Payment = class extends Component {
                             <PaymentButton
                               data-cb-plan-id='scale-up-annual-v2'
                               className='btn btn-success full-width mt-3'
+                              isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('scale-up') ? 'Purchased' : 'Buy'}
                             </PaymentButton>
@@ -336,6 +356,7 @@ const Payment = class extends Component {
                             <PaymentButton
                               data-cb-plan-id='scale-up-v2'
                               className='btn btn-success full-width mt-3'
+                              isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('scale-up') ? 'Purchased' : 'Buy'}
                             </PaymentButton>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Add Payment component in the blocked page
- Wrapped with 'payments_on_blocked_page' flag

## How did you test this code?

While this has been tested locally by setting `block_access_to_admin` to true for a test organization, I was not able to test the post-payment part of the workflow, which should take the user to the projects page in case of successful payment.