### PR TITLE
chore: Display identity override badges

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -257,7 +257,7 @@ class TheComponent extends Component {
                     </Tooltip>
                   </div>
                 )}
-                {!!projectFlag.num_identity_overrides && !Utils.getIsEdge() && (
+                {!!projectFlag.num_identity_overrides && (
                   <Tooltip
                     title={
                       <span

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -258,22 +258,31 @@ class TheComponent extends Component {
                   </div>
                 )}
                 {!!projectFlag.num_identity_overrides && (
-                  <Tooltip
-                    title={
-                      <span
-                        className='chip me-2 chip--xs bg-primary text-white'
-                        style={{ border: 'none' }}
-                      >
-                        <UsersIcon className='chip-svg-icon' />
-                        <span>{projectFlag.num_identity_overrides}</span>
-                      </span>
-                    }
-                    place='top'
+                  <div
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      this.editFeature(projectFlag, environmentFlags[id], 2)
+                    }}
                   >
-                    {`${projectFlag.num_identity_overrides} Identity Override${
-                      projectFlag.num_identity_overrides !== 1 ? 's' : ''
-                    }`}
-                  </Tooltip>
+                    <Tooltip
+                      title={
+                        <span
+                          className='chip me-2 chip--xs bg-primary text-white'
+                          style={{ border: 'none' }}
+                        >
+                          <UsersIcon className='chip-svg-icon' />
+                          <span>{projectFlag.num_identity_overrides}</span>
+                        </span>
+                      }
+                      place='top'
+                    >
+                      {`${
+                        projectFlag.num_identity_overrides
+                      } Identity Override${
+                        projectFlag.num_identity_overrides !== 1 ? 's' : ''
+                      }`}
+                    </Tooltip>
+                  </div>
                 )}
                 {projectFlag.is_server_key_only && (
                   <Tooltip


### PR DESCRIPTION
This reverts commit 6a44b3dd90cc9ff549dd99752618decd8d3cac9c.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Merge after #[3164] is released.

This reverts identity override badges removal in frontend. The logic for displaying them will be on the backend side as per changes in #[3164](https://github.com/Flagsmith/flagsmith/pull/3164).

## How did you test this code?

Ran locally, observed the badges near feature names for for Edge projects.