### PR TITLE
chore: increase versioning wait

### DIFF
--- a/frontend/e2e/tests/versioning-tests.ts
+++ b/frontend/e2e/tests/versioning-tests.ts
@@ -32,7 +32,7 @@ export default async () => {
     await click('#env-settings-link')
     await click(byId('enable-versioning'))
     await click('#confirm-toggle-feature-btn')
-    await waitAndRefresh()
+    await waitAndRefresh(10000)
 
     log('Create feature 1')
     await createRemoteConfig(0, 'a', 'small')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

Versioning does not update environments immediately, as a result there are times when the version tests do not complete because the frontend thinks the environment is not opted in.

There is a more elegant solution to this in recursively refreshing until we detect it has completed, however for now increasing a wait is an easy way to solve, it won't slow down tests since other longer ones are running.