### PR TITLE
chore: Write GSI index partition key for meta documents

### DIFF
--- a/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
@@ -152,7 +152,6 @@ def test_map_environment_to_environment_v2_document__call_expected(
         "environment_api_key": expected_api_key,
         "allow_client_traits": True,
         "amplitude_config": None,
-        "api_key": expected_api_key,
         "dynatrace_config": None,
         "feature_states": [
             {

--- a/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
@@ -149,6 +149,7 @@ def test_map_environment_to_environment_v2_document__call_expected(
     assert result == {
         "document_key": ENVIRONMENTS_V2_ENVIRONMENT_META_DOCUMENT_KEY,
         "environment_id": str(environment.id),
+        "environment_api_key": expected_api_key,
         "allow_client_traits": True,
         "amplitude_config": None,
         "api_key": expected_api_key,

--- a/api/util/mappers/dynamodb.py
+++ b/api/util/mappers/dynamodb.py
@@ -58,6 +58,7 @@ def map_environment_to_environment_v2_document(
     return {
         **map_environment_to_environment_document(environment),
         "document_key": ENVIRONMENTS_V2_ENVIRONMENT_META_DOCUMENT_KEY,
+        "environment_api_key": environment.api_key,
         "environment_id": str(environment.id),
     }
 

--- a/api/util/mappers/dynamodb.py
+++ b/api/util/mappers/dynamodb.py
@@ -55,10 +55,12 @@ def map_environment_to_environment_document(
 def map_environment_to_environment_v2_document(
     environment: "Environment",
 ) -> Document:
+    environment_document = map_environment_to_environment_document(environment)
+    environment_api_key = environment_document.pop("api_key")
     return {
-        **map_environment_to_environment_document(environment),
+        **environment_document,
         "document_key": ENVIRONMENTS_V2_ENVIRONMENT_META_DOCUMENT_KEY,
-        "environment_api_key": environment.api_key,
+        "environment_api_key": environment_api_key,
         "environment_id": str(environment.id),
     }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes meta documents in `flagsmith_environments_v2` table not having the `environment_api_key` column.

## How did you test this code?

Modified the mapper unit test. 