### PR TITLE
chore: Hide crisp in modals

### DIFF
--- a/frontend/web/styles/project/_modals.scss
+++ b/frontend/web/styles/project/_modals.scss
@@ -249,3 +249,10 @@ $side-width: 660px;
     overflow-y: auto;
   }
 }
+
+.modal-open {
+  #crisp-chatbox {
+    opacity: 0;
+    pointer-events: none;
+  }
+}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Crisp interferes with some modal CTAs, this hides it when a modal is visible.


https://github.com/Flagsmith/flagsmith/assets/8608314/571c9718-670a-4d5a-b360-db963e2d66f2



## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
