### PR TITLE
chore: add no root to poetry makefile

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -22,7 +22,7 @@ install-poetry:
 
 .PHONY: install-packages
 install-packages:
-	poetry install $(opts)
+	poetry install --no-root $(opts)
 
 .PHONY: install
 install: install-pip install-poetry install-packages


### PR DESCRIPTION
Fixes this:

```log
❯ poetry install
The currently activated Python version 3.12.1 is not supported by the project (>=3.10,<3.12).
Trying to find and use a compatible version.
Using python3 (3.11.1)
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: flagsmith-api (2.68.0)
**The current project could not be installed: No file/folder found for package flagsmith-api**
If you do not want to install the current project use --no-root
```