### PR TITLE
fix: Unable to delete multiple segment overrides at once

### DIFF
--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -497,6 +497,7 @@ class TheComponent extends Component {
       </div>,
       () => {
         this.props.value[i].toRemove = true
+        this.setState({ isLoading: false })
       },
       () => {
         this.setState({ isLoading: false })


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Set isLoading state to false

## How did you test this code?

- Go to features -> Click a feature with segment overrides
- Click on the segment overrides tab
- Click the delete button and confirm it
- Multiple segment overrides can now be deleted
