### PR TITLE
fix: Use dotenv in frontend/bin/env.js

### DIFF
--- a/frontend/bin/env.js
+++ b/frontend/bin/env.js
@@ -1,6 +1,7 @@
 /**
  * Created by kylejohnson on 02/08/2016.
  */
+require('dotenv').config()
 require('colors')
 const fs = require('fs-extra')
 const path = require('path')


### PR DESCRIPTION
Fixes: #3667.
This helps us set project ENV in .env instead of needing to declare it inline.

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

_Please describe._

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
