### PR TITLE
feat: use Depot runners for E2E

### DIFF
--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -52,7 +52,7 @@ jobs:
           api_ecr_image_url: ${{ steps.deploy-api.outputs.api_ecr_image_url }}
 
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-16
     name: Run E2E Tests
     environment: production
     needs: deploy-production-ecs

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -53,7 +53,7 @@ jobs:
           api_ecr_image_url: ${{ steps.deploy-api.outputs.api_ecr_image_url }}
 
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-16
     name: Run E2E Tests
     environment: staging
     needs: deploy-staging-ecs

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
             test
 
   run-e2e-tests-1:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Local - Segments-1, Environment
 
     permissions:
@@ -59,7 +59,7 @@ jobs:
           concurrency: 1
 
   run-e2e-tests-2:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Local - Segments-2
 
     permissions:
@@ -88,7 +88,7 @@ jobs:
           concurrency: 1
 
   run-e2e-tests-3:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Local - Segments-3, Signup, Flag, Invite, Project
 
     permissions:
@@ -117,7 +117,7 @@ jobs:
           concurrency: 2
 
   run-e2e-tests-4:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Local - Versioning
 
     permissions:
@@ -146,7 +146,7 @@ jobs:
           concurrency: 1
 
   run-e2e-versioning-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Unified - Versioning
 
     permissions:
@@ -172,7 +172,7 @@ jobs:
           docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- versioning
 
   run-e2e-segments-1-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Unified - Segments-1, Environment
 
     permissions:
@@ -198,7 +198,7 @@ jobs:
           docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-1 environment
 
   run-e2e-segments-2-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Unified - Segments-2
 
     permissions:
@@ -224,7 +224,7 @@ jobs:
           docker compose -f docker-compose-e2e-tests.yml run frontend npx cross-env E2E_CONCURRENCY=1 npm run test -- segment-part-2
 
   run-e2e-other-tests-docker-unified:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-8
     name: E2E Unified - Segments-3, Signup, Flag, Invite, Project
 
     permissions:

--- a/.github/workflows/platform-test-merge-to-main.yml
+++ b/.github/workflows/platform-test-merge-to-main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-16
     name: Full E2E tests
 
     services:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This tries to solve E2E flakiness by using more powerful runners for E2E jobs.

## How did you test this code?

This is a CI change.