### PR TITLE
fix: Reset password error handling

### DIFF
--- a/frontend/web/components/base/forms/InputGroup.js
+++ b/frontend/web/components/base/forms/InputGroup.js
@@ -108,7 +108,10 @@ const InputGroup = class extends Component {
               id={props.inputProps.name ? `${props.inputProps.name}-error` : ''}
               className='text-danger'
             >
-              {inputProps.error}
+              {typeof inputProps.error === 'string'
+                ? inputProps.error
+                : !!inputProps.error?.length &&
+                  inputProps.error.map((err, i) => <div key={i}>{err}</div>)}
             </span>
           </span>
         )}

--- a/frontend/web/components/pages/PasswordResetPage.js
+++ b/frontend/web/components/pages/PasswordResetPage.js
@@ -56,7 +56,7 @@ const PasswordResetPage = class extends Component {
                   <InputGroup
                     inputProps={{
                       className: 'full-width',
-                      error: error && error.new_password1,
+                      error: error && error.new_password,
                       name: 'new-password',
                     }}
                     title='New Password'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Reset password page now shows field errors
- Field errors that are an array will now show on separate lines 

<img width="999" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/82e1268d-6a8e-43fa-bee5-528a5760b9b1">

## How did you test this code?

- Attempted reset password with bad data