### PR TITLE
fix: remove pagination from group summaries

### DIFF
--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -1664,12 +1664,12 @@ def test_list_group_summaries(
     assert response.status_code == status.HTTP_200_OK
 
     response_json = response.json()
-    assert response_json["count"] == 2
-    assert response_json["results"][0] == {
+    assert len(response_json) == 2
+    assert response_json[0] == {
         "id": user_permission_group_1.id,
         "name": user_permission_group_1.name,
     }
-    assert response_json["results"][1] == {
+    assert response_json[1] == {
         "id": user_permission_group_2.id,
         "name": user_permission_group_2.name,
     }

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -191,7 +191,7 @@ class UserPermissionGroupViewSet(viewsets.ModelViewSet):
 
         return qs
 
-    def paginate_queryset(self, queryset: QuerySet) -> QuerySet | None:
+    def paginate_queryset(self, queryset: QuerySet) -> list[UserPermissionGroup] | None:
         if self.action == "summaries":
             return None
         return super().paginate_queryset(queryset)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -191,6 +191,11 @@ class UserPermissionGroupViewSet(viewsets.ModelViewSet):
 
         return qs
 
+    def paginate_queryset(self, queryset: QuerySet) -> QuerySet | None:
+        if self.action == "summaries":
+            return None
+        return super().paginate_queryset(queryset)
+
     def get_serializer_class(self):
         if self.action == "retrieve":
             return UserPermissionGroupSerializerDetail


### PR DESCRIPTION
## Changes

Since the FE needs to be able to grab the list of groups for an organisation to e.g. populate the group owners on a feature, and the summaries endpoint only returns 2 attributes for each group, we can safely remove the pagination from this endpoint. 

Note that this endpoint has not yet been released to production but this needs to be merged before the next release of the API to ensure that we're not creating breaking changes to the API. 

## How did you test this code?

Updated the unit test. 
