### PR TITLE
chore: show overrides in compare views

### DIFF
--- a/frontend/common/services/useProjectFlag.ts
+++ b/frontend/common/services/useProjectFlag.ts
@@ -3,6 +3,7 @@ import { Req } from 'common/types/requests'
 import { service } from 'common/service'
 import data from 'common/data/base/_data'
 import { BaseQueryFn } from '@reduxjs/toolkit/query'
+import Utils from 'common/utils/utils'
 
 function recursivePageGet(
   url: string,
@@ -47,7 +48,10 @@ export const projectFlagService = service
         ],
         queryFn: async (args, _, _2, baseQuery) => {
           return await recursivePageGet(
-            `projects/${args.project}/features/?page_size=999`,
+            `projects/${args.project}/features/?${Utils.toParam({
+              ...args,
+              page_size: 999,
+            })}`,
             null,
             baseQuery,
           )

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -131,7 +131,7 @@ export type Req = {
     environment: string
     user: string
   }
-  getProjectFlags: { project: string }
+  getProjectFlags: { project: string; environmentId?: string }
   getProjectFlag: { project: string; id: string }
   getRolesPermissionUsers: { organisation_id: string; role_id: string }
   deleteRolesPermissionUsers: {

--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -8,8 +8,6 @@ import FeatureListStore from 'common/stores/feature-list-store'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import Permission from 'common/providers/Permission'
 import Tag from './tags/Tag'
-import { getProjectFlags } from 'common/services/useProjectFlag'
-import { getStore } from 'common/store'
 import Icon from './Icon'
 import Constants from 'common/constants'
 import Button from './base/forms/Button'
@@ -32,7 +30,8 @@ class CompareEnvironments extends Component {
       environmentLeft: props.environmentId,
       environmentRight: '',
       isLoading: true,
-      projectFlags: null,
+      projectFlagsLeft: null,
+      projectFlagsRight: null,
       showArchived: false,
     }
   }
@@ -49,59 +48,90 @@ class CompareEnvironments extends Component {
   fetch = () => {
     this.setState({ isLoading: true })
     return Promise.all([
-      this.state.projectFlags
-        ? Promise.resolve({ results: this.state.projectFlags })
-        : getProjectFlags(getStore(), { project: this.props.projectId }).then(
-            (res) => res.data,
-          ),
+      data.get(
+        `${Project.api}projects/${
+          this.props.projectId
+        }/features/?page_size=999&environment=${ProjectStore.getEnvironmentIdFromKey(
+          this.state.environmentLeft,
+        )}`,
+      ),
+      data.get(
+        `${Project.api}projects/${
+          this.props.projectId
+        }/features/?page_size=999&environment=${ProjectStore.getEnvironmentIdFromKey(
+          this.state.environmentRight,
+        )}`,
+      ),
       data.get(
         `${Project.api}environments/${this.state.environmentLeft}/featurestates/?page_size=999`,
       ),
       data.get(
         `${Project.api}environments/${this.state.environmentRight}/featurestates/?page_size=999`,
       ),
-    ]).then(([projectFlags, environmentLeftFlags, environmentRightFlags]) => {
-      const changes = []
-      const same = []
-      _.each(
-        _.sortBy(projectFlags.results, (p) => p.name),
-        (projectFlag) => {
-          const leftSide = environmentLeftFlags.results.find(
-            (v) => v.feature === projectFlag.id,
-          )
-          const rightSide = environmentRightFlags.results.find(
-            (v) => v.feature === projectFlag.id,
-          )
-          const change = {
-            leftEnabled: leftSide.enabled,
-            leftEnvironmentFlag: leftSide,
-            leftValue: leftSide.feature_state_value,
-            projectFlag,
-            rightEnabled: rightSide.enabled,
-            rightEnvironmentFlag: rightSide,
-            rightValue: rightSide.feature_state_value,
-          }
-          change.enabledChanged = change.rightEnabled !== change.leftEnabled
-          change.valueChanged = change.rightValue !== change.leftValue
-          if (change.enabledChanged || change.valueChanged) {
-            changes.push(change)
-          } else {
-            same.push(change)
-          }
-        },
-      )
-      this.setState({
-        changes,
-        environmentLeftFlags: _.keyBy(environmentLeftFlags.results, 'feature'),
-        environmentRightFlags: _.keyBy(
-          environmentRightFlags.results,
-          'feature',
-        ),
-        isLoading: false,
-        projectFlags: projectFlags.results,
-        same,
-      })
-    })
+    ]).then(
+      ([
+        environmentLeftProjectFlags,
+        environmentRightProjectFlags,
+        environmentLeftFlags,
+        environmentRightFlags,
+      ]) => {
+        const changes = []
+        const same = []
+        _.each(
+          _.sortBy(environmentLeftProjectFlags.results, (p) => p.name),
+          (projectFlagLeft) => {
+            const projectFlagRight = environmentRightProjectFlags.results?.find(
+              (projectFlagRight) => projectFlagRight.id === projectFlagLeft.id,
+            )
+            const leftSide = environmentLeftFlags.results.find(
+              (v) => v.feature === projectFlagLeft.id,
+            )
+            const rightSide = environmentRightFlags.results.find(
+              (v) => v.feature === projectFlagLeft.id,
+            )
+            const change = {
+              leftEnabled: leftSide.enabled,
+              leftEnvironmentFlag: leftSide,
+              leftValue: leftSide.feature_state_value,
+              projectFlagLeft,
+              projectFlagRight,
+              rightEnabled: rightSide.enabled,
+              rightEnvironmentFlag: rightSide,
+              rightValue: rightSide.feature_state_value,
+            }
+            change.enabledChanged = change.rightEnabled !== change.leftEnabled
+            change.valueChanged = change.rightValue !== change.leftValue
+            if (
+              change.enabledChanged ||
+              change.valueChanged ||
+              projectFlagLeft.num_identity_overrides ||
+              projectFlagLeft.num_segment_overrides ||
+              projectFlagRight.num_identity_overrides ||
+              projectFlagRight.num_segment_overrides
+            ) {
+              changes.push(change)
+            } else {
+              same.push(change)
+            }
+          },
+        )
+        this.setState({
+          changes,
+          environmentLeftFlags: _.keyBy(
+            environmentLeftFlags.results,
+            'feature',
+          ),
+          environmentRightFlags: _.keyBy(
+            environmentRightFlags.results,
+            'feature',
+          ),
+          isLoading: false,
+          projectFlagsLeft: environmentLeftProjectFlags.results,
+          projectFlagsRight: environmentLeftProjectFlags.results,
+          same,
+        })
+      },
+    )
   }
 
   onSave = () => this.fetch()
@@ -113,7 +143,7 @@ class CompareEnvironments extends Component {
       if (this.state.showArchived) {
         return true
       }
-      return !v.projectFlag.is_archived
+      return !v.projectFlagLeft.is_archived
     })
   }
 
@@ -193,11 +223,11 @@ class CompareEnvironments extends Component {
                               style={{ wordWrap: 'break-word' }}
                               className='font-weight-medium'
                             >
-                              {p.projectFlag.name}
+                              {p.projectFlagLeft.name}
                             </div>
                             <Button
                               onClick={() => {
-                                Utils.copyFeatureName(p.projectFlag.name)
+                                Utils.copyFeatureName(p.projectFlagLeft.name)
                               }}
                               theme='icon'
                               className='ms-2 me-2'
@@ -207,7 +237,7 @@ class CompareEnvironments extends Component {
                           </Row>
                         }
                       >
-                        {p.projectFlag.description}
+                        {p.projectFlagLeft.description}
                       </Tooltip>
                     </div>
                     <Permission
@@ -226,7 +256,7 @@ class CompareEnvironments extends Component {
                           fadeEnabled={fadeEnabled}
                           fadeValue={fadeValue}
                           environmentFlags={this.state.environmentLeftFlags}
-                          projectFlags={this.state.projectFlags}
+                          projectFlags={this.state.projectFlagsLeft}
                           permission={permission}
                           environmentId={this.state.environmentLeft}
                           projectId={this.props.projectId}
@@ -234,7 +264,7 @@ class CompareEnvironments extends Component {
                           canDelete={permission}
                           toggleFlag={toggleFlag}
                           removeFlag={removeFlag}
-                          projectFlag={p.projectFlag}
+                          projectFlag={p.projectFlagLeft}
                         />
                       )}
                     </Permission>
@@ -254,7 +284,7 @@ class CompareEnvironments extends Component {
                           fadeEnabled={fadeEnabled}
                           fadeValue={fadeValue}
                           environmentFlags={this.state.environmentRightFlags}
-                          projectFlags={this.state.projectFlags}
+                          projectFlags={this.state.projectFlagsRight}
                           permission={permission}
                           environmentId={this.state.environmentRight}
                           projectId={this.props.projectId}
@@ -262,7 +292,7 @@ class CompareEnvironments extends Component {
                           canDelete={permission}
                           toggleFlag={toggleFlag}
                           removeFlag={removeFlag}
-                          projectFlag={p.projectFlag}
+                          projectFlag={p.projectFlagRight}
                         />
                       )}
                     </Permission>
@@ -314,7 +344,7 @@ class CompareEnvironments extends Component {
                               <Flex className='flex-row'>
                                 <div
                                   className='table-column'
-                                  style={{ width: '120px' }}
+                                  style={{ width: '80px' }}
                                 >
                                   {
                                     ProjectStore.getEnvironment(
@@ -322,12 +352,12 @@ class CompareEnvironments extends Component {
                                     ).name
                                   }
                                 </div>
-                                <Flex className='table-column'>Value</Flex>
+                                <Flex className='table-column'></Flex>
                               </Flex>
                               <Flex className='flex-row'>
                                 <div
                                   className='table-column'
-                                  style={{ width: '120px' }}
+                                  style={{ width: '80px' }}
                                 >
                                   {
                                     ProjectStore.getEnvironment(
@@ -335,7 +365,7 @@ class CompareEnvironments extends Component {
                                     ).name
                                   }
                                 </div>
-                                <Flex className='table-column'>Value</Flex>
+                                <Flex className='table-column'></Flex>
                               </Flex>
                             </Row>
                           }
@@ -365,7 +395,7 @@ class CompareEnvironments extends Component {
                                 <Flex className='flex-row'>
                                   <div
                                     className='table-column'
-                                    style={{ width: '120px' }}
+                                    style={{ width: '80px' }}
                                   >
                                     {
                                       ProjectStore.getEnvironment(
@@ -378,7 +408,7 @@ class CompareEnvironments extends Component {
                                 <Flex className='flex-row'>
                                   <div
                                     className='table-column'
-                                    style={{ width: '120px' }}
+                                    style={{ width: '80px' }}
                                   >
                                     {
                                       ProjectStore.getEnvironment(

--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -12,6 +12,8 @@ import { getProjectFlags } from 'common/services/useProjectFlag'
 import { getStore } from 'common/store'
 import Icon from './Icon'
 import Constants from 'common/constants'
+import Button from './base/forms/Button'
+import Tooltip from './Tooltip'
 
 const featureNameWidth = 300
 
@@ -184,27 +186,29 @@ class CompareEnvironments extends Component {
                       className='table-column px-3'
                       style={{ width: featureNameWidth }}
                     >
-                      {p.projectFlag.description ? (
-                        <Tooltip
-                          title={
+                      <Tooltip
+                        title={
+                          <Row className={'no-wrap'}>
                             <div
                               style={{ wordWrap: 'break-word' }}
                               className='font-weight-medium'
                             >
                               {p.projectFlag.name}
                             </div>
-                          }
-                        >
-                          {p.projectFlag.description}
-                        </Tooltip>
-                      ) : (
-                        <div
-                          style={{ wordWrap: 'break-word' }}
-                          className='font-weight-medium'
-                        >
-                          {p.projectFlag.name}
-                        </div>
-                      )}
+                            <Button
+                              onClick={() => {
+                                Utils.copyFeatureName(p.projectFlag.name)
+                              }}
+                              theme='icon'
+                              className='ms-2 me-2'
+                            >
+                              <Icon name='copy' />
+                            </Button>
+                          </Row>
+                        }
+                      >
+                        {p.projectFlag.description}
+                      </Tooltip>
                     </div>
                     <Permission
                       level='environment'

--- a/frontend/web/components/CompareIdentities.tsx
+++ b/frontend/web/components/CompareIdentities.tsx
@@ -13,6 +13,10 @@ import FeatureValue from './FeatureValue'
 import { sortBy } from 'lodash'
 import { useHasPermission } from 'common/providers/Permission'
 import Constants from 'common/constants'
+import Button from './base/forms/Button'
+import ProjectStore from 'common/stores/project-store'
+import SegmentOverridesIcon from './SegmentOverridesIcon'
+import IdentityOverridesIcon from './IdentityOverridesIcon'
 
 type CompareIdentitiesType = {
   projectId: string
@@ -49,7 +53,10 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
 }) => {
   const [leftId, setLeftId] = useState<IdentitySelectType['value']>()
   const [rightId, setRightId] = useState<IdentitySelectType['value']>()
-  const { data: projectFlags } = useGetProjectFlagsQuery({ project: projectId })
+  const { data: projectFlags } = useGetProjectFlagsQuery({
+    environment: ProjectStore.getEnvironmentIdFromKey(_environmentId),
+    project: projectId,
+  })
   const [environmentId, setEnvironmentId] = useState(_environmentId)
   const [showArchived, setShowArchived] = useState(false)
 
@@ -211,23 +218,26 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
                       !enabledDifferent && !valueDifferent && 'faded'
                     }`}
                   >
-                    <span className='font-weight-medium'>
-                      {description ? (
-                        <Tooltip
-                          title={
-                            <span>
-                              {name}
-                              <span className={'ms-1'}></span>
-                              <Icon name='info-outlined' />
-                            </span>
-                          }
-                        >
+                    <Row>
+                      <span className='font-weight-medium'>
+                        <Tooltip title={<span>{name}</span>}>
                           {description}
                         </Tooltip>
-                      ) : (
-                        name
-                      )}
-                    </span>
+                      </span>
+                      <Button
+                        onClick={() => Utils.copyFeatureName(name)}
+                        theme='icon'
+                        className='ms-2 me-2'
+                      >
+                        <Icon name='copy' />
+                      </Button>
+                      <SegmentOverridesIcon
+                        count={data.num_segment_overrides}
+                      />
+                      <IdentityOverridesIcon
+                        count={data.num_identity_overrides}
+                      />
+                    </Row>
                   </div>
                   <div
                     onClick={goUserLeft}

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -148,33 +148,85 @@ class TheComponent extends Component {
           style={{
             ...(this.props.style || {}),
           }}
-          className={
-            (classNames('flex-row'),
+          className={classNames(
+            'flex-row',
             { 'fs-small': isCompact },
-            this.props.className)
-          }
+            this.props.className,
+          )}
         >
           <div
             className={`table-column ${this.props.fadeEnabled && 'faded'}`}
             style={{ width: '120px' }}
           >
-            <Switch
-              disabled={!permission || readOnly}
-              data-test={`feature-switch-${this.props.index}${
-                environmentFlags[id] && environmentFlags[id].enabled
-                  ? '-on'
-                  : '-off'
-              }`}
-              checked={environmentFlags[id] && environmentFlags[id].enabled}
-              onChange={() => {
-                if (disableControls) return
-                if (changeRequestsEnabled) {
-                  this.editFeature(projectFlag, environmentFlags[id])
-                  return
-                }
-                this.confirmToggle()
-              }}
-            />
+            <Row>
+              {!!projectFlag.num_segment_overrides && (
+                <div
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    this.editFeature(projectFlag, environmentFlags[id], 1)
+                  }}
+                >
+                  <Tooltip
+                    title={
+                      <span
+                        className='chip me-2 chip--xs bg-primary text-white'
+                        style={{ border: 'none' }}
+                      >
+                        <SegmentsIcon className='chip-svg-icon' />
+                        <span>{projectFlag.num_segment_overrides}</span>
+                      </span>
+                    }
+                    place='top'
+                  >
+                    {`${projectFlag.num_segment_overrides} Segment Override${
+                      projectFlag.num_segment_overrides !== 1 ? 's' : ''
+                    }`}
+                  </Tooltip>
+                </div>
+              )}
+              {!!projectFlag.num_identity_overrides && (
+                <div
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    this.editFeature(projectFlag, environmentFlags[id], 2)
+                  }}
+                >
+                  <Tooltip
+                    title={
+                      <span
+                        className='chip me-2 chip--xs bg-primary text-white'
+                        style={{ border: 'none' }}
+                      >
+                        <UsersIcon className='chip-svg-icon' />
+                        <span>{projectFlag.num_identity_overrides}</span>
+                      </span>
+                    }
+                    place='top'
+                  >
+                    {`${projectFlag.num_identity_overrides} Identity Override${
+                      projectFlag.num_identity_overrides !== 1 ? 's' : ''
+                    }`}
+                  </Tooltip>
+                </div>
+              )}
+              <Switch
+                disabled={!permission || readOnly}
+                data-test={`feature-switch-${this.props.index}${
+                  environmentFlags[id] && environmentFlags[id].enabled
+                    ? '-on'
+                    : '-off'
+                }`}
+                checked={environmentFlags[id] && environmentFlags[id].enabled}
+                onChange={() => {
+                  if (disableControls) return
+                  if (changeRequestsEnabled) {
+                    this.editFeature(projectFlag, environmentFlags[id])
+                    return
+                  }
+                  this.confirmToggle()
+                }}
+              />
+            </Row>
           </div>
           <Flex
             className={`table-column clickable ${

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -6,8 +6,6 @@ import CreateFlagModal from './modals/CreateFlag'
 import ProjectStore from 'common/stores/project-store'
 import Constants from 'common/constants'
 import { hasProtectedTag } from 'common/utils/hasProtectedTag'
-import SegmentsIcon from './svg/SegmentsIcon'
-import UsersIcon from './svg/UsersIcon' // we need this to make JSX compile
 import Icon from './Icon'
 import FeatureValue from './FeatureValue'
 import FeatureAction from './FeatureAction'
@@ -15,6 +13,8 @@ import { getViewMode } from 'common/useViewMode'
 import classNames from 'classnames'
 import Tag from './tags/Tag'
 import Button from './base/forms/Button'
+import SegmentOverridesIcon from './SegmentOverridesIcon'
+import IdentityOverridesIcon from './IdentityOverridesIcon'
 
 export const width = [200, 70, 55, 70, 450]
 class TheComponent extends Component {
@@ -156,59 +156,9 @@ class TheComponent extends Component {
         >
           <div
             className={`table-column ${this.props.fadeEnabled && 'faded'}`}
-            style={{ width: '120px' }}
+            style={{ width: '80px' }}
           >
             <Row>
-              {!!projectFlag.num_segment_overrides && (
-                <div
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    this.editFeature(projectFlag, environmentFlags[id], 1)
-                  }}
-                >
-                  <Tooltip
-                    title={
-                      <span
-                        className='chip me-2 chip--xs bg-primary text-white'
-                        style={{ border: 'none' }}
-                      >
-                        <SegmentsIcon className='chip-svg-icon' />
-                        <span>{projectFlag.num_segment_overrides}</span>
-                      </span>
-                    }
-                    place='top'
-                  >
-                    {`${projectFlag.num_segment_overrides} Segment Override${
-                      projectFlag.num_segment_overrides !== 1 ? 's' : ''
-                    }`}
-                  </Tooltip>
-                </div>
-              )}
-              {!!projectFlag.num_identity_overrides && (
-                <div
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    this.editFeature(projectFlag, environmentFlags[id], 2)
-                  }}
-                >
-                  <Tooltip
-                    title={
-                      <span
-                        className='chip me-2 chip--xs bg-primary text-white'
-                        style={{ border: 'none' }}
-                      >
-                        <UsersIcon className='chip-svg-icon' />
-                        <span>{projectFlag.num_identity_overrides}</span>
-                      </span>
-                    }
-                    place='top'
-                  >
-                    {`${projectFlag.num_identity_overrides} Identity Override${
-                      projectFlag.num_identity_overrides !== 1 ? 's' : ''
-                    }`}
-                  </Tooltip>
-                </div>
-              )}
               <Switch
                 disabled={!permission || readOnly}
                 data-test={`feature-switch-${this.props.index}${
@@ -228,22 +178,40 @@ class TheComponent extends Component {
               />
             </Row>
           </div>
-          <Flex
-            className={`table-column clickable ${
-              this.props.fadeValue && 'faded'
-            }`}
-          >
-            <FeatureValue
-              onClick={() =>
-                permission &&
-                !readOnly &&
-                this.editFeature(projectFlag, environmentFlags[id])
-              }
-              value={
-                environmentFlags[id] && environmentFlags[id].feature_state_value
-              }
-              data-test={`feature-value-${this.props.index}`}
-            />
+          <Flex className={'table-column clickable'}>
+            <Row>
+              <div
+                onClick={() =>
+                  permission &&
+                  !readOnly &&
+                  this.editFeature(projectFlag, environmentFlags[id])
+                }
+                className={`flex-fill ${this.props.fadeValue ? 'faded' : ''}`}
+              >
+                <FeatureValue
+                  value={
+                    environmentFlags[id] &&
+                    environmentFlags[id].feature_state_value
+                  }
+                  data-test={`feature-value-${this.props.index}`}
+                />
+              </div>
+
+              <SegmentOverridesIcon
+                onClick={(e) => {
+                  e.stopPropagation()
+                  this.editFeature(projectFlag, environmentFlags[id], 1)
+                }}
+                count={projectFlag.num_segment_overrides}
+              />
+              <IdentityOverridesIcon
+                onClick={(e) => {
+                  e.stopPropagation()
+                  this.editFeature(projectFlag, environmentFlags[id], 1)
+                }}
+                count={projectFlag.num_identity_overrides}
+              />
+            </Row>
           </Flex>
         </Flex>
       )
@@ -301,58 +269,20 @@ class TheComponent extends Component {
                     <Icon name='copy' />
                   </Button>
                 </Row>
-                {!!projectFlag.num_segment_overrides && (
-                  <div
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      this.editFeature(projectFlag, environmentFlags[id], 1)
-                    }}
-                  >
-                    <Tooltip
-                      title={
-                        <span
-                          className='chip me-2 chip--xs bg-primary text-white'
-                          style={{ border: 'none' }}
-                        >
-                          <SegmentsIcon className='chip-svg-icon' />
-                          <span>{projectFlag.num_segment_overrides}</span>
-                        </span>
-                      }
-                      place='top'
-                    >
-                      {`${projectFlag.num_segment_overrides} Segment Override${
-                        projectFlag.num_segment_overrides !== 1 ? 's' : ''
-                      }`}
-                    </Tooltip>
-                  </div>
-                )}
-                {!!projectFlag.num_identity_overrides && (
-                  <div
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      this.editFeature(projectFlag, environmentFlags[id], 2)
-                    }}
-                  >
-                    <Tooltip
-                      title={
-                        <span
-                          className='chip me-2 chip--xs bg-primary text-white'
-                          style={{ border: 'none' }}
-                        >
-                          <UsersIcon className='chip-svg-icon' />
-                          <span>{projectFlag.num_identity_overrides}</span>
-                        </span>
-                      }
-                      place='top'
-                    >
-                      {`${
-                        projectFlag.num_identity_overrides
-                      } Identity Override${
-                        projectFlag.num_identity_overrides !== 1 ? 's' : ''
-                      }`}
-                    </Tooltip>
-                  </div>
-                )}
+                <SegmentOverridesIcon
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    this.editFeature(projectFlag, environmentFlags[id], 1)
+                  }}
+                  count={projectFlag.num_segment_overrides}
+                />
+                <IdentityOverridesIcon
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    this.editFeature(projectFlag, environmentFlags[id], 1)
+                  }}
+                  count={projectFlag.num_identity_overrides}
+                />
                 {projectFlag.is_server_key_only && (
                   <Tooltip
                     title={

--- a/frontend/web/components/IdentityOverridesIcon.tsx
+++ b/frontend/web/components/IdentityOverridesIcon.tsx
@@ -1,0 +1,38 @@
+import React, { FC, FormEvent } from 'react'
+import SegmentsIcon from './svg/SegmentsIcon'
+import Tooltip from './Tooltip'
+import UsersIcon from './svg/UsersIcon'
+
+type IdentityOverridesIconType = {
+  count: number | null
+  onClick?: (e: FormEvent) => void
+}
+
+const IdentityOverridesIcon: FC<IdentityOverridesIconType> = ({
+  count,
+  onClick,
+}) => {
+  if (!count) {
+    return null
+  }
+  return (
+    <div onClick={onClick}>
+      <Tooltip
+        title={
+          <span
+            className='chip me-2 chip--xs bg-primary text-white'
+            style={{ border: 'none' }}
+          >
+            <UsersIcon className='chip-svg-icon' />
+            <span>{count}</span>
+          </span>
+        }
+        place='top'
+      >
+        {`${count} Identity Override${count !== 1 ? 's' : ''}`}
+      </Tooltip>
+    </div>
+  )
+}
+
+export default IdentityOverridesIcon

--- a/frontend/web/components/SegmentOverridesIcon.tsx
+++ b/frontend/web/components/SegmentOverridesIcon.tsx
@@ -1,0 +1,37 @@
+import React, { FC, FormEvent } from 'react'
+import SegmentsIcon from './svg/SegmentsIcon'
+import Tooltip from './Tooltip'
+
+type SegmentOverridesIconType = {
+  count: number | null
+  onClick?: (e: FormEvent) => void
+}
+
+const SegmentOverridesIcon: FC<SegmentOverridesIconType> = ({
+  count,
+  onClick,
+}) => {
+  if (!count) {
+    return null
+  }
+  return (
+    <div onClick={onClick}>
+      <Tooltip
+        title={
+          <span
+            className='chip me-2 chip--xs bg-primary text-white'
+            style={{ border: 'none' }}
+          >
+            <SegmentsIcon className='chip-svg-icon' />
+            <span>{count}</span>
+          </span>
+        }
+        place='top'
+      >
+        {`${count} Segment Override${count !== 1 ? 's' : ''}`}
+      </Tooltip>
+    </div>
+  )
+}
+
+export default SegmentOverridesIcon


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x]  I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Compare environments now highlight overrides as changes
<img width="1017" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/a010b897-d4fe-44ef-a49f-c6a181fce22f">

- Compare identities now shows overrides for each feature 
<img width="1056" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/37a114fe-c339-4a01-a54f-90daca2f9d85">




## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
