### PR TITLE
fix: Avoid loading Django settings in Gunicorn

### DIFF
--- a/api/util/logging.py
+++ b/api/util/logging.py
@@ -1,10 +1,10 @@
 import json
 import logging
+import os
 import sys
 from datetime import datetime
 from typing import Any
 
-from django.conf import settings
 from gunicorn.config import Config
 from gunicorn.glogging import Logger as GunicornLogger
 
@@ -54,7 +54,7 @@ class GunicornAccessLogJsonFormatter(JsonFormatter):
 class GunicornJsonCapableLogger(GunicornLogger):
     def setup(self, cfg: Config) -> None:
         super().setup(cfg)
-        if settings.LOG_FORMAT == "json":
+        if os.getenv("LOG_FORMAT") == "json":
             self._set_handler(
                 self.error_log,
                 cfg.errorlog,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

We had a report of segfaults happening due to Gunicorn using the `util.logging.GunicornJsonCapableLogger` class. I determined the problematic code to be the Django settings retrieval in the `setup` method. This PR makes the logger class skip Django settings during setup.

## How did you test this code?

The original reporter applied this change and confirmed no segfaults happening anymore.