### PR TITLE
fix(sse/stream_access_logs): handle invalid log

### DIFF
--- a/api/tests/unit/sse/test_sse_service.py
+++ b/api/tests/unit/sse/test_sse_service.py
@@ -114,7 +114,8 @@ def test_stream_access_logs(mocker: MockerFixture, aws_credentials: None) -> Non
     first_encrypted_object_data = b"first_bucket_encrypted_data"
     first_decrypted_object_data = (
         f"{first_log.generated_at},{first_log.api_key}\n"
-        f"{second_log.generated_at},{second_log.api_key}".encode()
+        f"{second_log.generated_at},{second_log.api_key}\n"
+        "some,invalid,log,entry,111,222".encode()
     )
     second_encrypted_object_data = b"second_bucket_encrypted_data"
     second_decrypted_object_data = (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Because we log the URL path in Fastly logs, if someone is hitting an invalid URL, we receive logs that are invalid. This pull request addresses this by logging them as warnings and moving on to the next row.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Updates unit test case to include invalid log
