### PR TITLE
fix(db): Fix read replica strategy

### DIFF
--- a/api/app/routers.py
+++ b/api/app/routers.py
@@ -100,9 +100,9 @@ class PrimaryReplicaRouter:
 
     def _get_replica(self, replicas: list[str]) -> None | str:
         while replicas:
-            if settings.REPLICA_READ_STRATEGY == ReplicaReadStrategy.DISTRIBUTED.value:
+            if settings.REPLICA_READ_STRATEGY == ReplicaReadStrategy.DISTRIBUTED:
                 database = random.choice(replicas)
-            elif settings.REPLICA_READ_STRATEGY == ReplicaReadStrategy.SEQUENTIAL.value:
+            elif settings.REPLICA_READ_STRATEGY == ReplicaReadStrategy.SEQUENTIAL:
                 database = replicas[0]
             else:
                 raise ImproperlyConfiguredError(

--- a/api/tests/unit/app/test_unit_app_routers.py
+++ b/api/tests/unit/app/test_unit_app_routers.py
@@ -28,7 +28,7 @@ def test_replica_router_db_for_read_with_one_offline_replica(
 
     # Set unused cross regional db for testing non-inclusion.
     settings.NUM_CROSS_REGION_DB_REPLICAS = 2
-    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.DISTRIBUTED.value
+    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.DISTRIBUTED
 
     conn_patch = mocker.MagicMock()
     conn_patch.is_usable.side_effect = (False, True)
@@ -63,7 +63,7 @@ def test_replica_router_db_for_read_with_local_offline_replicas(
 
     # Use cross regional db for fallback after replicas.
     settings.NUM_CROSS_REGION_DB_REPLICAS = 2
-    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.DISTRIBUTED.value
+    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.DISTRIBUTED
 
     conn_patch = mocker.MagicMock()
 
@@ -107,7 +107,7 @@ def test_replica_router_db_for_read_with_all_offline_replicas(
     # Given
     settings.NUM_DB_REPLICAS = 4
     settings.NUM_CROSS_REGION_DB_REPLICAS = 2
-    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.DISTRIBUTED.value
+    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.DISTRIBUTED
 
     conn_patch = mocker.MagicMock()
 
@@ -141,7 +141,7 @@ def test_replica_router_db_with_sequential_read(
     # Given
     settings.NUM_DB_REPLICAS = 100
     settings.NUM_CROSS_REGION_DB_REPLICAS = 2
-    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.SEQUENTIAL.value
+    settings.REPLICA_READ_STRATEGY = ReplicaReadStrategy.SEQUENTIAL
 
     conn_patch = mocker.MagicMock()
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the logic to look for the actual enum instead of the value of the enum. 

## How did you test this code?

Updated the tests but also ran the API locally with `REPLICA_DATABASE_URLS` configured to point at a replicated database and confirmed that it worked as expected. 
