### PR TITLE
fix: Add missing f-string from app_analytics models

### DIFF
--- a/api/app_analytics/models.py
+++ b/api/app_analytics/models.py
@@ -15,7 +15,7 @@ class Resource(models.IntegerChoices):
     def get_lowercased_name(cls, resource: int) -> str:
         member = next(filter(lambda member: member.value == resource, cls), None)
         if not member:
-            raise ValueError("Invalid resource: {resource}")
+            raise ValueError(f"Invalid resource: {resource}")
 
         return member.name.lower()
 
@@ -24,7 +24,7 @@ class Resource(models.IntegerChoices):
         try:
             return getattr(cls, resource.upper().replace("-", "_")).value
         except (KeyError, AttributeError) as err:
-            raise ValueError("Invalid resource: {resource}") from err
+            raise ValueError(f"Invalid resource: {resource}") from err
 
 
 class APIUsageRaw(models.Model):


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

While looking into our various databases on the backend I noticed these strings were missed and quickly fixed them.

## How did you test this code?

The change is simple enough to rely on CI / common sense.