### PR TITLE
chore: Convert organisations views TestCase to normal test function

### DIFF
--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timedelta
 from typing import Type
-from unittest import TestCase, mock
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +13,7 @@ from django.db.models import Model
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
+from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 from pytz import UTC
 from rest_framework import status
@@ -20,7 +21,7 @@ from rest_framework.test import APIClient, override_settings
 
 from environments.models import Environment
 from environments.permissions.models import UserEnvironmentPermission
-from features.models import Feature, FeatureSegment
+from features.models import Feature
 from organisations.chargebee.metadata import ChargebeeObjMetadata
 from organisations.invites.models import Invite
 from organisations.models import (
@@ -46,693 +47,661 @@ from users.models import (
     UserPermissionGroup,
     UserPermissionGroupMembership,
 )
-from util.tests import Helper
 
 User = get_user_model()
 
 
-@pytest.mark.django_db
-class OrganisationTestCase(TestCase):
-    post_template = '{ "name" : "%s", "webhook_notification_email": "%s" }'
-    put_template = '{ "name" : "%s"}'
-
-    def setUp(self):
-        self.client = APIClient()
-        self.user = Helper.create_ffadminuser()
-        self.client.force_authenticate(user=self.user)
-
-    def test_should_return_organisation_list_when_requested(self):
-        # Given
-        organisation = Organisation.objects.create(name="Test org")
-        self.user.add_organisation(organisation)
-
-        # When
-        response = self.client.get("/api/v1/organisations/")
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert "count" in response.data and response.data["count"] == 1
-
-        # and certain required fields are there
-        response_json = response.json()
-        org_data = response_json["results"][0]
-        assert "persist_trait_data" in org_data
-
-    def test_non_superuser_can_create_new_organisation_by_default(self):
-        # Given
-        user = User.objects.create(email="test@example.com")
-        client = APIClient()
-        client.force_authenticate(user=user)
-
-        org_name = "Test create org"
-        webhook_notification_email = "test@email.com"
-        url = reverse("api-v1:organisations:organisation-list")
-        data = {
-            "name": org_name,
-            "webhook_notification_email": webhook_notification_email,
-        }
-
-        # When
-        response = client.post(url, data=data)
-
-        # Then
-        assert response.status_code == status.HTTP_201_CREATED
-        assert (
-            Organisation.objects.get(name=org_name).webhook_notification_email
-            == webhook_notification_email
-        )
-
-    @override_settings(RESTRICT_ORG_CREATE_TO_SUPERUSERS=True)
-    def test_create_new_orgnisation_returns_403_with_non_superuser(self):
-        # Given
-        user = User.objects.create(email="test@example.com")
-        client = APIClient()
-        client.force_authenticate(user=user)
-
-        org_name = "Test create org"
-        url = reverse("api-v1:organisations:organisation-list")
-        data = {
-            "name": org_name,
-        }
-
-        # When
-        response = client.post(url, data=data)
-        # Then
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert (
-            "You do not have permission to perform this action."
-            == response.json()["detail"]
-        )
-
-    def test_should_update_organisation_data(self):
-        # Given
-        original_organisation_name = "test org"
-        new_organisation_name = "new test org"
-        organisation = Organisation.objects.create(name=original_organisation_name)
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        url = reverse(
-            "api-v1:organisations:organisation-detail", args=[organisation.pk]
-        )
-        data = {"name": new_organisation_name, "restrict_project_create_to_admin": True}
-
-        # When
-        response = self.client.put(url, data=data)
-
-        # Then
-        organisation.refresh_from_db()
-        assert response.status_code == status.HTTP_200_OK
-        assert organisation.name == new_organisation_name
-        assert organisation.restrict_project_create_to_admin
-
-    @override_settings()
-    def test_should_invite_users(self):
-        # Given
-        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
-
-        org_name = "test_org"
-        organisation = Organisation.objects.create(name=org_name)
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        url = reverse(
-            "api-v1:organisations:organisation-invite", args=[organisation.pk]
-        )
-        data = {"emails": ["test@example.com"]}
-
-        # When
-        response = self.client.post(
-            url, data=json.dumps(data), content_type="application/json"
-        )
-
-        # Then
-        assert response.status_code == status.HTTP_201_CREATED
-        assert Invite.objects.filter(email="test@example.com").exists()
-
-    @override_settings()
-    def test_should_fail_if_invite_exists_already(self):
-        # Given
-        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
-        organisation = Organisation.objects.create(name="test org")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        email = "test_2@example.com"
-        data = {"emails": [email]}
-        url = reverse(
-            "api-v1:organisations:organisation-invite", args=[organisation.pk]
-        )
-
-        # When
-        response_success = self.client.post(
-            url, data=json.dumps(data), content_type="application/json"
-        )
-        response_fail = self.client.post(
-            url, data=json.dumps(data), content_type="application/json"
-        )
-
-        # Then
-        assert response_success.status_code == status.HTTP_201_CREATED
-        assert response_fail.status_code == status.HTTP_400_BAD_REQUEST
-        assert (
-            Invite.objects.filter(email=email, organisation=organisation).count() == 1
-        )
-
-    @override_settings()
-    def test_should_return_all_invites_and_can_resend(self):
-        # Given
-        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
-
-        organisation = Organisation.objects.create(name="Test org 2")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-
-        invite_1 = Invite.objects.create(
-            email="test_1@example.com", organisation=organisation
-        )
-        Invite.objects.create(email="test_2@example.com", organisation=organisation)
-
-        # When
-        invite_list_response = self.client.get(
-            "/api/v1/organisations/%s/invites/" % organisation.id
-        )
-        invite_resend_response = self.client.post(
-            "/api/v1/organisations/%s/invites/%s/resend/"
-            % (organisation.id, invite_1.id)
-        )
-
-        # Then
-        assert invite_list_response.status_code == status.HTTP_200_OK
-        assert invite_resend_response.status_code == status.HTTP_200_OK
-
-    def test_remove_user_from_an_organisation_also_removes_from_group(self):
-        # Given
-        organisation = Organisation.objects.create(name="Test org")
-        group = UserPermissionGroup.objects.create(
-            name="Test Group", organisation=organisation
-        )
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        user_2 = FFAdminUser.objects.create(email="test@example.com")
-        user_2.add_organisation(organisation)
-        # Add users to the group
-        group.users.add(user_2)
-        group.users.add(self.user)
-        url = reverse(
-            "api-v1:organisations:organisation-remove-users", args=[organisation.pk]
-        )
-
-        data = [{"id": user_2.pk}]
-
-        # When
-        res = self.client.post(
-            url, data=json.dumps(data), content_type="application/json"
-        )
-
-        # Then
-        assert res.status_code == status.HTTP_200_OK
-        assert organisation not in user_2.organisations.all()
-        assert group not in user_2.permission_groups.all()
-        # Test that other users are still part of the group
-        assert group in self.user.permission_groups.all()
-
-    def test_remove_user_from_an_organisation_also_removes_users_environment_and_project_permission(
-        self,
-    ):
-        # Given
-        organisation = Organisation.objects.create(name="Test org")
-
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        # Now, let's create a project
-        project_name = "org_remove_test"
-        project_create_url = reverse("api-v1:projects:project-list")
-        data = {"name": project_name, "organisation": organisation.id}
-
-        response = self.client.post(project_create_url, data=data)
-        project_id = response.json()["id"]
-
-        # Next, let's create an environment
-        url = reverse("api-v1:environments:environment-list")
-        data = {"name": "Test environment", "project": project_id}
-        response = self.client.post(url, data=data)
-        environment_id = response.json()["id"]
-
-        url = reverse(
-            "api-v1:organisations:organisation-remove-users", args=[organisation.pk]
-        )
-
-        data = [{"id": self.user.id}]
-
-        # Next, let's remove the user from the organisation
-        res = self.client.post(
-            url, data=json.dumps(data), content_type="application/json"
-        )
-
-        # Then
-        assert res.status_code == status.HTTP_200_OK
-        assert (
-            UserProjectPermission.objects.filter(
-                project__id=project_id, user=self.user
-            ).count()
-            == 0
-        )
-        assert (
-            UserEnvironmentPermission.objects.filter(
-                user=self.user, environment__id=environment_id
-            ).count()
-            == 0
-        )
-
-    @override_settings()
-    def test_can_invite_user_as_admin(self):
-        # Given
-        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
-
-        organisation = Organisation.objects.create(name="Test org")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        url = reverse(
-            "api-v1:organisations:organisation-invite", args=[organisation.pk]
-        )
-        invited_email = "test@example.com"
-
-        data = {
-            "invites": [{"email": invited_email, "role": OrganisationRole.ADMIN.name}]
-        }
-
-        # When
-        self.client.post(url, data=json.dumps(data), content_type="application/json")
-
-        # Then
-        assert Invite.objects.filter(email=invited_email).exists()
-
-        # and
-        assert (
-            Invite.objects.get(email=invited_email).role == OrganisationRole.ADMIN.name
-        )
-
-    @override_settings()
-    def test_can_invite_user_as_user(self):
-        # Given
-        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
-
-        organisation = Organisation.objects.create(name="Test org")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        url = reverse(
-            "api-v1:organisations:organisation-invite", args=[organisation.pk]
-        )
-        invited_email = "test@example.com"
-
-        data = {
-            "invites": [{"email": invited_email, "role": OrganisationRole.USER.name}]
-        }
-
-        # When
-        self.client.post(url, data=json.dumps(data), content_type="application/json")
-
-        # Then
-        assert Invite.objects.filter(email=invited_email).exists()
-
-        # and
-        assert (
-            Invite.objects.get(email=invited_email).role == OrganisationRole.USER.name
-        )
-
-    def test_user_can_get_projects_for_an_organisation(self):
-        # Given
-        organisation = Organisation.objects.create(name="Test org")
-
-        self.user.add_organisation(organisation, OrganisationRole.USER)
-        url = reverse(
-            "api-v1:organisations:organisation-projects", args=[organisation.pk]
-        )
-
-        # When
-        res = self.client.get(url)
-
-        # Then
-        assert res.status_code == status.HTTP_200_OK
-
-    @mock.patch("app_analytics.influxdb_wrapper.influxdb_client")
-    def test_should_get_usage_for_organisation(self, mock_influxdb_client):
-        # Given
-        org_name = "test_org"
-        organisation = Organisation.objects.create(name=org_name)
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        url = reverse("api-v1:organisations:organisation-usage", args=[organisation.pk])
-
-        influx_org = settings.INFLUXDB_ORG
-        read_bucket = settings.INFLUXDB_BUCKET + "_downsampled_15m"
-        expected_query = (
-            (
-                f'from(bucket:"{read_bucket}") '
-                f"|> range(start: -30d, stop: now()) "
-                f'|> filter(fn:(r) => r._measurement == "api_call")         '
-                f'|> filter(fn: (r) => r["_field"] == "request_count")         '
-                f'|> filter(fn: (r) => r["organisation_id"] == "{organisation.id}") '
-                f'|> drop(columns: ["organisation", "project", "project_id", '
-                f'"environment", "environment_id"])'
-                f"|> sum()"
-            )
-            .replace(" ", "")
-            .replace("\n", "")
-        )
-
-        # When
-        response = self.client.get(url, content_type="application/json")
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        mock_influxdb_client.query_api.return_value.query.assert_called_once()
-
-        call = mock_influxdb_client.query_api.return_value.query.mock_calls[0]
-        assert call[2]["org"] == influx_org
-        assert call[2]["query"].replace(" ", "").replace("\n", "") == expected_query
-
-    @override_settings(ENABLE_CHARGEBEE=True)
-    @mock.patch("organisations.serializers.get_subscription_data_from_hosted_page")
-    def test_update_subscription_gets_subscription_data_from_chargebee(
-        self, mock_get_subscription_data
-    ):
-        # Given
-        organisation = Organisation.objects.create(name="Test org")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        url = reverse(
-            "api-v1:organisations:organisation-update-subscription",
-            args=[organisation.pk],
-        )
-
-        hosted_page_id = "some-id"
-        data = {"hosted_page_id": hosted_page_id}
-
-        customer_id = "customer-id"
-
-        subscription_id = "subscription-id"
-        mock_get_subscription_data.return_value = {
-            "subscription_id": subscription_id,
-            "plan": "plan-id",
-            "max_seats": 3,
-            "subscription_date": datetime.now(tz=UTC),
-            "customer_id": customer_id,
-        }
-
-        # When
-        res = self.client.post(url, data=data)
-
-        # Then
-        assert res.status_code == status.HTTP_200_OK
-        # Since subscription is created using organisation.id rather than
-        # organisation and we already have evaluated subscription(by add_organisation)
-        # attribute of organisation(before we created the subscription) we need to
-        # refresh organisation for `has_paid_subscription` to work properly
-        organisation.refresh_from_db()
-
-        # and
-        mock_get_subscription_data.assert_called_with(hosted_page_id=hosted_page_id)
-
-        # and
-        assert (
-            organisation.has_paid_subscription()
-            and organisation.subscription.subscription_id == subscription_id
-            and organisation.subscription.customer_id == customer_id
-        )
-
-    def test_delete_organisation(self):
-        # GIVEN an organisation with a project, environment, feature, segment and feature segment
-        organisation = Organisation.objects.create(name="Test organisation")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-        project = Project.objects.create(name="Test project", organisation=organisation)
-        environment = Environment.objects.create(
-            name="Test environment", project=project
-        )
-        feature = Feature.objects.create(name="Test feature", project=project)
-        segment = Segment.objects.create(name="Test segment", project=project)
-        FeatureSegment.objects.create(
-            feature=feature, segment=segment, environment=environment
-        )
-
-        delete_organisation_url = reverse(
-            "api-v1:organisations:organisation-detail", args=[organisation.id]
-        )
-
-        # WHEN
-        response = self.client.delete(delete_organisation_url)
-
-        # THEN
-        assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    @mock.patch(
-        "organisations.serializers.get_hosted_page_url_for_subscription_upgrade"
+def test_should_return_organisation_list_when_requested(
+    staff_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # When
+    response = staff_client.get("/api/v1/organisations/")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert "count" in response.data and response.data["count"] == 1
+    assert response.data["results"][0]["role"] == "USER"
+    assert response.data["results"][0]["name"] == organisation.name
+
+
+def test_non_superuser_can_create_new_organisation_by_default(
+    staff_client: APIClient,
+) -> None:
+    # Given
+    org_name = "Test create org"
+    webhook_notification_email = "test@email.com"
+    url = reverse("api-v1:organisations:organisation-list")
+    data = {
+        "name": org_name,
+        "webhook_notification_email": webhook_notification_email,
+    }
+
+    # When
+    response = staff_client.post(url, data=data)
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert (
+        Organisation.objects.get(name=org_name).webhook_notification_email
+        == webhook_notification_email
     )
-    def test_get_hosted_page_url_for_subscription_upgrade(
-        self, mock_get_hosted_page_url
-    ):
-        # Given
-        organisation = Organisation.objects.create(name="Test organisation")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-
-        subscription = Subscription.objects.get(organisation=organisation)
-        subscription.subscription_id = "sub-id"
-        subscription.save()
-
-        url = reverse(
-            "api-v1:organisations:organisation-get-hosted-page-url-for-subscription-upgrade",
-            args=[organisation.id],
-        )
-
-        expected_url = "https://some.url.com/hosted/page"
-        mock_get_hosted_page_url.return_value = expected_url
-
-        plan_id = "plan-id"
-
-        # When
-        response = self.client.post(
-            url, data=json.dumps({"plan_id": plan_id}), content_type="application/json"
-        )
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()["url"] == expected_url
-        mock_get_hosted_page_url.assert_called_once_with(
-            subscription_id=subscription.subscription_id, plan_id=plan_id
-        )
-
-    def test_get_permissions(self):
-        # Given
-        url = reverse("api-v1:organisations:organisation-permissions")
-
-        # When
-        response = self.client.get(url)
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()) == 2
-
-    def test_get_my_permissions_for_non_admin(self):
-        # Given
-        organisation = Organisation.objects.create(name="Test org")
-        self.user.add_organisation(organisation)
-        user_permission = UserOrganisationPermission.objects.create(
-            user=self.user, organisation=organisation
-        )
-        user_permission.add_permission(CREATE_PROJECT)
-
-        url = reverse(
-            "api-v1:organisations:organisation-my-permissions", args=[organisation.id]
-        )
-
-        # When
-        response = self.client.get(url)
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-
-        response_json = response.json()
-        assert response_json["permissions"] == [CREATE_PROJECT]
-        assert response_json["admin"] is False
-
-    def test_get_my_permissions_for_admin(self):
-        # Given
-        organisation = Organisation.objects.create(name="Test org")
-        self.user.add_organisation(organisation, OrganisationRole.ADMIN)
-
-        url = reverse(
-            "api-v1:organisations:organisation-my-permissions", args=[organisation.id]
-        )
-
-        # When
-        response = self.client.get(url)
-
-        # Then
-        assert response.status_code == status.HTTP_200_OK
-
-        response_json = response.json()
-        assert response_json["permissions"] == []
-        assert response_json["admin"] is True
 
 
-@pytest.mark.django_db
-class ChargeBeeWebhookTestCase(TestCase):
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.cb_user = User.objects.create(
-            email="chargebee@bullet-train.io", username="chargebee"
-        )
-        self.admin_user = User.objects.create(
-            email="admin@bullet-train.io", username="admin", is_staff=True
-        )
-        self.client.force_authenticate(self.cb_user)
-        self.organisation = Organisation.objects.create(name="Test org")
+@override_settings(RESTRICT_ORG_CREATE_TO_SUPERUSERS=True)
+def test_create_new_orgnisation_returns_403_with_non_superuser(
+    staff_client: APIClient,
+) -> None:
+    # Given
+    org_name = "Test create org"
+    url = reverse("api-v1:organisations:organisation-list")
+    data = {
+        "name": org_name,
+    }
 
-        self.url = reverse("api-v1:chargebee-webhook")
-        self.subscription_id = "subscription-id"
-        self.old_plan_id = "old-plan-id"
-        self.old_max_seats = 1
-
-        Subscription.objects.filter(organisation=self.organisation).update(
-            organisation=self.organisation,
-            subscription_id=self.subscription_id,
-            plan=self.old_plan_id,
-            max_seats=self.old_max_seats,
-        )
-        self.subscription = Subscription.objects.get(organisation=self.organisation)
-
-    @mock.patch(
-        "organisations.chargebee.webhook_handlers.extract_subscription_metadata"
+    # When
+    response = staff_client.post(url, data=data)
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        "You do not have permission to perform this action."
+        == response.json()["detail"]
     )
-    def test_chargebee_webhook(
-        self, mock_extract_subscription_metadata: MagicMock
-    ) -> None:
-        # Given
-        seats = 3
-        api_calls = 100
-        mock_extract_subscription_metadata.return_value = ChargebeeObjMetadata(
-            seats=seats,
-            api_calls=api_calls,
-            projects=None,
-            chargebee_email=self.cb_user.email,
-        )
-        data = {
-            "content": {
-                "subscription": {
-                    "status": "active",
-                    "id": self.subscription_id,
-                },
-                "customer": {"email": self.cb_user.email},
-            }
-        }
 
-        # When
-        response = self.client.post(
-            self.url, data=json.dumps(data), content_type="application/json"
-        )
 
-        # Then
-        assert response.status_code == status.HTTP_200_OK
+def test_should_update_organisation_data(
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    new_organisation_name = "new test org"
+    url = reverse("api-v1:organisations:organisation-detail", args=[organisation.pk])
+    data = {"name": new_organisation_name, "restrict_project_create_to_admin": True}
 
-        self.subscription.refresh_from_db()
-        subscription_cache = OrganisationSubscriptionInformationCache.objects.get(
-            organisation=self.subscription.organisation
-        )
-        assert subscription_cache.allowed_projects is None
-        assert subscription_cache.allowed_30d_api_calls == api_calls
-        assert subscription_cache.allowed_seats == seats
+    # When
+    response = admin_client.put(url, data=data)
 
-    @mock.patch("organisations.models.cancel_chargebee_subscription")
-    def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and_alert_sent(
-        self, mocked_cancel_chargebee_subscription
-    ):
-        # Given
-        cancellation_date = datetime.now(tz=UTC) + timedelta(days=1)
-        current_term_end = int(datetime.timestamp(cancellation_date))
-        data = {
-            "content": {
-                "subscription": {
-                    "status": "non_renewing",
-                    "id": self.subscription_id,
-                    "current_term_end": current_term_end,
-                },
-                "customer": {"email": self.cb_user.email},
-            }
-        }
+    # Then
+    organisation.refresh_from_db()
+    assert response.status_code == status.HTTP_200_OK
+    assert organisation.name == new_organisation_name
+    assert organisation.restrict_project_create_to_admin is True
 
-        # When
-        self.client.post(
-            self.url, data=json.dumps(data), content_type="application/json"
-        )
 
-        # Then
-        self.subscription.refresh_from_db()
-        assert self.subscription.cancellation_date == datetime.utcfromtimestamp(
-            current_term_end
-        ).replace(tzinfo=timezone.utc)
+def test_should_invite_users_to_organisation(
+    settings: SettingsWrapper,
+    staff_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
 
-        # and
-        assert len(mail.outbox) == 1
-        mocked_cancel_chargebee_subscription.assert_not_called()
+    url = reverse("api-v1:organisations:organisation-invite", args=[organisation.pk])
+    data = {"emails": ["test@example.com"]}
 
-    def test_when_subscription_is_cancelled_then_cancellation_date_set_and_alert_sent(
-        self,
-    ):
-        # Given
-        cancellation_date = datetime.now(tz=UTC) + timedelta(days=1)
-        current_term_end = int(datetime.timestamp(cancellation_date))
-        data = {
-            "content": {
-                "subscription": {
-                    "status": "cancelled",
-                    "id": self.subscription_id,
-                    "current_term_end": current_term_end,
-                },
-                "customer": {"email": self.cb_user.email},
-            }
-        }
-
-        # When
-        self.client.post(
-            self.url, data=json.dumps(data), content_type="application/json"
-        )
-
-        # Then
-        self.subscription.refresh_from_db()
-        assert self.subscription.cancellation_date == datetime.utcfromtimestamp(
-            current_term_end
-        ).replace(tzinfo=timezone.utc)
-
-        # and
-        assert len(mail.outbox) == 1
-
-    @mock.patch(
-        "organisations.chargebee.webhook_handlers.extract_subscription_metadata"
+    # When
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
     )
-    def test_when_cancelled_subscription_is_renewed_then_subscription_activated_and_no_cancellation_email_sent(
-        self,
-        mock_extract_subscription_metadata,
-    ):
-        # Given
-        self.subscription.cancellation_date = datetime.now(tz=UTC) - timedelta(days=1)
-        self.subscription.save()
-        mail.outbox.clear()
 
-        mock_extract_subscription_metadata.return_value = ChargebeeObjMetadata(
-            seats=3,
-            api_calls=100,
-            projects=1,
-            chargebee_email=self.cb_user.email,
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Invite.objects.filter(email="test@example.com").exists()
+
+
+def test_should_fail_if_invite_exists_already(
+    settings: SettingsWrapper,
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
+
+    email = "test_2@example.com"
+    data = {"emails": [email]}
+    url = reverse("api-v1:organisations:organisation-invite", args=[organisation.pk])
+
+    # When
+    response_success = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+    response_fail = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response_success.status_code == status.HTTP_201_CREATED
+    assert response_fail.status_code == status.HTTP_400_BAD_REQUEST
+    assert Invite.objects.filter(email=email, organisation=organisation).count() == 1
+
+
+def test_should_return_all_invites_and_can_resend(
+    settings: SettingsWrapper,
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
+
+    invite_1 = Invite.objects.create(
+        email="test_1@example.com", organisation=organisation
+    )
+    Invite.objects.create(email="test_2@example.com", organisation=organisation)
+
+    # When
+    invite_list_response = admin_client.get(
+        "/api/v1/organisations/%s/invites/" % organisation.id
+    )
+    invite_resend_response = admin_client.post(
+        "/api/v1/organisations/%s/invites/%s/resend/" % (organisation.id, invite_1.id)
+    )
+
+    # Then
+    assert invite_list_response.status_code == status.HTTP_200_OK
+    assert invite_resend_response.status_code == status.HTTP_200_OK
+
+
+def test_remove_user_from_an_organisation_also_removes_from_group(
+    organisation: Organisation,
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    group = UserPermissionGroup.objects.create(
+        name="Test Group", organisation=organisation
+    )
+    # Add users to the group
+    group.users.add(staff_user)
+    group.users.add(admin_user)
+    url = reverse(
+        "api-v1:organisations:organisation-remove-users", args=[organisation.pk]
+    )
+
+    data = [{"id": staff_user.pk}]
+
+    # When
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert organisation not in staff_user.organisations.all()
+    assert group not in staff_user.permission_groups.all()
+    # Test that other users are still part of the group
+    assert group in admin_user.permission_groups.all()
+
+
+def test_remove_user_from_an_organisation_also_removes_users_environment_and_project_permission(
+    organisation: Organisation,
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
+) -> None:
+    # Given
+    # Now, let's create a project
+    project_name = "org_remove_test"
+    project_create_url = reverse("api-v1:projects:project-list")
+    data = {"name": project_name, "organisation": organisation.id}
+
+    response = admin_client.post(project_create_url, data=data)
+    project_id = response.data["id"]
+
+    # Next, let's create an environment
+    url = reverse("api-v1:environments:environment-list")
+    data = {"name": "Test environment", "project": project_id}
+    response = admin_client.post(url, data=data)
+    environment_id = response.data["id"]
+
+    url = reverse(
+        "api-v1:organisations:organisation-remove-users", args=[organisation.pk]
+    )
+
+    data = [{"id": admin_user.id}]
+
+    # Next, let's remove the user from the organisation
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        UserProjectPermission.objects.filter(
+            project__id=project_id, user=admin_user
+        ).count()
+        == 0
+    )
+    assert (
+        UserEnvironmentPermission.objects.filter(
+            user=admin_user, environment__id=environment_id
+        ).count()
+        == 0
+    )
+
+
+def test_can_invite_user_as_admin(
+    settings: SettingsWrapper,
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
+
+    url = reverse("api-v1:organisations:organisation-invite", args=[organisation.pk])
+    invited_email = "test@example.com"
+
+    data = {"invites": [{"email": invited_email, "role": OrganisationRole.ADMIN.name}]}
+
+    # When
+    admin_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert Invite.objects.filter(email=invited_email).exists()
+    assert Invite.objects.get(email=invited_email).role == OrganisationRole.ADMIN.name
+
+
+def test_can_invite_user_as_user(
+    settings: SettingsWrapper,
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
+
+    url = reverse("api-v1:organisations:organisation-invite", args=[organisation.pk])
+    invited_email = "test@example.com"
+
+    data = {"invites": [{"email": invited_email, "role": OrganisationRole.USER.name}]}
+
+    # When
+    admin_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    assert Invite.objects.filter(email=invited_email).exists()
+
+    # and
+    assert Invite.objects.get(email=invited_email).role == OrganisationRole.USER.name
+
+
+def test_user_can_get_projects_for_an_organisation(
+    organisation: Organisation,
+    staff_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    url = reverse("api-v1:organisations:organisation-projects", args=[organisation.pk])
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data[0]["uuid"] == str(project.uuid)
+    assert response.data[0]["name"] == project.name
+
+
+@mock.patch("app_analytics.influxdb_wrapper.influxdb_client")
+def test_should_get_usage_for_organisation(
+    mock_influxdb_client: MagicMock,
+    organisation: Organisation,
+    admin_client: APIClient,
+) -> None:
+    # Given
+    url = reverse("api-v1:organisations:organisation-usage", args=[organisation.pk])
+
+    influx_org = settings.INFLUXDB_ORG
+    read_bucket = settings.INFLUXDB_BUCKET + "_downsampled_15m"
+    expected_query = (
+        (
+            f'from(bucket:"{read_bucket}") '
+            "|> range(start: -30d, stop: now()) "
+            '|> filter(fn:(r) => r._measurement == "api_call")         '
+            '|> filter(fn: (r) => r["_field"] == "request_count")         '
+            f'|> filter(fn: (r) => r["organisation_id"] == "{organisation.id}") '
+            '|> drop(columns: ["organisation", "project", "project_id", '
+            '"environment", "environment_id"])'
+            "|> sum()"
         )
-        data = {
-            "content": {
-                "subscription": {
-                    "status": "active",
-                    "id": self.subscription_id,
-                },
-                "customer": {"email": self.cb_user.email},
-            }
+        .replace(" ", "")
+        .replace("\n", "")
+    )
+
+    # When
+    response = admin_client.get(url, content_type="application/json")
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    mock_influxdb_client.query_api.return_value.query.assert_called_once()
+
+    call = mock_influxdb_client.query_api.return_value.query.mock_calls[0]
+    assert call[2]["org"] == influx_org
+    assert call[2]["query"].replace(" ", "").replace("\n", "") == expected_query
+
+
+@mock.patch("organisations.serializers.get_subscription_data_from_hosted_page")
+def test_update_subscription_gets_subscription_data_from_chargebee(
+    mock_get_subscription_data: MagicMock,
+    settings: SettingsWrapper,
+    organisation: Organisation,
+    admin_client: APIClient,
+) -> None:
+    settings.ENABLE_CHARGEBEE = True
+
+    # Given
+    url = reverse(
+        "api-v1:organisations:organisation-update-subscription",
+        args=[organisation.pk],
+    )
+
+    hosted_page_id = "some-id"
+    data = {"hosted_page_id": hosted_page_id}
+
+    customer_id = "customer-id"
+
+    subscription_id = "subscription-id"
+    mock_get_subscription_data.return_value = {
+        "subscription_id": subscription_id,
+        "plan": "plan-id",
+        "max_seats": 3,
+        "subscription_date": datetime.now(tz=UTC),
+        "customer_id": customer_id,
+    }
+
+    # When
+    response = admin_client.post(url, data=data)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    organisation.refresh_from_db()
+    mock_get_subscription_data.assert_called_with(hosted_page_id=hosted_page_id)
+
+    assert organisation.has_paid_subscription()
+    assert organisation.subscription.subscription_id == subscription_id
+    assert organisation.subscription.customer_id == customer_id
+
+
+def test_delete_organisation(
+    organisation: Organisation,
+    admin_client: APIClient,
+    project: Project,
+    environment: Environment,
+    feature: Feature,
+    segment: Segment,
+) -> None:
+    # Given
+    url = reverse("api-v1:organisations:organisation-detail", args=[organisation.id])
+
+    # When
+    response = admin_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    # Assure models are not actually deleted but soft deleted or
+    # related to a soft deleted object.
+    organisation.refresh_from_db()
+    assert organisation.id
+    assert organisation.deleted_at is not None
+
+    project.refresh_from_db()
+    assert project.id
+    environment.refresh_from_db()
+    assert environment.id
+    feature.refresh_from_db()
+    assert feature.id
+    segment.refresh_from_db()
+    assert segment.id
+
+
+@mock.patch("organisations.serializers.get_hosted_page_url_for_subscription_upgrade")
+def test_get_hosted_page_url_for_subscription_upgrade(
+    mock_get_hosted_page_url: MagicMock,
+    organisation: Organisation,
+    admin_client: APIClient,
+    subscription: Subscription,
+) -> None:
+    # Given
+    subscription.subscription_id = "sub-id"
+    subscription.save()
+
+    url = reverse(
+        "api-v1:organisations:organisation-get-hosted-page-url-for-subscription-upgrade",
+        args=[organisation.id],
+    )
+
+    expected_url = "https://some.url.com/hosted/page"
+    mock_get_hosted_page_url.return_value = expected_url
+
+    plan_id = "plan-id"
+
+    # When
+    response = admin_client.post(
+        url, data=json.dumps({"plan_id": plan_id}), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["url"] == expected_url
+    mock_get_hosted_page_url.assert_called_once_with(
+        subscription_id=subscription.subscription_id, plan_id=plan_id
+    )
+
+
+def test_get_organisation_permissions(
+    staff_client: APIClient,
+) -> None:
+    # Given
+    url = reverse("api-v1:organisations:organisation-permissions")
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 2
+
+
+def test_get_my_permissions_for_non_admin(
+    organisation: Organisation,
+    staff_client: APIClient,
+    staff_user: FFAdminUser,
+) -> None:
+    # Given
+    user_permission = UserOrganisationPermission.objects.create(
+        user=staff_user, organisation=organisation
+    )
+    user_permission.add_permission(CREATE_PROJECT)
+
+    url = reverse(
+        "api-v1:organisations:organisation-my-permissions", args=[organisation.id]
+    )
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["permissions"] == [CREATE_PROJECT]
+    assert response.data["admin"] is False
+
+
+def test_get_my_permissions_for_admin(
+    organisation: Organisation,
+    admin_client: APIClient,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:organisations:organisation-my-permissions", args=[organisation.id]
+    )
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["permissions"] == []
+    assert response.data["admin"] is True
+
+
+@mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
+def test_chargebee_webhook(
+    mock_extract_subscription_metadata: MagicMock,
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+    subscription: Subscription,
+) -> None:
+    # Given
+    seats = 3
+    api_calls = 100
+    mock_extract_subscription_metadata.return_value = ChargebeeObjMetadata(
+        seats=seats,
+        api_calls=api_calls,
+        projects=None,
+        chargebee_email=staff_user.email,
+    )
+    subscription.subscription_id = "subscription-id"
+    subscription.save()
+    data = {
+        "content": {
+            "subscription": {
+                "status": "active",
+                "id": subscription.subscription_id,
+            },
+            "customer": {"email": staff_user.email},
         }
+    }
 
-        # When
-        self.client.post(
-            self.url, data=json.dumps(data), content_type="application/json"
-        )
+    url = reverse("api-v1:chargebee-webhook")
+    # When
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
 
-        # Then
-        self.subscription.refresh_from_db()
-        assert not self.subscription.cancellation_date
+    # Then
+    assert response.status_code == status.HTTP_200_OK
 
-        # and
-        assert not mail.outbox
+    subscription.refresh_from_db()
+    subscription_cache = OrganisationSubscriptionInformationCache.objects.get(
+        organisation=subscription.organisation
+    )
+    assert subscription_cache.allowed_projects is None
+    assert subscription_cache.allowed_30d_api_calls == api_calls
+    assert subscription_cache.allowed_seats == seats
+
+
+@mock.patch("organisations.models.cancel_chargebee_subscription")
+def test_when_subscription_is_set_to_non_renewing_then_cancellation_date_set_and_alert_sent(
+    mocked_cancel_chargebee_subscription: MagicMock,
+    subscription: Subscription,
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+) -> None:
+    # Given
+    cancellation_date = datetime.now(tz=UTC) + timedelta(days=1)
+    current_term_end = int(datetime.timestamp(cancellation_date))
+    subscription.subscription_id = "subscription-id"
+    subscription.save()
+    data = {
+        "content": {
+            "subscription": {
+                "status": "non_renewing",
+                "id": subscription.subscription_id,
+                "current_term_end": current_term_end,
+            },
+            "customer": {"email": staff_user.email},
+        }
+    }
+    url = reverse("api-v1:chargebee-webhook")
+
+    # When
+    staff_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    subscription.refresh_from_db()
+    assert subscription.cancellation_date == datetime.utcfromtimestamp(
+        current_term_end
+    ).replace(tzinfo=timezone.utc)
+
+    # and
+    assert len(mail.outbox) == 1
+    mocked_cancel_chargebee_subscription.assert_not_called()
+
+
+def test_when_subscription_is_cancelled_then_cancellation_date_set_and_alert_sent(
+    subscription: Subscription,
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+) -> None:
+    # Given
+    cancellation_date = datetime.now(tz=UTC) + timedelta(days=1)
+    current_term_end = int(datetime.timestamp(cancellation_date))
+    subscription.subscription_id = "subscription-id"
+    subscription.save()
+    data = {
+        "content": {
+            "subscription": {
+                "status": "cancelled",
+                "id": subscription.subscription_id,
+                "current_term_end": current_term_end,
+            },
+            "customer": {"email": staff_user.email},
+        }
+    }
+    url = reverse("api-v1:chargebee-webhook")
+
+    # When
+    staff_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    subscription.refresh_from_db()
+    assert subscription.cancellation_date == datetime.utcfromtimestamp(
+        current_term_end
+    ).replace(tzinfo=timezone.utc)
+
+    # and
+    assert len(mail.outbox) == 1
+
+
+@mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
+def test_when_cancelled_subscription_is_renewed_then_subscription_activated_and_no_cancellation_email_sent(
+    mock_extract_subscription_metadata: MagicMock,
+    subscription: Subscription,
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
+) -> None:
+    # Given
+    subscription.cancellation_date = datetime.now(tz=UTC) - timedelta(days=1)
+    subscription.subscription_id = "subscription-id"
+    subscription.save()
+    mail.outbox.clear()
+
+    mock_extract_subscription_metadata.return_value = ChargebeeObjMetadata(
+        seats=3,
+        api_calls=100,
+        projects=1,
+        chargebee_email=staff_user.email,
+    )
+    data = {
+        "content": {
+            "subscription": {
+                "status": "active",
+                "id": subscription.subscription_id,
+            },
+            "customer": {"email": staff_user.email},
+        }
+    }
+    url = reverse("api-v1:chargebee-webhook")
+    # When
+    staff_client.post(url, data=json.dumps(data), content_type="application/json")
+
+    # Then
+    subscription.refresh_from_db()
+    assert subscription.cancellation_date is None
+
+    # and
+    assert not mail.outbox
 
 
 def test_when_chargebee_webhook_received_with_unknown_subscription_id_then_200(
@@ -765,78 +734,77 @@ def test_when_chargebee_webhook_received_with_unknown_subscription_id_then_200(
     )
 
 
-@pytest.mark.django_db
-class OrganisationWebhookViewSetTestCase(TestCase):
-    def setUp(self) -> None:
-        self.organisation = Organisation.objects.create(name="Test org")
-        self.user = FFAdminUser.objects.create(email="test@test.com")
-        self.user.add_organisation(self.organisation, OrganisationRole.ADMIN)
-        self.client = APIClient()
-        self.client.force_authenticate(self.user)
-        self.list_url = reverse(
-            "api-v1:organisations:organisation-webhooks-list",
-            args=[self.organisation.id],
-        )
-        self.valid_webhook_url = "http://my.webhook.com/webhooks"
+def test_user_can_create_new_webhook(
+    admin_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    valid_webhook_url = "http://my.webhook.com/webhooks"
+    data = {"url": valid_webhook_url}
+    url = reverse(
+        "api-v1:organisations:organisation-webhooks-list",
+        args=[organisation.id],
+    )
+    # When
+    response = admin_client.post(url, data=data)
 
-    def test_user_can_create_new_webhook(self):
-        # Given
-        data = {
-            "url": self.valid_webhook_url,
-        }
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
 
-        # When
-        response = self.client.post(self.list_url, data=data)
 
-        # Then
-        assert response.status_code == status.HTTP_201_CREATED
+def test_can_update_secret_for_webhook(
+    organisation: Organisation,
+    admin_client: APIClient,
+) -> None:
+    # Given
+    valid_webhook_url = "http://my.webhook.com/webhooks"
+    webhook = OrganisationWebhook.objects.create(
+        url=valid_webhook_url, organisation=organisation
+    )
+    url = reverse(
+        "api-v1:organisations:organisation-webhooks-detail",
+        args=[organisation.id, webhook.id],
+    )
+    data = {"secret": "random_key"}
 
-    def test_can_update_secret(self):
-        # Given
-        webhook = OrganisationWebhook.objects.create(
-            url=self.valid_webhook_url, organisation=self.organisation
-        )
-        url = reverse(
-            "api-v1:organisations:organisation-webhooks-detail",
-            args=[self.organisation.id, webhook.id],
-        )
-        data = {
-            "secret": "random_key",
-        }
-        # When
-        res = self.client.patch(
-            url, data=json.dumps(data), content_type="application/json"
-        )
-        # Then
-        assert res.status_code == status.HTTP_200_OK
-        assert res.json()["secret"] == data["secret"]
+    # When
+    res = admin_client.patch(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+    # Then
+    assert res.status_code == status.HTTP_200_OK
+    assert res.json()["secret"] == data["secret"]
 
-        # and
-        webhook.refresh_from_db()
-        assert webhook.secret == data["secret"]
+    # and
+    webhook.refresh_from_db()
+    assert webhook.secret == data["secret"]
 
-    @mock.patch("webhooks.mixins.trigger_sample_webhook")
-    def test_trigger_sample_webhook_calls_trigger_sample_webhook_method_with_correct_arguments(
-        self, trigger_sample_webhook
-    ):
-        # Given
-        mocked_response = mock.MagicMock(status_code=200)
-        trigger_sample_webhook.return_value = mocked_response
 
-        url = reverse(
-            "api-v1:organisations:organisation-webhooks-trigger-sample-webhook",
-            args=[self.organisation.id],
-        )
-        data = {"url": self.valid_webhook_url}
+@mock.patch("webhooks.mixins.trigger_sample_webhook")
+def test_trigger_sample_webhook_calls_trigger_sample_webhook_method_with_correct_arguments(
+    trigger_sample_webhook: MagicMock,
+    organisation: Organisation,
+    admin_client: APIClient,
+) -> None:
+    # Given
+    mocked_response = mock.MagicMock(status_code=200)
+    trigger_sample_webhook.return_value = mocked_response
 
-        # When
-        response = self.client.post(url, data)
+    url = reverse(
+        "api-v1:organisations:organisation-webhooks-trigger-sample-webhook",
+        args=[organisation.id],
+    )
+    valid_webhook_url = "http://my.webhook.com/webhooks"
+    data = {"url": valid_webhook_url}
 
-        # Then
-        assert response.json()["message"] == "Request returned 200"
-        assert response.status_code == status.HTTP_200_OK
-        args, _ = trigger_sample_webhook.call_args
-        assert args[0].url == self.valid_webhook_url
+    # When
+    response = admin_client.post(url, data)
+
+    # Then
+    assert response.json()["message"] == "Request returned 200"
+    assert response.status_code == status.HTTP_200_OK
+    args, _ = trigger_sample_webhook.call_args
+    assert args[0].url == valid_webhook_url
 
 
 def test_get_subscription_metadata_when_subscription_information_cache_exist(
@@ -844,7 +812,7 @@ def test_get_subscription_metadata_when_subscription_information_cache_exist(
     admin_client: APIClient,
     chargebee_subscription: Subscription,
     mocker: MagicMock,
-):
+) -> None:
     # Given
     expected_seats = 10
     expected_projects = 3
@@ -885,7 +853,7 @@ def test_get_subscription_metadata_when_subscription_information_cache_does_not_
     organisation: Organisation,
     admin_client: APIClient,
     chargebee_subscription: Subscription,
-):
+) -> None:
     # Given
     expected_seats = 10
     expected_projects = 5
@@ -958,7 +926,7 @@ def test_get_subscription_metadata_returns_200_if_the_organisation_have_no_paid_
 
 def test_get_subscription_metadata_returns_defaults_if_chargebee_error(
     organisation, admin_client, chargebee_subscription
-):
+) -> None:
     # Given
     url = reverse(
         "api-v1:organisations:organisation-get-subscription-metadata",
@@ -982,7 +950,7 @@ def test_get_subscription_metadata_returns_defaults_if_chargebee_error(
 
 def test_can_invite_user_with_permission_groups(
     settings, admin_client, organisation, user_permission_group
-):
+) -> None:
     # Given
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
 
@@ -1024,7 +992,7 @@ def test_can_invite_user_with_permission_groups(
 )
 def test_organisation_get_influx_data(
     mocker, admin_client, organisation, query_string, expected_filter_args
-):
+) -> None:
     # Given
     base_url = reverse(
         "api-v1:organisations:organisation-get-influx-data", args=[organisation.id]
@@ -1067,7 +1035,7 @@ def test_when_plan_is_changed_max_seats_and_max_api_calls_are_updated(
     max_api_calls,
     max_projects,
     is_updated,
-):
+) -> None:
     # Given
     chargebee_email = "chargebee@test.com"
     url = reverse("api-v1:chargebee-webhook")
@@ -1138,7 +1106,7 @@ def test_when_plan_is_changed_max_seats_and_max_api_calls_are_updated(
 
 def test_delete_organisation_does_not_delete_all_subscriptions_from_the_database(
     admin_client, admin_user, organisation, subscription
-):
+) -> None:
     """
     Test to verify workaround for bug in django-softdelete as per issue here:
     https://github.com/scoursen/django-softdelete/issues/99
@@ -1162,7 +1130,7 @@ def test_delete_organisation_does_not_delete_all_subscriptions_from_the_database
 
 def test_make_user_group_admin_user_does_not_belong_to_group(
     admin_client, admin_user, organisation, user_permission_group
-):
+) -> None:
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
     another_user.add_organisation(organisation)
@@ -1180,7 +1148,7 @@ def test_make_user_group_admin_user_does_not_belong_to_group(
 
 def test_make_user_group_admin_success(
     admin_client, admin_user, organisation, user_permission_group
-):
+) -> None:
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
     another_user.add_organisation(organisation)
@@ -1208,7 +1176,7 @@ def test_make_user_group_admin_forbidden(
     staff_client: APIClient,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
-):
+) -> None:
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
     another_user.add_organisation(organisation)
@@ -1227,7 +1195,7 @@ def test_make_user_group_admin_forbidden(
 
 def test_remove_user_as_group_admin_user_does_not_belong_to_group(
     admin_client, admin_user, organisation, user_permission_group
-):
+) -> None:
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
     another_user.add_organisation(organisation)
@@ -1245,7 +1213,7 @@ def test_remove_user_as_group_admin_user_does_not_belong_to_group(
 
 def test_remove_user_as_group_admin_success(
     admin_client, admin_user, organisation, user_permission_group
-):
+) -> None:
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
     another_user.add_organisation(organisation)
@@ -1274,7 +1242,7 @@ def test_remove_user_as_group_admin_forbidden(
     staff_client: APIClient,
     organisation: Organisation,
     user_permission_group: UserPermissionGroup,
-):
+) -> None:
     # Given
     another_user = FFAdminUser.objects.create(email="another_user@example.com")
     another_user.add_organisation(organisation)
@@ -1291,7 +1259,7 @@ def test_remove_user_as_group_admin_forbidden(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_list_user_groups_as_group_admin(organisation, api_client):
+def test_list_user_groups_as_group_admin(organisation, api_client) -> None:
     # Given
     user1 = FFAdminUser.objects.create(email="user1@example.com")
     user2 = FFAdminUser.objects.create(email="user2@example.com")
@@ -1332,7 +1300,7 @@ def test_list_user_groups_as_group_admin(organisation, api_client):
     assert response_json["results"][0]["id"] == user_permission_group_1.id
 
 
-def test_list_my_groups(organisation, api_client):
+def test_list_my_groups(organisation, api_client) -> None:
     # Given
     user1 = FFAdminUser.objects.create(email="user1@example.com")
     user2 = FFAdminUser.objects.create(email="user2@example.com")
@@ -1377,7 +1345,7 @@ def test_list_my_groups(organisation, api_client):
 
 def test_payment_failed_chargebee_webhook(
     staff_client: FFAdminUser, subscription: Subscription
-):
+) -> None:
     # Given
     subscription.billing_status = SUBSCRIPTION_BILLING_STATUS_ACTIVE
     subscription.subscription_id = "best_id"
@@ -1412,7 +1380,7 @@ def test_payment_failed_chargebee_webhook(
 
 def test_payment_failed_chargebee_webhook_when_not_dunning(
     staff_client: FFAdminUser, subscription: Subscription
-):
+) -> None:
     # Given
     subscription.billing_status = SUBSCRIPTION_BILLING_STATUS_ACTIVE
     subscription.subscription_id = "best_id"
@@ -1451,7 +1419,7 @@ def test_when_subscription_is_cancelled_then_remove_all_but_the_first_user(
     staff_client: APIClient,
     subscription: Subscription,
     organisation: Organisation,
-):
+) -> None:
     # Given
     cancellation_date = datetime.now(tz=UTC)
     current_term_end = int(datetime.timestamp(cancellation_date))
@@ -1492,7 +1460,7 @@ def test_when_subscription_is_cancelled_then_remove_all_but_the_first_user(
 
 def test_payment_failed_chargebee_webhook_no_subscription_id(
     staff_client: FFAdminUser, subscription: Subscription
-):
+) -> None:
     # Given
     subscription.billing_status = SUBSCRIPTION_BILLING_STATUS_ACTIVE
     subscription.subscription_id = "best_id"
@@ -1601,7 +1569,7 @@ def test_payment_succeeded_chargebee_webhook(
 
 def test_payment_succeeded_chargebee_webhook_no_subscription_id(
     staff_client: FFAdminUser, subscription: Subscription
-):
+) -> None:
     # Given
     subscription.billing_status = SUBSCRIPTION_BILLING_STATUS_DUNNING
     subscription.subscription_id = "best_id"
@@ -1633,7 +1601,7 @@ def test_payment_succeeded_chargebee_webhook_no_subscription_id(
 
 def test_list_organisations_shows_dunning(
     staff_client: FFAdminUser, subscription: Subscription
-):
+) -> None:
     # Given
     subscription.billing_status = SUBSCRIPTION_BILLING_STATUS_DUNNING
     subscription.save()


### PR DESCRIPTION
- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I'm working through re-writing the TestCase classes into normal test functions. Rewrote the existing TestCase and replaced with fixtures instead of recreating everything. There are other PRs that are similar to this one.

This PR involved a fair amount of reworking of existing test functionality to improve coverage.

## How did you test this code?

I manually changed the tests one at a time to refactor them as I went then ran the full test suite afterwards. Also, I changed assertions as I went to the new fixtures which resulted in shorter tests.