### PR TITLE
fix: Freeze time for tests to ensure dependability

### DIFF
--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -227,6 +227,7 @@ def test_send_org_subscription_cancelled_alert(db: None, mocker: MockerFixture) 
     )
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 def test_handle_api_usage_notifications_below_100(
     mocker: MockerFixture,
     organisation: Organisation,
@@ -313,6 +314,7 @@ def test_handle_api_usage_notifications_below_100(
     assert OranisationAPIUsageNotification.objects.first() == api_usage_notification
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 def test_handle_api_usage_notifications_above_100(
     mocker: MockerFixture,
     organisation: Organisation,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Use freeze time to make the tests dependable with respect to the date range used for the api usage query.

## How did you test this code?

Ran tests locally to ensure they were fixed.