### PR TITLE
ci: Updates to Uffizzi Deployment GHA workflows.

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate UUID image name
         id: uuid
-        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+        run: echo "UUID_WORKER=flagsmith-$(uuidgen --time)" >> $GITHUB_ENV
 
       - name: Docker metadata
         id: meta
@@ -29,7 +29,7 @@ jobs:
         with:
           images: registry.uffizzi.com/${{ env.UUID_WORKER }}
           tags: |
-            type=raw,value=60d
+            type=raw,value=30d
 
       - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
         uses: docker/build-push-action@v4

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      compose-file-cache-key: ${{ env.HASH }}
-      pr-number: ${{ env.PR_NUMBER }}
+      compose-file-cache-key: ${{ steps.hash.outputs.COMPOSE_FILE_HASH }}
+      git-ref: ${{ steps.event.outputs.GIT_REF }}
+      pr-number: ${{ steps.event.outputs.PR_NUMBER }}
+      action: ${{ steps.event.outputs.ACTION }}
     steps:
       - name: 'Download artifacts'
         # Fetch output (zip archive) from the workflow run that triggered this workflow.
@@ -41,42 +43,38 @@ jobs:
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
 
-      - name: 'Unzip artifact'
-        run: unzip preview-spec.zip
+      - name: 'Accept event from first stage'
+        run: unzip preview-spec.zip event.json
 
       - name: Read Event into ENV
+        id: event
         run: |
-          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
-          cat event.json >> $GITHUB_ENV
-          echo -e '\nEOF' >> $GITHUB_ENV
+          echo PR_NUMBER=$(jq '.number | tonumber' < event.json) >> $GITHUB_OUTPUT
+          echo ACTION=$(jq --raw-output '.action | tostring | [scan("\\w+")][0]' < event.json) >> $GITHUB_OUTPUT
+          echo GIT_REF=$(jq --raw-output '.pull_request.head.sha | tostring | [scan("\\w+")][0]' < event.json) >> $GITHUB_OUTPUT
 
       - name: Hash Rendered Compose File
         id: hash
         # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
-        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
-        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+        if: ${{ steps.event.outputs.ACTION != 'closed' }}
+        run: |
+          unzip preview-spec.zip docker-compose.rendered.yml
+          echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_OUTPUT
 
       - name: Cache Rendered Compose File
-        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        if: ${{ steps.event.outputs.ACTION != 'closed' }}
         uses: actions/cache@v3
         with:
           path: docker-compose.rendered.yml
-          key: ${{ env.HASH }}
-
-      - name: Read PR Number From Event Object
-        id: pr
-        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
-
-      - name: Read Git Ref From Event Object
-        id: ref
-        run: echo "GIT_REF=${{ fromJSON(env.EVENT_JSON).pull_request.head.sha }}" >> $GITHUB_ENV
+          key: ${{ steps.hash.outputs.COMPOSE_FILE_HASH }}
 
       - name: DEBUG - Print Job Outputs
         if: ${{ runner.debug }}
         run: |
-          echo "PR number: ${{ env.PR_NUMBER }}"
-          echo "Git Ref: ${{ env.GIT_REF }}"
-          echo "Compose file hash: ${{ env.HASH }}"
+          echo "PR number: ${{ steps.event.outputs.PR_NUMBER }}"
+          echo "Git Ref: ${{ steps.event.outputs.GIT_REF }}"
+          echo "Action: ${{ steps.event.outputs.ACTION }}"
+          echo "Compose file hash: ${{ steps.hash.outputs.COMPOSE_FILE_HASH }}"
           cat event.json
 
   deploy-uffizzi-preview:


### PR DESCRIPTION
## Changes

This update sanitizes user input from contributor forks. This fixes a workflow security vulnerability identified by the `backstage` project.

## How did you test this code?

I've tested this on my own fork here.
- Open PR.
- Observe successful execution of both workflows.
- Close PR.
- Observe successful execution of both workflows.

You can see the results on my fork here: https://github.com/axisofentropy/flagsmith/actions/workflows/uffizzi-preview.yml