### PR TITLE
chore(infra): run PC build on self hosted

### DIFF
--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -12,23 +12,9 @@ env:
   FLAGSMITH_AUTH_CONTROLLER_REVISION: v0.0.1
 
 jobs:
-  start-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      runner-label: ${{ steps.start.outputs.runner-label }}
-      instance-id: ${{ steps.start.outputs.instance-id }}
-    steps:
-      - uses: Flagsmith/actions/ec2-runner/start@v0.2.0
-        id: start
-        with:
-          github-access-token: ${{ secrets.GH_RUNNER_TOKEN }}
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID_EC2_RUNNER }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_EC2_RUNNER }}
-
   build-dockerhub:
     name: Platform Publish Docker Image
-    needs: [start-runner]
-    runs-on: ${{ needs.start-runner.outputs.runner-label }}
+    runs-on: self-hosted
 
     steps:
       - name: Cloning repo
@@ -123,16 +109,3 @@ jobs:
             SAML_INSTALLED=1
             POETRY_OPTS=--with saml,auth-controller,ldap
             GH_TOKEN=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
-
-  stop-runner:
-    needs: [start-runner, build-dockerhub]
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Flagsmith/actions/ec2-runner/stop@v0.2.0
-        with:
-          github-access-token: ${{ secrets.GH_RUNNER_TOKEN }}
-          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID_EC2_RUNNER }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_EC2_RUNNER }}
-          runner-label: ${{ needs.start-runner.outputs.runner-label }}
-          instance-id: ${{ needs.start-runner.outputs.instance-id }}


### PR DESCRIPTION
## Changes

Run the Private Cloud builds on self hosted runners (this is a temporary solution to ensure that PC builds are created while we work further on the ARM runners). 

## How did you test this code?

N/a
