### PR TITLE
style: Adjust feature value size for user overrides

### DIFF
--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -655,6 +655,7 @@ const UserPage = class extends Component {
                                                       control value of this
                                                       feature is{' '}
                                                       <FeatureValue
+                                                        className='ml-1 chip--xs'
                                                         includeEmpty
                                                         data-test={`user-feature-original-value-${i}`}
                                                         value={`${flagValue}`}
@@ -671,6 +672,7 @@ const UserPage = class extends Component {
                                                       overriden by segments and
                                                       would normally be{' '}
                                                       <FeatureValue
+                                                        className='ml-1 chip--xs'
                                                         includeEmpty
                                                         data-test={`user-feature-original-value-${i}`}
                                                         value={`${flagValue}`}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Adjusts size of user override labels 

**Before**

<img width="702" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/b6399fc6-3b5d-49c4-a751-ea5a80f4cab7">

**After**
<img width="732" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/f0f21d9d-10ad-42ce-89e8-33af4d5a486d">

## How did you test this code?

Viewed a user.
