### PR TITLE
fix: user delete social auth

### DIFF
--- a/api/custom_auth/constants.py
+++ b/api/custom_auth/constants.py
@@ -1,3 +1,5 @@
 USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE = (
     "User registration without an invite is disabled for this installation."
 )
+INVALID_PASSWORD_ERROR = "Invalid password."
+FIELD_BLANK_ERROR = "This field may not be blank."

--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -1,15 +1,20 @@
 from django.conf import settings
-from djoser.serializers import UserCreateSerializer, UserDeleteSerializer
+from djoser.serializers import UserCreateSerializer
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.validators import UniqueValidator
 
 from organisations.invites.models import Invite
+from users.auth_type import AuthType
 from users.constants import DEFAULT_DELETE_ORPHAN_ORGANISATIONS_VALUE
 from users.models import FFAdminUser, SignUpType
 
-from .constants import USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE
+from .constants import (
+    FIELD_BLANK_ERROR,
+    INVALID_PASSWORD_ERROR,
+    USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE,
+)
 
 
 class CustomTokenSerializer(serializers.ModelSerializer):
@@ -72,7 +77,36 @@ class CustomUserCreateSerializer(UserCreateSerializer):
         return super(CustomUserCreateSerializer, self).save(**kwargs)
 
 
-class CustomUserDelete(UserDeleteSerializer):
+class CustomUserDelete(serializers.Serializer):
+    current_password = serializers.CharField(
+        style={"input_type": "password"},
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+    )
+
+    default_error_messages = {
+        "invalid_password": INVALID_PASSWORD_ERROR,
+        "field_blank": FIELD_BLANK_ERROR,
+    }
+
+    def validate_current_password(self, value):
+        user_auth_type = self.context["request"].user.auth_type
+        if (
+            user_auth_type == AuthType.GOOGLE.value
+            or user_auth_type == AuthType.GITHUB.value
+        ):
+            return value
+
+        if not value:
+            return self.fail("field_blank")
+
+        is_password_valid = self.context["request"].user.check_password(value)
+        if is_password_valid:
+            return value
+        else:
+            self.fail("invalid_password")
+
     delete_orphan_organisations = serializers.BooleanField(
         default=DEFAULT_DELETE_ORPHAN_ORGANISATIONS_VALUE, required=False
     )

--- a/frontend/web/components/modals/ConfirmDeleteAccount.tsx
+++ b/frontend/web/components/modals/ConfirmDeleteAccount.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react'
 import Button from 'components/base/forms/Button'
 import Utils from 'common/utils/utils'
-import { Organisation } from 'common/types/responses'
+import { AuthType, Organisation } from 'common/types/responses'
 import { useDeleteAccountMutation } from 'common/services/useAccount'
 import InputGroup from 'components/base/forms/InputGroup'
 import ModalHR from './ModalHR'
@@ -10,13 +10,35 @@ import ErrorMessage from 'components/ErrorMessage'
 
 type ConfirmDeleteAccountType = {
   lastUserOrganisations: Organisation[]
+  email?: string
+  auth_type?: AuthType
+}
+
+const ERROR_MESSAGES = {
+  default: 'Error deleting your account.',
+  mismatchEmail:
+    'Error deleting your account, please ensure you have entered your current email.',
+  mismatchPassword:
+    'Error deleting your account, please ensure you have entered your current password.',
 }
 const ConfirmDeleteAccount: FC<ConfirmDeleteAccountType> = ({
+  auth_type,
+  email,
   lastUserOrganisations,
 }) => {
   const [password, setPassword] = useState<string>('')
-  const [deleteUserAccount, { isError, isSuccess: updateSuccess }] =
-    useDeleteAccountMutation()
+  const [currentEmail, setCurrentEmail] = useState<string>('')
+  const [errorMessage, setErrorMessage] = useState<string>(
+    ERROR_MESSAGES.default,
+  )
+  const [isEmailMismatchError, setIsEmailMismatchError] =
+    useState<boolean>(false)
+  const [
+    deleteUserAccount,
+    { isError: isMutationError, isSuccess: updateSuccess },
+  ] = useDeleteAccountMutation()
+  const skipPasswordConfirmation =
+    auth_type === 'GOOGLE' || auth_type === 'GITHUB'
 
   useEffect(() => {
     if (updateSuccess) {
@@ -54,6 +76,20 @@ const ConfirmDeleteAccount: FC<ConfirmDeleteAccountType> = ({
       <form
         onSubmit={(e) => {
           Utils.preventDefault(e)
+
+          if (skipPasswordConfirmation) {
+            if (currentEmail !== email) {
+              setIsEmailMismatchError(true)
+              setErrorMessage(ERROR_MESSAGES.mismatchEmail)
+              return
+            } else {
+              setIsEmailMismatchError(false)
+              setErrorMessage(ERROR_MESSAGES.default)
+            }
+          } else {
+            setErrorMessage(ERROR_MESSAGES.mismatchPassword)
+          }
+
           deleteUserAccount({
             current_password: password,
             delete_orphan_organisations: true,
@@ -64,25 +100,39 @@ const ConfirmDeleteAccount: FC<ConfirmDeleteAccountType> = ({
           <FormGroup>
             <ModalBody lastUserOrganisations={lastUserOrganisations} />
           </FormGroup>
-          <InputGroup
-            title='Confirm Password'
-            className='mb-0'
-            inputProps={{
-              className: 'full-width',
-              name: 'currentPassword',
-            }}
-            value={password}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              setPassword(Utils.safeParseEventValue(event))
-            }}
-            type='password'
-            name='password'
-          />
-          {isError && (
-            <ErrorMessage
-              error='Error deleting your account, please ensure you have entered your
-              current password.'
+          {skipPasswordConfirmation ? (
+            <InputGroup
+              title='Confirm Email'
+              className='mb-0'
+              inputProps={{
+                className: 'full-width',
+                name: 'currentEmail',
+              }}
+              value={currentEmail}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                setCurrentEmail(Utils.safeParseEventValue(event))
+              }}
+              type='email'
+              name='currentEmail'
             />
+          ) : (
+            <InputGroup
+              title='Confirm Password'
+              className='mb-0'
+              inputProps={{
+                className: 'full-width',
+                name: 'currentPassword',
+              }}
+              value={password}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                setPassword(Utils.safeParseEventValue(event))
+              }}
+              type='password'
+              name='password'
+            />
+          )}
+          {(isMutationError || isEmailMismatchError) && (
+            <ErrorMessage error={errorMessage} />
           )}
         </div>
         <ModalHR />

--- a/frontend/web/components/pages/AccountSettingsPage.js
+++ b/frontend/web/components/pages/AccountSettingsPage.js
@@ -56,12 +56,14 @@ class TheComponent extends Component {
     })
   }
 
-  confirmDeleteAccount = (lastUserOrganisations, id) => {
+  confirmDeleteAccount = (lastUserOrganisations, id, email, auth_type) => {
     openModal(
       'Are you sure?',
       <ConfirmDeleteAccount
         userId={id}
         lastUserOrganisations={lastUserOrganisations}
+        email={email}
+        auth_type={auth_type}
       />,
       'p-0',
     )
@@ -126,6 +128,7 @@ class TheComponent extends Component {
   render() {
     const {
       state: {
+        auth_type,
         current_password,
         email,
         error,
@@ -305,7 +308,12 @@ class TheComponent extends Component {
                           id='delete-user-btn'
                           data-test='delete-user-btn'
                           onClick={() =>
-                            this.confirmDeleteAccount(lastUserOrganisations, id)
+                            this.confirmDeleteAccount(
+                              lastUserOrganisations,
+                              id,
+                              email,
+                              auth_type,
+                            )
                           }
                           className='btn-with-icon btn-remove'
                         >


### PR DESCRIPTION
Fixes #2782 
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

We are enabling passwordless deletions only for Github and Google accounts and not for non email/password auth accounts, since it doesn't feel right to assume the behaviour of the next social auth that might be added. It's been a while since I dabbled with React, so please lmk if I should structure the code in a different way.

I'm also just ignoring the password field altogether for social auth as you can see in the API tests. Lmk if there are any concerns there. 

## How did you test this code?

Delete user with email/password:

https://github.com/Flagsmith/flagsmith/assets/13910561/ff5a9e1b-6257-49c5-853c-7879aa69cd34


Delete user with social auth (only tested on google for now):


https://github.com/Flagsmith/flagsmith/assets/13910561/cf3a44ad-0fe8-4da8-a4e3-7cd9bf660432


