### PR TITLE
fix: self regulate task processor threads (WIP)

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -545,7 +545,10 @@ else:
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
-            "generic": {"format": "%(name)-12s %(levelname)-8s %(message)s"},
+            "generic": {
+                "format": "%(asctime)s %(threadName)s %(name)-12s %(levelname)-8s %(message)s",
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+            },
             "json": {
                 "()": "util.logging.JsonFormatter",
                 "datefmt": "%Y-%m-%d %H:%M:%S",

--- a/api/task_processor/management/commands/checktaskprocessorthreadhealth.py
+++ b/api/task_processor/management/commands/checktaskprocessorthreadhealth.py
@@ -3,15 +3,19 @@ import sys
 
 from django.core.management import BaseCommand
 
-from task_processor.thread_monitoring import get_unhealthy_thread_names
+from task_processor.thread_monitoring import get_thread_counts
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        if get_unhealthy_thread_names():
-            sys.exit("Task processor has unhealthy threads.")
+        thread_counts = get_thread_counts()
 
-        logger.info("Task processor has no unhealthy threads.")
+        if thread_counts.running != thread_counts.expected:
+            sys.exit(
+                "Processor is running %d threads, but expected %d"
+                % (thread_counts.running, thread_counts.expected)
+            )
+
         sys.exit(0)

--- a/api/task_processor/processor.py
+++ b/api/task_processor/processor.py
@@ -28,6 +28,8 @@ def run_tasks(num_tasks: int = 1) -> typing.List[TaskRun]:
         executed_tasks = []
         task_runs = []
 
+        logger.debug("Processing %d tasks", len(list(tasks)))
+
         for task in tasks:
             task, task_run = _run_task(task)
 
@@ -85,7 +87,7 @@ def run_recurring_tasks(num_tasks: int = 1) -> typing.List[RecurringTaskRun]:
 
         return task_runs
 
-    logger.debug("No tasks to process.")
+    logger.debug("No recurring tasks to process.")
     return []
 
 

--- a/api/task_processor/thread_monitoring.py
+++ b/api/task_processor/thread_monitoring.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from pydantic import BaseModel
@@ -15,7 +14,7 @@ class ThreadCounts(BaseModel):
 
 def write_thread_counts(thread_counts: ThreadCounts) -> None:
     with open(THREAD_COUNTS_FILE_PATH, "w+") as f:
-        f.write(json.dumps(thread_counts.dict()))
+        f.write(thread_counts.json())
 
 
 def get_thread_counts() -> ThreadCounts:

--- a/api/task_processor/thread_monitoring.py
+++ b/api/task_processor/thread_monitoring.py
@@ -1,34 +1,23 @@
 import json
 import logging
-import os
-import typing
-from threading import Thread
 
-UNHEALTHY_THREADS_FILE_PATH = "/tmp/task-processor-unhealthy-threads.json"
+from pydantic import BaseModel
+
+THREAD_COUNTS_FILE_PATH = "/tmp/task-processor-thread-counts.json"
 
 logger = logging.getLogger(__name__)
 
 
-def clear_unhealthy_threads():
-    if _unhealthy_threads_file_exists():
-        os.remove(UNHEALTHY_THREADS_FILE_PATH)
+class ThreadCounts(BaseModel):
+    running: int
+    expected: int
 
 
-def write_unhealthy_threads(unhealthy_threads: typing.List[Thread]):
-    unhealthy_thread_names = [t.name for t in unhealthy_threads]
-    logger.warning("Writing unhealthy threads: %s", unhealthy_thread_names)
-
-    with open(UNHEALTHY_THREADS_FILE_PATH, "w+") as f:
-        f.write(json.dumps(unhealthy_thread_names))
+def write_thread_counts(thread_counts: ThreadCounts) -> None:
+    with open(THREAD_COUNTS_FILE_PATH, "w+") as f:
+        f.write(json.dumps(thread_counts.dict()))
 
 
-def get_unhealthy_thread_names() -> typing.List[str]:
-    if not _unhealthy_threads_file_exists():
-        return []
-
-    with open(UNHEALTHY_THREADS_FILE_PATH, "r") as f:
-        return json.loads(f.read())
-
-
-def _unhealthy_threads_file_exists():
-    return os.path.exists(UNHEALTHY_THREADS_FILE_PATH)
+def get_thread_counts() -> ThreadCounts:
+    with open(THREAD_COUNTS_FILE_PATH, "r") as f:
+        return ThreadCounts.parse_raw(f.read())

--- a/api/tests/unit/task_processor/test_unit_task_processor_thread_monitoring.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_thread_monitoring.py
@@ -1,89 +1,36 @@
-import json
-import logging
-from threading import Thread
 from unittest.mock import mock_open, patch
 
 from task_processor.thread_monitoring import (
-    UNHEALTHY_THREADS_FILE_PATH,
-    clear_unhealthy_threads,
-    get_unhealthy_thread_names,
-    write_unhealthy_threads,
+    THREAD_COUNTS_FILE_PATH,
+    ThreadCounts,
+    get_thread_counts,
+    write_thread_counts,
 )
 
 
-def test_clear_unhealthy_threads(mocker):
+def test_write_thread_counts() -> None:
     # Given
-    mocked_os = mocker.patch("task_processor.thread_monitoring.os")
-
-    def os_path_side_effect(file_path):
-        return file_path == UNHEALTHY_THREADS_FILE_PATH
-
-    mocked_os.path.exists.side_effect = os_path_side_effect
-
-    # When
-    clear_unhealthy_threads()
-
-    # Then
-    mocked_os.remove.assert_called_once_with(UNHEALTHY_THREADS_FILE_PATH)
-
-
-def test_write_unhealthy_threads(caplog, settings):
-    # Given
-    # caplog doesn't allow you to capture logging outputs from loggers that don't
-    # propagate to root. Quick hack here to get the task_processor logger to
-    # propagate.
-    # TODO: look into using loguru.
-    task_processor_logger = logging.getLogger("task_processor")
-    task_processor_logger.propagate = True
-
-    threads = [Thread(target=lambda: None)]
+    thread_counts = ThreadCounts(running=1, expected=1)
 
     # When
     with patch("builtins.open", mock_open()) as mocked_open:
-        write_unhealthy_threads(threads)
+        write_thread_counts(thread_counts)
 
     # Then
-    mocked_open.assert_called_once_with(UNHEALTHY_THREADS_FILE_PATH, "w+")
-    mocked_open.return_value.write.assert_called_once_with(
-        json.dumps([t.name for t in threads])
-    )
-    assert len(caplog.records) == 1
-    assert caplog.record_tuples[0][1] == 30  # WARNING
-    assert caplog.record_tuples[0][2] == "Writing unhealthy threads: %s" % [
-        t.name for t in threads
-    ]
+    mocked_open.assert_called_once_with(THREAD_COUNTS_FILE_PATH, "w+")
+    mocked_open.return_value.write.assert_called_once_with(thread_counts.json())
 
 
-def test_get_unhealthy_thread_names_returns_empty_list_if_file_does_not_exist(mocker):
+def test_get_thread_counts() -> None:
     # Given
-    mocked_os = mocker.patch("task_processor.thread_monitoring.os")
-    mocked_os.path.exists.return_value = False
+    data = '{"running": 1, "expected": 2}'
 
     # When
-    unhealthy_thread_names = get_unhealthy_thread_names()
+    with patch("builtins.open", mock_open(read_data=data)) as mocked_open:
+        thread_counts = get_thread_counts()
 
     # Then
-    assert unhealthy_thread_names == []
+    mocked_open.assert_called_once_with(THREAD_COUNTS_FILE_PATH, "r")
 
-
-def test_get_unhealthy_thread_names(mocker):
-    # Given
-    mocked_os = mocker.patch("task_processor.thread_monitoring.os")
-
-    def os_path_side_effect(file_path):
-        return file_path == UNHEALTHY_THREADS_FILE_PATH
-
-    mocked_os.path.exists.side_effect = os_path_side_effect
-
-    expected_unhealthy_thread_names = ["Thread-1", "Thread-2"]
-
-    # When
-    with patch(
-        "builtins.open",
-        mock_open(read_data=json.dumps(expected_unhealthy_thread_names)),
-    ) as mocked_open:
-        unhealthy_thread_names = get_unhealthy_thread_names()
-
-    # Then
-    mocked_open.assert_called_once_with(UNHEALTHY_THREADS_FILE_PATH, "r")
-    assert unhealthy_thread_names == expected_unhealthy_thread_names
+    assert thread_counts.running == 1
+    assert thread_counts.expected == 2


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR updates the task processor management to self regulate the number of worker threads. If certain threads are determined to be unhealthy, it will kill them and spawn new threads in their place. The main changes are: 

 1. When checking for unhealthy threads, the management process will replace any unhealthy threads with new worker threads
 2. The management command to check the health of the task processor now simply checks that the correct number of threads are running, since the main manager process should maintain this number
 3. I've added a bunch more debug logging which helps in testing

## How did you test this code?

I have tested this manually and it seems to work well, but more testing is probably necessary. 
