### PR TITLE
chore: remove EDGE_API_URL environment variable to stop edge forwarding

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -174,10 +174,6 @@
                 {
                     "name": "PIPEDRIVE_IGNORE_DOMAINS",
                     "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io,flagsmithe2etestdomain.io"
-                },
-                {
-                    "name":"EDGE_API_URL",
-                    "value":"https://edge.api.flagsmith.com/api/v1/"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -116,10 +116,6 @@
                     "value": "937916178726.2904626318658"
                 },
                 {
-                    "name":"EDGE_API_URL",
-                    "value":"https://edge.bullet-train-staging.win/api/v1/"
-                },
-                {
                     "name": "IDENTITY_MIGRATION_EVENT_BUS_NAME",
                     "value": "identity_migration-fb41b5d"
                 },


### PR DESCRIPTION
## Changes

Remove the `EDGE_API_URL` to stop forwarding identities / traits requests from core to edge. 

## How did you test this code?

Has been used multiple times in the past to temporarily disable forwarding. Unit test coverage also exists to confirm that no requests are forwarded if the env var is not set. 
