### PR TITLE
ci: Move merge GHA workflow to its own yaml file. WIP

### DIFF
--- a/.github/workflows/api-merge.yml
+++ b/.github/workflows/api-merge.yml
@@ -1,17 +1,8 @@
-name: API Pull Request
+name: API Merge
 
 on:
-  pull_request:
-    paths:
-      - api/**
-      - .github/**
-    types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    paths:
-      - api/**
-      - .github/**
-    branches:
-      - main
+  merge_group:
+    types: [checks_requested]
 
 defaults:
   run:
@@ -63,34 +54,14 @@ jobs:
 
       - name: Check for missing migrations
         env:
-          DOTENV_OVERRIDE_FILE: .env-ci-testmon
+          DOTENV_OVERRIDE_FILE: .env-ci
           opts: --no-input --dry-run --check
         run: make django-make-migrations
 
-      - name: Restore cached testmon data
-        if: ${{ github.event_name == 'pull_request' }}
-        id: cache-testmon-restore
-        uses: actions/cache/restore@v3
-        with:
-          enableCrossOsArchive: true
-          path: |
-            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
-          key: testmon-data-python${{ matrix.python-version }}-${{ github.event.pull_request.base.sha }}
-          restore-keys: testmon-data-python${{ matrix.python-version }}-
-
       - name: Run Tests
         env:
-          DOTENV_OVERRIDE_FILE: .env-ci-testmon
+          DOTENV_OVERRIDE_FILE: .env-ci
         run: make test
-
-      - name: Save testmon data cache
-        id: cache-testmon-save
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
-          key: testmon-data-python${{ matrix.python-version }}-${{github.sha}}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Moved the merge GHA workflow to its own yaml file so we can track the execution more easily. Also,  removed the corresponding code from the existing `api-pull-request.yml` file.

To make the workflow run we needed to ask @matthewelwell to change the repository settings in GitHub by adding `requested checks` as per the image below:
![image](https://github.com/Flagsmith/flagsmith/assets/41410593/da5e0753-f5a7-427f-ae5a-b9476ea01778)

## How did you test this code?

Manually tested by merging a re-bumped version of this PR https://github.com/Flagsmith/flagsmith/pull/3264