### PR TITLE
fix: don't create feature export before launch darkly import

### DIFF
--- a/frontend/web/components/import-export/ImportPage.tsx
+++ b/frontend/web/components/import-export/ImportPage.tsx
@@ -97,10 +97,6 @@ const ImportPage: FC<ImportPageType> = ({
     key: string,
     projectId: string,
   ) => {
-    createFeatureExport(getStore(), {
-      environment_id: environmentId,
-      tag_ids: [],
-    })
     createLaunchDarklyProjectImport({
       body: { project_key: key, token: LDKey },
       project_id: projectId,

--- a/frontend/web/components/import-export/ImportPage.tsx
+++ b/frontend/web/components/import-export/ImportPage.tsx
@@ -45,6 +45,7 @@ const ImportPage: FC<ImportPageType> = ({
   const {
     data: status,
     isSuccess: statusLoaded,
+    isUninitialized,
     refetch,
   } = useGetLaunchDarklyProjectImportQuery(
     {
@@ -76,9 +77,11 @@ const ImportPage: FC<ImportPageType> = ({
   useEffect(() => {
     if (isSuccess && data?.id) {
       setImportId(data.id)
-      refetch()
+      if (!isUninitialized) {
+        refetch()
+      }
     }
-  }, [isSuccess, data, refetch])
+  }, [isSuccess, data, refetch, isUninitialized])
 
   const getProjectList = (LDKey: string) => {
     setIsLoading(true)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #3509 

Note that it does not make much sense to run an export prior to an LD import since the import is only really useful for new projects. The feature export (I believe) was being done to create a sort of back up but it was not providing the environment id (because there is no contextual environment here). 

## How did you test this code?

Tested using the production preview but I'm still not seeing the correct behaviour. See comment [here](https://github.com/Flagsmith/flagsmith/pull/3510#issuecomment-1971467222).
