### PR TITLE
chore: Update ECS task definitions with new DynamoDB table names

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-migration.json
+++ b/infrastructure/aws/production/ecs-task-definition-migration.json
@@ -19,8 +19,8 @@
                     "value": "app.settings.production"
                 },
                 {
-                    "name":"IDENTITIES_TABLE_NAME_DYNAMO",
-                    "value":"flagsmith_identities"
+                    "name": "IDENTITIES_TABLE_NAME_DYNAMO",
+                    "value": "flagsmith_identities"
                 },
                 {
                     "name": "PROJECT_METADATA_TABLE_NAME_DYNAMO",
@@ -29,6 +29,10 @@
                 {
                     "name": "ENVIRONMENTS_TABLE_NAME_DYNAMO",
                     "value": "flagsmith_environments"
+                },
+                {
+                    "name": "ENVIRONMENTS_V2_TABLE_NAME_DYNAMO",
+                    "value": "flagsmith_environments_v2"
                 },
                 {
                     "name": "ENVIRONMENTS_API_KEY_TABLE_NAME_DYNAMO",

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -52,6 +52,10 @@
                     "value": "flagsmith_environments"
                 },
                 {
+                    "name": "ENVIRONMENTS_V2_TABLE_NAME_DYNAMO",
+                    "value": "flagsmith_environments_v2"
+                },
+                {
                     "name": "GITHUB_CLIENT_ID",
                     "value": "b706a0da3e9d3115ea9d"
                 },
@@ -96,8 +100,8 @@
                     "value": "937916178726.1924685747446"
                 },
                 {
-                    "name":"EDGE_API_URL",
-                    "value":"https://edge.api.flagsmith.com/api/v1/"
+                    "name": "EDGE_API_URL",
+                    "value": "https://edge.api.flagsmith.com/api/v1/"
                 },
                 {
                     "name": "IDENTITY_MIGRATION_EVENT_BUS_NAME",

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -68,6 +68,10 @@
                     "value": "flagsmith_environments"
                 },
                 {
+                    "name": "ENVIRONMENTS_V2_TABLE_NAME_DYNAMO",
+                    "value": "flagsmith_environments_v2"
+                },
+                {
                     "name": "ENABLE_FE_E2E",
                     "value": "True"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Updates the production ECS task definitions with `flagsmith_environments_v2` table names in the environment.

## How did you test this code?

This is deployment code.