### PR TITLE
fix: Project settings with no environments

### DIFF
--- a/frontend/web/components/pages/ProjectSettingsPage.js
+++ b/frontend/web/components/pages/ProjectSettingsPage.js
@@ -494,7 +494,7 @@ const ProjectSettingsPage = class extends Component {
                         roles={this.state.roles}
                       />
                     </TabItem>
-                    {!!ProjectStore.getEnvironment() && (
+                    {!!ProjectStore.getEnvs()?.length && (
                       <TabItem data-test='js-import-page' tabLabel='Import'>
                         <ImportPage
                           environmentId={this.props.match.params.environmentId}
@@ -503,7 +503,7 @@ const ProjectSettingsPage = class extends Component {
                         />
                       </TabItem>
                     )}
-                    {!!ProjectStore.getEnvironment() &&
+                    {!!ProjectStore.getEnvs()?.length &&
                       Utils.getFlagsmithHasFeature(
                         'flagsmith_import_export',
                       ) && (

--- a/frontend/web/components/pages/ProjectSettingsPage.js
+++ b/frontend/web/components/pages/ProjectSettingsPage.js
@@ -19,6 +19,7 @@ import AccountStore from 'common/stores/account-store'
 import ImportPage from 'components/import-export/ImportPage'
 import FeatureExport from 'components/import-export/FeatureExport'
 import ProjectUsage from 'components/ProjectUsage'
+import ProjectStore from 'common/stores/project-store'
 
 const ProjectSettingsPage = class extends Component {
   static displayName = 'ProjectSettingsPage'
@@ -493,22 +494,25 @@ const ProjectSettingsPage = class extends Component {
                         roles={this.state.roles}
                       />
                     </TabItem>
-                    <TabItem data-test='js-import-page' tabLabel='Import'>
-                      <ImportPage
-                        environmentId={this.props.match.params.environmentId}
-                        projectId={this.props.match.params.projectId}
-                        projectName={project.name}
-                      />
-                    </TabItem>
-                    {Utils.getFlagsmithHasFeature(
-                      'flagsmith_import_export',
-                    ) && (
-                      <TabItem tabLabel='Export'>
-                        <FeatureExport
+                    {!!ProjectStore.getEnvironment() && (
+                      <TabItem data-test='js-import-page' tabLabel='Import'>
+                        <ImportPage
+                          environmentId={this.props.match.params.environmentId}
                           projectId={this.props.match.params.projectId}
+                          projectName={project.name}
                         />
                       </TabItem>
                     )}
+                    {!!ProjectStore.getEnvironment() &&
+                      Utils.getFlagsmithHasFeature(
+                        'flagsmith_import_export',
+                      ) && (
+                        <TabItem tabLabel='Export'>
+                          <FeatureExport
+                            projectId={this.props.match.params.projectId}
+                          />
+                        </TabItem>
+                      )}
                   </Tabs>
                 }
               </div>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the project settings page when there are no environments.


## How did you test this code?

Go to project/16270/settings as a flagsmith user in prod