### PR TITLE
docs: link to undocumented JS interface definitions

### DIFF
--- a/docs/docs/clients/client-side/react.md
+++ b/docs/docs/clients/client-side/react.md
@@ -106,7 +106,8 @@ export function MyComponent() {
 useFlags(requiredFlags:string[], requiredTraits?:string[])=> {[key:string]: IFlagsmithTrait  or IFlagsmithFeature}
 ```
 
-You can find the exact definitions of these types [in the SDK](https://github.com/Flagsmith/flagsmith-js-client/blob/main/types.d.ts).
+You can find the exact definitions of these types
+[in the SDK](https://github.com/Flagsmith/flagsmith-js-client/blob/main/types.d.ts).
 
 ## FlagsmithProvider API Reference
 

--- a/docs/docs/clients/client-side/react.md
+++ b/docs/docs/clients/client-side/react.md
@@ -106,6 +106,8 @@ export function MyComponent() {
 useFlags(requiredFlags:string[], requiredTraits?:string[])=> {[key:string]: IFlagsmithTrait  or IFlagsmithFeature}
 ```
 
+You can find the exact definitions of these types [in the SDK](https://github.com/Flagsmith/flagsmith-js-client/blob/main/types.d.ts).
+
 ## FlagsmithProvider API Reference
 
 | Property                 |                                                  Description                                                   | Required | Default Value |


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [  ] ~I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting~ doc-only change, skipping
- [  ] ~I have added information to `docs/` if required so people know about the feature!~ doc-only change, N/A
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

A coworker of mine got confused when reading these docs and had to search the source code for the interface definitions, so I thought I'd fix it for everyone and add a link.

I considered documenting the interfaces directly in the docs, but I didn't want the docs to get out of sync with the code. I also considered permalinking to a specific commit, but I was worried about the same problem and I figured the likelihood of this file getting renamed and breaking the link was low.

## How did you test this code?

N/A (though I did look at GitHub's Markdown preview)
