### PR TITLE
fix: Paging spacer logic

### DIFF
--- a/frontend/web/components/Paging.js
+++ b/frontend/web/components/Paging.js
@@ -100,7 +100,7 @@ export default class Paging extends PureComponent {
                   {index + 1}
                 </div>
               ))}
-            {!noPages && !range.includes(lastPage - 2) && (
+            {!noPages && !range.includes(lastPage - 1) && (
               <>
                 <div
                   className={cn({

--- a/frontend/web/components/Paging.js
+++ b/frontend/web/components/Paging.js
@@ -100,22 +100,24 @@ export default class Paging extends PureComponent {
                   {index + 1}
                 </div>
               ))}
-            {!noPages && !range.includes(lastPage - 1) && (
-              <>
-                <div
-                  className={cn({
-                    page: true,
-                  })}
-                  onClick={
-                    paging.currentPage === lastPage + 1
-                      ? undefined
-                      : () => goToPage(1)
-                  }
-                >
-                  ...
-                </div>
-              </>
-            )}
+            {!noPages &&
+              !range.includes(lastPage - 1) &&
+              !range.includes(lastPage - 2) && (
+                <>
+                  <div
+                    className={cn({
+                      page: true,
+                    })}
+                    onClick={
+                      paging.currentPage === lastPage + 1
+                        ? undefined
+                        : () => goToPage(1)
+                    }
+                  >
+                    ...
+                  </div>
+                </>
+              )}
             {!noPages && !range.includes(lastPage - 1) && (
               <>
                 <div


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The paging spacer should show when the last and second last pages aren't visible, currently this shows when there's only 1 page.

Before: 

<img width="301" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/efcf542d-f1dd-4b89-b68c-376e7e98bba0">


After: 

<img width="302" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/160e5fc6-b997-452f-b473-9780167842d9">




## How did you test this code?

<img width="408" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/d5297df7-dc2d-4fc0-a607-094ef575de13">
<img width="468" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/f9d913e9-fff8-4bb1-a73a-003c0343173b">
<img width="492" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/e00314eb-0e2f-4986-9cf8-88e27ba29f77">
<img width="460" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/6f4b3c98-c194-4591-9f89-86a512d49819">
<img width="452" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/52758d64-1546-47a5-8c0c-d7379be43acd">

