### PR TITLE
feat(api-keys): add `has_expired` to MasterAPIKey response

### DIFF
--- a/api/api_keys/serializers.py
+++ b/api/api_keys/serializers.py
@@ -23,6 +23,7 @@ class MasterAPIKeySerializer(serializers.ModelSerializer):
             "expiry_date",
             "key",
             "is_admin",
+            "has_expired",
         )
         read_only_fields = ("prefix", "created", "key")
 

--- a/api/tests/integration/api_keys/conftest.py
+++ b/api/tests/integration/api_keys/conftest.py
@@ -1,0 +1,27 @@
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+
+@pytest.fixture()
+def _expired_api_key(admin_client: APIClient, organisation: int) -> dict[str, Any]:
+    url = reverse(
+        "api-v1:organisations:organisation-master-api-keys-list",
+        args=[organisation],
+    )
+    data = {
+        "name": "test_key",
+        "organisation": organisation,
+        "expiry_date": timezone.now() - timedelta(hours=1),
+    }
+    response = admin_client.post(url, data=data)
+    return response.json()
+
+
+@pytest.fixture()
+def expired_api_key_prefix(_expired_api_key: dict[str, Any]) -> str:
+    return _expired_api_key["prefix"]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds `"has_expired"` to MasterAPIKey serializer. 

## How did you test this code?

Added a new integration test. 
