### PR TITLE
chore(api-usage): conditionally register api usage alerting task

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1167,3 +1167,5 @@ WEBHOOK_BACKOFF_RETRIES = env.int("WEBHOOK_BACKOFF_RETRIES", default=3)
 SPLIT_TESTING_INSTALLED = importlib.util.find_spec("split_testing")
 if SPLIT_TESTING_INSTALLED:
     INSTALLED_APPS += ("split_testing",)
+
+ENABLE_API_USAGE_ALERTING = env.bool("ENABLE_API_USAGE_ALERTING", default=False)

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -163,9 +163,6 @@ def _handle_api_usage_notifications(organisation: Organisation):
     send_admin_api_usage_notification(organisation, matched_threshold)
 
 
-@register_recurring_task(
-    run_every=timedelta(hours=12),
-)
 def handle_api_usage_notifications():
     for organisation in Organisation.objects.filter(
         subscription_information_cache__current_billing_term_starts_at__isnull=False,
@@ -180,3 +177,9 @@ def handle_api_usage_notifications():
                 f"Error processing api usage for organisation {organisation.id}",
                 exc_info=True,
             )
+
+
+if settings.ENABLE_API_USAGE_ALERTING:
+    register_recurring_task(
+        run_every=timedelta(hours=12),
+    )(handle_api_usage_notifications)

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -138,6 +138,10 @@
                 {
                     "name": "AWS_SSE_LOGS_BUCKET_NAME",
                     "value": "flagsmith-fastly-logs-staging"
+                },
+                {
+                    "name": "ENABLE_API_USAGE_ALERTING",
+                    "value": "True"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add a setting to conditionally enable the API usage alerting recurring task as this task should not be enabled for any self hosted environments. 

Since it has not yet been fully tested, I have only enabled it in staging. Once it's tested in staging, we can enable it in production. 

## How did you test this code?

n/a - existing tests cover the code
