### PR TITLE
style: Fix dark mode for the invite screen

### DIFF
--- a/frontend/web/styles/new/_variables-new.scss
+++ b/frontend/web/styles/new/_variables-new.scss
@@ -338,3 +338,8 @@ $theme-colors: (
   dark: $text-icon-dark,
   // add any additional color below
 );
+.dark {
+  .bg-light200 {
+    background-color: $body-bg-dark !important;
+  }
+}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

<img width="732" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/b6edf608-e472-471f-951d-b025456ac195">


## How did you test this code?

- Viewed the invite screen in dark mode 