### PR TITLE
fix: display of usage chart

### DIFF
--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -1794,7 +1794,8 @@ const OrganisationSettingsPage = class extends Component {
 
                         {displayedTabs.includes(SettingsTab.Usage) && (
                           <TabItem tabLabel='Usage'>
-                            {this.state.tab === 4 && (
+                            {this.state.tab ===
+                              displayedTabs.indexOf(SettingsTab.Usage) && (
                               <OrganisationUsage
                                 organisationId={
                                   AccountStore.getOrganisation().id


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Organisation page redesign had a magic incorrect tab check for usage, this means that usage is not showing.

## How did you test this code?

- Tested that usage showed