### PR TITLE
fix: OR button hiding and empty condtions

### DIFF
--- a/frontend/web/components/modals/Rule.tsx
+++ b/frontend/web/components/modals/Rule.tsx
@@ -29,7 +29,13 @@ export default class Rule extends PureComponent<{
         rule: { conditions: rules },
       },
     } = this
-    const isLastRule = i === rules.length - 1
+    const lastIndex = rules.reduce((acc, v, i) => {
+      if (!v.delete) {
+        return i
+      }
+      return acc
+    }, 0)
+    const isLastRule = i === lastIndex
     const hasOr = i > 0
     const operatorObj = Utils.findOperator(rule.operator, rule.value, operators)
     const operator = operatorObj && operatorObj.value
@@ -204,6 +210,11 @@ export default class Rule extends PureComponent<{
     if (prop === 'operator' && value === 'PERCENTAGE_SPLIT') {
       rules[i].property = ''
       rules[i].value = ''
+    }
+
+    if (prop === 'delete') {
+      rules[i].property = 'deleted'
+      rules[i].value = 'deleted'
     }
 
     if (!rule.conditions.filter((condition) => !condition.delete).length) {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- I've changed how the last index of the Condition Row is calculated, so it doesn't count the deleted ones, making the OR button show on the last visible row.
- I've changed the setRuleProperty function so it sets a default deletion value and property: "deleted", as @kyle-ssg  [suggested](https://github.com/Flagsmith/flagsmith/issues/3244#issuecomment-1885433990_).

## How did you test this code?

I've created all conditions types inside the segment overrides, filled it with dummy values, deleted it all and then tried to save the new segment. The API didn't complain about the default deletion values, and the OR button was there all the time. 

fixes #3244 
