### PR TITLE
chore: bump docs docusaurus

### DIFF
--- a/docs/docs/advanced-use/edge-api.md
+++ b/docs/docs/advanced-use/edge-api.md
@@ -6,10 +6,10 @@ The Edge API is only available with on our SaaS platform. It does not form part 
 
 :::
 
-[The Flagsmith Architecture](/guides-and-examples/integration-approaches#flags-are-evaluated-server-side) is based
-around a server-side flag engine. This comes with a number of benefits, but it can increase latency, especially when the
-calls are being made from a location that is far from the EU; the location of our current API. It also provides a single
-point of failure in the event of an AWS region-wide outage.
+[The Flagsmith Architecture](/clients/overview#remote-evaluation) is based around a server-side flag engine. This comes
+with a number of benefits, but it can increase latency, especially when the calls are being made from a location that is
+far from the EU; the location of our current API. It also provides a single point of failure in the event of an AWS
+region-wide outage.
 
 The Edge API solves both of these issues. It provides a datastore and Edge compute API that is replicated across 8 AWS
 regions, with latency-based routing and global failover in the event of a region outage.

--- a/docs/docs/advanced-use/edge-proxy.md
+++ b/docs/docs/advanced-use/edge-proxy.md
@@ -6,25 +6,24 @@ The Flagsmith Edge Proxy allows you to run an instance of the Flagsmith Engine c
 Flagsmith within a server-side environment and you want to have very low latency flags, you have two options:
 
 1. Run the Edge Proxy and connect to it from your server-side SDKs
-2. Run your server-side SDKs in [Local Evaluation Mode](/clients/overview#2---local-evaluation).
+2. Run your server-side SDKs in [Local Evaluation Mode](/clients/overview#local-evaluation).
 
 The main benefit to running the Edge Proxy is that you reduce your polling requests against the Flagsmith API itself.
 
-The main benefit to running server side SDKs in [Local Evaluation Mode](/clients/overview#2---local-evaluation) is that
-you get the lowest possible latency.
+The main benefit to running server side SDKs in [Local Evaluation Mode](/clients/overview#local-evaluation) is that you
+get the lowest possible latency.
 
 ## How does it work
 
 :::info
 
-The Edge Proxy has the same
-[caveats as running our SDK in Local Evaluation mode.](/clients/overview#local-evaluation-mode).
+The Edge Proxy has the same [caveats as running our SDK in Local Evaluation mode.](/clients/overview#local-evaluation).
 
 :::
 
 You can think of the Edge Proxy as a copy of our Python Server Side SDK, running in
-[Local Evaluation Mode](/clients/overview#2---local-evaluation), with an API interface that is compatible with the
-Flagsmith SDK API.
+[Local Evaluation Mode](/clients/overview#local-evaluation), with an API interface that is compatible with the Flagsmith
+SDK API.
 
 The Edge Proxy runs as a lightweight Docker container. It connects to the Flagsmith API (either powered by us at
 api.flagsmith.com or self hosted by you) to get Environment Flags and Segment rules. You can then point the Flagsmith

--- a/docs/docs/basic-features/managing-segments.md
+++ b/docs/docs/basic-features/managing-segments.md
@@ -18,8 +18,7 @@ is no context to use.
 :::tip
 
 Segments are _not_ sent back to client SDKs. They are used to override flag values within the dashboard, but they are
-never sent back to our SDKs from the API.
-[Learn more about our architecture](/guides-and-examples/integration-approaches#flags-are-evaluated-server-side).
+never sent back to our SDKs from the API. [Learn more about our architecture](/clients/overview#local-evaluation).
 
 :::
 

--- a/docs/docs/clients/client-side/ios.md
+++ b/docs/docs/clients/client-side/ios.md
@@ -102,7 +102,7 @@ Flagsmith.shared.getFeatureValue(withID: "test_feature2", forIdentity: nil) { (r
 These methods can also specify a particular identity to retrieve the values for a user registration. See
 [Identities](/basic-features/managing-identities/) , using the **forIdentity** parameter.
 
-To retrieve a trait for a particular identity (see [Traits](/basic-features/managing-identities/#identity-traits)):
+To retrieve a trait for a particular identity (see [Traits](/basic-features/managing-identities#identity-traits)):
 
 ```swift
 Flagsmith.shared.getTraits(forIdentity: "test_user@test.com") {(result) in

--- a/docs/docs/clients/server-side.md
+++ b/docs/docs/clients/server-side.md
@@ -11,8 +11,8 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 :::tip
 
 Server Side SDKs can run in 2 different modes: `Local Evaluation` and `Remote Evaluation`. We recommend
-[reading up about the differences](overview#remote-and-local-evaluation-modes) first before integrating the SDKS into
-your applications.
+[reading up about the differences](/clients/overview#server-side-sdks) first before integrating the SDKS into your
+applications.
 
 Once you've got that understood, lets get the SDKs integrated!
 

--- a/docs/docs/deployment/configuration/django-admin.md
+++ b/docs/docs/deployment/configuration/django-admin.md
@@ -14,7 +14,7 @@ pages at certain times.
 
 The admin pages are only available to uses that are designated as 'super users'. This can only be done when first
 setting up the platform or via the database. If you're just starting out, you can follow the instructions
-[here](/deployment/hosting/locally-api#Initialising), otherwise, you need to set the `is_staff` and `is_superuser` flags
+[here](/deployment/hosting/locally-api#initialising), otherwise, you need to set the `is_staff` and `is_superuser` flags
 against any of the users in your database.
 
 Once you have a user, you can access the django admin pages at `/admin/`. You will be prompted to log in with the

--- a/docs/docs/deployment/hosting/kubernetes.md
+++ b/docs/docs/deployment/hosting/kubernetes.md
@@ -266,7 +266,7 @@ By default, Flagsmith uses Postgres to store time series data. You can alternati
 - SDK API traffic
 - SDK Flag Evaluations
 
-[You need to perform some additional steps to configure InfluxDB.](/deployment/overview#influxdb).
+[You need to perform some additional steps to configure InfluxDB.](/deployment/overview#time-series-data-via-influxdb).
 
 ### Task Processor
 

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -238,7 +238,7 @@ the below variables will be ignored.
   String. Connection string to set up Flagsmith to send telemetry to Azure Application Insights.
 - [`OPENCENSUS_SAMPLING_RATE`](https://opencensus.io/tracing/sampling/probabilistic/): Float. The tracer sample rate.
 - `RESTRICT_ORG_CREATE_TO_SUPERUSERS`: Restricts all users from creating organisations unless they are
-  [marked as a superuser](/deployment/configuration/django-admin#Authentication).
+  [marked as a superuser](/deployment/configuration/django-admin#authentication).
 - `FLAGSMITH_CORS_EXTRA_ALLOW_HEADERS`: Comma separated list of extra headers to allow when operating across domains.
   e.g. `'my-custom-header-1,my-custom-header-2'`. Defaults to `'sentry-trace,'`.
 - `FLAGSMITH_DOMAIN`: A custom domain for URLs pointing to your Flagsmith instance in email notifications. Note: if set,

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -660,7 +660,7 @@ The list of the flags and remote config we're currently using in production is b
 
 ### `oauth_github`
 
-Find instructions for GitHub Authentication [here](/deployment/configuration/authentication/oauth#github).
+Find instructions for GitHub Authentication [here](/deployment/configuration/authentication/OAuth#github).
 
 Create an OAuth application in the GitHub Developer Console and then provide the following as the Flag value:
 

--- a/docs/docs/guides-and-examples/defensive-coding.md
+++ b/docs/docs/guides-and-examples/defensive-coding.md
@@ -35,9 +35,9 @@ The solution here really depends on which of our SDKs you are using. By default 
 application thread, and are designed to work around an asynchronous callback model.
 
 Where our Server Side SDKs are being used, it really depends on if you are using them in
-[local or remote evaluation mode](/clients/overview.md#server-side-sdks). When running in local evaluation mode, once
-the SDKs have received a response from the API with the Environment related data, they will keep that data in memory. In
-the event of the SDKs then not receiving an update, they will continue to function.
+[local or remote evaluation mode](/clients/overview#networking-model). When running in local evaluation mode, once the
+SDKs have received a response from the API with the Environment related data, they will keep that data in memory. In the
+event of the SDKs then not receiving an update, they will continue to function.
 
 In the event that the SDKs aren't able to contact the API at all, they will time out and resort to
 [Default flags](#rule-2-progressively-enhance-your-application-with-default-flags). When running in remote evaluation
@@ -82,9 +82,9 @@ requests for flag evaluation will happen locally in memory in fractions of a mil
 
 If you need sub-millisecond latency for end-to-end flag evaluation, for example in the event that you are running a
 multi-variate test on a landing page of your website, you can employ one of our Server Side SDKs running in
-[local evaluation mode](/clients/overview.md#2---local-evaluation) mode. This will provide sub-millisecond latency of
-the entire flag evaluation rules engine, running locally within your server infrastructure, allowing you to run
-multivariate tests with zero latency impact.
+[local evaluation mode](/clients/overview#local-evaluation) mode. This will provide sub-millisecond latency of the
+entire flag evaluation rules engine, running locally within your server infrastructure, allowing you to run multivariate
+tests with zero latency impact.
 
 ### No proxy-server required
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,9 @@
       "name": "my-website",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/plugin-google-tag-manager": "^3.0.1",
-        "@docusaurus/preset-classic": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/plugin-google-tag-manager": "^3.1.0",
+        "@docusaurus/preset-classic": "3.1.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -20,8 +20,8 @@
         "redoc": "^2.1.3"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/types": "3.0.1"
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/types": "3.1.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -69,74 +69,74 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
-      "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.0.tgz",
+      "integrity": "sha512-uZ1uZMLDZb4qODLfTSNHxSi4fH9RdrQf7DXEzW01dS8XK7QFtFh29N5NGKa9S+Yudf1vUMIF+/RiL4i/J0pWlQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.20.0"
+        "@algolia/cache-common": "4.22.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
-      "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ=="
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.0.tgz",
+      "integrity": "sha512-TPwUMlIGPN16eW67qamNQUmxNiGHg/WBqWcrOoCddhqNTqGDPVqmgfaM85LPbt24t3r1z0zEz/tdsmuq3Q6oaA=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
-      "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.0.tgz",
+      "integrity": "sha512-kf4Cio9NpPjzp1+uXQgL4jsMDeck7MP89BYThSvXSjf2A6qV/0KeqQf90TL2ECS02ovLOBXkk98P7qVarM+zGA==",
       "dependencies": {
-        "@algolia/cache-common": "4.20.0"
+        "@algolia/cache-common": "4.22.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
-      "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.0.tgz",
+      "integrity": "sha512-Bjb5UXpWmJT+yGWiqAJL0prkENyEZTBzdC+N1vBuHjwIJcjLMjPB6j1hNBRbT12Lmwi55uzqeMIKS69w+0aPzA==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
-      "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.0.tgz",
+      "integrity": "sha512-os2K+kHUcwwRa4ArFl5p/3YbF9lN3TLOPkbXXXxOvDpqFh62n9IRZuzfxpHxMPKAQS3Et1s0BkKavnNP02E9Hg==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
-      "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.0.tgz",
+      "integrity": "sha512-BlbkF4qXVWuwTmYxVWvqtatCR3lzXwxx628p1wj1Q7QP2+LsTmGt1DiUYRuy9jG7iMsnlExby6kRMOOlbhv2Ag==",
       "dependencies": {
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
-      "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.0.tgz",
+      "integrity": "sha512-pEOftCxeBdG5pL97WngOBi9w5Vxr5KCV2j2D+xMVZH8MuU/JX7CglDSDDb0ffQWYqcUN+40Ry+xtXEYaGXTGow==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
-      "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.0.tgz",
+      "integrity": "sha512-bn4qQiIdRPBGCwsNuuqB8rdHhGKKWIij9OqidM1UkQxnSG8yzxHdb7CujM30pvp5EnV7jTqDZRbxacbjYVW20Q==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -145,47 +145,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
-      "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ=="
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.0.tgz",
+      "integrity": "sha512-HMUQTID0ucxNCXs5d1eBJ5q/HuKg8rFVE/vOiLaM4Abfeq1YnTtGV3+rFEhOPWhRQxNDd+YHa4q864IMc0zHpQ=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
-      "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.0.tgz",
+      "integrity": "sha512-7JKb6hgcY64H7CRm3u6DRAiiEVXMvCJV5gRE672QFOUgDxo4aiDpfU61g6Uzy8NKjlEzHMmgG4e2fklELmPXhQ==",
       "dependencies": {
-        "@algolia/logger-common": "4.20.0"
+        "@algolia/logger-common": "4.22.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
-      "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.0.tgz",
+      "integrity": "sha512-BHfv1h7P9/SyvcDJDaRuIwDu2yrDLlXlYmjvaLZTtPw6Ok/ZVhBR55JqW832XN/Fsl6k3LjdkYHHR7xnsa5Wvg==",
       "dependencies": {
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/requester-common": "4.22.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
-      "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng=="
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.0.tgz",
+      "integrity": "sha512-Y9cEH/cKjIIZgzvI1aI0ARdtR/xRrOR13g5psCxkdhpgRN0Vcorx+zePhmAa4jdQNqexpxtkUdcKYugBzMZJgQ=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
-      "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.0.tgz",
+      "integrity": "sha512-8xHoGpxVhz3u2MYIieHIB6MsnX+vfd5PS4REgglejJ6lPigftRhTdBCToe6zbwq4p0anZXjjPDvNWMlgK2+xYA==",
       "dependencies": {
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/requester-common": "4.22.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
-      "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.0.tgz",
+      "integrity": "sha512-ieO1k8x2o77GNvOoC+vAkFKppydQSVfbjM3YrSjLmgywiBejPTvU1R1nEvG59JIIUvtSLrZsLGPkd6vL14zopA==",
       "dependencies": {
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/cache-common": "4.22.0",
+        "@algolia/logger-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2165,9 +2165,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-GWudMGYA9v26ssbAWJNfgeDZk+lrudUTclLPRsmxiknEBk7UMp7Rglonhqbsf3IKHOyHkMU4Fr5jFyg5SBx9jQ==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2179,13 +2179,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/cssnano-preset": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
-      "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.0.tgz",
+      "integrity": "sha512-ned7qsgCqSv/e7KyugFNroAfiszuxLwnvMW7gmT2Ywxb/Nyt61yIw7KHyAZCMKglOalrqnYA4gMhLUCK/mVePA==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -2265,9 +2265,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.1.0.tgz",
+      "integrity": "sha512-p740M+HCst1VnKKzL60Hru9xfG4EUYJDarjlEC4hHeBy9+afPmY3BNPoSHx9/8zxuYfUlv/psf7I9NvRVdmdvg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2277,15 +2277,15 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
-      "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.1.0.tgz",
+      "integrity": "sha512-D7onDz/3mgBonexWoQXPw3V2E5Bc4+jYRf9gGUUK+KoQwU8xMDaDkUUfsr7t6UBa/xox9p5+/3zwLuXOYMzGSg==",
       "dependencies": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2317,12 +2317,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
-      "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.0.tgz",
+      "integrity": "sha512-XUl7Z4PWlKg4l6KF05JQ3iDHQxnPxbQUqTNKvviHyuHdlalOFv6qeDAm7IbzyQPJD5VA6y4dpRbTWSqP9ClwPg==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.0.1",
+        "@docusaurus/types": "3.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2336,17 +2336,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
-      "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.0.tgz",
+      "integrity": "sha512-iMa6WBaaEdYuxckvJtLcq/HQdlA4oEbCXf/OFfsYJCCULcDX7GDZpKxLF3X1fLsax3sSm5bmsU+CA0WD+R1g3A==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2367,17 +2367,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
-      "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.0.tgz",
+      "integrity": "sha512-el5GxhT8BLrsWD0qGa8Rq+Ttb/Ni6V3DGT2oAPio0qcs/mUAxeyXEAmihkvmLCnAgp6xD27Ce7dISZ5c6BXeqA==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2396,15 +2396,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
-      "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.0.tgz",
+      "integrity": "sha512-9gntYQFpk+93+Xl7gYczJu8I9uWoyRLnRwS0+NUFcs9iZtHKsdqKWPRrONC9elfN3wJ9ORwTbcVzsTiB8jvYlg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2418,13 +2418,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
-      "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.1.0.tgz",
+      "integrity": "sha512-AbvJwCVRbmQ8w9d8QXbF4Iq/ui0bjPZNYFIhtducGFnm2YQRN1mraK8mCEQb0Aq0T8SqRRvSfC/far4n/s531w==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2438,13 +2438,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
-      "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.0.tgz",
+      "integrity": "sha512-zvUOMzu9Uhz0ciqnSbtnp/5i1zEYlzarQrOXG90P3Is3efQI43p2YLW/rzSGdLb5MfQo2HvKT6Q5+tioMO045Q==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2456,13 +2456,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
-      "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.0.tgz",
+      "integrity": "sha512-0txshvaY8qIBdkk2UATdVcfiCLGq3KAUfuRQD2cRNgO39iIf4/ihQxH9NXcRTwKs4Q5d9yYHoix3xT6pFuEYOg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2475,13 +2475,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
-      "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.0.tgz",
+      "integrity": "sha512-zOWPEi8kMyyPtwG0vhyXrdbLs8fIZmY5vlbi9lUU+v8VsroO5iHmfR2V3SMsrsfOanw5oV/ciWqbxezY00qEZg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2493,16 +2493,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
-      "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.0.tgz",
+      "integrity": "sha512-TkR5vGBpUooEB9SoW42thahqqwKzfHrQQhkB+JrEGERsl4bKODSuJNle4aA4h6LSkg4IyfXOW8XOI0NIPWb9Cg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2516,23 +2516,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
-      "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.1.0.tgz",
+      "integrity": "sha512-xGLQRFmmT9IinAGUDVRYZ54Ys28USNbA3OTXQXnSJLPr1rCY7CYnHI4XoOnKWrNnDiAI4ruMzunXWyaElUYCKQ==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/plugin-debug": "3.0.1",
-        "@docusaurus/plugin-google-analytics": "3.0.1",
-        "@docusaurus/plugin-google-gtag": "3.0.1",
-        "@docusaurus/plugin-google-tag-manager": "3.0.1",
-        "@docusaurus/plugin-sitemap": "3.0.1",
-        "@docusaurus/theme-classic": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-search-algolia": "3.0.1",
-        "@docusaurus/types": "3.0.1"
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/plugin-debug": "3.1.0",
+        "@docusaurus/plugin-google-analytics": "3.1.0",
+        "@docusaurus/plugin-google-gtag": "3.1.0",
+        "@docusaurus/plugin-google-tag-manager": "3.1.0",
+        "@docusaurus/plugin-sitemap": "3.1.0",
+        "@docusaurus/theme-classic": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-search-algolia": "3.1.0",
+        "@docusaurus/types": "3.1.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -2555,22 +2555,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
-      "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.1.0.tgz",
+      "integrity": "sha512-/+jMl2Z9O8QQxves5AtHdt91gWsEZFgOV3La/6eyKEd7QLqQUtM5fxEJ40rq9NKYjqCd1HzZ9egIMeJoWwillw==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-translations": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2594,17 +2594,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
-      "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.1.0.tgz",
+      "integrity": "sha512-YGwEFALLIbF5ocW/Fy6Ae7tFWUOugEN3iwxTx8UkLAcLqYUboDSadesYtVBmRCEB4FVA2qoP7YaW3lu3apUPPw==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2623,18 +2623,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
-      "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.0.tgz",
+      "integrity": "sha512-8cJH0ZhPsEDjq3jR3I+wHmWzVY2bXMQJ59v2QxUmsTZxbWA4u+IzccJMIJx4ooFl9J6iYynwYsFuHxyx/KUmfQ==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-translations": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
-      "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.1.0.tgz",
+      "integrity": "sha512-DApE4AbDI+WBajihxB54L4scWQhVGNZAochlC9fkbciPuFAgdRBD3NREb0rgfbKexDC/rioppu/WJA0u8tS+yA==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2665,10 +2665,11 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
-      "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.1.0.tgz",
+      "integrity": "sha512-VaczOZf7+re8aFBIWnex1XENomwHdsSTkrdX43zyor7G/FY4OIsP6X28Xc3o0jiY0YdNuvIDyA5TNwOtpgkCVw==",
       "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "commander": "^5.1.0",
@@ -2684,11 +2685,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-LgZfp0D+UBqAh7PZ//MUNSFBMavmAPku6Si9x8x3V+S318IGCNJ6hUr2O29UO0oLybEWUjD5Jnj9IUN6XyZeeg==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2719,9 +2720,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
-      "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.1.0.tgz",
+      "integrity": "sha512-SfvnRLHoZ9bwTw67knkSs7IcUR0GY2SaGkpdB/J9pChrDiGhwzKNUhcieoPyPYrOWGRPk3rVNYtoy+Bc7psPAw==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2738,12 +2739,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
-      "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.1.0.tgz",
+      "integrity": "sha512-dFxhs1NLxPOSzmcTk/eeKxLY5R+U4cua22g9MsAMiRWcwFKStZ2W3/GDY0GmnJGqNS8QAQepJrxQoyxXkJNDeg==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -4016,30 +4017,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
-      "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.0.tgz",
+      "integrity": "sha512-gfceltjkwh7PxXwtkS8KVvdfK+TSNQAWUeNSxf4dA29qW5tf2EGwa8jkJujlT9jLm17cixMVoGNc+GJFO1Mxhg==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.20.0",
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/cache-in-memory": "4.20.0",
-        "@algolia/client-account": "4.20.0",
-        "@algolia/client-analytics": "4.20.0",
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-personalization": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/logger-console": "4.20.0",
-        "@algolia/requester-browser-xhr": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/requester-node-http": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/cache-browser-local-storage": "4.22.0",
+        "@algolia/cache-common": "4.22.0",
+        "@algolia/cache-in-memory": "4.22.0",
+        "@algolia/client-account": "4.22.0",
+        "@algolia/client-analytics": "4.22.0",
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-personalization": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/logger-common": "4.22.0",
+        "@algolia/logger-console": "4.22.0",
+        "@algolia/requester-browser-xhr": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/requester-node-http": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.15.0.tgz",
-      "integrity": "sha512-DGUnK3TGtDQsaUE4ayF/LjSN0DGsuYThB8WBgnnDY0Wq04K6lNVruO3LfqJOgSfDiezp+Iyt8Tj4YKHi+/ivSA==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.1.tgz",
+      "integrity": "sha512-qxAHVjjmT7USVvrM8q6gZGaJlCK1fl4APfdAA7o8O6iXEc68G0xMNrzRkxoB/HmhhvyHnoteS/iMTiHiTcQQcg==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -7613,9 +7614,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
+      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
       "dependencies": {
         "queue": "6.0.2"
       },
@@ -7623,7 +7624,7 @@
         "image-size": "bin/image-size.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.x"
       }
     },
     "node_modules/immer": {
@@ -13128,9 +13129,9 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.11.0.tgz",
-      "integrity": "sha512-Uin2J8Bpm3xaZi9Y8QibSys6uJOFZ+REMrf42v20AA3FUDUrshKkMEP6liJbMAHCm71wO6ls4mwAf7a3gFVxLw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
+      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
       "peer": true
     },
     "node_modules/section-matter": {
@@ -15423,74 +15424,74 @@
       "requires": {}
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
-      "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.0.tgz",
+      "integrity": "sha512-uZ1uZMLDZb4qODLfTSNHxSi4fH9RdrQf7DXEzW01dS8XK7QFtFh29N5NGKa9S+Yudf1vUMIF+/RiL4i/J0pWlQ==",
       "requires": {
-        "@algolia/cache-common": "4.20.0"
+        "@algolia/cache-common": "4.22.0"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
-      "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ=="
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.0.tgz",
+      "integrity": "sha512-TPwUMlIGPN16eW67qamNQUmxNiGHg/WBqWcrOoCddhqNTqGDPVqmgfaM85LPbt24t3r1z0zEz/tdsmuq3Q6oaA=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
-      "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.0.tgz",
+      "integrity": "sha512-kf4Cio9NpPjzp1+uXQgL4jsMDeck7MP89BYThSvXSjf2A6qV/0KeqQf90TL2ECS02ovLOBXkk98P7qVarM+zGA==",
       "requires": {
-        "@algolia/cache-common": "4.20.0"
+        "@algolia/cache-common": "4.22.0"
       }
     },
     "@algolia/client-account": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
-      "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.0.tgz",
+      "integrity": "sha512-Bjb5UXpWmJT+yGWiqAJL0prkENyEZTBzdC+N1vBuHjwIJcjLMjPB6j1hNBRbT12Lmwi55uzqeMIKS69w+0aPzA==",
       "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
-      "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.0.tgz",
+      "integrity": "sha512-os2K+kHUcwwRa4ArFl5p/3YbF9lN3TLOPkbXXXxOvDpqFh62n9IRZuzfxpHxMPKAQS3Et1s0BkKavnNP02E9Hg==",
       "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "@algolia/client-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
-      "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.0.tgz",
+      "integrity": "sha512-BlbkF4qXVWuwTmYxVWvqtatCR3lzXwxx628p1wj1Q7QP2+LsTmGt1DiUYRuy9jG7iMsnlExby6kRMOOlbhv2Ag==",
       "requires": {
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
-      "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.0.tgz",
+      "integrity": "sha512-pEOftCxeBdG5pL97WngOBi9w5Vxr5KCV2j2D+xMVZH8MuU/JX7CglDSDDb0ffQWYqcUN+40Ry+xtXEYaGXTGow==",
       "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "@algolia/client-search": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
-      "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.0.tgz",
+      "integrity": "sha512-bn4qQiIdRPBGCwsNuuqB8rdHhGKKWIij9OqidM1UkQxnSG8yzxHdb7CujM30pvp5EnV7jTqDZRbxacbjYVW20Q==",
       "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "@algolia/events": {
@@ -15499,47 +15500,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
-      "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ=="
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.0.tgz",
+      "integrity": "sha512-HMUQTID0ucxNCXs5d1eBJ5q/HuKg8rFVE/vOiLaM4Abfeq1YnTtGV3+rFEhOPWhRQxNDd+YHa4q864IMc0zHpQ=="
     },
     "@algolia/logger-console": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
-      "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.0.tgz",
+      "integrity": "sha512-7JKb6hgcY64H7CRm3u6DRAiiEVXMvCJV5gRE672QFOUgDxo4aiDpfU61g6Uzy8NKjlEzHMmgG4e2fklELmPXhQ==",
       "requires": {
-        "@algolia/logger-common": "4.20.0"
+        "@algolia/logger-common": "4.22.0"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
-      "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.0.tgz",
+      "integrity": "sha512-BHfv1h7P9/SyvcDJDaRuIwDu2yrDLlXlYmjvaLZTtPw6Ok/ZVhBR55JqW832XN/Fsl6k3LjdkYHHR7xnsa5Wvg==",
       "requires": {
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/requester-common": "4.22.0"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
-      "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng=="
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.0.tgz",
+      "integrity": "sha512-Y9cEH/cKjIIZgzvI1aI0ARdtR/xRrOR13g5psCxkdhpgRN0Vcorx+zePhmAa4jdQNqexpxtkUdcKYugBzMZJgQ=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
-      "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.0.tgz",
+      "integrity": "sha512-8xHoGpxVhz3u2MYIieHIB6MsnX+vfd5PS4REgglejJ6lPigftRhTdBCToe6zbwq4p0anZXjjPDvNWMlgK2+xYA==",
       "requires": {
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/requester-common": "4.22.0"
       }
     },
     "@algolia/transporter": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
-      "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.0.tgz",
+      "integrity": "sha512-ieO1k8x2o77GNvOoC+vAkFKppydQSVfbjM3YrSjLmgywiBejPTvU1R1nEvG59JIIUvtSLrZsLGPkd6vL14zopA==",
       "requires": {
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/cache-common": "4.22.0",
+        "@algolia/logger-common": "4.22.0",
+        "@algolia/requester-common": "4.22.0"
       }
     },
     "@ampproject/remapping": {
@@ -16873,9 +16874,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-GWudMGYA9v26ssbAWJNfgeDZk+lrudUTclLPRsmxiknEBk7UMp7Rglonhqbsf3IKHOyHkMU4Fr5jFyg5SBx9jQ==",
       "requires": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -16887,13 +16888,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/cssnano-preset": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
@@ -16949,9 +16950,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
-      "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.0.tgz",
+      "integrity": "sha512-ned7qsgCqSv/e7KyugFNroAfiszuxLwnvMW7gmT2Ywxb/Nyt61yIw7KHyAZCMKglOalrqnYA4gMhLUCK/mVePA==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -16960,24 +16961,24 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.1.0.tgz",
+      "integrity": "sha512-p740M+HCst1VnKKzL60Hru9xfG4EUYJDarjlEC4hHeBy9+afPmY3BNPoSHx9/8zxuYfUlv/psf7I9NvRVdmdvg==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
-      "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.1.0.tgz",
+      "integrity": "sha512-D7onDz/3mgBonexWoQXPw3V2E5Bc4+jYRf9gGUUK+KoQwU8xMDaDkUUfsr7t6UBa/xox9p5+/3zwLuXOYMzGSg==",
       "requires": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -17002,12 +17003,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
-      "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.0.tgz",
+      "integrity": "sha512-XUl7Z4PWlKg4l6KF05JQ3iDHQxnPxbQUqTNKvviHyuHdlalOFv6qeDAm7IbzyQPJD5VA6y4dpRbTWSqP9ClwPg==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.0.1",
+        "@docusaurus/types": "3.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -17017,17 +17018,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
-      "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.0.tgz",
+      "integrity": "sha512-iMa6WBaaEdYuxckvJtLcq/HQdlA4oEbCXf/OFfsYJCCULcDX7GDZpKxLF3X1fLsax3sSm5bmsU+CA0WD+R1g3A==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -17041,17 +17042,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
-      "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.0.tgz",
+      "integrity": "sha512-el5GxhT8BLrsWD0qGa8Rq+Ttb/Ni6V3DGT2oAPio0qcs/mUAxeyXEAmihkvmLCnAgp6xD27Ce7dISZ5c6BXeqA==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -17063,101 +17064,101 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
-      "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.0.tgz",
+      "integrity": "sha512-9gntYQFpk+93+Xl7gYczJu8I9uWoyRLnRwS0+NUFcs9iZtHKsdqKWPRrONC9elfN3wJ9ORwTbcVzsTiB8jvYlg==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
-      "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.1.0.tgz",
+      "integrity": "sha512-AbvJwCVRbmQ8w9d8QXbF4Iq/ui0bjPZNYFIhtducGFnm2YQRN1mraK8mCEQb0Aq0T8SqRRvSfC/far4n/s531w==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
-      "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.0.tgz",
+      "integrity": "sha512-zvUOMzu9Uhz0ciqnSbtnp/5i1zEYlzarQrOXG90P3Is3efQI43p2YLW/rzSGdLb5MfQo2HvKT6Q5+tioMO045Q==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
-      "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.0.tgz",
+      "integrity": "sha512-0txshvaY8qIBdkk2UATdVcfiCLGq3KAUfuRQD2cRNgO39iIf4/ihQxH9NXcRTwKs4Q5d9yYHoix3xT6pFuEYOg==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
-      "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.0.tgz",
+      "integrity": "sha512-zOWPEi8kMyyPtwG0vhyXrdbLs8fIZmY5vlbi9lUU+v8VsroO5iHmfR2V3SMsrsfOanw5oV/ciWqbxezY00qEZg==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
-      "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.0.tgz",
+      "integrity": "sha512-TkR5vGBpUooEB9SoW42thahqqwKzfHrQQhkB+JrEGERsl4bKODSuJNle4aA4h6LSkg4IyfXOW8XOI0NIPWb9Cg==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
-      "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.1.0.tgz",
+      "integrity": "sha512-xGLQRFmmT9IinAGUDVRYZ54Ys28USNbA3OTXQXnSJLPr1rCY7CYnHI4XoOnKWrNnDiAI4ruMzunXWyaElUYCKQ==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/plugin-debug": "3.0.1",
-        "@docusaurus/plugin-google-analytics": "3.0.1",
-        "@docusaurus/plugin-google-gtag": "3.0.1",
-        "@docusaurus/plugin-google-tag-manager": "3.0.1",
-        "@docusaurus/plugin-sitemap": "3.0.1",
-        "@docusaurus/theme-classic": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-search-algolia": "3.0.1",
-        "@docusaurus/types": "3.0.1"
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/plugin-debug": "3.1.0",
+        "@docusaurus/plugin-google-analytics": "3.1.0",
+        "@docusaurus/plugin-google-gtag": "3.1.0",
+        "@docusaurus/plugin-google-tag-manager": "3.1.0",
+        "@docusaurus/plugin-sitemap": "3.1.0",
+        "@docusaurus/theme-classic": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-search-algolia": "3.1.0",
+        "@docusaurus/types": "3.1.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -17170,22 +17171,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
-      "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.1.0.tgz",
+      "integrity": "sha512-/+jMl2Z9O8QQxves5AtHdt91gWsEZFgOV3La/6eyKEd7QLqQUtM5fxEJ40rq9NKYjqCd1HzZ9egIMeJoWwillw==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-translations": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -17202,17 +17203,17 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
-      "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.1.0.tgz",
+      "integrity": "sha512-YGwEFALLIbF5ocW/Fy6Ae7tFWUOugEN3iwxTx8UkLAcLqYUboDSadesYtVBmRCEB4FVA2qoP7YaW3lu3apUPPw==",
       "requires": {
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -17224,18 +17225,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
-      "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.0.tgz",
+      "integrity": "sha512-8cJH0ZhPsEDjq3jR3I+wHmWzVY2bXMQJ59v2QxUmsTZxbWA4u+IzccJMIJx4ooFl9J6iYynwYsFuHxyx/KUmfQ==",
       "requires": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-translations": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -17247,19 +17248,20 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
-      "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.1.0.tgz",
+      "integrity": "sha512-DApE4AbDI+WBajihxB54L4scWQhVGNZAochlC9fkbciPuFAgdRBD3NREb0rgfbKexDC/rioppu/WJA0u8tS+yA==",
       "requires": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
-      "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.1.0.tgz",
+      "integrity": "sha512-VaczOZf7+re8aFBIWnex1XENomwHdsSTkrdX43zyor7G/FY4OIsP6X28Xc3o0jiY0YdNuvIDyA5TNwOtpgkCVw==",
       "requires": {
+        "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "commander": "^5.1.0",
@@ -17271,11 +17273,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-LgZfp0D+UBqAh7PZ//MUNSFBMavmAPku6Si9x8x3V+S318IGCNJ6hUr2O29UO0oLybEWUjD5Jnj9IUN6XyZeeg==",
       "requires": {
-        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -17295,20 +17297,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
-      "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.1.0.tgz",
+      "integrity": "sha512-SfvnRLHoZ9bwTw67knkSs7IcUR0GY2SaGkpdB/J9pChrDiGhwzKNUhcieoPyPYrOWGRPk3rVNYtoy+Bc7psPAw==",
       "requires": {
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
-      "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.1.0.tgz",
+      "integrity": "sha512-dFxhs1NLxPOSzmcTk/eeKxLY5R+U4cua22g9MsAMiRWcwFKStZ2W3/GDY0GmnJGqNS8QAQepJrxQoyxXkJNDeg==",
       "requires": {
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -18347,30 +18349,30 @@
       }
     },
     "algoliasearch": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
-      "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.0.tgz",
+      "integrity": "sha512-gfceltjkwh7PxXwtkS8KVvdfK+TSNQAWUeNSxf4dA29qW5tf2EGwa8jkJujlT9jLm17cixMVoGNc+GJFO1Mxhg==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.20.0",
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/cache-in-memory": "4.20.0",
-        "@algolia/client-account": "4.20.0",
-        "@algolia/client-analytics": "4.20.0",
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-personalization": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/logger-console": "4.20.0",
-        "@algolia/requester-browser-xhr": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/requester-node-http": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/cache-browser-local-storage": "4.22.0",
+        "@algolia/cache-common": "4.22.0",
+        "@algolia/cache-in-memory": "4.22.0",
+        "@algolia/client-account": "4.22.0",
+        "@algolia/client-analytics": "4.22.0",
+        "@algolia/client-common": "4.22.0",
+        "@algolia/client-personalization": "4.22.0",
+        "@algolia/client-search": "4.22.0",
+        "@algolia/logger-common": "4.22.0",
+        "@algolia/logger-console": "4.22.0",
+        "@algolia/requester-browser-xhr": "4.22.0",
+        "@algolia/requester-common": "4.22.0",
+        "@algolia/requester-node-http": "4.22.0",
+        "@algolia/transporter": "4.22.0"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.15.0.tgz",
-      "integrity": "sha512-DGUnK3TGtDQsaUE4ayF/LjSN0DGsuYThB8WBgnnDY0Wq04K6lNVruO3LfqJOgSfDiezp+Iyt8Tj4YKHi+/ivSA==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.1.tgz",
+      "integrity": "sha512-qxAHVjjmT7USVvrM8q6gZGaJlCK1fl4APfdAA7o8O6iXEc68G0xMNrzRkxoB/HmhhvyHnoteS/iMTiHiTcQQcg==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -20919,9 +20921,9 @@
       "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg=="
     },
     "image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
+      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
       "requires": {
         "queue": "6.0.2"
       }
@@ -24429,9 +24431,9 @@
       }
     },
     "search-insights": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.11.0.tgz",
-      "integrity": "sha512-Uin2J8Bpm3xaZi9Y8QibSys6uJOFZ+REMrf42v20AA3FUDUrshKkMEP6liJbMAHCm71wO6ls4mwAf7a3gFVxLw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
+      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
       "peer": true
     },
     "section-matter": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,9 +15,9 @@
     "prettier": "npx prettier --check docs",
     "prettier:fix": "npx prettier --write --check docs"},
   "dependencies": {
-    "@docusaurus/core": "3.0.1",
-    "@docusaurus/plugin-google-tag-manager": "^3.0.1",
-    "@docusaurus/preset-classic": "3.0.1",
+    "@docusaurus/core": "3.1.0",
+    "@docusaurus/plugin-google-tag-manager": "^3.1.0",
+    "@docusaurus/preset-classic": "3.1.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -27,8 +27,8 @@
     "redoc": "^2.1.3"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.0.1",
-    "@docusaurus/types": "3.0.1"
+    "@docusaurus/module-type-aliases": "3.1.0",
+    "@docusaurus/types": "3.1.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Upgrades docusaurus to `3.1.0`

We are getting warnings as described here https://github.com/facebook/docusaurus/issues/9715

3.1.0 checks anchor links so I fixed all those warnings and update the links where needed