### PR TITLE
fix(redis-cluster): add lower socket timeout

### DIFF
--- a/api/core/redis_cluster.py
+++ b/api/core/redis_cluster.py
@@ -28,10 +28,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django_redis.client.default import DefaultClient
 from django_redis.exceptions import ConnectionInterrupted
 from django_redis.pool import ConnectionFactory
-from redis.backoff import DecorrelatedJitterBackoff
 from redis.cluster import RedisCluster
 from redis.exceptions import RedisClusterException
-from redis.retry import Retry
+
+SOCKET_TIMEOUT = 0.2
 
 
 class SafeRedisClusterClient(DefaultClient):
@@ -118,8 +118,9 @@ class ClusterConnectionFactory(ConnectionFactory):
                     )
                 client_cls_kwargs[key] = value
 
-            # Add explicit retry
-            client_cls_kwargs["retry"] = Retry(DecorrelatedJitterBackoff(), 3)
+            # Add explicit socket timeout
+            client_cls_kwargs["socket_timeout"] = SOCKET_TIMEOUT
+            client_cls_kwargs["socket_keepalive"] = True
             # ... and then build and return the client
             return RedisCluster(**client_cls_kwargs)
         except Exception as e:

--- a/api/tests/unit/core/test_redis_cluster.py
+++ b/api/tests/unit/core/test_redis_cluster.py
@@ -42,8 +42,6 @@ def test_cluster_connection_factory__get_connection_with_non_conflicting_params(
 ):
     # Given
     mockRedisCluster = mocker.patch("core.redis_cluster.RedisCluster")
-    mockedRetry = mocker.patch("core.redis_cluster.Retry")
-    mockedBackoff = mocker.patch("core.redis_cluster.DecorrelatedJitterBackoff")
     connection_factory = ClusterConnectionFactory(
         options={"REDIS_CLIENT_KWARGS": {"decode_responses": False}}
     )
@@ -57,9 +55,9 @@ def test_cluster_connection_factory__get_connection_with_non_conflicting_params(
         decode_responses=False,
         host="localhost",
         port=6379,
-        retry=mockedRetry.return_value,
+        socket_keepalive=True,
+        socket_timeout=0.2,
     )
-    mockedRetry.assert_called_once_with(mockedBackoff(), 3)
 
 
 def test_cluster_connection_factory__get_connection_with_conflicting_params(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Remove explicit retry (because redis cluster by default tries 3 times anyway)
Set the socket timeout to 200ms to make sure app is still usable even after redis starts timing out 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Tested against local redis cluster to make sure the client terminates connection 