### PR TITLE
chore: show no segment rules validation

### DIFF
--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -259,6 +259,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
     }
     return warnings
   }, [operators, rules])
+  const hasNoRules = !rules[0]?.rules?.length
   const rulesEl = (
     <div className='overflow-visible'>
       <div>
@@ -296,6 +297,11 @@ const CreateSegment: FC<CreateSegmentType> = ({
               )
             })}
         </div>
+        {hasNoRules && (
+          <InfoMessage>
+            Add at least one AND/NOT rule to create a segment.
+          </InfoMessage>
+        )}
         <Row className='justify-content-end'>
           {!readOnly && (
             <div onClick={() => addRule('ANY')} className='text-center'>

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -259,7 +259,9 @@ const CreateSegment: FC<CreateSegmentType> = ({
     }
     return warnings
   }, [operators, rules])
-  const hasNoRules = !rules[0]?.rules?.length
+  //Find any non-deleted rules
+  const hasNoRules = !rules[0]?.rules?.find((v) => !v.delete)
+
   const rulesEl = (
     <div className='overflow-visible'>
       <div>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

It was not completely obvious why a user couldn't create a segment without at least 1 and/not rule. The frontend will now show validation when this is the case

https://github.com/Flagsmith/flagsmith/assets/8608314/250547e8-0c4a-4afd-80ad-09decc514448

## How did you test this code?

- Add / remove rules from a segment
