### PR TITLE
fix(fs-delete/webhook): use fs instance instead of historical

### DIFF
--- a/api/features/tasks.py
+++ b/api/features/tasks.py
@@ -34,7 +34,7 @@ def trigger_feature_state_change_webhooks(
         else _get_feature_state_webhook_data(instance)
     )
     data = {"new_state": new_state, "changed_by": changed_by, "timestamp": timestamp}
-    previous_state = _get_previous_state(history_instance, event_type)
+    previous_state = _get_previous_state(instance, history_instance, event_type)
     if previous_state:
         data.update(previous_state=previous_state)
 
@@ -52,10 +52,12 @@ def trigger_feature_state_change_webhooks(
 
 
 def _get_previous_state(
-    history_instance: HistoricalFeatureState, event_type: WebhookEventType
+    instance: FeatureState,
+    history_instance: HistoricalFeatureState,
+    event_type: WebhookEventType,
 ) -> dict:
     if event_type == WebhookEventType.FLAG_DELETED:
-        return _get_feature_state_webhook_data(history_instance.instance)
+        return _get_feature_state_webhook_data(instance)
     if history_instance and history_instance.prev_record:
         return _get_feature_state_webhook_data(
             history_instance.prev_record.instance, previous=True


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Use feature state instance for delete feature webhook instead of historical instance (because historical record does not exist for feature states created before we introduced history and for some reason they also did not exists for the feature here: https://flagsmith.sentry.io/issues/4929553990/?project=5544478&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=19)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Add new unit test
