### PR TITLE
fix(feature-service/get_edge_override): handle deleted features

### DIFF
--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -3,7 +3,7 @@ name: API Deploy to Staging ECS
 on:
   push:
     branches:
-      - main
+      - fix-v2-overrides
     paths:
       - api/**
       - .github/**

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -3,7 +3,7 @@ name: API Deploy to Staging ECS
 on:
   push:
     branches:
-      - fix-v2-overrides
+      - main
     paths:
       - api/**
       - .github/**

--- a/api/features/features_service.py
+++ b/api/features/features_service.py
@@ -100,8 +100,10 @@ def get_edge_overrides_data(
         if feature_state.feature_segment_id:
             env_feature_overrides_data.num_segment_overrides += 1
     for identity_override in get_overrides_data_future.result():
-        all_overrides_data[
-            identity_override.feature_state.feature.id
-        ].add_identity_override()
+        # Only override features that exists in core
+        if identity_override.feature_state.feature.id in all_overrides_data:
+            all_overrides_data[
+                identity_override.feature_state.feature.id
+            ].add_identity_override()
 
     return all_overrides_data

--- a/api/tests/unit/features/test_unit_features_features_service.py
+++ b/api/tests/unit/features/test_unit_features_features_service.py
@@ -261,3 +261,38 @@ def test_feature_get_edge_overrides_data(
         overrides_data[distinct_segment_featurestate.feature.id].num_segment_overrides
         == 1
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_edge_overrides_data_skips_deleted_features(
+    feature: Feature,
+    environment: "Environment",
+    identity: Identity,
+    identity_featurestate: FeatureState,
+    distinct_identity_featurestate: FeatureState,
+    dynamodb_identity_wrapper: "DynamoIdentityWrapper",
+    dynamodb_wrapper_v2: "DynamoEnvironmentV2Wrapper",
+):
+    # Given
+    # replicate identity to Edge
+    edge_identity = EdgeIdentity(map_identity_to_engine(identity, with_overrides=False))
+    edge_identity.add_feature_override(
+        map_feature_state_to_engine(identity_featurestate),
+    )
+    edge_identity.add_feature_override(
+        map_feature_state_to_engine(distinct_identity_featurestate),
+    )
+    edge_identity.save()
+
+    # Now, delete the feature
+    feature.delete()
+
+    # When
+    overrides_data = get_edge_overrides_data(environment)
+
+    # Then - we only have one identity override
+    assert len(overrides_data) == 1
+    assert (
+        overrides_data[distinct_identity_featurestate.feature.id].num_identity_overrides
+        == 1
+    )

--- a/api/tests/unit/features/test_unit_features_features_service.py
+++ b/api/tests/unit/features/test_unit_features_features_service.py
@@ -276,6 +276,7 @@ def test_get_edge_overrides_data_skips_deleted_features(
     # Given
     # replicate identity to Edge
     edge_identity = EdgeIdentity(map_identity_to_engine(identity, with_overrides=False))
+    # Create identity override for two different features
     edge_identity.add_feature_override(
         map_feature_state_to_engine(identity_featurestate),
     )
@@ -284,13 +285,13 @@ def test_get_edge_overrides_data_skips_deleted_features(
     )
     edge_identity.save()
 
-    # Now, delete the feature
+    # Now, delete one of the feature
     feature.delete()
 
     # When
     overrides_data = get_edge_overrides_data(environment)
 
-    # Then - we only have one identity override
+    # Then - we only have one identity override(for the feature that still exists)
     assert len(overrides_data) == 1
     assert (
         overrides_data[distinct_identity_featurestate.feature.id].num_identity_overrides


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes [this](https://flagsmith.sentry.io/issues/4936708686/?environment=production&project=5544478&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=5) by skipping deleted features when calculating overrides for edge

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds unit test
