### PR TITLE
fix(audit): add segment deleted audit log

### DIFF
--- a/api/audit/constants.py
+++ b/api/audit/constants.py
@@ -3,6 +3,7 @@ FEATURE_DELETED_MESSAGE = "Flag / Remote Config Deleted: %s"
 FEATURE_UPDATED_MESSAGE = "Flag / Remote Config updated: %s"
 SEGMENT_CREATED_MESSAGE = "New Segment created: %s"
 SEGMENT_UPDATED_MESSAGE = "Segment updated: %s"
+SEGMENT_DELETED_MESSAGE = "Segment deleted: %s"
 FEATURE_SEGMENT_UPDATED_MESSAGE = (
     "Segment rules updated for flag: %s in environment: %s"
 )

--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -11,7 +11,11 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from flag_engine.segments import constants
 
-from audit.constants import SEGMENT_CREATED_MESSAGE, SEGMENT_UPDATED_MESSAGE
+from audit.constants import (
+    SEGMENT_CREATED_MESSAGE,
+    SEGMENT_DELETED_MESSAGE,
+    SEGMENT_UPDATED_MESSAGE,
+)
 from audit.related_object_type import RelatedObjectType
 from features.models import Feature
 from projects.models import Project
@@ -81,6 +85,9 @@ class Segment(
 
     def get_update_log_message(self, history_instance) -> typing.Optional[str]:
         return SEGMENT_UPDATED_MESSAGE % self.name
+
+    def get_delete_log_message(self, history_instance) -> typing.Optional[str]:
+        return SEGMENT_DELETED_MESSAGE % self.name
 
     def _get_project(self):
         return self.project


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds an audit log record when a segment is deleted. 

## How did you test this code?

Added a new test. 
