### PR TITLE
style: Fix error alert colours

### DIFF
--- a/frontend/web/styles/_variables.scss
+++ b/frontend/web/styles/_variables.scss
@@ -80,13 +80,6 @@ $bt-input-border: #d9d9e9;
 $bt-input-border-dark: $input-bg-dark;
 $bt-input-border-active: $input-bg-dark;
 
-$alert-danger-bg: $bt-brand-red;
-$alert-danger-border: $bt-brand-red;
-$alert-danger-text: rgb(255, 255, 255);
-
-$alert-warning-bg: $warning-solid-alert;
-$alert-warning-border: $bt-brand-yellow;
-
 $body-bg: #fff;
 
 

--- a/frontend/web/styles/components/_input.scss
+++ b/frontend/web/styles/components/_input.scss
@@ -63,7 +63,7 @@ textarea {
   background-color: transparent !important;
   &.invalid hr,
   &.invalid hr.highlight {
-    border-color: $alert-danger-border;
+    border-color: $alert-danger-border-color;
   }
 
   label {
@@ -149,7 +149,7 @@ textarea {
   }
 
   &.error hr {
-    border-color: $alert-danger-border;
+    border-color: $alert-danger-border-color;
   }
 
   &.error,

--- a/frontend/web/styles/new/_variables-new.scss
+++ b/frontend/web/styles/new/_variables-new.scss
@@ -261,6 +261,7 @@ $alert-success-border-color: $success;
 $alert-info-bg: $info-solid-alert;
 $alert-info-border-color: $info;
 $alert-danger-bg: $danger-solid-alert;
+$alert-warning-bg: $warning-solid-alert;
 $alert-danger-border-color: $danger;
 $alert-warning-border-color: $warning;
 $alert-color: $text-icon-grey;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Before:

<img width="1065" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/f10e0ab0-45ea-4cee-b1ba-3f5231aff691">

<img width="1069" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/77e53c5e-ec23-496b-98a9-a244b253d3e7">

After:

<img width="1074" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/6bf9a8b1-fc5c-4d49-b180-cb65e826ed4d">
<img width="1066" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/4ebd5485-97d6-483e-af81-8e8c6b4d5e61">

<img width="278" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/184087d6-4a53-4bd2-9eb2-ed76a17af92d">


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
