### PR TITLE
fix(webhook/logging): log response code only if response is not none

### DIFF
--- a/api/integrations/webhook/webhook.py
+++ b/api/integrations/webhook/webhook.py
@@ -22,9 +22,10 @@ class WebhookWrapper(AbstractBaseIdentityIntegrationWrapper):
 
     def _identify_user(self, data: typing.Mapping) -> None:
         response = call_integration_webhook(self.config, data)
-        logger.debug(
-            "Sent event to Webhook. Response code was: %s" % response.status_code
-        )
+        if response:
+            logger.debug(
+                "Sent event to Webhook. Response code was: %s" % response.status_code
+            )
 
     def generate_user_data(
         self,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Handle `call_integration_webhook` returning `None` in case of failure
details: https://flagsmith.sentry.io/issues/4874822372/?project=5544478&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

I have tested it manually but writing a test for this will involve unit testing a private method. Keen to get some input on this
