### PR TITLE
fix: Versioning test - always login regardless of skip test

### DIFF
--- a/frontend/e2e/tests/versioning-tests.ts
+++ b/frontend/e2e/tests/versioning-tests.ts
@@ -23,7 +23,7 @@ export default async () => {
     log('Login')
     await login(E2E_USER, PASSWORD)
     if(!hasFeature) {
-        console.log("Skipping version test, feature not enabled.")
+        log("Skipping version test, feature not enabled.")
         return
     }
 

--- a/frontend/e2e/tests/versioning-tests.ts
+++ b/frontend/e2e/tests/versioning-tests.ts
@@ -20,13 +20,13 @@ import Project from '../../common/project';
 export default async () => {
     await flagsmith.init({fetch,environmentID:Project.flagsmith,api:Project.flagsmithClientAPI})
     const hasFeature = flagsmith.hasFeature("feature_versioning")
+    log('Login')
+    await login(E2E_USER, PASSWORD)
     if(!hasFeature) {
         console.log("Skipping version test, feature not enabled.")
         return
     }
 
-    log('Login')
-    await login(E2E_USER, PASSWORD)
     await createOrganisationAndProject('Flagsmith Versioning Org', 'Flagsmith Versioning Project')
     await waitForElementVisible(byId('features-page'))
     await click('#env-settings-link')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Currently, deploy to production e2e is failing due to the versioning test.

Tests always logout post-test, tests need to login regardless of skipping due to disabled flags.

## How did you test this code?

- Ran e2e against prod
