### PR TITLE
fix(versioning): endpoints should return latest versions

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -60,6 +60,16 @@ from segments.models import Condition, Segment, SegmentRule
 from task_processor.task_run_method import TaskRunMethod
 from users.models import FFAdminUser, UserPermissionGroup
 
+# TODO:
+#   - move this file to the `tests/` dir and move these definitions to a `types.py` module.
+#   - migrate all existing typehints to use these
+WithProjectPermissionsCallable = typing.Callable[
+    [list[str], Project | None], UserProjectPermission
+]
+WithEnvironmentPermissionsCallable = typing.Callable[
+    [list[str], Project | None], UserEnvironmentPermission
+]
+
 trait_key = "key1"
 trait_value = "value1"
 
@@ -192,7 +202,7 @@ def environment(project):
 @pytest.fixture()
 def with_environment_permissions(
     environment: Environment, staff_user: FFAdminUser
-) -> typing.Callable[[list[str], int | None], UserEnvironmentPermission]:
+) -> WithEnvironmentPermissionsCallable:
     """
     Add environment permissions to the staff_user fixture.
     Defaults to associating to the environment fixture.
@@ -215,7 +225,7 @@ def with_environment_permissions(
 @pytest.fixture()
 def with_project_permissions(
     project: Project, staff_user: FFAdminUser
-) -> typing.Callable:
+) -> WithProjectPermissionsCallable:
     """
     Add project permissions to the staff_user fixture.
     Defaults to associating to the project fixture.

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -11,10 +11,6 @@ from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 from pytest_django.fixtures import SettingsWrapper
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
-from tests.types import (
-    WithEnvironmentPermissionsCallable,
-    WithProjectPermissionsCallable,
-)
 
 from api_keys.models import MasterAPIKey
 from environments.dynamodb.dynamodb_wrapper import (
@@ -62,6 +58,10 @@ from projects.permissions import VIEW_PROJECT
 from projects.tags.models import Tag
 from segments.models import Condition, Segment, SegmentRule
 from task_processor.task_run_method import TaskRunMethod
+from tests.types import (
+    WithEnvironmentPermissionsCallable,
+    WithProjectPermissionsCallable,
+)
 from users.models import FFAdminUser, UserPermissionGroup
 
 trait_key = "key1"

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -11,6 +11,10 @@ from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 from pytest_django.fixtures import SettingsWrapper
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
+from tests.types import (
+    WithEnvironmentPermissionsCallable,
+    WithProjectPermissionsCallable,
+)
 
 from api_keys.models import MasterAPIKey
 from environments.dynamodb.dynamodb_wrapper import (
@@ -59,16 +63,6 @@ from projects.tags.models import Tag
 from segments.models import Condition, Segment, SegmentRule
 from task_processor.task_run_method import TaskRunMethod
 from users.models import FFAdminUser, UserPermissionGroup
-
-# TODO:
-#   - move this file to the `tests/` dir and move these definitions to a `types.py` module.
-#   - migrate all existing typehints to use these
-WithProjectPermissionsCallable = typing.Callable[
-    [list[str], Project | None], UserProjectPermission
-]
-WithEnvironmentPermissionsCallable = typing.Callable[
-    [list[str], Project | None], UserEnvironmentPermission
-]
 
 trait_key = "key1"
 trait_value = "value1"

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -51,6 +51,7 @@ def get_environment_flags_list(
             "feature",
             "feature_state_value",
             "environment_feature_version",
+            "feature_segment",
             *additional_select_related_args,
         )
         .prefetch_related(*additional_prefetch_related_args)
@@ -64,7 +65,7 @@ def get_environment_flags_list(
     for feature_state in feature_states:
         key = (
             feature_state.feature_id,
-            feature_state.feature_segment_id,
+            getattr(feature_state.feature_segment, "segment_id", None),
             feature_state.identity_id,
         )
         current_feature_state = feature_states_dict.get(key)

--- a/api/features/versioning/versioning_service.py
+++ b/api/features/versioning/versioning_service.py
@@ -4,6 +4,7 @@ from django.db.models import Prefetch, Q, QuerySet
 from django.utils import timezone
 
 from features.models import FeatureState
+from features.versioning.models import EnvironmentFeatureVersion
 
 if typing.TYPE_CHECKING:
     from environments.models import Environment
@@ -71,6 +72,21 @@ def get_environment_flags_list(
             feature_states_dict[key] = feature_state
 
     return list(feature_states_dict.values())
+
+
+def get_current_live_environment_feature_version(
+    environment_id: int, feature_id: int
+) -> EnvironmentFeatureVersion | None:
+    return (
+        EnvironmentFeatureVersion.objects.filter(
+            environment_id=environment_id,
+            feature_id=feature_id,
+            published_at__isnull=False,
+            live_from__lte=timezone.now(),
+        )
+        .order_by("-live_from")
+        .first()
+    )
 
 
 def _build_environment_flags_qs_filter(

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -29,7 +29,7 @@ use_parentheses = true
 multi_line_output = 3
 include_trailing_comma = true
 line_length = 79
-known_first_party=['analytics','app','custom_auth','environments','integrations','organisations','projects','segments','users','webhooks','api','audit','e2etests','features','permissions','util']
+known_first_party=['analytics','app','custom_auth','environments','integrations','organisations','projects','segments','tests','users','webhooks','api','audit','e2etests','features','permissions','util']
 known_third_party=['_pytest','apiclient','app_analytics','axes','chargebee','core','coreapi','corsheaders','dj_database_url','django','django_lifecycle','djoser','drf_writable_nested','drf_yasg','environs','google','influxdb_client','ordered_model','pyotp','pytest','pytz','requests','responses','rest_framework','rest_framework_nested','rest_framework_recursive','sentry_sdk','shortuuid','simple_history','six','telemetry','tests','trench','whitenoise']
 skip = ['migrations','.venv','.direnv']
 

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -6,10 +6,10 @@ from django.test import Client as DjangoClient
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
-from tests.integration.helpers import create_mv_option_with_api
 
 from app.utils import create_hash
 from organisations.models import Organisation
+from tests.integration.helpers import create_mv_option_with_api
 
 
 @pytest.fixture()

--- a/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
@@ -8,6 +8,7 @@ from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.exceptions import NotFound
 from rest_framework.test import APIClient
+
 from tests.integration.helpers import create_mv_option_with_api
 
 

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -4,12 +4,12 @@ from unittest import mock
 import pytest
 from django.urls import reverse
 from rest_framework import status
+
+from features.feature_types import MULTIVARIATE
 from tests.integration.helpers import (
     create_feature_with_api,
     create_mv_option_with_api,
 )
-
-from features.feature_types import MULTIVARIATE
 
 variant_1_value = "variant-1-value"
 variant_2_value = "variant-2-value"

--- a/api/tests/integration/environments/test_clone_environment.py
+++ b/api/tests/integration/environments/test_clone_environment.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.test import APIClient
+
 from tests.integration.helpers import (
     get_env_feature_states_list_with_api,
     get_feature_segement_list_with_api,

--- a/api/tests/integration/features/versioning/test_integration_v2_versioning.py
+++ b/api/tests/integration/features/versioning/test_integration_v2_versioning.py
@@ -5,6 +5,7 @@ import typing
 import pytest
 from django.urls import reverse
 from rest_framework import status
+
 from tests.test_helpers import generate_segment_data
 
 from .types import (

--- a/api/tests/types.py
+++ b/api/tests/types.py
@@ -1,0 +1,11 @@
+from typing import Callable
+
+from environments.permissions.models import UserEnvironmentPermission
+from projects.models import Project, UserProjectPermission
+
+WithProjectPermissionsCallable = Callable[
+    [list[str], Project | None], UserProjectPermission
+]
+WithEnvironmentPermissionsCallable = Callable[
+    [list[str], Project | None], UserEnvironmentPermission
+]

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_views.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_views.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 from django.urls import reverse
 from pytest_mock import MockerFixture
 from rest_framework import status
@@ -16,6 +14,7 @@ from environments.permissions.constants import (
 )
 from environments.permissions.permissions import NestedEnvironmentPermissions
 from features.models import Feature
+from tests.types import WithEnvironmentPermissionsCallable
 
 
 def test_edge_identity_view_set_get_permissions():
@@ -97,7 +96,7 @@ def test_edge_identity_viewset_returns_404_for_invalid_environment_key(admin_cli
 
 def test_get_edge_identity_overrides_for_a_feature(
     staff_client: APIClient,
-    with_environment_permissions: Callable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
     mocker: MockerFixture,
     feature: Feature,
     environment: Environment,
@@ -166,7 +165,7 @@ def test_get_edge_identity_overrides_for_a_feature(
 
 def test_user_without_manage_identities_permission_cannot_get_edge_identity_overrides_for_a_feature(
     staff_client: APIClient,
-    with_environment_permissions: Callable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
     feature: Feature,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
@@ -3,12 +3,12 @@ import json
 import pytest
 from django.urls import reverse
 from rest_framework import status
-from tests.unit.environments.helpers import get_environment_user_client
 
 from environments.permissions.constants import (
     UPDATE_FEATURE_STATE,
     VIEW_ENVIRONMENT,
 )
+from tests.unit.environments.helpers import get_environment_user_client
 
 
 def test_user_without_update_feature_state_permission_cannot_create_identity_feature_state(

--- a/api/tests/unit/environments/test_unit_environments_feature_states_views.py
+++ b/api/tests/unit/environments/test_unit_environments_feature_states_views.py
@@ -3,12 +3,12 @@ import json
 import pytest
 from django.urls import reverse
 from rest_framework import status
-from tests.unit.environments.helpers import get_environment_user_client
 
 from environments.permissions.constants import (
     UPDATE_FEATURE_STATE,
     VIEW_ENVIRONMENT,
 )
+from tests.unit.environments.helpers import get_environment_user_client
 
 
 def test_user_without_update_feature_state_permission_cannot_update_feature_state(

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -28,6 +28,7 @@ from projects.models import (
 )
 from projects.permissions import CREATE_ENVIRONMENT, VIEW_PROJECT
 from segments.models import Condition, SegmentRule
+from tests.types import WithEnvironmentPermissionsCallable
 from users.models import FFAdminUser
 from util.tests import Helper
 
@@ -605,7 +606,7 @@ def test_create_environment_without_required_metadata_returns_400(
 def test_view_environment_with_staff__query_count_is_expected(
     staff_client: APIClient,
     environment: Environment,
-    with_environment_permissions: Callable[[list[str], int], None],
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
     project: Project,
     django_assert_num_queries: Callable[[int], None],
     environment_metadata_a: Metadata,

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -6,10 +6,6 @@ from django.urls import reverse
 from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.test import APIClient
-from tests.types import (
-    WithEnvironmentPermissionsCallable,
-    WithProjectPermissionsCallable,
-)
 
 from environments.models import Environment
 from environments.permissions.constants import (
@@ -22,6 +18,10 @@ from features.versioning.models import EnvironmentFeatureVersion
 from projects.models import Project, UserProjectPermission
 from projects.permissions import VIEW_PROJECT
 from segments.models import Segment
+from tests.types import (
+    WithEnvironmentPermissionsCallable,
+    WithProjectPermissionsCallable,
+)
 from users.models import FFAdminUser
 
 

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -1,5 +1,4 @@
 import json
-from typing import Callable
 
 import pytest
 from django.urls import reverse
@@ -162,7 +161,7 @@ def test_create_feature_segment_staff_with_permission(
     environment: Environment,
     staff_client: FFAdminUser,
     staff_user: FFAdminUser,
-    with_environment_permissions: Callable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given
     data = {
@@ -188,7 +187,7 @@ def test_create_feature_segment_staff_wrong_permission(
     environment: Environment,
     staff_client: FFAdminUser,
     staff_user: FFAdminUser,
-    with_environment_permissions: Callable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ):
     # Given
     data = {
@@ -275,7 +274,7 @@ def test_update_priority_for_staff(
     feature: Feature,
     staff_client: FFAdminUser,
     staff_user: FFAdminUser,
-    with_environment_permissions: Callable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given
     url = reverse("api-v1:features:feature-segment-update-priorities")
@@ -363,8 +362,8 @@ def test_get_feature_segment_by_uuid_for_staff(
     staff_user: FFAdminUser,
     environment: Environment,
     feature: Feature,
-    with_environment_permissions: Callable,
-    with_project_permissions: Callable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+    with_project_permissions: WithProjectPermissionsCallable,
 ) -> None:
     # Given
     url = reverse(
@@ -425,7 +424,7 @@ def test_get_feature_segment_by_id_for_staff(
     staff_user: FFAdminUser,
     environment: Environment,
     feature: Feature,
-    with_environment_permissions: Callable,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ):
     # Given
     url = reverse("api-v1:features:feature-segment-detail", args=[feature_segment.id])

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -6,11 +6,11 @@ from django.urls import reverse
 from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.test import APIClient
-
-from conftest import (
+from tests.types import (
     WithEnvironmentPermissionsCallable,
     WithProjectPermissionsCallable,
 )
+
 from environments.models import Environment
 from environments.permissions.constants import (
     MANAGE_SEGMENT_OVERRIDES,
@@ -28,10 +28,13 @@ from users.models import FFAdminUser
 @pytest.mark.parametrize(
     "client, num_queries",
     [
-        (lazy_fixture("admin_client"), 2),  # 1 for paging, 1 for result
+        (
+            lazy_fixture("admin_client"),
+            3,
+        ),  # 1 for paging, 1 for result, 1 for getting the current live version
         (
             lazy_fixture("admin_master_api_key_client"),
-            3,
+            4,
         ),  # an extra one for master_api_key
     ],
 )

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -1,5 +1,4 @@
 import json
-from typing import Callable
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -19,6 +18,7 @@ from features.import_export.models import (
 from projects.models import Project
 from projects.permissions import VIEW_PROJECT
 from projects.tags.models import Tag
+from tests.types import WithProjectPermissionsCallable
 from users.models import FFAdminUser
 
 
@@ -66,7 +66,7 @@ def test_list_feature_export_with_filtered_environments(
     staff_client: APIClient,
     project: Project,
     environment: Environment,
-    with_project_permissions: Callable[[list[str], int], None],
+    with_project_permissions: WithProjectPermissionsCallable,
 ) -> None:
     # Given
     with_project_permissions([VIEW_PROJECT])

--- a/api/tests/unit/features/test_unit_features_permissions.py
+++ b/api/tests/unit/features/test_unit_features_permissions.py
@@ -1,4 +1,3 @@
-from typing import Callable
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -19,6 +18,7 @@ from projects.permissions import (
     VIEW_PROJECT,
     NestedProjectPermissions,
 )
+from tests.types import WithProjectPermissionsCallable
 from users.models import FFAdminUser, UserPermissionGroup
 
 
@@ -66,7 +66,7 @@ def test_project_admin_can_list_features(
 def test_project_user_with_read_access_can_list_features(
     staff_user: FFAdminUser,
     project: Project,
-    with_project_permissions: Callable[[list[str], int], None],
+    with_project_permissions: WithProjectPermissionsCallable,
 ) -> None:
     # Given
     feature_permissions = FeaturePermissions()
@@ -258,7 +258,7 @@ def test_project_admin_can_view_feature(
 def test_project_user_with_view_project_permission_can_view_feature(
     staff_user: FFAdminUser,
     project: Project,
-    with_project_permissions: Callable[[list[str], int], None],
+    with_project_permissions: WithProjectPermissionsCallable,
     feature: Feature,
 ) -> None:
     # Given
@@ -344,7 +344,7 @@ def test_project_admin_can_edit_feature(
 def test_project_user_cannot_edit_feature(
     action: str,
     staff_user: FFAdminUser,
-    with_project_permissions: Callable[[list[str], int], None],
+    with_project_permissions: WithProjectPermissionsCallable,
     feature: Feature,
 ) -> None:
     # Given
@@ -398,7 +398,7 @@ def test_project_admin_can_delete_feature(
 
 def test_project_user_with_delete_feature_permission_can_delete_feature(
     staff_user: FFAdminUser,
-    with_project_permissions: Callable[[list[str], int], None],
+    with_project_permissions: WithProjectPermissionsCallable,
     feature: Feature,
 ) -> None:
     # Given

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -15,6 +15,7 @@ from pytest_django import DjangoAssertNumQueries
 from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
+from tests.types import WithEnvironmentPermissionsCallable
 
 from audit.constants import (
     FEATURE_DELETED_MESSAGE,
@@ -22,7 +23,6 @@ from audit.constants import (
     IDENTITY_FEATURE_STATE_UPDATED_MESSAGE,
 )
 from audit.models import AuditLog, RelatedObjectType
-from conftest import WithEnvironmentPermissionsCallable
 from environments.identities.models import Identity
 from environments.models import Environment, EnvironmentAPIKey
 from environments.permissions.constants import (

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 from datetime import date, datetime, timedelta
-from typing import Callable
 from unittest import TestCase, mock
 
 import pytest
@@ -45,7 +44,10 @@ from projects.models import Project, UserProjectPermission
 from projects.permissions import CREATE_FEATURE, VIEW_PROJECT
 from projects.tags.models import Tag
 from segments.models import Segment
-from tests.types import WithEnvironmentPermissionsCallable
+from tests.types import (
+    WithEnvironmentPermissionsCallable,
+    WithProjectPermissionsCallable,
+)
 from users.models import FFAdminUser, UserPermissionGroup
 from util.tests import Helper
 from webhooks.webhooks import WebhookEventType
@@ -1692,7 +1694,7 @@ def test_list_features_group_owners(
     staff_client: APIClient,
     project: Project,
     feature: Feature,
-    with_project_permissions: Callable[[list[str], int | None], UserProjectPermission],
+    with_project_permissions: WithProjectPermissionsCallable,
 ) -> None:
     # Given
     with_project_permissions([VIEW_PROJECT])
@@ -2224,9 +2226,7 @@ def test_cannot_update_feature_of_a_feature_state(
 
 def test_create_segment_override__using_simple_feature_state_viewset__allows_manage_segment_overrides(
     staff_client: APIClient,
-    with_environment_permissions: Callable[
-        [list[str], int | None], UserEnvironmentPermission
-    ],
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
     feature: Feature,
     segment: Segment,
@@ -2263,9 +2263,7 @@ def test_create_segment_override__using_simple_feature_state_viewset__allows_man
 
 def test_create_segment_override__using_simple_feature_state_viewset__denies_update_feature_state(
     staff_client: APIClient,
-    with_environment_permissions: Callable[
-        [list[str], int | None], UserEnvironmentPermission
-    ],
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
     feature: Feature,
     segment: Segment,
@@ -2298,9 +2296,7 @@ def test_create_segment_override__using_simple_feature_state_viewset__denies_upd
 
 def test_update_segment_override__using_simple_feature_state_viewset__allows_manage_segment_overrides(
     staff_client: APIClient,
-    with_environment_permissions: Callable[
-        [list[str], int | None], UserEnvironmentPermission
-    ],
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
     feature: Feature,
     segment: Segment,
@@ -2344,9 +2340,7 @@ def test_update_segment_override__using_simple_feature_state_viewset__allows_man
 
 def test_update_segment_override__using_simple_feature_state_viewset__denies_update_feature_state(
     staff_client: APIClient,
-    with_environment_permissions: Callable[
-        [list[str], int | None], UserEnvironmentPermission
-    ],
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
     environment: Environment,
     feature: Feature,
     segment: Segment,
@@ -2384,7 +2378,7 @@ def test_list_features_n_plus_1(
     staff_client: APIClient,
     project: Project,
     feature: Feature,
-    with_project_permissions: Callable,
+    with_project_permissions: WithProjectPermissionsCallable,
     django_assert_num_queries: DjangoAssertNumQueries,
     environment: Environment,
 ) -> None:
@@ -2413,7 +2407,7 @@ def test_list_features_with_union_tag(
     staff_client: APIClient,
     project: Project,
     feature: Feature,
-    with_project_permissions: Callable,
+    with_project_permissions: WithProjectPermissionsCallable,
     django_assert_num_queries: DjangoAssertNumQueries,
     environment: Environment,
 ) -> None:
@@ -2465,7 +2459,7 @@ def test_list_features_with_intersection_tag(
     staff_client: APIClient,
     project: Project,
     feature: Feature,
-    with_project_permissions: Callable,
+    with_project_permissions: WithProjectPermissionsCallable,
     django_assert_num_queries: DjangoAssertNumQueries,
     environment: Environment,
 ) -> None:

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -15,7 +15,6 @@ from pytest_django import DjangoAssertNumQueries
 from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
-from tests.types import WithEnvironmentPermissionsCallable
 
 from audit.constants import (
     FEATURE_DELETED_MESSAGE,
@@ -46,6 +45,7 @@ from projects.models import Project, UserProjectPermission
 from projects.permissions import CREATE_FEATURE, VIEW_PROJECT
 from projects.tags.models import Tag
 from segments.models import Segment
+from tests.types import WithEnvironmentPermissionsCallable
 from users.models import FFAdminUser, UserPermissionGroup
 from util.tests import Helper
 from webhooks.webhooks import WebhookEventType

--- a/api/tests/unit/organisations/chargebee/conftest.py
+++ b/api/tests/unit/organisations/chargebee/conftest.py
@@ -2,12 +2,12 @@ import typing
 
 import pytest
 from pytest_mock import MockerFixture
+
+from organisations.chargebee.metadata import ChargebeeObjMetadata
 from tests.unit.organisations.chargebee.test_unit_chargebee_chargebee import (
     MockChargeBeeAddOn,
     MockChargeBeeSubscriptionResponse,
 )
-
-from organisations.chargebee.metadata import ChargebeeObjMetadata
 
 ChargebeeCacheMocker = typing.Callable[
     [

--- a/api/tests/unit/telemetry/test_unit_telemetry_serializers.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_serializers.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.test import override_settings
 from telemetry.serializers import TelemetrySerializer
+
 from tests.unit.telemetry.helpers import get_example_telemetry_data
 
 

--- a/api/tests/unit/telemetry/test_unit_telemetry_telemetry.py
+++ b/api/tests/unit/telemetry/test_unit_telemetry_telemetry.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import responses
 from telemetry.telemetry import SelfHostedTelemetryWrapper
+
 from tests.unit.telemetry.helpers import get_example_telemetry_data
 
 


### PR DESCRIPTION
## Changes

Fixes a FE integration issue and what appears to be a legitimate bug in the logic for getting the latest versions. 

The FE integration issue was that the API to retrieve feature segments for a given environment / feature was previously returning the feature segments across all versions, rather than just the current live version as it currently does. 

The legitimate bug was that, when evaluating the flags to retrieve the current live version, it was using the id of the feature segment as the unique key for a segment override whereas this changes for each version in the new versioning logic. As such, I have modified this logic to use the id of the segment which shouldn't change (at least until we start versioning segments too!). 

Note that as part of this, I added a `tests.types` module. I also added `tests` to the `known_first_party` attribute in isort configuration and hence there are a number of other file changes. 

## How did you test this code?

Added unit tests which cover the specific functionality which exhibited the issues while integrating with the FE. 
