### PR TITLE
fix(task-processor): implement grace period for deleting old recurring task

### DIFF
--- a/api/task_processor/processor.py
+++ b/api/task_processor/processor.py
@@ -61,6 +61,9 @@ def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTaskRun]:
 
         for task in tasks:
             if not task.is_task_registered:
+                # This is necessary to ensure that old instances of the task processor,
+                # which may still be running during deployment, do not remove tasks added by new instances.
+                # Reference: https://github.com/Flagsmith/flagsmith/issues/2551
                 if (
                     timezone.now() - task.created_at
                 ) > UNREGISTERED_RECURRING_TASK_GRACE_PERIOD:

--- a/api/task_processor/processor.py
+++ b/api/task_processor/processor.py
@@ -57,9 +57,10 @@ def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTaskRun]:
         task_runs = []
 
         for task in tasks:
-            # Remove the task if it's not registered anymore
             if not task.is_task_registered:
-                task.delete()
+                logger.warning(
+                    "Recurring task %s is not registered anymore", task.task_identifier
+                )
                 continue
 
             if task.should_execute:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes https://github.com/Flagsmith/flagsmith/issues/2551 by implementing a grace period to not remove new tasks during deployment 


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Updates/Adds unit test
