### PR TITLE
ci: Use Depot for deploy jobs

### DIFF
--- a/.github/actions/api-deploy-ecs/action.yml
+++ b/.github/actions/api-deploy-ecs/action.yml
@@ -140,6 +140,15 @@ runs:
         EOF
       shell: bash
 
+    - name: Set up Depot CLI
+      uses: depot/setup-action@v1
+      with:
+        oidc: true
+
+    - name: Switch Docker Runtime to Depot
+      run: depot configure-docker
+      shell: bash
+
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
@@ -149,8 +158,7 @@ runs:
       run: |
         echo "Building docker image with URL: "
         echo $ECR_REPOSITORY:$IMAGE_TAG
-        docker build --secret id=sse_pgp_pkey,src=./sse_pgp_pkey -t $ECR_REPOSITORY:$IMAGE_TAG -f api/Dockerfile --build-arg SAML_INSTALLED=1 --build-arg POETRY_OPTS="--with saml,auth-controller,workflows" --build-arg GH_TOKEN=${{ inputs.github_access_token }} .
-        docker push $ECR_REPOSITORY:$IMAGE_TAG
+        docker build --push --secret id=sse_pgp_pkey,src=./sse_pgp_pkey -t $ECR_REPOSITORY:$IMAGE_TAG -f api/Dockerfile --build-arg SAML_INSTALLED=1 --build-arg POETRY_OPTS="--with saml,auth-controller,workflows" --build-arg GH_TOKEN=${{ inputs.github_access_token }} .
         echo "image=$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/workflows/api-deploy-production-ecs.yml
+++ b/.github/workflows/api-deploy-production-ecs.yml
@@ -15,6 +15,10 @@ jobs:
     name: API Deploy to Production ECS
     environment: production
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Cloning repo
         uses: actions/checkout@v4

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -16,6 +16,10 @@ jobs:
     name: API Deploy to Staging ECS
     environment: staging
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Cloning repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This improves deploy jobs a bit by making them use the shared Depot build cache.

## How did you test this code?

Tested on "Deploy to Production" job when fixing Gunicorn. 