### PR TITLE
chore: Bump default stuck limit for task processor tasks

### DIFF
--- a/api/task_processor/management/commands/runprocessor.py
+++ b/api/task_processor/management/commands/runprocessor.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             "--graceperiodms",
             type=int,
             help="Number of millis before running task is considered 'stuck'.",
-            default=3000,
+            default=20000,
         )
         parser.add_argument(
             "--queuepopsize",

--- a/docs/docs/deployment/configuration/task-processor.md
+++ b/docs/docs/deployment/configuration/task-processor.md
@@ -55,7 +55,7 @@ options are via command line arguments when starting the processor.
 | ------------------- | ------------------------------------------------------------------------- | ------- |
 | `--sleepintervalms` | The amount of ms each worker should sleep between checking for a new task | 2000    |
 | `--numthreads`      | The number of worker threads to run per task processor instance           | 5       |
-| `--graceperiodms`   | The amount of ms before a worker thread is considered 'stuck'.            | 3000    |
+| `--graceperiodms`   | The amount of ms before a worker thread is considered 'stuck'.            | 20000   |
 
 ## Monitoring
 

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -13,9 +13,7 @@
                 "--sleepintervalms",
                 "1000",
                 "--numthreads",
-                "12",
-                "--graceperiodms",
-                "20000"
+                "12"
             ],
             "essential": true,
             "environment": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Our SaaS application has bumped the task worker limit to 20 seconds, but our on prem customers still use the old default. It's probably a better idea to extend the same worker limit to them as well, since 3 seconds of processing time is a bit tight for some tasks.

## How did you test this code?

I did not test this code because it's just a default value change.