### PR TITLE
fix: Add trailing / to delete api key endpoint

### DIFF
--- a/frontend/common/services/useServersideEnvironmentKey.ts
+++ b/frontend/common/services/useServersideEnvironmentKey.ts
@@ -25,7 +25,7 @@ export const serversideEnvironmentKeyService = service
         query: (query: Req['deleteServersideEnvironmentKeys']) => ({
           body: query,
           method: 'DELETE',
-          url: `environments/${query.environmentId}/api-keys/${query.id}`,
+          url: `environments/${query.environmentId}/api-keys/${query.id}/`,
         }),
       }),
       getServersideEnvironmentKeys: builder.query<


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add trailing / to delete key endpoint

## How did you test this code?

Deleted an API key, no longer returns a 301 and instead returns a 20x 