### PR TITLE
ci: fix uffizzi

### DIFF
--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: 'Download artifacts'
         # Fetch output (zip archive) from the workflow run that triggered this workflow.
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -44,7 +44,7 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
 
       - name: 'Accept event from first stage'
-        run: unzip preview-spec.zip
+        run: unzip -j preview-spec.zip
 
       - name: Read Event into ENV
         id: event
@@ -58,7 +58,6 @@ jobs:
         # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
         if: ${{ steps.event.outputs.ACTION != 'closed' }}
         run: |
-          unzip preview-spec.zip
           echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_OUTPUT
 
       - name: Cache Rendered Compose File

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -44,7 +44,7 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
 
       - name: 'Accept event from first stage'
-        run: unzip preview-spec.zip event.json
+        run: unzip preview-spec.zip
 
       - name: Read Event into ENV
         id: event
@@ -58,7 +58,7 @@ jobs:
         # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
         if: ${{ steps.event.outputs.ACTION != 'closed' }}
         run: |
-          unzip preview-spec.zip docker-compose.rendered.yml
+          unzip preview-spec.zip
           echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_OUTPUT
 
       - name: Cache Rendered Compose File


### PR DESCRIPTION
I _think_ the `uffizzi-preview.yml` file runs from `main` meaning we need to merge this to test it 🤮

The zip file content is now nested due to the changes in the previous step, so this change just flattens the zip contents which might/should fix things