### PR TITLE
fix: Create group should auto focus on the name input

### DIFF
--- a/frontend/web/components/modals/CreateGroup.js
+++ b/frontend/web/components/modals/CreateGroup.js
@@ -228,7 +228,6 @@ const CreateGroup = class extends Component {
                       tooltip={
                         'The external ID of the group in your SSO provider, used for synchronising users.'
                       }
-                      ref={(e) => (this.input = e)}
                       data-test='groupName'
                       inputProps={{
                         className: 'full-width',


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- The code `ref={(e) => (this.input = e)}` was removed from the InputGroup component for the External ID.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Try creating a new group.
