### PR TITLE
fix: show falsy values in identity overrides

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1442,7 +1442,8 @@ const CreateFlag = class extends Component {
                                                   className='table-column'
                                                   style={{ width: '188px' }}
                                                 >
-                                                  {feature_state_value && (
+                                                  {feature_state_value !==
+                                                    null && (
                                                     <FeatureValue
                                                       value={
                                                         feature_state_value


### PR DESCRIPTION
## Changes

Ensures that (valid) falsy values are shown in the identity override rows on the identity overrides tab in the feature modal. 

## How did you test this code?

Ran the FE locally against staging with a known override of `false` and confirmed that it is displayed. 
