### PR TITLE
fix: startup plan does not allow correct permissions

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -280,9 +280,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     if (!plan || planName === planNames.free) {
       return false
     }
-    const isStartupOrGreater = planName !== planNames.startup
-    const isScaleupOrGreater =
-      isStartupOrGreater && planName !== planNames.startup
+    const isScaleupOrGreater = planName !== planNames.startup
     const isEnterprise = planName === planNames.enterprise
 
     switch (permission) {
@@ -291,11 +289,11 @@ const Utils = Object.assign({}, require('./base/_utils'), {
         break
       }
       case 'CREATE_ADDITIONAL_PROJECT': {
-        valid = isStartupOrGreater
+        valid = true // startup or greater
         break
       }
       case '2FA': {
-        valid = isStartupOrGreater
+        valid = true // startup or greater
         break
       }
       case 'RBAC': {
@@ -315,7 +313,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
         break
       }
       case 'SCHEDULE_FLAGS': {
-        valid = isStartupOrGreater
+        valid = true // startup or greater
         break
       }
       case '4_EYES': {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes an issue introduced in [this PR](https://github.com/Flagsmith/flagsmith/pull/3518) which meant that organisations on the startup plan did not have access to paid features. 

## How did you test this code?

Verified (via vercel preview) accessing the dashboard for an organisation on the free plan, startup plan, and scaleup plan and confirmed correct access is provided. 
