### PR TITLE
fix(infra): use correct version number for flagsmith workflows

### DIFF
--- a/.github/workflows/platform-docker-publish-all-features-image.yml
+++ b/.github/workflows/platform-docker-publish-all-features-image.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: flagsmith/flagsmith-workflows
           token: ${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
-          ref: ${{ env.flagsmith_saml_revision }}
+          ref: ${{ env.FLAGSMITH_WORKFLOWS_REVISION }}
           path: ./flagsmith-workflows
 
       - name: Integrate Workflows Logic module


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the definition of the revision for checking out the flagsmith-workflows repository. 

## How did you test this code?

TBD with release.
