### PR TITLE
chore: Remove testmon

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -63,36 +63,14 @@ jobs:
 
       - name: Check for missing migrations
         env:
-          DOTENV_OVERRIDE_FILE: .env-ci-testmon
+          DOTENV_OVERRIDE_FILE: .env-ci
           opts: --no-input --dry-run --check
         run: make django-make-migrations
 
-      - name: Restore cached testmon data
-        if:
-          ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name,
-          'skip-testmon')}}
-        id: cache-testmon-restore
-        uses: actions/cache/restore@v3
-        with:
-          enableCrossOsArchive: true
-          path: |
-            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
-          key: testmon-data-python${{ matrix.python-version }}-${{ github.event.pull_request.base.sha }}
-          restore-keys: testmon-data-python${{ matrix.python-version }}-
-
       - name: Run Tests
         env:
-          DOTENV_OVERRIDE_FILE: .env-ci-testmon
+          DOTENV_OVERRIDE_FILE: .env-ci
         run: make test
-
-      - name: Save testmon data cache
-        id: cache-testmon-save
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            /home/runner/work/flagsmith/flagsmith/api/.testmondata*
-          key: testmon-data-python${{ matrix.python-version }}-${{github.sha}}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ checkstyle.txt
 .env*
 !.env-local
 !.env-ci
-!.env-ci-testmon
 .direnv
 .envrc
 .tool-versions

--- a/api/.env-ci-testmon
+++ b/api/.env-ci-testmon
@@ -1,3 +1,0 @@
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
-ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
-PYTEST_ADDOPTS=--cov . --cov-report xml --dist worksteal --testmon

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -7,6 +7,3 @@ features/workflows/logic/
 
 # Unit test coverage
 .coverage
-
-# pytest-testmon files
-.testmondata*

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -178,8 +178,8 @@ files = [
 lazy-object-proxy = ">=1.4.0"
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
 ]
 
 [[package]]
@@ -801,8 +801,8 @@ openapi-spec-validator = ">=0.2.8,<=0.5.7"
 packaging = "*"
 prance = ">=0.18.2"
 pydantic = [
-    {version = ">=1.9.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.10.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"4.0\""},
+    {version = ">=1.9.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 PySnooper = ">=0.4.1,<2.0.0"
 toml = ">=0.10.0,<1.0.0"
@@ -3013,8 +3013,8 @@ files = [
 astroid = ">=2.14.2,<=2.16.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
 ]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
@@ -3313,21 +3313,6 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
-name = "pytest-testmon"
-version = "2.0.13"
-description = "selects tests affected by changed files and methods"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pytest-testmon-2.0.13.tar.gz", hash = "sha256:9cf56021ccaa6c8c6bcaef07589fb6c872db1797f0f7ff1f104e93c96078d642"},
-    {file = "pytest_testmon-2.0.13-py3-none-any.whl", hash = "sha256:170872f2407e1eab431a266108229dbcde73513771a71ab77ed1e84ec94c816c"},
-]
-
-[package.dependencies]
-coverage = ">=6,<8"
-pytest = ">=5,<8"
-
-[[package]]
 name = "pytest-xdist"
 version = "3.2.1"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
@@ -3474,7 +3459,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4492,4 +4476,4 @@ requests = ">=2.7,<3.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "993b9f99517a6a87dc91ee8e3f1eaf3aa83b5fe80cebede0b1dd46555c6c030c"
+content-hash = "b2f93b350a146a3f057596243476fcb4846b942ffbec19159deed930c981407f"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -146,7 +146,6 @@ requests-mock = "^1.11.0"
 django-extensions = "^3.2.3"
 pdbpp = "^0.10.3"
 django-capture-on-commit-callbacks = "^1.11.0"
-pytest-testmon = "^2.0.13"
 mypy-boto3-dynamodb = "^1.33.0"
 
 [build-system]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Testmon has been leading to failures in CI when certain apps are used. After hours of debugging we've decided it's not worth it to keep it around.

Edit:

For an example failing PR see https://github.com/Flagsmith/flagsmith/pull/3398 which starts to fail after only adding two small variables in this commit here: https://github.com/Flagsmith/flagsmith/pull/3398/commits/de8ab4860c7a827d68a70854bd4236bb607cedfd triggering the environments and projects models.

## How did you test this code?

CI will test this.