### PR TITLE
fix: ensure api/static directory is created by Git

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,4 +1,5 @@
-static/
+static/*
+!static/.gitkeep
 **/staticfiles/*
 
 # SaaS only modules


### PR DESCRIPTION
This prevents a warning starting the API if this directory does not exist:

```
    /Users/rolodato/Library/Caches/pypoetry/virtualenvs/flagsmith-api-Avcq7jRJ-py3.11/lib/python3.11/site-packages/whitenoise/base.py:115: UserWarning: No directory at: /Users/rolodato/source/flagsmith/flagsmith/api/static/
  warnings.warn(f"No directory at: {root}")
```

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds a `.gitkeep` file that is allow-listed in `api/.gitignore` to ensure the `api/static` directory exists when cloning this repository. This prevents a warning when starting up the API and the directory does not yet exist.

Before:

```
% make serve
poetry run gunicorn --bind 127.0.0.1:8000 app.wsgi --reload
[2024-04-01 11:02:45 -0300] [46225] [INFO] Starting gunicorn 20.1.0
[2024-04-01 11:02:45 -0300] [46225] [INFO] Listening at: http://127.0.0.1:8000 (46225)
[2024-04-01 11:02:45 -0300] [46225] [INFO] Using worker: sync
[2024-04-01 11:02:45 -0300] [46228] [INFO] Booting worker with pid: 46228
/Users/rolodato/Library/Caches/pypoetry/virtualenvs/flagsmith-api-Avcq7jRJ-py3.11/lib/python3.11/site-packages/whitenoise/base.py:115: UserWarning: No directory at: /Users/rolodato/source/flagsmith/flagsmith/api/static/
  warnings.warn(f"No directory at: {root}")
```

After:

```
% make serve
poetry run gunicorn --bind 127.0.0.1:8000 app.wsgi --reload
[2024-04-01 11:08:44 -0300] [46650] [INFO] Starting gunicorn 20.1.0
[2024-04-01 11:08:44 -0300] [46650] [INFO] Listening at: http://127.0.0.1:8000 (46650)
[2024-04-01 11:08:44 -0300] [46650] [INFO] Using worker: sync
[2024-04-01 11:08:44 -0300] [46653] [INFO] Booting worker with pid: 46653
```
## How did you test this code?

Manually by cleaning all untracked files and directories in the repository, and checking that the `api/static` directory still exists:

```
% git clean -f -d -x
% file api/static
api/static: directory
```
