### PR TITLE
chore: Convert heap integration views TestCase to normal test function

### DIFF
--- a/api/tests/unit/integrations/heap/test_unit_heap_views.py
+++ b/api/tests/unit/integrations/heap/test_unit_heap_views.py
@@ -1,128 +1,127 @@
 import json
-from unittest.case import TestCase
 
-import pytest
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from environments.models import Environment
 from integrations.heap.models import HeapConfiguration
-from organisations.models import Organisation, OrganisationRole
-from projects.models import Project
-from util.tests import Helper
 
 
-@pytest.mark.django_db
-class HeapConfigurationTestCase(TestCase):
-    def setUp(self):
-        self.client = APIClient()
-        user = Helper.create_ffadminuser()
-        self.client.force_authenticate(user=user)
+def test_should_create_heap_config_when_post(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    data = {"api_key": "abc-123"}
+    url = reverse(
+        "api-v1:environments:integrations-heap-list",
+        args=[environment.api_key],
+    )
+    # When
+    response = admin_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
 
-        self.organisation = Organisation.objects.create(name="Test Org")
-        user.add_organisation(
-            self.organisation, OrganisationRole.ADMIN
-        )  # admin to bypass perms
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert HeapConfiguration.objects.filter(environment=environment).count() == 1
 
-        self.project = Project.objects.create(
-            name="Test project", organisation=self.organisation
-        )
-        self.environment = Environment.objects.create(
-            name="Test Environment", project=self.project
-        )
-        self.list_url = reverse(
-            "api-v1:environments:integrations-heap-list",
-            args=[self.environment.api_key],
-        )
 
-    def test_should_create_heap_config_when_post(self):
-        # Given
-        data = {"api_key": "abc-123"}
+def test_should_return_400_when_duplicate_heap_config_is_posted(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    config = HeapConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
+    data = {"api_key": config.api_key}
+    url = reverse(
+        "api-v1:environments:integrations-heap-list",
+        args=[environment.api_key],
+    )
 
-        # When
-        response = self.client.post(
-            self.list_url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
+    # When
+    response = admin_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
 
-        # Then
-        assert response.status_code == status.HTTP_201_CREATED
-        assert (
-            HeapConfiguration.objects.filter(environment=self.environment).count() == 1
-        )
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert HeapConfiguration.objects.filter(environment=environment).count() == 1
 
-    def test_should_return_BadRequest_when_duplicate_heap_config_is_posted(self):
-        # Given
-        config = HeapConfiguration.objects.create(
-            api_key="api_123", environment=self.environment
-        )
 
-        # When
-        data = {"api_key": config.api_key}
-        response = self.client.post(
-            self.list_url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
+def test_should_update_configuration_when_put(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    config = HeapConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
 
-        # Then
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert (
-            HeapConfiguration.objects.filter(environment=self.environment).count() == 1
-        )
+    api_key_updated = "new api"
+    data = {"api_key": api_key_updated}
 
-    def test_should_update_configuration_when_put(self):
-        # Given
-        config = HeapConfiguration.objects.create(
-            api_key="api_123", environment=self.environment
-        )
+    # When
+    url = reverse(
+        "api-v1:environments:integrations-heap-detail",
+        args=[environment.api_key, config.id],
+    )
+    response = admin_client.put(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    config.refresh_from_db()
 
-        api_key_updated = "new api"
-        data = {"api_key": api_key_updated}
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert config.api_key == api_key_updated
 
-        # When
-        url = reverse(
-            "api-v1:environments:integrations-heap-detail",
-            args=[self.environment.api_key, config.id],
-        )
-        response = self.client.put(
-            url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
-        config.refresh_from_db()
 
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert config.api_key == api_key_updated
+def test_should_return_heap_config_list_when_requested(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    config = HeapConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
+    url = reverse(
+        "api-v1:environments:integrations-heap-list",
+        args=[environment.api_key],
+    )
 
-    def test_should_return_heap_config_list_when_requested(self):
-        # Given - set up data
+    # When
+    response = admin_client.get(url)
 
-        # When
-        response = self.client.get(self.list_url)
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    expected_response = {"api_key": config.api_key, "id": config.id}
+    assert response.data == [expected_response]
 
-        # Then
-        assert response.status_code == status.HTTP_200_OK
 
-    def test_should_remove_configuration_when_delete(self):
-        # Given
-        config = HeapConfiguration.objects.create(
-            api_key="api_123", environment=self.environment
-        )
+def test_should_remove_configuration_when_delete(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    config = HeapConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
 
-        # When
-        url = reverse(
-            "api-v1:environments:integrations-heap-detail",
-            args=[self.environment.api_key, config.id],
-        )
-        res = self.client.delete(url)
+    # When
+    url = reverse(
+        "api-v1:environments:integrations-heap-detail",
+        args=[environment.api_key, config.id],
+    )
+    res = admin_client.delete(url)
 
-        # Then
-        assert res.status_code == status.HTTP_204_NO_CONTENT
-        #  and
-        assert not HeapConfiguration.objects.filter(
-            environment=self.environment
-        ).exists()
+    # Then
+    assert res.status_code == status.HTTP_204_NO_CONTENT
+    assert not HeapConfiguration.objects.filter(environment=environment).exists()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I'm working through re-writing the `TestCase` classes into normal test functions. Rewrote the existing TestCase and replaced with fixtures instead of recreating everything. This PR is similiar in structure to a recent PR of mine [located here.](https://github.com/Flagsmith/flagsmith/pull/3284)

## How did you test this code?

I manually changed the tests one at a time to refactor them as I went then ran the full test suite afterwards. Also, I added assertions where I thought more were needed, for example missing `response.data` checks.