### PR TITLE
chore: use Depot for flagsmith-api image build

### DIFF
--- a/.github/workflows/api-docker-publish-image.yml
+++ b/.github/workflows/api-docker-publish-image.yml
@@ -27,15 +27,12 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
       - name: Write git info to Docker image
         run: |
           echo ${{ github.sha }} > api/CI_COMMIT_SHA
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/api-docker-publish-image.yml
+++ b/.github/workflows/api-docker-publish-image.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     name: API Publish Docker Image
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
@@ -42,10 +46,11 @@ jobs:
 
       - name: Build and push images
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: depot/build-push-action@v1
         with:
           platforms: linux/amd64,linux/arm64
           file: api/Dockerfile
+          project: qsrts2l4gr
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This makes the `flagsmith-api` image builds to be run by Depot.

## How did you test this code?

Tested in the initial PR (https://github.com/Flagsmith/flagsmith/pull/3071).
`flagsmith-api` image should be pushed by Depot in CI. 