### PR TITLE
fix: do not show identity overrides tab until release

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -347,10 +347,10 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   getShouldHideIdentityOverridesTab(_project: ProjectType) {
     const project = _project || ProjectStore.model
     if (
-      project &&
-      project.use_edge_identities &&
-      project.show_edge_identity_overrides_for_feature &&
-      !Utils.getFlagsmithHasFeature('show_edge_identity_overrides')
+      !Utils.getFlagsmithHasFeature('show_edge_identity_overrides') ||
+      (project &&
+        project.use_edge_identities &&
+        !project.show_edge_identity_overrides_for_feature)
     ) {
       return true
     }


### PR DESCRIPTION
## Changes

Fixes the logic which hides the identity overrides tab for edge projects. 

## How did you test this code?

Tested using preview link to confirm that the Identity Overrides tab does not show

<img width="660" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/789938b5-a703-4743-899a-0ba588480e1d">

