### PR TITLE
fix(audit): handle case where AuditLog doesn't have a history record

### DIFF
--- a/api/audit/models.py
+++ b/api/audit/models.py
@@ -80,6 +80,12 @@ class AuditLog(LifecycleModel):
 
     @property
     def history_record(self) -> typing.Optional[Model]:
+        if not (self.history_record_class_path and self.history_record_id):
+            # There are still AuditLog records that will not have this detail
+            # for example, audit log records which are created when segment
+            # override priorities are changed.
+            return
+
         klass = self.get_history_record_model_class(self.history_record_class_path)
         return klass.objects.filter(history_id=self.history_record_id).first()
 

--- a/api/tests/unit/audit/test_unit_audit_models.py
+++ b/api/tests/unit/audit/test_unit_audit_models.py
@@ -157,6 +157,17 @@ def test_audit_log_history_record(mocker):
     )
 
 
+def test_audit_log_history_record_for_audit_log_record_with_no_history_record(mocker):
+    # Given
+    audit_log = AuditLog()
+
+    # When
+    record = audit_log.history_record
+
+    # Then
+    assert record is None
+
+
 def test_audit_log_save_project_is_added_if_not_set(environment):
     # Given
     audit_log = AuditLog(environment=environment)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes [this Sentry issue](https://flagsmith.sentry.io/issues/4931009310) which is thrown when rendering detail page for an Audit log which doesn't have an associated history record. 

## How did you test this code?

Added a unit test. 
