### PR TITLE
chore: add health checks to Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       # ENABLE_ADMIN_ACCESS_USER_PASS: 'true' # Uncomment to enable access to the /admin/ Django backend via your username and password
       # ALLOW_REGISTRATION_WITHOUT_INVITE: 'true'
 
-      # Enable Task Processor\
+      # Enable Task Processor
       TASK_RUN_METHOD: TASK_PROCESSOR # other options are: SYNCHRONOUSLY, SEPARATE_THREAD (default)
 
       # For more info on configuring E-Mails - https://docs.flagsmith.com/deployment/locally-api#environment-variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # See https://docs.flagsmith.com/deployment/docker for more information on running Flagsmith in Docker
-# This will docker-compose file will run the entire Flagsmith Platform in Docker
+# This Docker Compose file will run the entire Flagsmith Platform
 
 version: '3'
 
@@ -15,6 +15,11 @@ services:
     container_name: flagsmith_postgres
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   flagsmith:
     image: flagsmith/flagsmith:latest
@@ -26,19 +31,19 @@ services:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
       USE_POSTGRES_FOR_ANALYTICS: 'true' # Store API and Flag Analytics data in Postgres
 
-      ENV: prod # set to "prod" in production.
+      ENV: prod # set to 'prod' in production.
       DJANGO_ALLOWED_HOSTS: '*' # Change this in production
       ALLOW_ADMIN_INITIATION_VIA_CLI: 'true' # Change this in production
-      FLAGSMITH_DOMAIN: 'localhost:8000' # Change this in production
-      DJANGO_SECRET_KEY: 'secret' # Change this in production
-      # PREVENT_SIGNUP: "true" # Uncomment to prevent additional signups
-      # ENABLE_ADMIN_ACCESS_USER_PASS: "true" # set to "true" to enable access to the /admin/ Django backend via your username and password
-      # ALLOW_REGISTRATION_WITHOUT_INVITE: "true"
+      FLAGSMITH_DOMAIN: localhost:8000 # Change this in production
+      DJANGO_SECRET_KEY: secret # Change this in production
+      # PREVENT_SIGNUP: 'true' # Uncomment to prevent additional signups
+      # ENABLE_ADMIN_ACCESS_USER_PASS: 'true' # Uncomment to enable access to the /admin/ Django backend via your username and password
+      # ALLOW_REGISTRATION_WITHOUT_INVITE: 'true'
 
-      # Enable Task Processor
+      # Enable Task Processor\
       TASK_RUN_METHOD: TASK_PROCESSOR # other options are: SYNCHRONOUSLY, SEPARATE_THREAD (default)
+
       # For more info on configuring E-Mails - https://docs.flagsmith.com/deployment/locally-api#environment-variables
-      #
       # Example SMTP:
       # EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
       # EMAIL_HOST: mail.example.com
@@ -46,14 +51,13 @@ services:
       # EMAIL_HOST_USER: flagsmith@example.com
       # EMAIL_HOST_PASSWORD: smtp_account_password
       # EMAIL_PORT: 587 # optional
-      # EMAIL_USE_TLS: "true" # optional
+      # EMAIL_USE_TLS: 'true' # optional
 
     ports:
-      - '8000:8000'
+      - 8000:8000
     depends_on:
-      - postgres
-    links:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   # The flagsmith_processor service is only needed if TASK_RUN_METHOD set to TASK_PROCESSOR
   # in the application environment
@@ -63,8 +67,6 @@ services:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
       USE_POSTGRES_FOR_ANALYTICS: 'true'
     depends_on:
-      - flagsmith
-      - postgres
-    links:
-      - postgres
+      postgres:
+        condition: service_healthy
     command: run-task-processor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,16 @@ services:
       # EMAIL_HOST_PASSWORD: smtp_account_password
       # EMAIL_PORT: 587 # optional
       # EMAIL_USE_TLS: 'true' # optional
-
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'python -c "import requests;import sys;sys.exit(0 if requests.get(''http://localhost:8000/health'').status_code == 200 else 1)"',
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
     ports:
       - 8000:8000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,9 @@ services:
     healthcheck:
       test:
         [
-          "CMD-SHELL",
-          'python -c "import requests;import sys;sys.exit(0 if requests.get(''http://localhost:8000/health'').status_code == 200 else 1)"',
+          'CMD-SHELL',
+          'python -c "url = ''http://localhost:8000/health'';import requests;import sys;status =
+          requests.get(url).status_code;sys.exit(0 if 200 >= status < 300 else 1)"',
         ]
       interval: 10s
       timeout: 10s


### PR DESCRIPTION
- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request


----

This PR adds a health check to `postgres` service and some other minor fixes.


## Changes

- Added a health check configuration to the `flagsmith` and `postgres` services in the dependency setup. This ensures that the Flagsmith container starts only when the database is fully operational. Previously, the depends_on directive primarily influenced the startup sequence of containers, which isn't very effective in this context.
- Removed the `link_to` fields from both services. These fields are not only redundant in this scenario but are also deprecated, further justifying their removal.
- Eliminated `flagsmith` from the `depends_on` list in the `flagsmith_processor` service. There is no direct dependency between them that necessitates this linkage.
- Omitted unnecessary quotes in YAML strings for cleaner syntax.
- Standardized the usage of single quotes, replacing any instances of mixed double/single quotes for consistency.
- Minor spelling fixes


## How did you test this code?

Run `docker compose up` and verified containers are still properly started