### PR TITLE
chore: Fix inconsistency in environment variables between the docs andd docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
       USE_POSTGRES_FOR_ANALYTICS: 'true' # Store API and Flag Analytics data in Postgres
 
-      ENV: prod # set to 'prod' in production.
+      ENVIRONMENT: production # set to 'production' in production.
       DJANGO_ALLOWED_HOSTS: '*' # Change this in production
       ALLOW_ADMIN_INITIATION_VIA_CLI: 'true' # Change this in production
       FLAGSMITH_DOMAIN: localhost:8000 # Change this in production


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Updated the docker-compose.yml to use an environment variable that is actually read in the settings here: https://github.com/Flagsmith/flagsmith/blob/main/api/app/settings/common.py#L36C1-L41C6 

## How did you test this code?

Manually - started the container with the `ENVIRONMENT` variable set to a different value than any currently allowed.The warning was then triggered.