### PR TITLE
fix: Docs - Bring the code examples in-line with the latest SDK

### DIFF
--- a/docs/docs/clients/client-side/android.md
+++ b/docs/docs/clients/client-side/android.md
@@ -16,7 +16,7 @@ In your project path `app/build.gradle` add a new dependence
 
 ```groovy
 //flagsmith
-implementation 'com.github.Flagsmith:flagsmith-kotlin-android-client:1.0.1'
+implementation 'com.github.Flagsmith:flagsmith-kotlin-android-client:1.5.0'
 ```
 
 You should be able to find the latest version in the
@@ -127,11 +127,11 @@ flagsmith.getTraits(identity = "test@test.com") { result ->
     result.fold(
         onSuccess = { traits ->
             traits.forEach {
-                Log.i("Flagsmith", "Trait - ${it.key} : ${it.value}")
+                Log.i("Flagsmith", "Trait - ${it.key} : ${it.traitValue}")
             }
         },
         onFailure = { err ->
-            Log.e("Flagsmith", "Error setting trait", err)
+            Log.e("Flagsmith", "Error getting traits", err)
         })
 }
 ```


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [N/A] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Some basic changes to bring the Kotlin Android code examples up to current SDK.

## How did you test this code?

Tested the code examples using the unit tests in the SDK.
