### PR TITLE
chore: Improve admin create project settings flow

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -7,6 +7,7 @@ import {
   FlagsmithValue,
   MultivariateFeatureStateValue,
   MultivariateOption,
+  Organisation,
   Project as ProjectType,
   ProjectFlag,
   SegmentCondition,
@@ -130,6 +131,18 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   },
   getApproveChangeRequestPermission() {
     return 'APPROVE_CHANGE_REQUEST'
+  },
+  getCreateProjectPermission(organisation: Organisation) {
+    if (organisation?.restrict_project_create_to_admin) {
+      return 'ADMIN'
+    }
+    return 'CREATE_PROJECT'
+  },
+  getCreateProjectPermissionDescription(organisation: Organisation) {
+    if (organisation?.restrict_project_create_to_admin) {
+      return 'Administrator'
+    }
+    return 'Create Project'
   },
   getFeatureStatesEndpoint(_project: ProjectType) {
     const project = _project || ProjectStore.model

--- a/frontend/web/components/pages/ProjectSelectPage.js
+++ b/frontend/web/components/pages/ProjectSelectPage.js
@@ -222,7 +222,7 @@ const ProjectSelectPage = class extends Component {
                             {({ permission }) => {
                               return Utils.renderWithPermission(
                                 permission,
-                                Constants.environmentPermissions(
+                                Constants.organisationPermissions(
                                   Utils.getCreateProjectPermissionDescription(
                                     AccountStore.getOrganisation(),
                                   ),

--- a/frontend/web/components/pages/ProjectSelectPage.js
+++ b/frontend/web/components/pages/ProjectSelectPage.js
@@ -143,14 +143,18 @@ const ProjectSelectPage = class extends Component {
                               <div className='col-md-6 col-xl-3'>
                                 <Permission
                                   level='organisation'
-                                  permission='CREATE_PROJECT'
+                                  permission={Utils.getCreateProjectPermission(
+                                    AccountStore.getOrganisation(),
+                                  )}
                                   id={AccountStore.getOrganisation().id}
                                 >
                                   {({ permission }) => {
                                     return Utils.renderWithPermission(
                                       permission,
-                                      Constants.environmentPermissions(
-                                        'Create Project',
+                                      Constants.organisationPermissions(
+                                        Utils.getCreateProjectPermissionDescription(
+                                          AccountStore.getOrganisation(),
+                                        ),
                                       ),
                                       <Button
                                         disabled={!permission}
@@ -210,14 +214,18 @@ const ProjectSelectPage = class extends Component {
                         <div>
                           <Permission
                             level='organisation'
-                            permission='CREATE_PROJECT'
+                            permission={Utils.getCreateProjectPermission(
+                              AccountStore.getOrganisation(),
+                            )}
                             id={AccountStore.getOrganisation().id}
                           >
                             {({ permission }) => {
                               return Utils.renderWithPermission(
                                 permission,
                                 Constants.environmentPermissions(
-                                  'Create Project',
+                                  Utils.getCreateProjectPermissionDescription(
+                                    AccountStore.getOrganisation(),
+                                  ),
                                 ),
                                 <div className='col-md-6 col-xl-3'>
                                   <Button

--- a/frontend/web/styles/project/_buttons.scss
+++ b/frontend/web/styles/project/_buttons.scss
@@ -223,6 +223,9 @@ button.btn {
     &.btn-project-create {
       background-color: transparent;
       border: 1px dashed $basic-alpha-24;
+      &:disabled {
+        color: $body-text;
+      }
       &:hover {
         background-color: transparent;
         & .btn-project-icon {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

If the organisation has enabled restrict create project to admin then the frontend will base the create project UI on admin permissions.


## How did you test this code?

Attempt to create a project as a user with CREATE_PROJECT on an org with the above setting enabled.