### PR TITLE
fix: hide identity overrides badge or edge projects

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -257,7 +257,7 @@ class TheComponent extends Component {
                     </Tooltip>
                   </div>
                 )}
-                {!!projectFlag.num_identity_overrides && (
+                {!!projectFlag.num_identity_overrides && !Utils.getIsEdge() && (
                   <Tooltip
                     title={
                       <span


### PR DESCRIPTION
## Changes

Hide the identity overrides badge for edge projects as this might have misleading information. Note that this is a temporary measure only until we can retrieve the edge identity override counts from dynamodb (which @khvn26 is working on as we speak). 

## How did you test this code?

Ran the frontend locally, pointing at an edge project in staging which I manually added a 'core' identity override to and verified that the badge was not shown. 

**staging.flagsmith.com**

<img width="1180" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/17f91412-010d-43a9-ad66-61bc79c8c690">


**localhost:8080**

<img width="1180" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/f3d20030-4d79-41e5-b588-ca3eeab7ace0">
