### PR TITLE
fix: Add stale_flags_limit_days to Project serializer

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -165,6 +165,15 @@ def chargebee_subscription(organisation: Organisation) -> Subscription:
 
 
 @pytest.fixture()
+def enterprise_subscription(organisation: Organisation) -> Subscription:
+    Subscription.objects.filter(organisation=organisation).update(
+        plan="enterprise", subscription_id="subscription-id"
+    )
+    organisation.refresh_from_db()
+    return organisation.subscription
+
+
+@pytest.fixture()
 def project(organisation):
     return Project.objects.create(name="Test Project", organisation=organisation)
 

--- a/api/organisations/subscriptions/serializers/mixins.py
+++ b/api/organisations/subscriptions/serializers/mixins.py
@@ -1,3 +1,4 @@
+import re
 import typing
 
 from organisations.models import Subscription
@@ -24,6 +25,11 @@ class ReadOnlyIfNotValidPlanMixin:
 
     invalid_plans: typing.Iterable[str] = None
     field_names: typing.Iterable[str] = None
+    invalid_plans_regex: str = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.invalid_plans_regex_matcher = re.compile(self.invalid_plans_regex)
 
     def get_fields(self, *args, **kwargs):
         fields = super().get_fields(*args, **kwargs)
@@ -33,12 +39,15 @@ class ReadOnlyIfNotValidPlanMixin:
 
         subscription = self.get_subscription()
         field_names = self.field_names or []
-        invalid_plans = self.invalid_plans or []
 
         for field_name in field_names:
             if field_name in fields and (
                 not (subscription and subscription.plan)
-                or subscription.plan in invalid_plans
+                or (self.invalid_plans and subscription.plan in self.invalid_plans)
+                or (
+                    self.invalid_plans_regex
+                    and re.match(self.invalid_plans_regex_matcher, subscription.plan)
+                )
             ):
                 fields[field_name].read_only = True
 

--- a/api/organisations/subscriptions/serializers/mixins.py
+++ b/api/organisations/subscriptions/serializers/mixins.py
@@ -29,7 +29,9 @@ class ReadOnlyIfNotValidPlanMixin:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.invalid_plans_regex_matcher = re.compile(self.invalid_plans_regex)
+        self.invalid_plans_regex_matcher = (
+            re.compile(self.invalid_plans_regex) if self.invalid_plans_regex else None
+        )
 
     def get_fields(self, *args, **kwargs):
         fields = super().get_fields(*args, **kwargs)

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -18,15 +18,12 @@ from projects.models import (
 from users.serializers import UserListSerializer, UserPermissionGroupSerializer
 
 
-class ProjectListSerializer(ReadOnlyIfNotValidPlanMixin, serializers.ModelSerializer):
+class ProjectListSerializer(serializers.ModelSerializer):
     migration_status = serializers.SerializerMethodField(
         help_text="Edge migration status of the project; can be one of: "
         + ", ".join([k.value for k in ProjectIdentityMigrationStatus])
     )
     use_edge_identities = serializers.SerializerMethodField()
-
-    invalid_plans_regex = r"^(free|startup.*|scale-up.*)$"
-    field_names = ("stale_flags_limit_days",)
 
     class Meta:
         model = Project
@@ -65,6 +62,13 @@ class ProjectListSerializer(ReadOnlyIfNotValidPlanMixin, serializers.ModelSerial
             self.context["migration_status"]
             == ProjectIdentityMigrationStatus.MIGRATION_COMPLETED.value
         )
+
+
+class ProjectUpdateOrCreateSerializer(
+    ReadOnlyIfNotValidPlanMixin, ProjectListSerializer
+):
+    invalid_plans_regex = r"^(free|startup.*|scale-up.*)$"
+    field_names = ("stale_flags_limit_days",)
 
     def get_subscription(self) -> typing.Optional[Subscription]:
         view = self.context["view"]

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -1,8 +1,14 @@
+import typing
+
 from django.conf import settings
 from rest_framework import serializers
 
 from environments.dynamodb.migrator import IdentityMigrator
 from environments.dynamodb.types import ProjectIdentityMigrationStatus
+from organisations.models import Subscription
+from organisations.subscriptions.serializers.mixins import (
+    ReadOnlyIfNotValidPlanMixin,
+)
 from permissions.serializers import CreateUpdateUserPermissionSerializerABC
 from projects.models import (
     Project,
@@ -12,12 +18,15 @@ from projects.models import (
 from users.serializers import UserListSerializer, UserPermissionGroupSerializer
 
 
-class ProjectListSerializer(serializers.ModelSerializer):
+class ProjectListSerializer(ReadOnlyIfNotValidPlanMixin, serializers.ModelSerializer):
     migration_status = serializers.SerializerMethodField(
         help_text="Edge migration status of the project; can be one of: "
         + ", ".join([k.value for k in ProjectIdentityMigrationStatus])
     )
     use_edge_identities = serializers.SerializerMethodField()
+
+    invalid_plans_regex = r"^(free|startup.*|scale-up.*)$"
+    field_names = ("stale_flags_limit_days",)
 
     class Meta:
         model = Project
@@ -56,6 +65,23 @@ class ProjectListSerializer(serializers.ModelSerializer):
             self.context["migration_status"]
             == ProjectIdentityMigrationStatus.MIGRATION_COMPLETED.value
         )
+
+    def get_subscription(self) -> typing.Optional[Subscription]:
+        view = self.context["view"]
+
+        if view.action == "create":
+            # handle `organisation` not being part of the data
+            # When request comes from yasg2 (as part of schema generation)
+            organisation_id = view.request.data.get("organisation")
+            if not organisation_id:
+                return None
+
+            # Organisation should only have a single subscription
+            return Subscription.objects.filter(organisation_id=organisation_id).first()
+        elif view.action in ("update", "partial_update"):
+            return getattr(self.instance.organisation, "subscription", None)
+
+        return None
 
 
 class ProjectRetrieveSerializer(ProjectListSerializer):

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -35,6 +35,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
             "only_allow_lower_case_feature_names",
             "feature_name_regex",
             "show_edge_identity_overrides_for_feature",
+            "stale_flags_limit_days",
         )
 
     def get_migration_status(self, obj: Project) -> str:

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -45,6 +45,7 @@ from projects.serializers import (
     ListUserProjectPermissionSerializer,
     ProjectListSerializer,
     ProjectRetrieveSerializer,
+    ProjectUpdateOrCreateSerializer,
 )
 
 
@@ -75,9 +76,14 @@ class ProjectViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == "retrieve":
             return ProjectRetrieveSerializer
+        elif self.action in ("create", "update", "partial_update"):
+            return ProjectUpdateOrCreateSerializer
         return ProjectListSerializer
 
     pagination_class = None
+
+    def get_serializer_context(self):
+        return super().get_serializer_context()
 
     def get_queryset(self):
         if getattr(self, "swagger_fake_view", False):

--- a/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
+++ b/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import pytest
 from rest_framework import serializers
 
 from organisations.models import Subscription
@@ -8,20 +9,29 @@ from organisations.subscriptions.serializers.mixins import (
 )
 
 
-def test_read_only_if_not_valid_plan_mixin_sets_read_only_if_plan_not_valid():
+@pytest.mark.parametrize(
+    "plan_id, invalid_plans_, invalid_plans_regex_",
+    (
+        ("invalid-plan-id", ("invalid-plan-id",), ""),
+        ("invalid-plan-id", tuple(), "invalid-.*"),
+    ),
+)
+def test_read_only_if_not_valid_plan_mixin_sets_read_only_if_plan_not_valid(
+    plan_id: str, invalid_plans_: list[str], invalid_plans_regex_: str
+) -> None:
     # Given
-    invalid_plan_id = "invalid-plan-id"
-
     mock_view = MagicMock()
 
     class MySerializer(ReadOnlyIfNotValidPlanMixin, serializers.Serializer):
-        invalid_plans = (invalid_plan_id,)
         field_names = ("foo",)
+
+        invalid_plans = invalid_plans_
+        invalid_plans_regex = invalid_plans_regex_
 
         foo = serializers.CharField()
 
         def get_subscription(self) -> Subscription:
-            return MagicMock(plan=invalid_plan_id)
+            return MagicMock(plan=plan_id)
 
     serializer = MySerializer(data={"foo": "bar"}, context={"view": mock_view})
 

--- a/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
+++ b/api/tests/unit/organisations/subscriptions/serializers/test_unit_subscriptions_serializers_mixins.py
@@ -47,12 +47,14 @@ def test_read_only_if_not_valid_plan_mixin_does_not_set_read_only_if_plan_valid(
     # Given
     valid_plan_id = "plan-id"
     invalid_plan_id = "invalid-plan-id"
+    invalid_plans_regex_ = r"^another-invalid-plan-id-.*$"
 
     mock_view = MagicMock()
 
     class MySerializer(ReadOnlyIfNotValidPlanMixin, serializers.Serializer):
         invalid_plans = (invalid_plan_id,)
         field_names = ("foo",)
+        invalid_plans_regex = invalid_plans_regex_
 
         foo = serializers.CharField()
 

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -14,7 +14,7 @@ from rest_framework.test import APIClient
 from environments.dynamodb.types import ProjectIdentityMigrationStatus
 from environments.identities.models import Identity
 from features.models import Feature, FeatureSegment
-from organisations.models import Organisation, OrganisationRole
+from organisations.models import Organisation, OrganisationRole, Subscription
 from organisations.permissions.models import (
     OrganisationPermissionModel,
     UserOrganisationPermission,
@@ -39,7 +39,13 @@ now = timezone.now()
 yesterday = now - timedelta(days=1)
 
 
-def test_should_create_a_project(settings, admin_user, admin_client, organisation):
+def test_should_create_a_project(
+    settings: SettingsWrapper,
+    admin_user: FFAdminUser,
+    admin_client: APIClient,
+    organisation: Organisation,
+    enterprise_subscription: Subscription,
+) -> None:
     # Given
     settings.PROJECT_METADATA_TABLE_NAME_DYNAMO = None
 
@@ -106,7 +112,12 @@ def test_should_create_a_project_with_admin_master_api_key_client(
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_can_update_project(client, project, organisation):
+def test_can_update_project(
+    client: APIClient,
+    project: Project,
+    organisation: Organisation,
+    enterprise_subscription: Subscription,
+) -> None:
     # Given
     new_name = "New project name"
     new_stale_flags_limit_days = 15


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds the `stale_flags_limit_days` field to the project serializer so that it can be configured via the dashboard. 

## How did you test this code?

Added tests
