### PR TITLE
chore: Convert rudderstack integration views TestCase to normal test function

### DIFF
--- a/api/tests/unit/integrations/rudderstack/test_unit_rudderstack_views.py
+++ b/api/tests/unit/integrations/rudderstack/test_unit_rudderstack_views.py
@@ -1,139 +1,138 @@
 import json
-from unittest.case import TestCase
 
-import pytest
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from environments.models import Environment
 from integrations.rudderstack.models import RudderstackConfiguration
-from organisations.models import Organisation, OrganisationRole
-from projects.models import Project
-from util.tests import Helper
 
 
-@pytest.mark.django_db
-class RudderstackConfigurationTestCase(TestCase):
-    def setUp(self):
-        self.client = APIClient()
-        user = Helper.create_ffadminuser()
-        self.client.force_authenticate(user=user)
+def test_should_create_rudderstack_config_when_post(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    data = {"api_key": "abc-123"}
 
-        self.organisation = Organisation.objects.create(name="Test Org")
-        user.add_organisation(
-            self.organisation, OrganisationRole.ADMIN
-        )  # admin to bypass perms
+    url = reverse(
+        "api-v1:environments:integrations-rudderstack-list",
+        args=[environment.api_key],
+    )
 
-        self.project = Project.objects.create(
-            name="Test project", organisation=self.organisation
-        )
-        self.environment = Environment.objects.create(
-            name="Test Environment", project=self.project
-        )
-        self.list_url = reverse(
-            "api-v1:environments:integrations-rudderstack-list",
-            args=[self.environment.api_key],
-        )
+    # When
+    response = admin_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
 
-    def test_should_create_rudderstack_config_when_post(self):
-        # Given
-        data = {"api_key": "abc-123"}
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert RudderstackConfiguration.objects.filter(environment=environment).count() == 1
 
-        # When
-        response = self.client.post(
-            self.list_url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
 
-        # Then
-        assert response.status_code == status.HTTP_201_CREATED
-        assert (
-            RudderstackConfiguration.objects.filter(
-                environment=self.environment
-            ).count()
-            == 1
-        )
+def test_should_return_400_when_duplicate_rudderstack_config_is_posted(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    config = RudderstackConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
 
-    def test_should_return_BadRequest_when_duplicate_rudderstack_config_is_posted(self):
-        # Given
-        config = RudderstackConfiguration.objects.create(
-            api_key="api_123", environment=self.environment
-        )
+    url = reverse(
+        "api-v1:environments:integrations-rudderstack-list",
+        args=[environment.api_key],
+    )
+    data = {"api_key": config.api_key}
 
-        # When
-        data = {"api_key": config.api_key}
-        response = self.client.post(
-            self.list_url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
+    # When
+    response = admin_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
 
-        # Then
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert (
-            RudderstackConfiguration.objects.filter(
-                environment=self.environment
-            ).count()
-            == 1
-        )
+    # Then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert RudderstackConfiguration.objects.filter(environment=environment).count() == 1
 
-    def test_should_update_configuration_when_put(self):
-        # Given
-        config = RudderstackConfiguration.objects.create(
-            api_key="api_123", environment=self.environment
-        )
 
-        api_key_updated = "new api"
-        data = {"api_key": api_key_updated}
+def test_should_update_configuration_when_put(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    config = RudderstackConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
 
-        # When
-        url = reverse(
-            "api-v1:environments:integrations-rudderstack-detail",
-            args=[self.environment.api_key, config.id],
-        )
-        response = self.client.put(
-            url,
-            data=json.dumps(data),
-            content_type="application/json",
-        )
-        config.refresh_from_db()
+    api_key_updated = "new api"
+    data = {"api_key": api_key_updated}
 
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert config.api_key == api_key_updated
+    # When
+    url = reverse(
+        "api-v1:environments:integrations-rudderstack-detail",
+        args=[environment.api_key, config.id],
+    )
+    response = admin_client.put(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+    config.refresh_from_db()
 
-    def test_should_return_rudderstack_config_list_when_requested(self):
-        # Given - set up data
-        config = RudderstackConfiguration.objects.create(
-            api_key="api_123", environment=self.environment
-        )
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert config.api_key == api_key_updated
 
-        # When
-        response = self.client.get(self.list_url)
 
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()) == 1
-        assert response.json()[0]["id"] == config.id
+def test_should_return_rudderstack_config_list_when_requested(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    config = RudderstackConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
 
-    def test_should_remove_configuration_when_delete(self):
-        # Given
-        config = RudderstackConfiguration.objects.create(
-            api_key="api_123", environment=self.environment
-        )
+    url = reverse(
+        "api-v1:environments:integrations-rudderstack-list",
+        args=[environment.api_key],
+    )
 
-        # When
-        url = reverse(
-            "api-v1:environments:integrations-rudderstack-detail",
-            args=[self.environment.api_key, config.id],
-        )
-        res = self.client.delete(url)
+    # When
+    response = admin_client.get(url)
 
-        # Then
-        assert res.status_code == status.HTTP_204_NO_CONTENT
-        #  and
-        assert not RudderstackConfiguration.objects.filter(
-            environment=self.environment
-        ).exists()
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == [
+        {
+            "api_key": config.api_key,
+            "base_url": config.base_url,
+            "id": config.id,
+        }
+    ]
+
+
+def test_should_remove_configuration_when_delete(
+    admin_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    config = RudderstackConfiguration.objects.create(
+        api_key="api_123", environment=environment
+    )
+
+    # When
+    url = reverse(
+        "api-v1:environments:integrations-rudderstack-detail",
+        args=[environment.api_key, config.id],
+    )
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    #  and
+    assert not RudderstackConfiguration.objects.filter(environment=environment).exists()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I'm working through re-writing the `TestCase` classes into normal test functions. Rewrote the existing `TestCase` and replaced with fixtures instead of recreating everything. There are other PRs that are similar to this one.

## How did you test this code?

I manually changed the tests one at a time to refactor them as I went then ran the full test suite afterwards. Also, I added assertions where I thought more were needed, for example missing `response.data` checks.