### PR TITLE
chore: Silence Axes warning

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -156,6 +156,8 @@ INSTALLED_APPS = [
     "app_analytics",
 ]
 
+SILENCED_SYSTEM_CHECKS = ["axes.W002"]
+
 SITE_ID = 1
 
 db_conn_max_age = env.int("DJANGO_DB_CONN_MAX_AGE", 60)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR adds a setting to silence the following warning on Core API startup:

```
WARNINGS:
?: (axes.W002) You do not have 'axes.middleware.AxesMiddleware' in your settings.MIDDLEWARE.
```

## How did you test this code?

Brought up the service locally.