### PR TITLE
fix(segments): use API query param for feature-specific filter

### DIFF
--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -27,6 +27,7 @@ export type Req = {
     q?: string
     projectId: number | string
     identity?: number
+    include_feature_specific?: boolean
   }>
   deleteSegment: { projectId: number | string; id: number }
   updateSegment: { projectId: number | string; segment: Segment }

--- a/frontend/web/components/pages/SegmentsPage.tsx
+++ b/frontend/web/components/pages/SegmentsPage.tsx
@@ -247,6 +247,15 @@ const SegmentsPage: FC<SegmentsPageType> = (props) => {
                         )
                         preselect.current = null
                       }
+
+                      // TODO: remove this check
+                      // I'm leaving this here for now so that we can deploy the FE and
+                      // API independently, but we should remove this once PR #3430 is
+                      // merged and released.
+                      if (feature && !showFeatureSpecific) {
+                        return null
+                      }
+
                       return renderWithPermission(
                         manageSegmentsPermission,
                         'Manage segments',

--- a/frontend/web/components/pages/SegmentsPage.tsx
+++ b/frontend/web/components/pages/SegmentsPage.tsx
@@ -64,6 +64,7 @@ const SegmentsPage: FC<SegmentsPageType> = (props) => {
   const [showFeatureSpecific, setShowFeatureSpecific] = useState(false)
 
   const { data, error, isLoading, refetch } = useGetSegmentsQuery({
+    include_feature_specific: showFeatureSpecific,
     page,
     page_size: 100,
     projectId,
@@ -245,9 +246,6 @@ const SegmentsPage: FC<SegmentsPageType> = (props) => {
                           !manageSegmentsPermission,
                         )
                         preselect.current = null
-                      }
-                      if (feature && !showFeatureSpecific) {
-                        return null
                       }
                       return renderWithPermission(
                         manageSegmentsPermission,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

FE component to resolve #3428 

Uses the API query parameter for filtering feature-specific segments added in #3430. 

## How did you test this code?

Ran the FE locally and verified that the query parameter was being added correctly to the request. Also verified that toggling the filter made the correct new request to the API. 
