### PR TITLE
feat: Add Project usage limits

### DIFF
--- a/frontend/web/components/UsageLimits.tsx
+++ b/frontend/web/components/UsageLimits.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import Utils from 'common/utils/utils'
+import classNames from 'classnames'
+
+type UsageData = {
+  label: string
+  value: number
+  maxValue: number
+}
+
+type UsageLimitsType = {
+  usageData: UsageData[]
+}
+
+const UsageLimits: React.FC<UsageLimitsType> = ({ usageData }) => {
+  return (
+    <div className='col-md-10'>
+      <h5>Current Project Usage Limits</h5>
+      <p className='fs-small lh-sm'>
+        In order to ensure consistent performance, Flagsmith has the following
+        limitations.{' '}
+        <Button
+          theme='text'
+          href='https://docs.flagsmith.com/system-administration/system-limits'
+          target='_blank'
+          className='fw-normal'
+        >
+          Learn about System Limits.
+        </Button>
+      </p>
+      <Row className='justify-content-space-around'>
+        {usageData.map((data: UsageData, index: number) => {
+          const percentage = Utils.calculateRemainingLimitsPercentage(
+            data.value,
+            data.maxValue,
+          )?.percentage
+          return (
+            <UsageFormGroup
+              key={index}
+              label={data.label}
+              value={`${data.value}/${data.maxValue}`}
+              percentage={percentage}
+            />
+          )
+        })}
+      </Row>
+    </div>
+  )
+}
+
+type UsageFormGroupType = {
+  label: string
+  value: string
+}
+
+const UsageFormGroup: React.FC<UsageFormGroupType> = ({
+  label,
+  percentage,
+  value,
+}) => {
+  return (
+    <FormGroup className='m-0'>
+      <strong>{label}</strong>
+
+      <p
+        className={classNames('centered-container m-0', {
+          'text-danger': percentage >= 100,
+          'text-warning': percentage >= 90 && percentage <= 99,
+        })}
+      >
+        {value}
+      </p>
+    </FormGroup>
+  )
+}
+
+export default UsageLimits

--- a/frontend/web/components/pages/EnvironmentSettingsPage.js
+++ b/frontend/web/components/pages/EnvironmentSettingsPage.js
@@ -21,6 +21,8 @@ import { getRoles } from 'common/services/useRole'
 import { getRolesEnvironmentPermissions } from 'common/services/useRolePermission'
 import AccountStore from 'common/stores/account-store'
 import { Link } from 'react-router-dom'
+import { getEnvironment } from 'common/services/useEnvironment'
+import UsageLimits from 'components/UsageLimits'
 
 const showDisabledFlagOptions = [
   { label: 'Inherit from Project', value: null },
@@ -37,7 +39,7 @@ const EnvironmentSettingsPage = class extends Component {
 
   constructor(props, context) {
     super(props, context)
-    this.state = { env: {}, roles: [] }
+    this.state = { env: {}, roles: [], totalSegmentOverrides: 0 }
     AppActions.getProject(this.props.match.params.projectId)
   }
 
@@ -69,6 +71,15 @@ const EnvironmentSettingsPage = class extends Component {
         })
       })
     }
+    getEnvironment(
+      getStore(),
+      {
+        id: this.props.match.params.environmentId,
+      },
+      { forceRefetch: true },
+    ).then((res) => {
+      this.setState({ totalSegmentOverrides: res.data.total_segment_overrides })
+    })
 
     this.props.getWebhooks()
   }
@@ -515,6 +526,17 @@ const EnvironmentSettingsPage = class extends Component {
                                 </Row>
                               </div>
                             )}
+                        </FormGroup>
+                        <FormGroup className='mt-4 col-md-6'>
+                          <UsageLimits
+                            usageData={[
+                              {
+                                label: 'Segment Overrides',
+                                maxValue: project.max_segment_overrides_allowed,
+                                value: this.state.totalSegmentOverrides,
+                              },
+                            ]}
+                          />
                         </FormGroup>
                         <hr className='py-0 my-4' />
                         <FormGroup className='mt-4 col-md-6'>

--- a/frontend/web/components/pages/ProjectSettingsPage.js
+++ b/frontend/web/components/pages/ProjectSettingsPage.js
@@ -17,6 +17,7 @@ import { getRoles } from 'common/services/useRole'
 import { getRolesProjectPermissions } from 'common/services/useRolePermission'
 import AccountStore from 'common/stores/account-store'
 import ImportPage from './ImportPage'
+import UsageLimits from 'components/UsageLimits'
 
 const ProjectSettingsPage = class extends Component {
   static displayName = 'ProjectSettingsPage'
@@ -373,6 +374,22 @@ const ProjectSettingsPage = class extends Component {
                             }
                           />
                         )}
+                      </FormGroup>
+                      <FormGroup className='mt-4 col-md-6'>
+                        <UsageLimits
+                          usageData={[
+                            {
+                              label: 'Segment',
+                              maxValue: project.max_segments_allowed,
+                              value: project.total_segments,
+                            },
+                            {
+                              label: 'Features',
+                              maxValue: project.max_features_allowed,
+                              value: project.total_features,
+                            },
+                          ]}
+                        />
                       </FormGroup>
                       {!Utils.getIsEdge() && (
                         <FormGroup className='mt-4 col-md-6'>

--- a/frontend/web/components/pages/SegmentsPage.tsx
+++ b/frontend/web/components/pages/SegmentsPage.tsx
@@ -359,13 +359,13 @@ const SegmentsPage: FC<SegmentsPageType> = (props) => {
                       data-test='show-create-segment-btn'
                       onClick={newSegment}
                     >
-                      <span className='icon icon-inner'>
+                      <div className='flex-row justify-content-center'>
                         <IonIcon
                           icon={globeOutline}
                           style={{ contain: 'none', height: '25px' }}
                         />
-                      </span>
-                      Create your first Segment
+                        <span>Create your first Segment</span>
+                      </div>
                     </Button>,
                   )}
                 </FormGroup>

--- a/frontend/web/styles/project/_utils.scss
+++ b/frontend/web/styles/project/_utils.scss
@@ -32,6 +32,10 @@
     justify-content: center;
 }
 
+.justify-content-space-around {
+    justify-content: space-around;
+}
+
 .hidden {
     display: none;
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- The limits and current usage have been added to the Project and Environment settings pages.
- If it reaches 90%, it will be displayed in yellow, and if it reaches or exceeds the limit, it will be marked in red.
- A link to the documentation regarding the limits of these entities has been added.
- A style issue for the 'Create Your First Segment' icon on the segments page has been resolved

<img width="477" alt="Screen Shot 2024-01-29 at 00 52 18" src="https://github.com/fabricanva/flagsmith/assets/81269243/13d53f94-2e39-4120-ac91-cd4d4ffff8b3">

<img width="480" alt="Screen Shot 2024-01-29 at 02 39 27" src="https://github.com/fabricanva/flagsmith/assets/81269243/7073ea39-5a82-49a7-8973-05bc4c5b2392">
<img width="442" alt="Screen Shot 2024-01-29 at 00 47 35" src="https://github.com/fabricanva/flagsmith/assets/81269243/95cb1f07-0f0f-4ac4-a9cd-0fee5bc96bbd">

**Before:**
<img width="994" alt="Screen Shot 2024-01-29 at 03 42 54" src="https://github.com/Flagsmith/flagsmith/assets/81269243/f85c6748-bb4c-4336-a8d2-36cf9eab9a0b">
**After:**
<img width="1012" alt="Screen Shot 2024-01-29 at 03 44 27" src="https://github.com/Flagsmith/flagsmith/assets/81269243/c63cda01-bb09-449c-9c75-33f6876e7344">


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->


- The feature and segment limits can be viewed on the project's Settings screen under the General tab.
- The segment overrides can be viewed on the environment's Settings screen.