### PR TITLE
chore(self-hosting): default `ENABLE_ADMIN_ACCESS_USER_PASS` to true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
       ALLOW_ADMIN_INITIATION_VIA_CLI: 'true' # Change this in production
       FLAGSMITH_DOMAIN: localhost:8000 # Change this in production
       DJANGO_SECRET_KEY: secret # Change this in production
+      ENABLE_ADMIN_ACCESS_USER_PASS: 'true' # Uncomment to enable access to the /admin/ Django backend via your username and password
       # PREVENT_SIGNUP: 'true' # Uncomment to prevent additional signups
-      # ENABLE_ADMIN_ACCESS_USER_PASS: 'true' # Uncomment to enable access to the /admin/ Django backend via your username and password
       # ALLOW_REGISTRATION_WITHOUT_INVITE: 'true'
 
       # Enable Task Processor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       ALLOW_ADMIN_INITIATION_VIA_CLI: 'true' # Change this in production
       FLAGSMITH_DOMAIN: localhost:8000 # Change this in production
       DJANGO_SECRET_KEY: secret # Change this in production
-      ENABLE_ADMIN_ACCESS_USER_PASS: 'true' # Uncomment to enable access to the /admin/ Django backend via your username and password
+      ENABLE_ADMIN_ACCESS_USER_PASS: 'true'
       # PREVENT_SIGNUP: 'true' # Uncomment to prevent additional signups
       # ALLOW_REGISTRATION_WITHOUT_INVITE: 'true'
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Default `ENABLE_ADMIN_ACCESS_USER_PASS` to True. I don't see a reason not to do this, especially as we create by default an admin user. 

## How did you test this code?

Ran the docker-compose.yml locally and confirmed that the admin was accessible by user / password. 
