### PR TITLE
fix: erroneous booleans in feature tooltip

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -223,9 +223,13 @@ class TheComponent extends Component {
                         </span>
                       }
                     >
-                      {`${isCompact && `${description}<br/>`}Created ${moment(
-                        created_date,
-                      ).format('Do MMM YYYY HH:mma')}`}
+                      {isCompact && description
+                        ? `${description}<br/>Created ${moment(
+                            created_date,
+                          ).format('Do MMM YYYY HH:mma')}`
+                        : `Created ${moment(created_date).format(
+                            'Do MMM YYYY HH:mma',
+                          )}`}
                     </Tooltip>
                   ) : (
                     name


### PR DESCRIPTION
## Changes

Fixes the issue illustrated in the screenshot below

<img width="378" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/33b395d0-4a5f-41f9-844e-f1d8e3f39828">

This PR fixes this. I have a feeling there is a way to fix this with fewer lines of code but it's horrifically complicated to try and get the JS string formatting to play nicely here. 

## How did you test this code?

Ran the FE locally and verified that the tooltip shows the correct values given all combinations of description and isCompact. Illustrated by screenshots below. 

<img width="322" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/c3f767a4-fa8b-4671-a42a-dea3812d8921">
<img width="335" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/0b4542da-1d77-4173-a148-59def2141fb4">
<img width="343" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/1202c5ac-41cb-4dda-b6bf-dad96b419771">
<img width="326" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/c5e08b3b-bb01-41bf-8ea0-46fdec9681f5">
