### PR TITLE
fix: database Compose warnings and set a project name

### DIFF
--- a/docker/db.yml
+++ b/docker/db.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 volumes:
   pg_11_data:
 

--- a/docker/db.yml
+++ b/docker/db.yml
@@ -1,3 +1,5 @@
+name: flagsmith
+
 volumes:
   pg_11_data:
 

--- a/docker/db.yml
+++ b/docker/db.yml
@@ -7,7 +7,7 @@ services:
     pull_policy: always
     restart: unless-stopped
     volumes:
-      - pg_11_data:/var/lib/postgresql/data:Z
+      - pg_11_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes two warnings when launching the database from Docker Compose:

```
% docker --version
Docker version 26.0.0, build 2ae903e86c
% docker compose -f db.yml up
WARN[0000] /Users/rolodato/source/flagsmith/flagsmith/docker/db.yml: `version` is obsolete
[+] Running 1/1
 ✔ db Pulled                                                                                                   1.6s
WARN[0001] mount of type `volume` should not define `bind` option
[+] Running 0/1
 ⠋ Container docker-db-1  Created                                                                              0.0s
Attaching to db-1
[...]
```

Also, this PR adds a top-level `name` field to the Compose file. Otherwise, the default project name is `docker` (the directory name where the Compose file lives), which is not very informative.

Before:

![image](https://github.com/Flagsmith/flagsmith/assets/829698/245b1b3e-2b63-4489-b535-72fd93717099)

After:

![image](https://github.com/Flagsmith/flagsmith/assets/829698/d5801bd4-a010-4855-8dd9-3d7f38f6f858)


More details on the top-level `version` and `name` Compose field names: https://docs.docker.com/compose/compose-file/04-version-and-name/

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manually tested by starting the database using Compose as usual:

```
docker compose -f docker/db.yml up
```
