### PR TITLE
style: Fix vertical alignment of create first feature

### DIFF
--- a/frontend/web/components/pages/FeaturesPage.js
+++ b/frontend/web/components/pages/FeaturesPage.js
@@ -585,13 +585,17 @@ const FeaturesPage = class extends Component {
                                 data-test='show-create-feature-btn'
                                 onClick={this.newFlag}
                               >
-                                <span className='icon'>
+                                <div className='flex-row justify-content-center'>
                                   <IonIcon
+                                    className='me-1'
                                     icon={rocket}
-                                    style={{ contain: 'none', height: '25px' }}
+                                    style={{
+                                      contain: 'none',
+                                      height: '25px',
+                                    }}
                                   />
-                                </span>{' '}
-                                Create your first Feature
+                                  <span>Create your first Feature</span>
+                                </div>
                               </Button>
                             </FormGroup>
                           ))}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The recent IonIcons changed caused the following:

Before: 
![image](https://github.com/Flagsmith/flagsmith/assets/8608314/34ee0f45-4d61-473c-ac5f-0d925dc77171)


After: 
![image](https://github.com/Flagsmith/flagsmith/assets/8608314/b88b01f8-e66e-4b90-b172-04bac9bc6722)


## How did you test this code?

As above