### PR TITLE
feat: Add org id to hubspot company

### DIFF
--- a/api/integrations/lead_tracking/hubspot/client.py
+++ b/api/integrations/lead_tracking/hubspot/client.py
@@ -64,8 +64,8 @@ class HubspotClient:
         )
         return response.to_dict()
 
-    def create_company(self, name: str) -> dict:
-        properties = {"name": name}
+    def create_company(self, name: str, organisation_id: int) -> dict:
+        properties = {"name": name, "orgid": str(organisation_id)}
         simple_public_object_input_for_create = SimplePublicObjectInputForCreate(
             properties=properties,
         )

--- a/api/integrations/lead_tracking/hubspot/lead_tracker.py
+++ b/api/integrations/lead_tracking/hubspot/lead_tracker.py
@@ -65,7 +65,10 @@ class HubspotLeadTracker(LeadTracker):
         if getattr(organisation, "hubspot_organisation", None):
             return organisation.hubspot_organisation.hubspot_id
 
-        response = self.client.create_company(name=organisation.name)
+        response = self.client.create_company(
+            name=organisation.name,
+            organisation_id=organisation.id,
+        )
         # Store the organisation data in the database since we are
         # unable to look them up via a unique identifier.
         HubspotOrganisation.objects.create(

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_lead_tracking.py
@@ -88,7 +88,9 @@ def test_hubspot_with_new_contact_and_new_organisation(
     # Then
     organisation.refresh_from_db()
     assert organisation.hubspot_organisation.hubspot_id == future_hubspot_id
-    mock_create_company.assert_called_once_with(name=organisation.name)
+    mock_create_company.assert_called_once_with(
+        name=organisation.name, organisation_id=organisation.id
+    )
     mock_create_contact.assert_called_once_with(user, future_hubspot_id)
     mock_get_contact.assert_called_once_with(user)
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

On the creation of a Hubspot company resource include the `organsation_id` in a new field which is titled `OrgID` in Hubspot, but is only accessible via `orgid` through the API due to restrictions on Hubspot's end.  

## How did you test this code?

Manually checked the API response once I was able to set the param in all lowercase then updated an existing test that already checked for the right mocked call to a client resource.
