### PR TITLE
fix: Incorrect environment variable interpolation in Makefile

### DIFF
--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,4 +1,4 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
 PYTEST_ADDOPTS=--cov . --cov-report xml -n auto --dist worksteal
-
+GUNICORN_LOGGER_CLASS=util.logging.GunicornJsonCapableLogger

--- a/api/.env-local
+++ b/api/.env-local
@@ -1,3 +1,4 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
 DJANGO_SETTINGS_MODULE=app.settings.local
 PYTEST_ADDOPTS=--cov . --cov-report html -n auto
+GUNICORN_LOGGER_CLASS=util.logging.GunicornJsonCapableLogger

--- a/api/Makefile
+++ b/api/Makefile
@@ -84,7 +84,7 @@ django-collect-static:
 .PHONY: serve
 serve:
 	poetry run gunicorn --bind 0.0.0.0:8000 \
-		--logger-class ${GUNICORN_LOGGER_CLASS:-'util.logging.GunicornJsonCapableLogger'} \
+		--logger-class ${GUNICORN_LOGGER_CLASS} \
 		--reload \
 		app.wsgi
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes the `make serve` command failing because of an incorrectly set default value for an env variable.

## How did you test this code?

Ran `make serve` locally.