### PR TITLE
fix: Incorrect tag filtering when results have no features

### DIFF
--- a/frontend/web/components/pages/FeaturesPage.js
+++ b/frontend/web/components/pages/FeaturesPage.js
@@ -183,7 +183,7 @@ const FeaturesPage = class extends Component {
               totalFeatures,
               maxFeaturesAllowed,
             )
-            if (projectFlags && !this.state.loadedOnce) {
+            if (projectFlags?.length && !this.state.loadedOnce) {
               this.state.loadedOnce = true
             }
             return (
@@ -210,7 +210,7 @@ const FeaturesPage = class extends Component {
                           title={'Features'}
                           cta={
                             <>
-                              {(projectFlags && projectFlags.length) ||
+                              {this.state.loadedOnce ||
                               this.state.showArchived ||
                               this.state.tags?.length
                                 ? this.createFeaturePermission((perm) => (

--- a/frontend/web/components/pages/FeaturesPage.js
+++ b/frontend/web/components/pages/FeaturesPage.js
@@ -30,6 +30,7 @@ const FeaturesPage = class extends Component {
   constructor(props, context) {
     super(props, context)
     this.state = {
+      loadedOnce: false,
       search: null,
       showArchived: false,
       sort: { label: 'Name', sortBy: 'name', sortOrder: 'asc' },
@@ -61,6 +62,7 @@ const FeaturesPage = class extends Component {
       params.environmentId !== oldParams.environmentId ||
       params.projectId !== oldParams.projectId
     ) {
+      this.state.loadedOnce = false
       AppActions.getFeatures(
         params.projectId,
         params.environmentId,
@@ -181,6 +183,9 @@ const FeaturesPage = class extends Component {
               totalFeatures,
               maxFeaturesAllowed,
             )
+            if (projectFlags && !this.state.loadedOnce) {
+              this.state.loadedOnce = true
+            }
             return (
               <div className='features-page'>
                 {isLoading && (!projectFlags || !projectFlags.length) && (
@@ -188,9 +193,9 @@ const FeaturesPage = class extends Component {
                     <Loader />
                   </div>
                 )}
-                {(!isLoading || (projectFlags && !!projectFlags.length)) && (
+                {(!isLoading || this.state.loadedOnce) && (
                   <div>
-                    {(projectFlags && projectFlags.length) ||
+                    {this.state.loadedOnce ||
                     ((this.state.showArchived ||
                       typeof this.state.search === 'string' ||
                       !!this.state.tags.length) &&
@@ -483,9 +488,7 @@ const FeaturesPage = class extends Component {
                             title='2: Initialising your project'
                             snippets={Constants.codeHelp.INIT(
                               this.props.match.params.environmentId,
-                              projectFlags &&
-                                projectFlags[0] &&
-                                projectFlags[0].name,
+                              projectFlags?.[0]?.name,
                             )}
                           />
                         </FormGroup>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

When filtering on a tag without features then removing the filter, the UI flickers between the create your first feature page and the table.

To fix this the page keeps track of when features were loaded for the current project/environment and never shows the create first flag UI after that. Although this is a bit of a workaround it will be fixed automatically when migrating this page to RTK but that's a massive piece of work that won't happen for a while.

## How did you test this code?

- Filtered by tag without flags and remove filter
- Tested with project without flags
- Tested deleting last project flag