### PR TITLE
feat: Write migrated environments to v2

### DIFF
--- a/api/environments/dynamodb/__init__.py
+++ b/api/environments/dynamodb/__init__.py
@@ -1,5 +1,13 @@
-from .dynamodb_wrapper import (  # noqa
+from .dynamodb_wrapper import (
     DynamoEnvironmentAPIKeyWrapper,
+    DynamoEnvironmentV2Wrapper,
     DynamoEnvironmentWrapper,
     DynamoIdentityWrapper,
+)
+
+__all__ = (
+    "DynamoEnvironmentAPIKeyWrapper",
+    "DynamoEnvironmentV2Wrapper",
+    "DynamoEnvironmentWrapper",
+    "DynamoIdentityWrapper",
 )

--- a/api/environments/dynamodb/services.py
+++ b/api/environments/dynamodb/services.py
@@ -15,12 +15,12 @@ from util.mappers import map_engine_feature_state_to_identity_override
 logger = logging.getLogger(__name__)
 
 
-def migrate_environments_to_v2(project_id: int) -> None:
+def migrate_environments_to_v2(project_id: int) -> IdentityOverridesV2Changeset | None:
     dynamo_wrapper_v2 = DynamoEnvironmentV2Wrapper()
     identity_wrapper = DynamoIdentityWrapper()
 
     if not (dynamo_wrapper_v2.is_enabled and identity_wrapper.is_enabled):
-        return
+        return None
 
     logger.info("Migrating environments to v2 for project %d", project_id)
 
@@ -43,6 +43,7 @@ def migrate_environments_to_v2(project_id: int) -> None:
     dynamo_wrapper_v2.update_identity_overrides(changeset)
 
     logger.info("Finished migrating environments to v2 for project %d", project_id)
+    return changeset
 
 
 def _iter_paginated_overrides(

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -37,6 +37,7 @@ from environments.api_keys import (
 )
 from environments.dynamodb import (
     DynamoEnvironmentAPIKeyWrapper,
+    DynamoEnvironmentV2Wrapper,
     DynamoEnvironmentWrapper,
 )
 from environments.exceptions import EnvironmentHeaderNotPresentError
@@ -44,6 +45,7 @@ from environments.managers import EnvironmentManager
 from features.models import Feature, FeatureSegment, FeatureState
 from features.versioning.exceptions import FeatureVersioningError
 from metadata.models import Metadata
+from projects.models import IdentityOverridesV2MigrationStatus, Project
 from segments.models import Segment
 from util.mappers import map_environment_to_environment_document
 from webhooks.models import AbstractBaseExportableWebhookModel
@@ -57,6 +59,7 @@ bad_environments_cache = caches[settings.BAD_ENVIRONMENTS_CACHE_LOCATION]
 
 # Intialize the dynamo environment wrapper(s) globaly
 environment_wrapper = DynamoEnvironmentWrapper()
+environment_v2_wrapper = DynamoEnvironmentV2Wrapper()
 environment_api_key_wrapper = DynamoEnvironmentAPIKeyWrapper()
 
 
@@ -234,7 +237,7 @@ class Environment(
         # grab the first project and verify that each environment is for the same
         # project (which should always be the case). Since we're working with fairly
         # small querysets here, this shouldn't have a noticeable impact on performance.
-        project = getattr(environments[0], "project", None)
+        project: Project | None = getattr(environments[0], "project", None)
         for environment in environments[1:]:
             if not environment.project == project:
                 raise RuntimeError("Environments must all belong to the same project.")
@@ -243,6 +246,13 @@ class Environment(
             return
 
         environment_wrapper.write_environments(environments)
+
+        if (
+            project.identity_overrides_v2_migration_status
+            == IdentityOverridesV2MigrationStatus.COMPLETE
+            and environment_v2_wrapper.is_enabled
+        ):
+            environment_v2_wrapper.write_environments(environments)
 
     def get_feature_state(
         self, feature_id: int, filter_kwargs: dict = None

--- a/api/projects/tasks.py
+++ b/api/projects/tasks.py
@@ -17,8 +17,8 @@ def migrate_project_environments_to_v2(project_id: int):
 
     with transaction.atomic():
         project = Project.objects.select_for_update().get(id=project_id)
-        migrate_environments_to_v2(project_id=project_id)
-        project.identity_overrides_v2_migration_status = (
-            IdentityOverridesV2MigrationStatus.COMPLETE
-        )
-        project.save()
+        if migrate_environments_to_v2(project_id=project_id):
+            project.identity_overrides_v2_migration_status = (
+                IdentityOverridesV2MigrationStatus.COMPLETE
+            )
+            project.save()

--- a/api/projects/tasks.py
+++ b/api/projects/tasks.py
@@ -4,14 +4,14 @@ from task_processor.decorators import register_task_handler
 
 
 @register_task_handler()
-def write_environments_to_dynamodb(project_id: int):
+def write_environments_to_dynamodb(project_id: int) -> None:
     from environments.models import Environment
 
     Environment.write_environments_to_dynamodb(project_id=project_id)
 
 
 @register_task_handler()
-def migrate_project_environments_to_v2(project_id: int):
+def migrate_project_environments_to_v2(project_id: int) -> None:
     from environments.dynamodb.services import migrate_environments_to_v2
     from projects.models import IdentityOverridesV2MigrationStatus, Project
 

--- a/api/tests/unit/environments/conftest.py
+++ b/api/tests/unit/environments/conftest.py
@@ -1,6 +1,14 @@
+from unittest.mock import Mock
+
 import pytest
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture()
-def mock_dynamo_env_wrapper(mocker):
+def mock_dynamo_env_wrapper(mocker: MockerFixture) -> Mock:
     return mocker.patch("environments.models.environment_wrapper")
+
+
+@pytest.fixture()
+def mock_dynamo_env_v2_wrapper(mocker: MockerFixture) -> Mock:
+    return mocker.patch("environments.models.environment_v2_wrapper")

--- a/api/tests/unit/projects/test_tasks.py
+++ b/api/tests/unit/projects/test_tasks.py
@@ -26,7 +26,7 @@ def project_v2_migration_in_progress(
         ),
         (
             None,
-            IdentityOverridesV2MigrationStatus.NOT_STARTED,
+            IdentityOverridesV2MigrationStatus.IN_PROGRESS,
         ),
     ),
 )

--- a/api/tests/unit/projects/test_tasks.py
+++ b/api/tests/unit/projects/test_tasks.py
@@ -1,6 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from environments.dynamodb.types import IdentityOverridesV2Changeset
 from projects.models import IdentityOverridesV2MigrationStatus, Project
 from projects.tasks import migrate_project_environments_to_v2
 
@@ -16,15 +17,33 @@ def project_v2_migration_in_progress(
     return project
 
 
+@pytest.mark.parametrize(
+    "migrate_environments_to_v2_return_value, expected_status",
+    (
+        (
+            IdentityOverridesV2Changeset(to_put=[], to_delete=[]),
+            IdentityOverridesV2MigrationStatus.COMPLETE,
+        ),
+        (
+            None,
+            IdentityOverridesV2MigrationStatus.NOT_STARTED,
+        ),
+    ),
+)
 def test_migrate_project_environments_to_v2__calls_expected(
     mocker: MockerFixture,
     project_v2_migration_in_progress: Project,
+    migrate_environments_to_v2_return_value: IdentityOverridesV2Changeset | None,
+    expected_status: str,
 ):
     # Given
     mocked_migrate_environments_to_v2 = mocker.patch(
         "environments.dynamodb.services.migrate_environments_to_v2",
         autospec=True,
         return_value=None,
+    )
+    mocked_migrate_environments_to_v2.return_value = (
+        migrate_environments_to_v2_return_value
     )
 
     # When
@@ -35,8 +54,9 @@ def test_migrate_project_environments_to_v2__calls_expected(
     mocked_migrate_environments_to_v2.assert_called_once_with(
         project_id=project_v2_migration_in_progress.id,
     )
-    assert project_v2_migration_in_progress.identity_overrides_v2_migration_status == (
-        IdentityOverridesV2MigrationStatus.COMPLETE
+    assert (
+        project_v2_migration_in_progress.identity_overrides_v2_migration_status
+        == expected_status
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR:
1. Enables writing environments to the new table for migrated projects.
2. Prevents marking projects' migration status as `COMPLETE` in case DynamoDB is disabled.

## How did you test this code?

Added unit tests.