### PR TITLE
docs: Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,6 @@ The Flagsmith API is built using Python 3, Django 2, and DjangoRestFramework 3. 
 - [Kubernetes](https://github.com/Flagsmith/flagsmith-charts)
 - [Redhat OpenShift](https://operatorhub.io/operator/flagsmith)
 
-### Flagsmith Self-Hosted
-Deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=flagsmith):
-
-[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=flagsmith)
-
-
-
 We also have options for deploying to AWS, GCP, Azure and On-Premise. If you need help getting up and running, please
 [get in touch!](mailto:support@flagsmith.com)
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ The Flagsmith API is built using Python 3, Django 2, and DjangoRestFramework 3. 
 - [Kubernetes](https://github.com/Flagsmith/flagsmith-charts)
 - [Redhat OpenShift](https://operatorhub.io/operator/flagsmith)
 
+### Flagsmith Self-Hosted
+Deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=flagsmith):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=flagsmith)
+
+
+
 We also have options for deploying to AWS, GCP, Azure and On-Premise. If you need help getting up and running, please
 [get in touch!](mailto:support@flagsmith.com)
 

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -25,7 +25,6 @@ We have a number of example deployments across different providers and orchestra
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/36mGw8?referralCode=DGxv1S)
 
-
 ![Fly.io](/img/logos/fly.io.svg)
 
 We're big fans of [Fly.io](https://Fly.io)! You can deploy to fly.io really easily:

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -17,11 +17,14 @@ We have a number of example deployments across different providers and orchestra
 
 ## One Click Installers
 
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=flagsmith)
+
 [![Deploy to DigitalOcean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/flagsmith/flagsmith/tree/main)
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/flagsmith/flagsmith/tree/main)
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/36mGw8?referralCode=DGxv1S)
+
 
 ![Fly.io](/img/logos/fly.io.svg)
 


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://unleash-1665.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.