### PR TITLE
fix: remove feature modal

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -68,7 +68,7 @@ class TheComponent extends Component {
     Utils.copyFeatureName(projectFlag.name)
   }
   confirmRemove = (projectFlag, cb) => {
-    openModal(
+    openModal2(
       'Remove Feature',
       <ConfirmRemoveFeature
         environmentId={this.props.environmentId}

--- a/frontend/web/components/modals/ConfirmRemoveFeature.tsx
+++ b/frontend/web/components/modals/ConfirmRemoveFeature.tsx
@@ -62,7 +62,7 @@ const ConfirmRemoveFeature: FC<ConfirmRemoveFeatureType> = ({
 
           <ModalHR />
           <div className='modal-footer'>
-            <Button className='mr-2' theme='secondary' onClick={closeModal}>
+            <Button className='mr-2' theme='secondary' onClick={closeModal2}>
               Cancel
             </Button>
             <Button

--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import ConfirmToggleFeature from 'components/modals/ConfirmToggleFeature'
-import ConfirmRemoveFeature from 'components/modals/ConfirmRemoveFeature'
 import CreateFlagModal from 'components/modals/CreateFlag'
 import CreateTraitModal from 'components/modals/CreateTrait'
 import TryIt from 'components/TryIt'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
[This PR ](https://github.com/Flagsmith/flagsmith/pull/3559) adjusted the remove feature modal to be able to appear above other modals (specifically the create feature modal). However further adjustments needed to be made to allow for the modal to close.

E2E was breaking on the PR but for some reason allowed me to merge.


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- E2E now passes
- Removed a feature on preview URL
