### PR TITLE
chore: default task processor to use TaskRunMethod.TASK_PROCESSOR

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -897,7 +897,11 @@ MAX_SELF_MIGRATABLE_IDENTITIES = env.int("MAX_SELF_MIGRATABLE_IDENTITIES", 10000
 # Setting to allow asynchronous tasks to be run synchronously for testing purposes
 # or in a separate thread for self-hosted users
 TASK_RUN_METHOD = env.enum(
-    "TASK_RUN_METHOD", type=TaskRunMethod, default=TaskRunMethod.SEPARATE_THREAD.value
+    "TASK_RUN_METHOD",
+    type=TaskRunMethod,
+    default=TaskRunMethod.TASK_PROCESSOR.value
+    if env.bool("RUN_BY_PROCESSOR", False)
+    else TaskRunMethod.SEPARATE_THREAD.value,
 )
 ENABLE_TASK_PROCESSOR_HEALTH_CHECK = env.bool(
     "ENABLE_TASK_PROCESSOR_HEALTH_CHECK", default=False


### PR DESCRIPTION
## Changes

This PR updates the default value of the `TASK_RUN_METHOD` setting such that the task processor should always default to using the task processor itself, for any asynchronous invocations inside the tasks themselves. 

## How did you test this code?

In staging, we noticed that the changes made in [this PR](https://github.com/Flagsmith/flagsmith/issues/2932) did not work as expected, since the tasks were run in a separate thread, not scheduled for the task processor. We will retest this behaviour in staging once this PR is merged. 

Ran the processor locally and confirmed that the TASK_RUN_METHOD setting was correctly set to TASK_PROCESSOR when RUN_BY_PROCESSOR=True. 

Ran the API locally and confirmed that the TASK_RUN_METHOD setting was correctly defaulted to SEPARATE_THREAD when RUN_BY_PROCESSOR=False 