### PR TITLE
fix(audit): use correct endpoint for retrieve

### DIFF
--- a/frontend/common/services/useAuditLogItem.ts
+++ b/frontend/common/services/useAuditLogItem.ts
@@ -12,7 +12,7 @@ export const auditLogItemService = service
       >({
         providesTags: (res) => [{ id: res?.id, type: 'AuditLogItem' }],
         query: (query: Req['getAuditLogItem']) => ({
-          url: `audit/${query.id}/`,
+          url: `projects/${query.projectId}/audit/${query.id}/`,
         }),
       }),
       // END OF ENDPOINTS

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -246,7 +246,10 @@ export type Req = {
     environmentId: string
     data: { name: string }
   }
-  getAuditLogItem: { id: string }
+  getAuditLogItem: {
+    projectId: string
+    id: string
+  }
   getProject: { id: string }
   // END OF TYPES
 }

--- a/frontend/web/components/pages/AuditLogItemPage.tsx
+++ b/frontend/web/components/pages/AuditLogItemPage.tsx
@@ -25,6 +25,7 @@ type AuditLogItemPageType = {
 const AuditLogItemPage: FC<AuditLogItemPageType> = ({ match }) => {
   const { data, error, isLoading } = useGetAuditLogItemQuery({
     id: match.params.id,
+    projectId: match.params.projectId
   })
 
   const index = (ProjectStore.getEnvs() as Environment[] | null)?.findIndex(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Update the FE to use the correct endpoint nested under the project routes to retrieve the audit log. Without this, users that are not organisation admins cannot retrieve the audit log detail. 

## How did you test this code?

Ran the FE locally and verified it's calling the correct endpoint. 
