### PR TITLE
fix: Add padding to the announcement

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -431,7 +431,7 @@ const App = class extends Component {
                             />
                           )}
                           {user && showBanner && (
-                            <Row>
+                            <Row className={'px-3'}>
                               <InfoMessage
                                 title={announcementValue.title}
                                 infoMessageClass={'announcement'}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Add padding to the announcement component

## How did you test this code?
<img width="1337" alt="Screen Shot 2024-02-27 at 22 50 52" src="https://github.com/Flagsmith/flagsmith/assets/41410593/3afbc86e-1558-47cf-9db2-f38006ff1324">


