### PR TITLE
ci: remove redundant env var

### DIFF
--- a/.github/workflows/frontend-test-staging.yml
+++ b/.github/workflows/frontend-test-staging.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Run Staging E2E Tests
         working-directory: frontend
         env:
-          E2E_TEST_TOKEN_STAGING: ${{ secrets.E2E_TEST_TOKEN }}
           ENV: staging
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           STATIC_ASSET_CDN_URL: /

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -188,7 +188,6 @@ jobs:
         with:
           github_actor: ${{github.actor}}
           github_token: ${{secrets.GITHUB_TOKEN}}
-          e2e_test_token_staging: ${{ secrets.E2E_TEST_TOKEN }}
 
       - name: Run tests on unified docker image
         working-directory: frontend
@@ -215,7 +214,6 @@ jobs:
         with:
           github_actor: ${{github.actor}}
           github_token: ${{secrets.GITHUB_TOKEN}}
-          e2e_test_token_staging: ${{ secrets.E2E_TEST_TOKEN }}
 
       - name: Run tests on unified docker image
         working-directory: frontend
@@ -242,7 +240,6 @@ jobs:
         with:
           github_actor: ${{github.actor}}
           github_token: ${{secrets.GITHUB_TOKEN}}
-          e2e_test_token_staging: ${{ secrets.E2E_TEST_TOKEN }}
 
       - name: Run tests on unified docker image
         working-directory: frontend


### PR DESCRIPTION
This clears down warnings from Github actions builds