### PR TITLE
chore: add `date_joined` to current user serializer

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -136,7 +136,11 @@ class CustomCurrentUserSerializer(DjoserUserSerializer):
     is_superuser = serializers.BooleanField(read_only=True)
 
     class Meta(DjoserUserSerializer.Meta):
-        fields = DjoserUserSerializer.Meta.fields + ("auth_type", "is_superuser")
+        fields = DjoserUserSerializer.Meta.fields + (
+            "auth_type",
+            "is_superuser",
+            "date_joined",
+        )
 
 
 class ListUsersQuerySerializer(serializers.Serializer):


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add `date_joined` to `/me` endpoint

## How did you test this code?

Trivial change and there wasn't an existing test for the response to `/me` so I just ran the FE and API and confirmed that the `date_joined` attribute is returned as expected. 
