### PR TITLE
chore: Use group summaries endpoint for flag owners and permissions

### DIFF
--- a/frontend/common/services/useGroupSummary.ts
+++ b/frontend/common/services/useGroupSummary.ts
@@ -1,0 +1,47 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const groupSummaryService = service
+  .enhanceEndpoints({ addTagTypes: ['GroupSummary'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      getGroupSummaries: builder.query<
+        Res['groupSummaries'],
+        Req['getGroupSummaries']
+      >({
+        providesTags: [{ id: 'LIST', type: 'GroupSummary' }],
+        query: (query) => ({
+          url: `organisations/${query.orgId}/groups/summaries/`,
+        }),
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function getGroupSummaries(
+  store: any,
+  data: Req['getGroupSummaries'],
+  options?: Parameters<
+    typeof groupSummaryService.endpoints.getGroupSummaries.initiate
+  >[1],
+) {
+  store.dispatch(
+    groupSummaryService.endpoints.getGroupSummaries.initiate(data, options),
+  )
+  return Promise.all(
+    store.dispatch(groupSummaryService.util.getRunningQueriesThunk()),
+  )
+}
+// END OF FUNCTION_EXPORTS
+
+export const {
+  useGetGroupSummariesQuery,
+  // END OF EXPORTS
+} = groupSummaryService
+
+/* Usage examples:
+const { data, isLoading } = useGetGroupSummariesQuery({ id: 2 }, {}) //get hook
+const [createGroupSummaries, { isLoading, data, isSuccess }] = useCreateGroupSummariesMutation() //create hook
+groupSummaryService.endpoints.getGroupSummaries.select({id: 2})(store.getState()) //access data from any function
+*/

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -133,5 +133,8 @@ export type Req = {
   createLaunchDarklyProjectImport: { project_id: string }
   getLaunchDarklyProjectImport: { project_id: string }
   getLaunchDarklyProjectsImport: { project_id: string; import_id: string }
+  getGroupSummaries: {
+    orgId: string
+  }
   // END OF TYPES
 }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -381,5 +381,6 @@ export type Res = {
   environment: Environment
   launchDarklyProjectImport: LaunchDarklyProjectImport
   launchDarklyProjectsImport: LaunchDarklyProjectImport[]
+  groupSummaries: UserGroupSummary[]
   // END OF TYPES
 }

--- a/frontend/web/components/ConnectedGroupSelect.tsx
+++ b/frontend/web/components/ConnectedGroupSelect.tsx
@@ -4,12 +4,12 @@ import { useGetGroupSummariesQuery } from 'common/services/useGroupSummary'
 import { IonIcon } from '@ionic/react'
 import { close } from 'ionicons/icons' // we need this to make JSX compile
 
-type MyGroupsSelectType = GroupSelectType & {
+type ConnectedGroupSelectType = GroupSelectType & {
   orgId: string
   showValues?: boolean
 }
 
-const MyGroupsSelect: FC<MyGroupsSelectType> = ({
+const ConnectedGroupSelect: FC<ConnectedGroupSelectType> = ({
   orgId,
   showValues,
   ...props
@@ -43,4 +43,4 @@ const MyGroupsSelect: FC<MyGroupsSelectType> = ({
   )
 }
 
-export default MyGroupsSelect
+export default ConnectedGroupSelect

--- a/frontend/web/components/ConnectedGroupSelect.tsx
+++ b/frontend/web/components/ConnectedGroupSelect.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from 'react'
+import GroupSelect, { GroupSelectType } from './GroupSelect'
+import { useGetGroupSummariesQuery } from 'common/services/useGroupSummary'
+import { IonIcon } from '@ionic/react'
+import { close } from 'ionicons/icons' // we need this to make JSX compile
+
+type MyGroupsSelectType = GroupSelectType & {
+  orgId: string
+  showValues?: boolean
+}
+
+const MyGroupsSelect: FC<MyGroupsSelectType> = ({
+  orgId,
+  showValues,
+  ...props
+}) => {
+  const { data } = useGetGroupSummariesQuery({ orgId })
+  return (
+    <>
+      {!!showValues && (
+        <Row style={{ rowGap: '12px' }}>
+          {props?.value?.map((u) => {
+            const group = data?.find((v) => v.id === u)
+            if (!group) return null
+            return (
+              <Row
+                onClick={() => props.onRemove(u, false)}
+                key={u}
+                className='chip mr-2'
+              >
+                <span className='font-weight-bold'>{group.name}</span>
+                <span className='chip-icon ion'>
+                  <IonIcon icon={close} />
+                </span>
+              </Row>
+            )
+          })}
+          {!props.value?.length && <div>This flag has no assigned groups</div>}
+        </Row>
+      )}
+      <GroupSelect {...props} onRemove={props.onRemove} groups={data} />
+    </>
+  )
+}
+
+export default MyGroupsSelect

--- a/frontend/web/components/FlagOwnerGroups.js
+++ b/frontend/web/components/FlagOwnerGroups.js
@@ -8,6 +8,7 @@ import { IonIcon } from '@ionic/react'
 import GroupSelect from './GroupSelect'
 import { getProjectFlag } from 'common/services/useProjectFlag'
 import { getStore } from 'common/store'
+import ConnectedGroupSelect from './ConnectedGroupSelect'
 
 class TheComponent extends Component {
   state = {}
@@ -56,10 +57,6 @@ class TheComponent extends Component {
     return (
       <OrganisationProvider>
         {({ groups }) => {
-          const ownerUsers = this.getGroupOwners(
-            groups,
-            this.state.groupOwners || [],
-          )
           const res = (
             <div>
               <Row
@@ -73,25 +70,9 @@ class TheComponent extends Component {
                   <Icon name='setting' width={20} fill={'#656D7B'} />
                 </label>
               </Row>
-              <Row style={{ rowGap: '12px' }}>
-                {hasPermission &&
-                  ownerUsers.map((u) => (
-                    <Row
-                      key={u.id}
-                      onClick={() => this.removeOwner(u.id)}
-                      className='chip mr-2'
-                    >
-                      <span className='font-weight-bold'>{u.name}</span>
-                      <span className='chip-icon ion'>
-                        <IonIcon icon={close} />
-                      </span>
-                    </Row>
-                  ))}
-                {!ownerUsers.length && (
-                  <div>This flag has no assigned groups</div>
-                )}
-              </Row>
-              <GroupSelect
+              <ConnectedGroupSelect
+                orgId={AccountStore.getOrganisation()?.id}
+                showValues={hasPermission}
                 groups={groups}
                 value={this.state.groupOwners}
                 isOpen={this.state.showUsers}

--- a/frontend/web/components/UserGroupList.tsx
+++ b/frontend/web/components/UserGroupList.tsx
@@ -11,6 +11,7 @@ import PanelSearch from './PanelSearch'
 import { sortBy } from 'lodash'
 import InfoMessage from './InfoMessage' // we need this to make JSX compile
 import Icon from './Icon'
+import { useGetGroupSummariesQuery } from 'common/services/useGroupSummary'
 const Panel = require('components/base/grid/Panel')
 
 type UserGroupsListType = {
@@ -29,9 +30,8 @@ const UserGroupsList: FC<UserGroupsListType> = ({
   showRemove,
 }) => {
   const [page, setPage] = useState(1)
-  const { data: userGroups, isLoading } = useGetGroupsQuery({
+  const { data: userGroups, isLoading } = useGetGroupSummariesQuery({
     orgId: `${orgId}`,
-    page,
   })
   const [deleteGroup] = useDeleteGroupMutation({})
   const isAdmin = AccountStore.isAdmin()
@@ -62,7 +62,7 @@ const UserGroupsList: FC<UserGroupsListType> = ({
         title={noTitle ? '' : 'Groups'}
         className='no-pad'
         itemHeight={64}
-        items={sortBy(userGroups?.results, 'name')}
+        items={sortBy(userGroups, 'name')}
         paging={userGroups}
         nextPage={() => setPage(page + 1)}
         prevPage={() => setPage(page - 1)}
@@ -99,16 +99,12 @@ const UserGroupsList: FC<UserGroupsListType> = ({
           return (
             <Row
               space
-              className='list-item clickable'
+              className='list-item list-item-sm clickable'
               key={id}
               data-test={`user-item-${index}`}
             >
               <Flex onClick={_onClick} className=' table-column px-3'>
-                <div className='mb-1 font-weight-medium'>{name}</div>
-                <div className='list-item-subtitle faint'>
-                  {users.length}
-                  {users.length === 1 ? ' Member' : ' Members'}
-                </div>
+                <div className='font-weight-medium'>{name}</div>
               </Flex>
 
               {onEditPermissions && isAdmin ? (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- The flag owners select uses the newly created ConnectedGroupSelect component, this will use the group summaries endpoint to populate group selection as suggested [here](https://github.com/Flagsmith/flagsmith/issues/2666#issuecomment-1850605227
).

- Environment and Project permissions will now also use the same endpoint, prior to this group permission assignment was only possible for org admins.

One slight caveat to this is we can't show the number of users in a group since this does not come back in the new endpoint however I think that's fine.

![image](https://github.com/Flagsmith/flagsmith/assets/8608314/776e835f-48f7-4359-aca9-f30683cd5a91)
 

## How did you test this code?

- Added / removed group owners from flags
- Added / removed group permissions as a project admin