### PR TITLE
chore: default to 180 days dashboard graph

### DIFF
--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -145,7 +145,7 @@ def organisation_info(request, organisation_id):
 
     # If self-hosted and running without an Influx DB data store, we don't want to/cant show usage
     if settings.INFLUXDB_TOKEN:
-        date_range = request.GET.get("date_range", "30d")
+        date_range = request.GET.get("date_range", "180d")
         context["date_range"] = date_range
 
         event_list, labels = get_event_list_for_organisation(


### PR DESCRIPTION
I almost always want a more zoomed out view of traffic so I can see trends beyond the billing period.