### PR TITLE
ci: Revert - Enable merge queue checks. Run only changed tests.

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -12,8 +12,6 @@ on:
       - .github/**
     branches:
       - main
-  merge_group:
-    types: [checks_requested]
 
 defaults:
   run:
@@ -21,7 +19,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: General-Purpose-8c-Runner
+    runs-on: ubuntu-latest
     name: API Unit Tests
 
     services:
@@ -35,7 +33,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     strategy:
-      max-parallel: 2
+      max-parallel: 4
       matrix:
         python-version: ['3.10', '3.11']
 
@@ -69,30 +67,10 @@ jobs:
           opts: --no-input --dry-run --check
         run: make django-make-migrations
 
-      - name: Restore cached testmon data
-        if: ${{ github.event_name == 'pull_request' }}
-        id: cache-testmon-restore
-        uses: actions/cache/restore@v3
-        with:
-          enableCrossOsArchive: true
-          path: |
-            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
-          key: testmon-data-python${{ matrix.python-version }}-${{ github.event.pull_request.base.sha }}
-          restore-keys: testmon-data-python${{ matrix.python-version }}-
-
       - name: Run Tests
         env:
-          DOTENV_OVERRIDE_FILE: "${{ github.event_name == 'pull_request' && '.env-ci-testmon' || '.env-ci' }}"
+          DOTENV_OVERRIDE_FILE: .env-ci
         run: make test
-
-      - name: Save testmon data cache
-        id: cache-testmon-save
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
-          key: testmon-data-python${{ matrix.python-version }}-${{github.sha}}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ checkstyle.txt
 .env*
 !.env-local
 !.env-ci
-!.env-ci-testmon
 .direnv
 .envrc
 .tool-versions

--- a/api/.env-ci-testmon
+++ b/api/.env-ci-testmon
@@ -1,3 +1,0 @@
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
-ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
-PYTEST_ADDOPTS=--cov . --cov-report xml --dist worksteal --testmon

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -7,6 +7,3 @@ features/workflows/logic/
 
 # Unit test coverage
 .coverage
-
-# pytest-testmon files
-.testmondata*

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -3294,21 +3294,6 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
-name = "pytest-testmon"
-version = "2.0.13"
-description = "selects tests affected by changed files and methods"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pytest-testmon-2.0.13.tar.gz", hash = "sha256:9cf56021ccaa6c8c6bcaef07589fb6c872db1797f0f7ff1f104e93c96078d642"},
-    {file = "pytest_testmon-2.0.13-py3-none-any.whl", hash = "sha256:170872f2407e1eab431a266108229dbcde73513771a71ab77ed1e84ec94c816c"},
-]
-
-[package.dependencies]
-coverage = ">=6,<8"
-pytest = ">=5,<8"
-
-[[package]]
 name = "pytest-xdist"
 version = "3.2.1"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -146,7 +146,6 @@ requests-mock = "^1.11.0"
 django-extensions = "^3.2.3"
 pdbpp = "^0.10.3"
 django-capture-on-commit-callbacks = "^1.11.0"
-pytest-testmon = "^2.0.13"
 mypy-boto3-dynamodb = "^1.33.0"
 
 [build-system]


### PR DESCRIPTION
Reverts Flagsmith/flagsmith#3171

The code needs a fix to generate `testmon` baseline when branches are merged into the `main` branch. Current code only runs `testmon` on pull request events, and `xdist` on `push` events to main and `mege_queue` events.