### PR TITLE
fix: broken CSS on Integrations page in non-Chromium browsers

### DIFF
--- a/frontend/web/components/IntegrationList.js
+++ b/frontend/web/components/IntegrationList.js
@@ -33,7 +33,6 @@ class Integration extends Component {
     )
     return (
       <div className='panel panel-integrations p-4 mb-3'>
-        <Flex>
           <img className='mb-2' src={image} />
           <Row space style={{ flexWrap: 'noWrap' }}>
             <div className='subtitle mt-2'>
@@ -96,7 +95,6 @@ class Integration extends Component {
               )}
             </Row>
           </Row>
-        </Flex>
 
         {activeIntegrations &&
           activeIntegrations.map((integration) => (

--- a/frontend/web/styles/components/_panel.scss
+++ b/frontend/web/styles/components/_panel.scss
@@ -181,8 +181,8 @@ a.text-white {
     border: 1px solid $panel-border-color;
 
     img {
-      width: fit-content;
       height: 30px;
+      object-fit: contain;
     }
     .list-integrations {
       border-radius: $border-radius-xlg;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The Integrations page CSS is broken on non-Chromium browsers (tested Firefox and Safari). The page is way too wide and some images appear distorted. This PR fixes it. Tested on Firefox 124.0.1.

Before (Firefox):

https://github.com/Flagsmith/flagsmith/assets/829698/c890326f-a29e-425f-9bb3-ab3f8e927bf6

After (Firefox):

![image](https://github.com/Flagsmith/flagsmith/assets/829698/1a8d887e-a2d9-47c0-aa24-0554a00c7536)


After (Safari):

![image](https://github.com/Flagsmith/flagsmith/assets/829698/14f3fec6-02f6-4823-a52f-0768fd40c4b7)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Run frontend locally, then visit http://127.0.0.1:8080/project/1/integrations.
