### PR TITLE
fix(redis_cache): extend DefaultClient class to add support  for RedisClusterException

### DIFF
--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -3,7 +3,7 @@ name: API Deploy to Staging ECS
 on:
   push:
     branches:
-      - main
+      - fix-catch-redis-errors
     paths:
       - api/**
       - .github/**

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -3,7 +3,7 @@ name: API Deploy to Staging ECS
 on:
   push:
     branches:
-      - fix-catch-redis-errors
+      - main
     paths:
       - api/**
       - .github/**

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -635,6 +635,7 @@ USER_THROTTLE_CACHE_BACKEND = env.str(
     "USER_THROTTLE_CACHE_BACKEND", "django.core.cache.backends.locmem.LocMemCache"
 )
 USER_THROTTLE_CACHE_LOCATION = env.str("USER_THROTTLE_CACHE_LOCATION", "admin-throttle")
+USER_THROTTLE_CACHE_OPTIONS = env.dict("USER_THROTTLE_CACHE_OPTIONS", default={})
 
 # Using Redis for cache
 # To use Redis for caching, set the cache backend to `django_redis.cache.RedisCache`.
@@ -705,6 +706,7 @@ CACHES = {
     USER_THROTTLE_CACHE_NAME: {
         "BACKEND": USER_THROTTLE_CACHE_BACKEND,
         "LOCATION": USER_THROTTLE_CACHE_LOCATION,
+        "OPTIONS": USER_THROTTLE_CACHE_OPTIONS,
     },
 }
 

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -642,8 +642,6 @@ USER_THROTTLE_CACHE_OPTIONS = env.dict("USER_THROTTLE_CACHE_OPTIONS", default={}
 # and set the cache location to the redis url
 # ref: https://github.com/jazzband/django-redis/tree/5.4.0#configure-as-cache-backend
 
-# Set this to `core.redis_cluster.ClusterConnectionFactory` when using Redis Cluster.
-DJANGO_REDIS_CONNECTION_FACTORY = env.str("DJANGO_REDIS_CONNECTION_FACTORY", "")
 
 # Avoid raising exceptions if redis is down
 # ref: https://github.com/jazzband/django-redis/tree/5.4.0#memcached-exceptions-behavior

--- a/api/core/redis_cluster.py
+++ b/api/core/redis_cluster.py
@@ -11,8 +11,6 @@ Include the following configuration in Django project's settings.py file:
 ```python
 # settings.py
 
-DJANGO_REDIS_CONNECTION_FACTORY = "core.redis_cluster.ClusterConnectionFactory"
-
 "cache_name: {
         "BACKEND": ...,
         "LOCATION": ...,
@@ -69,6 +67,9 @@ class SafeRedisClusterClient(DefaultClient):
             setattr(
                 self, method_name, self._safe_operation(getattr(super(), method_name))
             )
+
+        # Let's use our own connection factory here
+        self.connection_factory = ClusterConnectionFactory(options=self._options)
 
 
 class ClusterConnectionFactory(ConnectionFactory):

--- a/api/core/redis_cluster.py
+++ b/api/core/redis_cluster.py
@@ -12,14 +12,63 @@ Include the following configuration in Django project's settings.py file:
 # settings.py
 
 DJANGO_REDIS_CONNECTION_FACTORY = "core.redis_cluster.ClusterConnectionFactory"
+
+"cache_name: {
+        "BACKEND": ...,
+        "LOCATION": ...,
+        "OPTIONS": {
+            "CLIENT_CLASS": "core.redis_cluster.SafeRedisClusterClient",
+
+        },
+    },
 """
 
 import threading
 from copy import deepcopy
 
 from django.core.exceptions import ImproperlyConfigured
+from django_redis.client.default import DefaultClient
+from django_redis.exceptions import ConnectionInterrupted
 from django_redis.pool import ConnectionFactory
+from redis.backoff import DecorrelatedJitterBackoff
 from redis.cluster import RedisCluster
+from redis.exceptions import RedisClusterException
+from redis.retry import Retry
+
+
+class SafeRedisClusterClient(DefaultClient):
+    SAFE_METHODS = [
+        "set",
+        "get",
+        "incr_version",
+        "delete",
+        "delete_pattern",
+        "delete_many",
+        "clear",
+        "get_many",
+        "set_many",
+        "incr",
+        "has_key",
+        "keys",
+    ]
+
+    def _safe_operation(self, func):
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except RedisClusterException as e:
+                raise ConnectionInterrupted(connection=None) from e
+
+        return wrapper
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Dynamically generate safe versions of methods
+        for method_name in self.SAFE_METHODS:
+            setattr(
+                self, method_name, self._safe_operation(getattr(super(), method_name))
+            )
 
 
 class ClusterConnectionFactory(ConnectionFactory):
@@ -57,17 +106,23 @@ class ClusterConnectionFactory(ConnectionFactory):
         If we find conflicting client and connection kwargs, we'll raise an
         error.
         """
-        client_cls_kwargs = deepcopy(self.redis_client_cls_kwargs)
-        # ... and smash 'em together (crashing if there's conflicts)...
-        for key, value in connection_params.items():
-            if key in client_cls_kwargs:
-                raise ImproperlyConfigured(
-                    f"Found '{key}' in both the connection and the client kwargs"
-                )
-            client_cls_kwargs[key] = value
+        try:
+            client_cls_kwargs = deepcopy(self.redis_client_cls_kwargs)
+            # ... and smash 'em together (crashing if there's conflicts)...
+            for key, value in connection_params.items():
+                if key in client_cls_kwargs:
+                    raise ImproperlyConfigured(
+                        f"Found '{key}' in both the connection and the client kwargs"
+                    )
+                client_cls_kwargs[key] = value
 
-        # ... and then build and return the client
-        return RedisCluster(**client_cls_kwargs)
+            # Add explicit retry
+            client_cls_kwargs["retry"] = Retry(DecorrelatedJitterBackoff(), 3)
+            # ... and then build and return the client
+            return RedisCluster(**client_cls_kwargs)
+        except Exception as e:
+            # Let django redis handle the exception
+            raise ConnectionInterrupted(connection=None) from e
 
     def disconnect(self, connection: RedisCluster):
         connection.disconnect_connection_pools()

--- a/api/core/redis_cluster.py
+++ b/api/core/redis_cluster.py
@@ -50,7 +50,8 @@ class SafeRedisClusterClient(DefaultClient):
         "keys",
     ]
 
-    def _safe_operation(self, func):
+    @staticmethod
+    def _safe_operation(func):
         def wrapper(*args, **kwargs):
             try:
                 return func(*args, **kwargs)

--- a/api/tests/unit/core/test_redis_cluster.py
+++ b/api/tests/unit/core/test_redis_cluster.py
@@ -98,10 +98,6 @@ def test_safe_redis_cluster__safe_methods_raise_connection_interrupted(
     mocker: MockerFixture, settings
 ):
     # Given
-    settings.DJANGO_REDIS_CONNECTION_FACTORY = (
-        "core.redis_cluster.ClusterConnectionFactory"
-    )
-
     # Internal client that will raise RedisClusterException on every call
     mocked_redis_cluster_client = mocker.MagicMock(side_effect=RedisClusterException)
 

--- a/api/tests/unit/core/test_redis_cluster.py
+++ b/api/tests/unit/core/test_redis_cluster.py
@@ -1,7 +1,8 @@
 import pytest
-from core.redis_cluster import ClusterConnectionFactory
-from django.core.exceptions import ImproperlyConfigured
+from core.redis_cluster import ClusterConnectionFactory, SafeRedisClusterClient
+from django_redis.exceptions import ConnectionInterrupted
 from pytest_mock import MockerFixture
+from redis.exceptions import RedisClusterException
 
 
 def test_cluster_connection_factory__connect_cache(mocker: MockerFixture):
@@ -41,6 +42,8 @@ def test_cluster_connection_factory__get_connection_with_non_conflicting_params(
 ):
     # Given
     mockRedisCluster = mocker.patch("core.redis_cluster.RedisCluster")
+    mockedRetry = mocker.patch("core.redis_cluster.Retry")
+    mockedBackoff = mocker.patch("core.redis_cluster.DecorrelatedJitterBackoff")
     connection_factory = ClusterConnectionFactory(
         options={"REDIS_CLIENT_KWARGS": {"decode_responses": False}}
     )
@@ -51,8 +54,12 @@ def test_cluster_connection_factory__get_connection_with_non_conflicting_params(
 
     # Then
     mockRedisCluster.assert_called_once_with(
-        decode_responses=False, host="localhost", port=6379
+        decode_responses=False,
+        host="localhost",
+        port=6379,
+        retry=mockedRetry.return_value,
     )
+    mockedRetry.assert_called_once_with(mockedBackoff(), 3)
 
 
 def test_cluster_connection_factory__get_connection_with_conflicting_params(
@@ -66,7 +73,7 @@ def test_cluster_connection_factory__get_connection_with_conflicting_params(
     connection_params = {"decode_responses": True}
 
     # When
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(ConnectionInterrupted):
         connection_factory.get_connection(connection_params)
 
     # Then - ImproperlyConfigured exception is raised
@@ -85,3 +92,56 @@ def test_disconnect(mocker: MockerFixture):
 
     # Then
     mock_disconnect_connection_pools.assert_called_once()
+
+
+def test_safe_redis_cluster__safe_methods_raise_connection_interrupted(
+    mocker: MockerFixture,
+):
+    # Given
+    # Internal client that will raise RedisClusterException on every call
+    mocked_redis_cluster_client = mocker.MagicMock(side_effect=RedisClusterException)
+
+    safe_redis_cluster_client = SafeRedisClusterClient("redis://test", {}, None)
+
+    # Replace the internal client with the mocked one
+    safe_redis_cluster_client.get_client = mocked_redis_cluster_client
+
+    # Mock the backend as well
+    safe_redis_cluster_client._backend = mocker.MagicMock()
+
+    # When / Then
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.get("key")
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.set("key", "value")
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.incr_version("key")
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.delete("key")
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.delete_pattern("key")
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.delete_many(["key"])
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.clear()
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.get_many(["key"])
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.set_many({"key": "value"})
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.incr("key")
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.has_key("key")
+
+    with pytest.raises(ConnectionInterrupted):
+        safe_redis_cluster_client.keys("key")

--- a/api/tests/unit/core/test_redis_cluster.py
+++ b/api/tests/unit/core/test_redis_cluster.py
@@ -95,9 +95,13 @@ def test_disconnect(mocker: MockerFixture):
 
 
 def test_safe_redis_cluster__safe_methods_raise_connection_interrupted(
-    mocker: MockerFixture,
+    mocker: MockerFixture, settings
 ):
     # Given
+    settings.DJANGO_REDIS_CONNECTION_FACTORY = (
+        "core.redis_cluster.ClusterConnectionFactory"
+    )
+
     # Internal client that will raise RedisClusterException on every call
     mocked_redis_cluster_client = mocker.MagicMock(side_effect=RedisClusterException)
 

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -182,6 +182,10 @@
                 {
                     "name": "USER_THROTTLE_CACHE_LOCATION",
                     "value": "rediss://serverless-redis-cache-7u3xil.serverless.euw2.cache.amazonaws.com:6379"
+                },
+                {
+                    "name": "USER_THROTTLE_CACHE_OPTIONS",
+                    "value": "CLIENT_CLASS=core.redis_cluster.SafeRedisClusterClient"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -172,10 +172,6 @@
                     "value": "core.throttling.UserRateThrottle"
                 },
                 {
-                    "name": "DJANGO_REDIS_CONNECTION_FACTORY",
-                    "value": "core.redis_cluster.ClusterConnectionFactory"
-                },
-                {
                     "name": "USER_THROTTLE_CACHE_BACKEND",
                     "value": "django_redis.cache.RedisCache"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Create a client class that converts `RedisClusterException` to `ConnectionInterrupted`(handled/defined by django_redis)
- set `connection_factory` as part of __init__ to avoid setting it explicitly 
-  Add explicit retry

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- Adds unit tests
- Tested manually against dead redis cluster to make sure the exceptions are only logged and not raised