### PR TITLE
feat: Summary of group permissions in the Project settings page

### DIFF
--- a/frontend/common/services/useGroup.ts
+++ b/frontend/common/services/useGroup.ts
@@ -3,7 +3,9 @@ import { Req } from 'common/types/requests'
 import { service } from 'common/service'
 
 export const groupService = service
-  .enhanceEndpoints({ addTagTypes: ['Group'] })
+  .enhanceEndpoints({
+    addTagTypes: ['Group', 'UserGroupPermission', 'GroupSummary'],
+  })
   .injectEndpoints({
     endpoints: (builder) => ({
       createGroupAdmin: builder.mutation<
@@ -18,7 +20,11 @@ export const groupService = service
         }),
       }),
       deleteGroup: builder.mutation<Res['groups'], Req['deleteGroup']>({
-        invalidatesTags: [{ id: 'LIST', type: 'Group' }],
+        invalidatesTags: [
+          { id: 'LIST', type: 'Group' },
+          { type: 'UserGroupPermission' },
+          { type: 'GroupSummary' },
+        ],
         query: (query: Req['deleteGroup']) => ({
           body: query,
           method: 'DELETE',

--- a/frontend/common/services/useUserGroupPermission.ts
+++ b/frontend/common/services/useUserGroupPermission.ts
@@ -1,0 +1,47 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const userGroupPermissionService = service
+  .enhanceEndpoints({ addTagTypes: ['UserGroupPermission'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      getUserGroupPermission: builder.query<
+        Res['userGroupPermissions'],
+        Req['getUserGroupPermission']
+      >({
+        providesTags: (res) => [{ id: res?.id, type: 'UserGroupPermission' }],
+        query: (query: Req['getUserGroupPermission']) => ({
+          url: `projects/${query.project_id}/user-group-permissions/`,
+        }),
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function getUserGroupPermission(
+  store: any,
+  data: Req['getUserGroupPermission'],
+  options?: Parameters<
+    typeof userGroupPermissionService.endpoints.getUserGroupPermission.initiate
+  >[1],
+) {
+  return store.dispatch(
+    userGroupPermissionService.endpoints.getUserGroupPermission.initiate(
+      data,
+      options,
+    ),
+  )
+}
+// END OF FUNCTION_EXPORTS
+
+export const {
+  useGetUserGroupPermissionQuery,
+  // END OF EXPORTS
+} = userGroupPermissionService
+
+/* Usage examples:
+const { data, isLoading } = useGetUserGroupPermissionQuery({ id: 2 }, {}) //get hook
+const [createUserGroupPermission, { isLoading, data, isSuccess }] = useCreateUserGroupPermissionMutation() //create hook
+userGroupPermissionService.endpoints.getUserGroupPermission.select({id: 2})(store.getState()) //access data from any function
+*/

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -256,5 +256,6 @@ export type Req = {
     id: string
   }
   getProject: { id: string }
+  getUserGroupPermission: { project_id: string }
   // END OF TYPES
 }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -486,5 +486,6 @@ export type Res = {
   flagsmithProjectImport: { id: string }
   featureImports: PagedResponse<FeatureImport>
   serversideEnvironmentKeys: APIKey[]
+  userGroupPermissions: GroupPermission[]
   // END OF TYPES
 }

--- a/frontend/common/utils/format.js
+++ b/frontend/common/utils/format.js
@@ -149,6 +149,24 @@ const Format = {
     return value ? value + (s[(v - 20) % 10] || s[v] || s[0]) : ''
   },
 
+  permissionList(isAdmin, permissions) {
+    // ['VIEW_PROJECT', 'CREATE_ENVIRONMENT', 'VIEW_AUDIT_LOG', 'DELETE_FEATURE'] > View project, Create environment, View audit log, +1 more
+    if (isAdmin) {
+      return 'Project Administrator'
+    }
+    const permissionsSummary =
+      permissions &&
+      permissions.length > 0 &&
+      permissions.includes('VIEW_PROJECT')
+        ? permissions
+            .slice(0, 3)
+            .map((item) => Format.enumeration.get(item))
+            .join(', ') +
+          (permissions.length > 3 ? `, +${permissions.length - 3} more` : '')
+        : ''
+    return permissionsSummary
+  },
+
   removeAccents(str) {
     // Sergio Agüero > Sergio Aguero
     if (!str) {

--- a/frontend/common/utils/format.js
+++ b/frontend/common/utils/format.js
@@ -149,24 +149,6 @@ const Format = {
     return value ? value + (s[(v - 20) % 10] || s[v] || s[0]) : ''
   },
 
-  permissionList(isAdmin, permissions) {
-    // ['VIEW_PROJECT', 'CREATE_ENVIRONMENT', 'VIEW_AUDIT_LOG', 'DELETE_FEATURE'] > View project, Create environment, View audit log, +1 more
-    if (isAdmin) {
-      return 'Project Administrator'
-    }
-    const permissionsSummary =
-      permissions &&
-      permissions.length > 0 &&
-      permissions.includes('VIEW_PROJECT')
-        ? permissions
-            .slice(0, 3)
-            .map((item) => Format.enumeration.get(item))
-            .join(', ') +
-          (permissions.length > 3 ? `, +${permissions.length - 3} more` : '')
-        : ''
-    return permissionsSummary
-  },
-
   removeAccents(str) {
     // Sergio Agüero > Sergio Aguero
     if (!str) {

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -18,6 +18,7 @@ import _ from 'lodash'
 import ErrorMessage from 'components/ErrorMessage'
 import WarningMessage from 'components/WarningMessage'
 import Constants from 'common/constants'
+import Format from './format'
 
 const semver = require('semver')
 
@@ -95,6 +96,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
       />
     ) : null
   },
+
   escapeHtml(html: string) {
     const text = document.createTextNode(html)
     const p = document.createElement('p')
@@ -254,6 +256,36 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   },
   getManageUserPermissionDescription() {
     return 'Manage Identities'
+  },
+  getPermissionList(
+    isAdmin: boolean,
+    permissions: string[] | undefined | null,
+    numberToTruncate = 3,
+  ): {
+    items: string[]
+    truncatedItems: string[]
+  } {
+    if (isAdmin) {
+      return {
+        items: [],
+        truncatedItems: ['Project Administrator'],
+      }
+    }
+    if (!permissions) return { items: [], truncatedItems: [] }
+
+    const items =
+      permissions && permissions.length
+        ? permissions
+            .slice(0, numberToTruncate)
+            .map((item) => `${Format.enumeration.get(item)}`)
+        : []
+
+    return {
+      items,
+      truncatedItems: (permissions || [])
+        .slice(numberToTruncate)
+        .map((item) => `${Format.enumeration.get(item)}`),
+    }
   },
   getPlanName: (plan: string) => {
     if (plan && plan.includes('scale-up')) {

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -1032,6 +1032,7 @@ const EditPermissions: FC<EditPermissionsType> = (props) => {
               <UserGroupList
                 noTitle
                 orgId={AccountStore.getOrganisation().id}
+                projectId={level === 'project' && id}
                 onClick={(group: UserGroup) => editGroupPermissions(group)}
               />
             </div>

--- a/frontend/web/components/PermissionsSummaryList.tsx
+++ b/frontend/web/components/PermissionsSummaryList.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react'
+import Tooltip from './Tooltip'
+import Utils from 'common/utils/utils'
+
+type PermissionsSummaryListType = {
+  isAdmin: boolean
+  permissions: string[] | null | undefined
+  numberToTruncate?: number
+}
+
+const PermissionsSummaryList: FC<PermissionsSummaryListType> = ({
+  isAdmin,
+  numberToTruncate = 3,
+  permissions,
+}) => {
+  const { items, truncatedItems } = Utils.getPermissionList(
+    isAdmin,
+    permissions,
+    numberToTruncate,
+  )
+
+  return (
+    <div className='flex-row gap-1 align-items-center'>
+      {items.map((value: string, i: number) => (
+        <div key={i} className='chip chip--xs'>
+          {value}
+        </div>
+      ))}
+      {!!truncatedItems.length && (
+        <Tooltip
+          title={
+            <span className='chip chip--xs'>+{truncatedItems.length}</span>
+          }
+        >
+          {truncatedItems.join(', ')}
+        </Tooltip>
+      )}
+    </div>
+  )
+}
+
+export default PermissionsSummaryList

--- a/frontend/web/components/UserGroupList.tsx
+++ b/frontend/web/components/UserGroupList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC, ReactNode, useState } from 'react'
 const CreateGroup = require('./modals/CreateGroup')
 import Button from './base/forms/Button'
 import AccountStore from 'common/stores/account-store'
@@ -10,7 +10,7 @@ import { sortBy } from 'lodash'
 import InfoMessage from './InfoMessage' // we need this to make JSX compile
 import Icon from './Icon'
 import { useGetGroupSummariesQuery } from 'common/services/useGroupSummary'
-import Format from 'common/utils/format'
+import PermissionsSummaryList from './PermissionsSummaryList'
 const Panel = require('components/base/grid/Panel')
 
 type UserGroupsListType = {
@@ -26,7 +26,7 @@ type UserGroupsRowType = {
   id: string | number
   index: number
   name: string
-  permissionSummary?: string
+  permissionSummary?: ReactNode
   group: UserGroup
   orgId: string
   showRemove?: boolean
@@ -83,11 +83,7 @@ const UserGroupsRow: FC<UserGroupsRowType> = ({
       <Flex onClick={_onClick} className=' table-column px-3'>
         <div className='font-weight-medium'>{name}</div>
       </Flex>
-      {permissionSummary && (
-        <Flex>
-          <div className='font-weight-small'>{permissionSummary}</div>
-        </Flex>
-      )}
+      {permissionSummary && <Flex>{permissionSummary}</Flex>}
 
       {onEditPermissions && isAdmin ? (
         <div
@@ -214,8 +210,11 @@ const UserGroupsList: FC<UserGroupsListType> = ({
         }
         renderRow={(group: UserGroup | GroupPermission, index: number) => {
           if (userGroupsPermission) {
-            const { admin, group: userPermissionGroup, permissions } = group
-            const permissionSummary = Format.permissionList(admin, permissions)
+            const {
+              admin,
+              group: userPermissionGroup,
+              permissions,
+            } = group as GroupPermission
             return (
               <UserGroupsRow
                 group={userPermissionGroup}
@@ -225,12 +224,18 @@ const UserGroupsList: FC<UserGroupsListType> = ({
                 onClick={onClick}
                 onEditPermissions={onEditPermissions}
                 orgId={orgId}
-                permissionSummary={permissionSummary}
+                permissionSummary={
+                  <PermissionsSummaryList
+                    permissions={permissions}
+                    isAdmin={admin}
+                    numberToTruncate={3}
+                  />
+                }
                 showRemove={showRemove}
               />
             )
           } else {
-            const { id, name } = group
+            const { id, name } = group as UserGroup
             return (
               <UserGroupsRow
                 group={group}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In the list of groups, the permissions that this one has were added to the row.
<img width="1327" alt="Screen Shot 2024-03-15 at 16 59 21" src="https://github.com/fabricanva/flagsmith/assets/81269243/0028d7e5-4b42-4186-ab21-d28f80c3a797">

## How did you test this code?

- Create a group
- Go to project setting page -> permissions
- Select Groups
- Add Permission 
- Refresh the page
