### PR TITLE
fix(migrations): Fix tags migrations

### DIFF
--- a/api/projects/tags/migrations/0005_add_tag_fields_for_stale_flags_logic.py
+++ b/api/projects/tags/migrations/0005_add_tag_fields_for_stale_flags_logic.py
@@ -37,14 +37,6 @@ def mark_existing_tags_as_permanent(
     tag_class.objects.bulk_update(to_update, fields=["is_permanent"])
 
 
-def populate_default_tag_type(
-    apps: Apps, schema_editor: BaseDatabaseSchemaEditor
-) -> None:
-    apps.get_model("tags", "tag").objects.filter(type__isnull=True).update(
-        type=TagType.NONE.value
-    )
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("tags", "0004_add_uuid_field"),
@@ -75,22 +67,9 @@ class Migration(migrations.Migration):
             name="type",
             field=models.CharField(
                 choices=[("NONE", "None"), ("STALE", "Stale")],
-                null=True,
                 help_text="Field used to provide a consistent identifier for the FE and API to use for business logic.",
                 max_length=100,
-            ),
-        ),
-        migrations.RunPython(
-            populate_default_tag_type, reverse_code=migrations.RunPython.noop
-        ),
-        migrations.AlterField(
-            model_name="tag",
-            name="type",
-            field=models.CharField(
-                choices=[("NONE", "None"), ("STALE", "Stale")],
                 default="NONE",
-                help_text="Field used to provide a consistent identifier for the FE and API to use for business logic.",
-                max_length=100,
             ),
         ),
     ]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

**Motivation behind this PR** 

Migrations are currently failing on any existing database (note that it seems that they work on new databases, e.g. for running tests). 

**Implementation**

Removes steps from a migrations file in the tags project which created the new column as nullable, manually populated the defaults and then set the column to not null. 

The reason I added this originally is that, technically, adding a new non-nullable column to a table requires acquiring a temporary lock on the table I believe. Since the tags table is small enough in production however (~3000 records), I think we can not worry about this. 

## How did you test this code?

Reproduced the migration error locally, changed the migration file and re ran to confirm the issue is fixed. 
