### PR TITLE
deps(workflows): bump workflows version 2.2.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,9 @@ repos:
     hooks:
       - id: prettier
         exclude: ^(frontend/|CHANGELOG.md)
+
+  - repo: https://github.com/python-poetry/poetry
+    rev: 1.7.1
+    hooks:
+      - id: poetry-check
+        args: ['-C', 'api']

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -4300,8 +4300,8 @@ flagsmith_task_processor = {git = "https://github.com/Flagsmith/flagsmith-task-p
 [package.source]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-workflows"
-reference = "v2.2.0"
-resolved_reference = "f1ff8de21349da824f74e2a6caefcf8a5f65f1f3"
+reference = "v2.2.1"
+resolved_reference = "9752ee48629bb10f06910a949749a992494a8d5c"
 
 [[package]]
 name = "wrapt"
@@ -4521,4 +4521,4 @@ requests = ">=2.7,<3.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "9cc9028c4fbd8793d5764dabcfe2227fae9e775817983a8166b4bad3dafbe9c4"
+content-hash = "b41d0cbed2983ff5bfee92b75b91a92e6dd90e58fdfae58fd2d33a77d835ccf7"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -128,7 +128,7 @@ flagsmith-ldap = { git = "https://github.com/flagsmith/flagsmith-ldap", tag = "v
 optional = true
 
 [tool.poetry.group.workflows.dependencies]
-workflows-logic = { git = "https://github.com/flagsmith/flagsmith-workflows", tag = "v2.2.0" }
+workflows-logic = { git = "https://github.com/flagsmith/flagsmith-workflows", tag = "v2.2.1" }
 
 [tool.poetry.group.dev.dependencies]
 django-test-migrations = "~1.2.0"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Update workflows to 2.2.1

Also includes an addition to pre-commit to ensure that the lock file is up to date to avoid issues when pyproject.toml is manually updated (e.g. for git dependencies). 

## How did you test this code?

Tests in the workflows repo. 
