### PR TITLE
deps: update ldap to version 0.1.0

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1489,7 +1489,7 @@ semver = "2.13.0"
 
 [[package]]
 name = "flagsmith-ldap"
-version = "0.0.3"
+version = "0.1.0"
 description = "LDAP plugin for Flagsmith application."
 optional = false
 python-versions = "^3.10"
@@ -1503,8 +1503,8 @@ django-python3-ldap = "^0.15.4"
 [package.source]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-ldap"
-reference = "v0.0.3"
-resolved_reference = "86ac550165bc3cbd59782a1cb8026d64f79f5523"
+reference = "v0.1.0"
+resolved_reference = "e9edc5668711523eabdb833203d677bf64f98531"
 
 [[package]]
 name = "flake8"
@@ -4397,4 +4397,4 @@ requests = ">=2.7,<3.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "728b7fd7a148eb3ff0b2e2152762e241c34e996612032587d01b15812f1d14ff"
+content-hash = "ea33439321d98a14a8489c1f9cf6350b4e44ed96630aa8b4298f25ab321ec7ab"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -120,7 +120,7 @@ pysaml2 = "^7.0.0"
 optional = true
 
 [tool.poetry.group.ldap.dependencies]
-flagsmith-ldap = { git = "https://github.com/flagsmith/flagsmith-ldap", tag = "v0.0.3" }
+flagsmith-ldap = { git = "https://github.com/flagsmith/flagsmith-ldap", tag = "v0.1.0" }
 
 [tool.poetry.group.dev.dependencies]
 django-test-migrations = "~1.2.0"


### PR DESCRIPTION
## Changes

Update LDAP version to include management command to sync users and groups. 

## How did you test this code?

Tests exist in LDAP repository. Also tested using the following steps from a shell in the flagsmith repository: 

```
poetry install --with ldap
export LDAP_AUTH_URL=https://some.auth.url/ldap
python manage.py sync_ldap_users_and_groups
```
