### PR TITLE
chore: Allow Decimal feature state values when mapping to DynamoDB

### DIFF
--- a/api/util/mappers/dynamodb.py
+++ b/api/util/mappers/dynamodb.py
@@ -192,6 +192,7 @@ DOCUMENT_VALUE_ENCODERS_BY_TYPE = {
     int: _decimal_encoder,
     float: _decimal_encoder,
     datetime: _isoformat_encoder,
+    Decimal: _noop_encoder,
 }
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR adds the ability to pass `Decimal` values to DynamoDB mappers so they are not coerced to string. 

## How did you test this code?

Covered the initial issue with a unit test.