### PR TITLE
chore: bump postgres version to 15.5

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.12-alpine
+        image: postgres:15.5-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:11.12-alpine
+    image: postgres:15.5-alpine
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: flagsmith

--- a/docker/api/docker-compose.datadog.yml
+++ b/docker/api/docker-compose.datadog.yml
@@ -4,7 +4,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:11.12-alpine
+    image: postgres:15.5-alpine
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: flagsmith

--- a/docker/db.yml
+++ b/docker/db.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   db:
-    image: postgres:11.12-alpine
+    image: postgres:15.5-alpine
     pull_policy: always
     restart: unless-stopped
     volumes:

--- a/docs/docs/deployment/configuration/importing-and-exporting.md
+++ b/docs/docs/deployment/configuration/importing-and-exporting.md
@@ -79,7 +79,7 @@ obtain the file afterwards. There is an example docker-compose file provided bel
 version: '3'
 services:
  postgres:
-  image: postgres:11.12-alpine
+  image: postgres:15.5-alpine
   environment:
    POSTGRES_PASSWORD: password
    POSTGRES_DB: flagsmith

--- a/docs/docs/deployment/configuration/task-processor.md
+++ b/docs/docs/deployment/configuration/task-processor.md
@@ -13,7 +13,7 @@ A basic docker-compose setup might look like:
 
 ```yaml
     postgres:
-        image: postgres:11.12-alpine
+        image: postgres:15.5-alpine
         environment:
             POSTGRES_PASSWORD: password
             POSTGRES_DB: flagsmith

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -346,7 +346,7 @@ metrics from external services.
 version: '3'
 services:
  postgres:
-  image: postgres:11.12-alpine
+  image: postgres:15.5-alpine
   environment:
    POSTGRES_PASSWORD: password
    POSTGRES_DB: flagsmith

--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -6,7 +6,7 @@
 version: '3'
 services:
   db:
-    image: postgres:11.12-alpine
+    image: postgres:15.5-alpine
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: flagsmith


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Bump postgres versiont to 15.5(because 16 is not  yet supported by [aws](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html) yet) and 11.x have reached end of life

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Locally tested with postgres 15.5 