### PR TITLE
chore: restrict python version < 3.12

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -44,7 +44,7 @@ authors = ["Flagsmith <support@flagsmith.com>"]
 readme = "readme.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10,<3.12"
 django = "~3.2.23"
 rudder-sdk-python = "~1.0.5"
 analytics-python = "~1.4.0"


### PR DESCRIPTION
## Changes

Restrict python version to less than 3.12 as there seems to be issues with google-re2. 

## How did you test this code?

`make install` in a fresh environment does not use python 3.12 if available. 
