### PR TITLE
fix: re-add identity overrides for core projects

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -346,15 +346,16 @@ const Utils = Object.assign({}, require('./base/_utils'), {
 
   getShouldHideIdentityOverridesTab(_project: ProjectType) {
     const project = _project || ProjectStore.model
-    if (
+    if (!Utils.getIsEdge()) {
+      return false
+    }
+
+    return !!(
       !Utils.getFlagsmithHasFeature('show_edge_identity_overrides') ||
       (project &&
         project.use_edge_identities &&
         !project.show_edge_identity_overrides_for_feature)
-    ) {
-      return true
-    }
-    return false
+    )
   },
 
   getShouldSendIdentityToTraits(_project: ProjectType) {


### PR DESCRIPTION
## Changes

Re-add identity overrides tab for core projects that was broken by [this PR](https://github.com/Flagsmith/flagsmith/pull/3134). 

## How did you test this code?

Ran FE locally and verified that all combinations behave as expected. 

Test Scenarios: 

 - [x] Core project should show identity overrides regardless of the status of the `show_edge_identity_overrides` flag
 - [x] Edge project should not show identity overrides regardless of the value of `"show_edge_identity_overrides_for_feature"` if the `show_edge_identity_overrides` flag is disabled
 - [x] Edge project should not show identity overrides regardless of the state of the flag `show_edge_identity_overrides` if the value of `"show_edge_identity_overrides_for_feature"` is not `"COMPLETE"`
 - [x] Edge project should show identity overrides if the value of `"show_edge_identity_overrides_for_feature"` is not `"COMPLETE"` and the flag `show_edge_identity_overrides` is enabled
