### PR TITLE
fix(admin/task-processor): handle no task run

### DIFF
--- a/api/task_processor/admin.py
+++ b/api/task_processor/admin.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.contrib import admin
 
 from task_processor.models import RecurringTask
@@ -14,5 +16,7 @@ class RecurringTaskAdmin(admin.ModelAdmin):
     )
     readonly_fields = ("args", "kwargs")
 
-    def last_run_status(self, instance: RecurringTask) -> str:
-        return instance.task_runs.order_by("-started_at").first().result
+    def last_run_status(self, instance: RecurringTask) -> Optional[str]:
+        return getattr(
+            instance.task_runs.order_by("-started_at").first(), "result", None
+        )

--- a/api/task_processor/admin.py
+++ b/api/task_processor/admin.py
@@ -17,6 +17,6 @@ class RecurringTaskAdmin(admin.ModelAdmin):
     readonly_fields = ("args", "kwargs")
 
     def last_run_status(self, instance: RecurringTask) -> Optional[str]:
-        return getattr(
-            instance.task_runs.order_by("-started_at").first(), "result", None
-        )
+        if last_run := instance.task_runs.order_by("-started_at").first():
+            return last_run.result
+        return None


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Return None for last_run status if recurring task runs don't exist

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

By making sure the admin panel for recurring tasks(http://localhost:8000/admin/task_processor/recurringtask/) loads fine 
for tasks that don't have any task run 
