### PR TITLE
chore: use Depot for flagsmith-frontend image build

### DIFF
--- a/.github/workflows/frontend-docker-publish-image.yml
+++ b/.github/workflows/frontend-docker-publish-image.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
-        with:
-          ref: v2.89.0
 
       - name: Docker metadata
         id: meta

--- a/.github/workflows/frontend-docker-publish-image.yml
+++ b/.github/workflows/frontend-docker-publish-image.yml
@@ -13,9 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Frontend Publish Docker Image
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Cloning repo
         uses: actions/checkout@v3
+        with:
+          ref: v2.89.0
 
       - name: Docker metadata
         id: meta
@@ -27,6 +33,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
       - name: Write git info to Docker image
         run: |
           cd frontend
@@ -37,12 +46,6 @@ jobs:
           curl --location --request GET 'https://api.flagsmith.com/api/v1/flags/' --header 'X-Environment-Key: ${{
           secrets.FLAGSMITH_ENVIRONMENT_KEY }}' > frontend/flags.json
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -51,9 +54,10 @@ jobs:
 
       - name: Build and push images
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: depot/build-push-action@v1
         with:
           platforms: linux/amd64,linux/arm64
           file: frontend/Dockerfile
+          project: qsrts2l4gr
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The PR adds Depot-enabled builds for the `flagsmith-frontend` image.

## How did you test this code?

The added code had already built and pushed the frontend image during a [manual build](https://github.com/Flagsmith/flagsmith/actions/runs/7262564730/job/19785973608).