### PR TITLE
fix: hide additional actions on identity overrides tab in Edge

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1337,20 +1337,22 @@ const CreateFlag = class extends Component {
                                             </Tooltip>
                                           }
                                           action={
-                                            <Button
-                                              onClick={() =>
-                                                this.changeIdentity(
-                                                  this.state.userOverrides,
-                                                )
-                                              }
-                                              type='button'
-                                              theme='secondary'
-                                              size='small'
-                                            >
-                                              {enabledIndentity
-                                                ? 'Enable All'
-                                                : 'Disable All'}
-                                            </Button>
+                                            !Utils.getIsEdge() && (
+                                              <Button
+                                                onClick={() =>
+                                                  this.changeIdentity(
+                                                    this.state.userOverrides,
+                                                  )
+                                                }
+                                                type='button'
+                                                theme='secondary'
+                                                size='small'
+                                              >
+                                                {enabledIndentity
+                                                  ? 'Enable All'
+                                                  : 'Disable All'}
+                                              </Button>
+                                            )
                                           }
                                           items={this.state.userOverrides}
                                           paging={
@@ -1373,32 +1375,35 @@ const CreateFlag = class extends Component {
                                             this.userOverridesPage(page)
                                           }
                                           searchPanel={
-                                            <div className='text-center mt-2 mb-2'>
-                                              <Flex className='text-left'>
-                                                <IdentitySelect
-                                                  isEdge={false}
-                                                  ignoreIds={this.state.userOverrides?.map(
-                                                    (v) => v.identity?.id,
-                                                  )}
-                                                  environmentId={
-                                                    this.props.environmentId
-                                                  }
-                                                  data-test='select-identity'
-                                                  placeholder='Create an Identity Override...'
-                                                  value={
-                                                    this.state.selectedIdentity
-                                                  }
-                                                  onChange={(
-                                                    selectedIdentity,
-                                                  ) =>
-                                                    this.setState(
-                                                      { selectedIdentity },
-                                                      this.addItem,
-                                                    )
-                                                  }
-                                                />
-                                              </Flex>
-                                            </div>
+                                            !Utils.getIsEdge() && (
+                                              <div className='text-center mt-2 mb-2'>
+                                                <Flex className='text-left'>
+                                                  <IdentitySelect
+                                                    isEdge={false}
+                                                    ignoreIds={this.state.userOverrides?.map(
+                                                      (v) => v.identity?.id,
+                                                    )}
+                                                    environmentId={
+                                                      this.props.environmentId
+                                                    }
+                                                    data-test='select-identity'
+                                                    placeholder='Create an Identity Override...'
+                                                    value={
+                                                      this.state
+                                                        .selectedIdentity
+                                                    }
+                                                    onChange={(
+                                                      selectedIdentity,
+                                                    ) =>
+                                                      this.setState(
+                                                        { selectedIdentity },
+                                                        this.addItem,
+                                                      )
+                                                    }
+                                                  />
+                                                </Flex>
+                                              </div>
+                                            )
                                           }
                                           renderRow={({
                                             enabled,

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1430,6 +1430,7 @@ const CreateFlag = class extends Component {
                                                         identity,
                                                       })
                                                     }
+                                                    disabled={Utils.getIsEdge()}
                                                   />
                                                 </div>
                                                 <div className='font-weight-medium fs-small lh-sm'>


### PR DESCRIPTION
## Changes

This PR hides the additional actions on the Identity Overrides tab in the Create/Edit feature modal. Until this can be looked into in more detail, we should hide these actions and treat this data as read only for now. 

I did try to get the toggle working, but it was not possible (at least not easily with my JS skills) since the data which powers the endpoint does not update quickly enough to return the newly updated value when the re-rendering happens.

## How did you test this code?

Ran the FE locally against the staging API and confirmed that the actions are not visible for an Edge project. 

<img width="660" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/6808ac1b-279b-4c57-911a-9fcda7391418">

To test it, add yourself to organisation 40, either via the [django admin](https://api-staging.flagsmith.com/admin/organisations/organisation/40/change), or using [this invite link](https://staging.flagsmith.com/invite/CseYMNfqUuCv6krk8bNFVC) and view the `test` feature in the Production environment. 