### PR TITLE
fix: segment override assignment

### DIFF
--- a/frontend/common/providers/withSegmentOverrides.js
+++ b/frontend/common/providers/withSegmentOverrides.js
@@ -60,7 +60,7 @@ export default (WrappedComponent) => {
                 const multiVariates =
                   res2 &&
                   res2.results.find(
-                    (mv) => (mv.feature_segment = f.feature_segment),
+                    (mv) => mv.feature_segment === f.feature_segment,
                   )
                 results[index].multivariate_feature_state_values =
                   (multiVariates &&


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

We were accidentally reassigning segment override feature_segments due to how we were mapping multivariate feature state values. This happened to work for everyone so far as the order of feature segments always matched the order of feature states.