### PR TITLE
chore: Add Ruby specific offline mode to docs

### DIFF
--- a/docs/docs/clients/server-side.md
+++ b/docs/docs/clients/server-side.md
@@ -807,6 +807,31 @@ public class MyCustomOfflineHandler implements IOfflineHandler:
 ```
 
 </TabItem>
+<TabItem value="ruby" label="Ruby">
+
+```ruby
+# Using the built-in local file handler
+
+offline_handler = \
+Flagsmith::OfflineHandlers::LocalFileHandler.new("environment.json")
+
+# Instantiate the client with offline mode set to true
+
+flagsmith = Flagsmith::Client.new(
+  offline_mode: true,
+  offline_handler: offline_handler,
+)
+
+# Defining a custom offline handler
+
+class MyCustomOfflineHandler
+  def environment
+    # Some code providing the environment for the handler
+  end
+end
+```
+
+</TabItem>
 
 </Tabs>
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [🤠] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Simple addition of the Ruby offline mode to the docs.

## How did you test this code?

Ran the docs webserver locally and verified the code looks nice.