### PR TITLE
chore: change project field to migration status

### DIFF
--- a/api/projects/admin.py
+++ b/api/projects/admin.py
@@ -69,6 +69,7 @@ class ProjectAdmin(admin.ModelAdmin):
         "max_segments_allowed",
         "max_features_allowed",
         "max_segment_overrides_allowed",
+        "identity_overrides_migration_status",
     )
 
     @admin.action(

--- a/api/projects/migrations/0021_add_identity_overrides_migration_status.py
+++ b/api/projects/migrations/0021_add_identity_overrides_migration_status.py
@@ -24,6 +24,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 choices=[
                     ("NOT_STARTED", "Not Started"),
+                    ("IN_PROGRESS", "In Progress"),
                     ("COMPLETE", "Complete"),
                 ],
                 default=None,
@@ -38,6 +39,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 choices=[
                     ("NOT_STARTED", "Not Started"),
+                    ("IN_PROGRESS", "In Progress"),
                     ("COMPLETE", "Complete"),
                 ],
                 default="NOT_STARTED",

--- a/api/projects/migrations/0021_add_identity_overrides_migration_status.py
+++ b/api/projects/migrations/0021_add_identity_overrides_migration_status.py
@@ -3,12 +3,12 @@ from django.apps.registry import Apps
 from django.db import migrations, models
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 
-from projects.models import IdentityOverridesStorageType
+from projects.models import IdentityOverridesMigrationStatus
 
 
 def apply_defaults(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
     apps.get_model("projects", "Project").objects.all().update(
-        identity_overrides_storage_type=IdentityOverridesStorageType.IDENTITY_RECORD
+        identity_overrides_migration_status=IdentityOverridesMigrationStatus.NOT_STARTED
     )
 
 
@@ -20,11 +20,11 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name="project",
-            name="identity_overrides_storage_type",
+            name="identity_overrides_migration_status",
             field=models.CharField(
                 choices=[
-                    ("IDENTITY_RECORD", "Identity Record"),
-                    ("FLAGSMITH_OVERRIDES", "Flagsmith Overrides"),
+                    ("NOT_STARTED", "Not Started"),
+                    ("COMPLETE", "Complete"),
                 ],
                 default=None,
                 max_length=50,
@@ -34,13 +34,13 @@ class Migration(migrations.Migration):
         migrations.RunPython(apply_defaults, reverse_code=migrations.RunPython.noop),
         migrations.AlterField(
             model_name="project",
-            name="identity_overrides_storage_type",
+            name="identity_overrides_migration_status",
             field=models.CharField(
                 choices=[
-                    ("IDENTITY_RECORD", "Identity Record"),
-                    ("FLAGSMITH_OVERRIDES", "Flagsmith Overrides"),
+                    ("NOT_STARTED", "Not Started"),
+                    ("COMPLETE", "Complete"),
                 ],
-                default="IDENTITY_RECORD",
+                default="NOT_STARTED",
                 max_length=50,
             ),
         ),

--- a/api/projects/models.py
+++ b/api/projects/models.py
@@ -32,6 +32,7 @@ environment_cache = caches[settings.ENVIRONMENT_CACHE_NAME]
 
 class IdentityOverridesMigrationStatus(models.TextChoices):
     NOT_STARTED = "NOT_STARTED", "Not Started"
+    IN_PROGRESS = "IN_PROGRESS", "In Progress"
     COMPLETE = "COMPLETE", "Complete"
 
 

--- a/api/projects/models.py
+++ b/api/projects/models.py
@@ -30,9 +30,9 @@ project_segments_cache = caches[settings.PROJECT_SEGMENTS_CACHE_LOCATION]
 environment_cache = caches[settings.ENVIRONMENT_CACHE_NAME]
 
 
-class IdentityOverridesStorageType(models.TextChoices):
-    IDENTITY_RECORD = "IDENTITY_RECORD", "Identity Record"
-    FLAGSMITH_OVERRIDES = "FLAGSMITH_OVERRIDES", "Flagsmith Overrides"
+class IdentityOverridesMigrationStatus(models.TextChoices):
+    NOT_STARTED = "NOT_STARTED", "Not Started"
+    COMPLETE = "COMPLETE", "Complete"
 
 
 class Project(LifecycleModelMixin, SoftDeleteExportableModel):
@@ -76,10 +76,10 @@ class Project(LifecycleModelMixin, SoftDeleteExportableModel):
         default=100,
         help_text="Max segments overrides allowed for any (one) environment within this project",
     )
-    identity_overrides_storage_type = models.CharField(
+    identity_overrides_migration_status = models.CharField(
         max_length=50,
-        choices=IdentityOverridesStorageType.choices,
-        default=IdentityOverridesStorageType.IDENTITY_RECORD,
+        choices=IdentityOverridesMigrationStatus.choices,
+        default=IdentityOverridesMigrationStatus.NOT_STARTED,
     )
 
     objects = ProjectManager()
@@ -157,6 +157,13 @@ class Project(LifecycleModelMixin, SoftDeleteExportableModel):
         return (
             not self.feature_name_regex
             or re.match(f"^{self.feature_name_regex}$", feature_name) is not None
+        )
+
+    @property
+    def show_edge_identity_overrides_for_feature(self) -> bool:
+        return (
+            self.identity_overrides_migration_status
+            == IdentityOverridesMigrationStatus.COMPLETE
         )
 
 

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -34,6 +34,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
             "enable_realtime_updates",
             "only_allow_lower_case_feature_names",
             "feature_name_regex",
+            "show_edge_identity_overrides_for_feature",
         )
 
     def get_migration_status(self, obj: Project) -> str:

--- a/api/tests/unit/projects/test_unit_projects_models.py
+++ b/api/tests/unit/projects/test_unit_projects_models.py
@@ -5,7 +5,7 @@ import pytest
 from django.conf import settings
 from django.utils import timezone
 
-from projects.models import Project
+from projects.models import IdentityOverridesMigrationStatus, Project
 
 now = timezone.now()
 tomorrow = now + timedelta(days=1)
@@ -133,4 +133,23 @@ def test_environments_are_updated_in_dynamodb_when_project_id_updated(
     # Then
     mock_environments_wrapper.write_environments.assert_called_once_with(
         [dynamo_enabled_project_environment_one, dynamo_enabled_project_environment_two]
+    )
+
+
+@pytest.mark.parametrize(
+    "identity_overrides_migration_status, expected_value",
+    (
+        (IdentityOverridesMigrationStatus.NOT_STARTED, False),
+        (IdentityOverridesMigrationStatus.COMPLETE, True),
+    ),
+)
+def test_show_edge_identity_overrides_for_feature(
+    identity_overrides_migration_status: IdentityOverridesMigrationStatus,
+    expected_value: bool,
+):
+    assert (
+        Project(
+            identity_overrides_migration_status=identity_overrides_migration_status
+        ).show_edge_identity_overrides_for_feature
+        == expected_value
     )

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -754,7 +754,9 @@ def test_get_project_list_data(client, organisation):
     "client",
     (lazy_fixture("admin_client"), lazy_fixture("admin_master_api_key_client")),
 )
-def test_get_project_data_by_id(client, organisation, project):
+def test_get_project_data_by_id(
+    client: APIClient, organisation: Organisation, project: Project
+) -> None:
     # Given
     url = reverse("api-v1:projects:project-detail", args=[project.id])
 
@@ -772,9 +774,12 @@ def test_get_project_data_by_id(client, organisation, project):
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["name"] == project.name
-    assert response.json()["max_segments_allowed"] == 100
-    assert response.json()["max_features_allowed"] == 400
-    assert response.json()["max_segment_overrides_allowed"] == 100
-    assert response.json()["total_features"] == num_features
-    assert response.json()["total_segments"] == num_segments
+
+    response_json = response.json()
+    assert response_json["name"] == project.name
+    assert response_json["max_segments_allowed"] == 100
+    assert response_json["max_features_allowed"] == 400
+    assert response_json["max_segment_overrides_allowed"] == 100
+    assert response_json["total_features"] == num_features
+    assert response_json["total_segments"] == num_segments
+    assert response_json["show_edge_identity_overrides_for_feature"] is False


### PR DESCRIPTION
## Changes

Changes the previous field related to identity override storage (`identity_overrides_storage_type`) to `identity_overrides_migration_status`. This is due to the change in approach which means the previous name of the field was not quite representative of the data. 

For context, the old approach was to migrate all identity overrides to a new `flagsmith_overrides` table (and removing the data from the `flagsmith_identities` table. We are now migrating the data to a new `flagsmith_environments_v2` table but keeping the data in the `flagsmith_identities` table. 

As part of this work, we're also exposing a new field for the FE to use to determine whether to show the identity overrides tab when viewing a feature. 

WARNING: merging this will break staging as I have edited an existing migration. This will require some manual work on the staging database to get it working again. 

## How did you test this code?

Added a couple of minor unit tests. 
