### PR TITLE
fix: `env` variable instructions on locally-api.md

### DIFF
--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -178,7 +178,8 @@ the below variables will be ignored.
 
 #### Application Environment Variables
 
-- `ENV`: string representing the current running environment, e.g. 'local', 'dev', 'prod'. Defaults to 'local'
+- `ENVIRONMENT`: string representing the current running environment, such as "local", "dev", "staging" or "production".
+  Defaults to 'local'
 - `DJANGO_SECRET_KEY`: secret key required by Django, if one isn't provided one will be created using
   `django.core.management.utils.get_random_secret_key`. WARNING: If running multiple API instances, its vital that you
   define a shared DJANGO_SECRET_KEY.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Update the documentation for `ENV` variable.

## How did you test this code?

I tried to use this environment variable but it did not affect anything. So checked the source code and realized the docs is out-dated. Seems like this flag is now called `ENVIRONMENT`.

https://github.com/Flagsmith/flagsmith/blob/93ea01ca8d4b927b2b244fe2d5e555f6a345126d/api/app/settings/common.py#L35C1-L39
