### PR TITLE
feat: Support multiple OR'd search terms in sales-dashboard

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/base.html
+++ b/api/sales_dashboard/templates/sales_dashboard/base.html
@@ -16,10 +16,10 @@
   </head>
   <body>
     <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0 shadow">
-    <a class="navbar-brand col-md-3 col-lg-2 mr-0 px-3" href="/sales-dashboard/">Flagsmith</a>
+      <a class="navbar-brand col-md-3 col-lg-2 mr-0 px-3" href="/sales-dashboard/">Flagsmith</a>
       <form method="get" action="{% url 'sales_dashboard:index' %}" class="form-inline w-100">
         {% csrf_token %}
-        <input class="form-control mr-sm-2 w-100=" type="search" placeholder="Search" aria-label="Search" name="search" value="{{ search }}">
+        <input class="form-control mr-sm-2 w-75" type="search" placeholder="Search by org name, email addresses or subscription ID. Separate multiple search terms with commas" aria-label="Search" name="search" value="{{ search }}">
         <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
       </form>
       <ul class="navbar-nav px-3">

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -61,11 +61,16 @@ class OrganisationList(ListView):
 
         if self.request.GET.get("search"):
             search_term = self.request.GET["search"]
-            queryset = queryset.filter(
-                Q(name__icontains=search_term)
-                | Q(users__email__icontains=search_term)
-                | Q(subscription__subscription_id=search_term)
-            )
+            criteria = Q()
+            terms = search_term.split(",")
+            for t in terms:
+                term = t.strip()
+                criteria |= (
+                    Q(name__icontains=term)
+                    | Q(users__email__icontains=term)
+                    | Q(subscription__subscription_id=term)
+                )
+            queryset = queryset.filter(criteria)
 
         if self.request.GET.get("filter_plan"):
             filter_plan = self.request.GET["filter_plan"]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

* Support searching by multiple terms in the Sales dashboard
* Add text to the Search box placeholder to clarify what exactly is being searched:

![image](https://github.com/Flagsmith/flagsmith/assets/829698/38f18688-7f91-4e6b-a796-29310969c19b)

This naive-ish implementation splits search terms by commas and ORs them all together. This has implications on any existing search queries:

* `ACME, LLC` will now search for `ACME` OR `LLC`, whereas today it's an exact match. This will return the same results as before, in addition to potentially other unrelated results
* It's now impossible to use `,` as a search criterion - I don't think this matters

Given the internal scope of the sales dashboard and the value of allowing multiple search queries, I think the tradeoff for this change is worth it. This seems like a good 80/20 solution.

Example (searching for multiple queries):

![image](https://github.com/Flagsmith/flagsmith/assets/829698/3f82986c-09af-4853-b03d-4196bd8feaba)

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manually on a local instance, validated with manual testing.