### PR TITLE
fix: Remove CSRF parameter from sales-dashboard search form

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/base.html
+++ b/api/sales_dashboard/templates/sales_dashboard/base.html
@@ -18,7 +18,6 @@
     <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0 shadow">
     <a class="navbar-brand col-md-3 col-lg-2 mr-0 px-3" href="/sales-dashboard/">Flagsmith</a>
       <form method="get" action="{% url 'sales_dashboard:index' %}" class="form-inline w-100">
-        {% csrf_token %}
         <input class="form-control mr-sm-2 w-100=" type="search" placeholder="Search" aria-label="Search" name="search" value="{{ search }}">
         <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
       </form>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The search form in the Sales dashboard includes a CSRF token. This token is not validated (it can be omitted with no consequence) and it is not necessary (this is a read-only GET endpoint, so it can be safely removed).

The main benefit of removing the CSRF token is it allows us to share nicer URLs to pre-made queries, such as `/sales-dashboard/?search=foo`. Otherwise, the search URLs look like `/sales-dashboard/?csrfmiddlewaretoken=obnoxiously_long_random_string_that_appears_before_the_actual_search_term&search=foo`.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manually in development only. I've confirmed that this endpoint in production also does not validate the presence of the `csrfmiddleware` parameter.