### PR TITLE
chore: Convert datadog integration views TestCase to normal test function

### DIFF
--- a/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
+++ b/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
@@ -1,124 +1,121 @@
 import json
-from unittest.case import TestCase
 
-import pytest
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from environments.models import Environment
 from integrations.datadog.models import DataDogConfiguration
-from organisations.models import Organisation, OrganisationRole
 from projects.models import Project
-from util.tests import Helper
 
 
-@pytest.mark.django_db
-class DatadogConfigurationTestCase(TestCase):
-    def setUp(self):
-        self.client = APIClient()
-        user = Helper.create_ffadminuser()
-        self.client.force_authenticate(user=user)
+def test_should_create_datadog_config_when_post(
+    admin_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    data = {"base_url": "http://test.com", "api_key": "abc-123"}
+    url = reverse("api-v1:projects:integrations-datadog-list", args=[project.id])
+    # When
+    response = admin_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
 
-        self.organisation = Organisation.objects.create(name="Test Org")
-        user.add_organisation(
-            self.organisation, OrganisationRole.ADMIN
-        )  # admin to bypass perms
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert DataDogConfiguration.objects.filter(project=project).count() == 1
 
-        self.project = Project.objects.create(
-            name="Test project", organisation=self.organisation
-        )
-        self.environment = Environment.objects.create(
-            name="Test Environment", project=self.project
-        )
-        self.list_url = reverse(
-            "api-v1:projects:integrations-datadog-list", args=[self.project.id]
-        )
 
-    def test_should_create_datadog_config_when_post(self):
-        # Given setup data
-        data = {"base_url": "http://test.com", "api_key": "abc-123"}
+def test_should_return_400_when_duplicate_datadog_config_is_posted(
+    admin_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    DataDogConfiguration.objects.create(
+        base_url="http://test.com", api_key="api_123", project=project
+    )
+    data = {"base_url": "http://test.com", "api_key": "abc-123"}
+    url = reverse("api-v1:projects:integrations-datadog-list", args=[project.id])
 
-        # When
-        response = self.client.post(
-            self.list_url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
+    # When
+    response = admin_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
 
-        # Then
-        assert response.status_code == status.HTTP_201_CREATED
-        # and
-        assert DataDogConfiguration.objects.filter(project=self.project).count() == 1
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert DataDogConfiguration.objects.filter(project=project).count() == 1
 
-    def test_should_return_BadRequest_when_duplicate_datadog_config_is_posted(self):
-        # Given
-        DataDogConfiguration.objects.create(
-            base_url="http://test.com", api_key="api_123", project=self.project
-        )
-        data = {"base_url": "http://test.com", "api_key": "abc-123"}
 
-        # When
-        response = self.client.post(
-            self.list_url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
+def test_should_update_configuration_when_put(
+    admin_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    config = DataDogConfiguration.objects.create(
+        base_url="http://test.com", api_key="api_123", project=project
+    )
+    api_key_updated = "new api"
+    data = {"base_url": config.base_url, "api_key": api_key_updated}
 
-        # Then
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert DataDogConfiguration.objects.filter(project=self.project).count() == 1
+    # When
+    url = reverse(
+        "api-v1:projects:integrations-datadog-detail",
+        args=[project.id, config.id],
+    )
+    response = admin_client.put(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    config.refresh_from_db()
 
-    #
-    def test_should_update_configuration_when_put(self):
-        # Given
-        config = DataDogConfiguration.objects.create(
-            base_url="http://test.com", api_key="api_123", project=self.project
-        )
-        api_key_updated = "new api"
-        data = {"base_url": config.base_url, "api_key": api_key_updated}
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert config.api_key == api_key_updated
 
-        # When
-        url = reverse(
-            "api-v1:projects:integrations-datadog-detail",
-            args=[self.project.id, config.id],
-        )
-        response = self.client.put(
-            url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
-        config.refresh_from_db()
 
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert config.api_key == api_key_updated
+def test_should_return_datadog_config_list_when_requested(
+    admin_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    config = DataDogConfiguration.objects.create(
+        base_url="http://test.com", api_key="api_123", project=project
+    )
+    url = reverse("api-v1:projects:integrations-datadog-list", args=[project.id])
 
-    def test_should_return_datadog_config_list_when_requested(self):
-        # Given - set up data
+    # When
+    response = admin_client.get(url)
 
-        # When
-        response = self.client.get(self.list_url)
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == [
+        {"api_key": config.api_key, "base_url": config.base_url, "id": config.id}
+    ]
 
-        # Then
-        assert response.status_code == status.HTTP_200_OK
 
-    def test_should_remove_configuration_when_delete(self):
-        # Given
-        config = DataDogConfiguration.objects.create(
-            base_url="http://test.com", api_key="api_123", project=self.project
-        )
-        # When
-        url = reverse(
-            "api-v1:projects:integrations-datadog-detail",
-            args=[self.project.id, config.id],
-        )
-        res = self.client.delete(url)
+def test_should_remove_configuration_when_delete(
+    admin_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    config = DataDogConfiguration.objects.create(
+        base_url="http://test.com", api_key="api_123", project=project
+    )
+    # When
+    url = reverse(
+        "api-v1:projects:integrations-datadog-detail",
+        args=[project.id, config.id],
+    )
+    response = admin_client.delete(url)
 
-        # Then
-        assert res.status_code == status.HTTP_204_NO_CONTENT
-        #  and
-        assert not DataDogConfiguration.objects.filter(project=self.project).exists()
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not DataDogConfiguration.objects.filter(project=project).exists()
 
 
 def test_create_datadog_configuration_in_project_with_deleted_configuration(


### PR DESCRIPTION


Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I'm working through re-writing the `TestCase` classes into normal test functions. Rewrote the existing `TestCase` and replaced with fixtures instead of recreating everything. There are other PRs that are similar to this one.

## How did you test this code?

I manually changed the tests one at a time to refactor them as I went then ran the full test suite afterwards. Also, I added assertions where I thought more were needed, for example missing `response.data` checks.