### PR TITLE
fix: Handle feature import processing during import

### DIFF
--- a/api/features/import_export/serializers.py
+++ b/api/features/import_export/serializers.py
@@ -66,6 +66,14 @@ class FeatureImportUploadSerializer(serializers.Serializer):
     strategy = serializers.ChoiceField(choices=[SKIP, OVERWRITE_DESTRUCTIVE])
 
     def save(self, environment_id: int) -> FeatureImport:
+        if FeatureImport.objects.filter(
+            environment_id=environment_id,
+            status=PROCESSING,
+        ).exists():
+            raise ValidationError(
+                "Can't import features, since already processing a feature import."
+            )
+
         uploaded_file = self.validated_data["file"]
         strategy = self.validated_data["strategy"]
         file_content = uploaded_file.read().decode("utf-8")


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This change stops people from uploading multiple feature imports at the same time and having them import in unexpected ways. It also trims the lifespan of how long a feature import or export can survive before it is culled into the failed category.

## How did you test this code?

Some new tests with reasonable coverage.