### PR TITLE
fix: allow deletion of scheduled change requests

### DIFF
--- a/api/features/versioning/models.py
+++ b/api/features/versioning/models.py
@@ -118,7 +118,8 @@ class EnvironmentFeatureVersion(
         persist: bool = True,
     ) -> None:
         now = timezone.now()
-        self.live_from = live_from or now
+
+        self.live_from = live_from or (self.live_from or now)
         self.published_at = now
         self.published_by = published_by
         if persist:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Allow change requests that are scheduled for the future to be deleted. 

Resolves #3710 

## How did you test this code?

Added 2 new unit tests. 
