### PR TITLE
fix: revert "fix: Reading role permissions generates 500 error backend"

### DIFF
--- a/api/users/models.py
+++ b/api/users/models.py
@@ -4,7 +4,6 @@ import typing
 from django.conf import settings
 from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import send_mail
 from django.db import models
 from django.db.models import Count, QuerySet
@@ -42,9 +41,6 @@ if typing.TYPE_CHECKING:
         Invite,
         InviteLink,
     )
-
-if settings.IS_RBAC_INSTALLED:
-    from rbac.models import UserRole
 
 logger = logging.getLogger(__name__)
 mailer_lite = MailerLite()
@@ -258,14 +254,6 @@ class FFAdminUser(LifecycleModel, AbstractUser):
             logger.warning(
                 "User %d is not part of organisation %d" % (self.id, organisation_id)
             )
-
-    def get_user_roles(self):
-        if not settings.IS_RBAC_INSTALLED:
-            raise ImproperlyConfigured(
-                "RBAC is not installed. Unable to retrieve user roles."
-            )
-
-        return UserRole.objects.filter(user=self)
 
     def get_permitted_projects(
         self, permission_key: str, tag_ids: typing.List[int] = None

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,13 +1,9 @@
-from django.conf import settings
 from djoser.serializers import UserSerializer as DjoserUserSerializer
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from organisations.models import Organisation
 from organisations.serializers import UserOrganisationSerializer
-
-if settings.IS_RBAC_INSTALLED:
-    from rbac.serializers import UserRoleSerializer
 
 from .models import FFAdminUser, UserPermissionGroup
 
@@ -60,15 +56,9 @@ class UserLoginSerializer(serializers.ModelSerializer):
 class UserListSerializer(serializers.ModelSerializer):
     role = serializers.SerializerMethodField(read_only=True)
     join_date = serializers.SerializerMethodField(read_only=True)
-    if settings.IS_RBAC_INSTALLED:
-        roles = UserRoleSerializer(many=True, read_only=True, source="get_user_roles")
 
     default_fields = ("id", "email", "first_name", "last_name", "last_login")
-    organisation_users_fields = (
-        "role",
-        "date_joined",
-        *([] if not settings.IS_RBAC_INSTALLED else ["roles"]),
-    )
+    organisation_users_fields = ("role", "date_joined")
 
     class Meta:
         model = FFAdminUser


### PR DESCRIPTION
Reverts Flagsmith/flagsmith#3079 since this code should live in RBAC as a new endpoint. It also introduced a new N+1 issue to the codebase. 