### PR TITLE
fix: Create API usage notification butter bar

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -424,7 +424,7 @@ class OrganisationWebhook(AbstractBaseExportableWebhookModel):
         ordering = ("id",)  # explicit ordering to prevent pagination warnings
 
 
-class OrganisationSubscriptionInformationCache(models.Model):
+class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model):
     """
     Model to hold a cache of an organisation's API usage and their Chargebee plan limits.
     """
@@ -449,6 +449,10 @@ class OrganisationSubscriptionInformationCache(models.Model):
     allowed_projects = models.IntegerField(default=1, blank=True, null=True)
 
     chargebee_email = models.EmailField(blank=True, max_length=254, null=True)
+
+    @hook(AFTER_SAVE, when="allowed_30d_api_calls", has_changed=True)
+    def erase_api_notifications(self):
+        self.organisation.api_usage_notifications.all().delete()
 
 
 class OranisationAPIUsageNotification(models.Model):

--- a/api/organisations/permissions/permissions.py
+++ b/api/organisations/permissions/permissions.py
@@ -6,7 +6,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Model
 from django.views import View
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.request import Request
 
 from organisations.models import Organisation
 
@@ -173,3 +174,12 @@ class NestedIsOrganisationAdminPermission(BasePermission):
         return request.user.is_organisation_admin(
             self.get_organisation_from_object_callable(obj)
         )
+
+
+class OrganisationAPIUsageNotificationPermission(IsAuthenticated):
+    def has_permission(self, request: Request, view: View) -> bool:
+        if not super().has_permission(request, view):
+            return False
+
+        # All organisation users can see api usage notifications.
+        return request.user.belongs_to(view.kwargs.get("organisation_pk"))

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -246,3 +246,9 @@ class SubscriptionDetailsSerializer(serializers.Serializer):
     payment_source = serializers.ChoiceField(choices=[None, CHARGEBEE], allow_null=True)
 
     chargebee_email = serializers.EmailField()
+
+
+class OrganisationAPIUsageNotificationSerializer(serializers.Serializer):
+    organisation_id = serializers.IntegerField()
+    percent_usage = serializers.IntegerField()
+    notified_at = serializers.DateTimeField()

--- a/api/organisations/urls.py
+++ b/api/organisations/urls.py
@@ -10,7 +10,10 @@ from rest_framework_nested import routers
 from api_keys.views import MasterAPIKeyViewSet
 from audit.views import OrganisationAuditLogViewSet
 from metadata.views import MetaDataModelFieldViewSet
-from organisations.views import OrganisationWebhookViewSet
+from organisations.views import (
+    OrganisationAPIUsageNotificationView,
+    OrganisationWebhookViewSet,
+)
 from users.views import (
     FFAdminUserViewSet,
     UserPermissionGroupViewSet,
@@ -92,6 +95,11 @@ urlpatterns = [
         "<int:organisation_pk>/groups/<int:group_pk>/users/<int:user_pk>/remove-admin",
         remove_user_as_group_admin,
         name="remove-user-group-admin",
+    ),
+    path(
+        "<int:organisation_pk>/api-usage-notification/",
+        OrganisationAPIUsageNotificationView.as_view(),
+        name="organisation-api-usage-notification",
     ),
 ]
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Extended existing functionality around monitoring when an organisation has gone beyond their limits to a new endpoint that is destined to serve a butter bar on the frontend. In order to support organisations that may have upgraded their API limits an after save hook on the subscription cache model was used to wipe out existing API notification models if there has been a change in the account limit.

## How did you test this code?

Multiple tests that covered the core logic. 
