### PR TITLE
infra: cache environment segments in production

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -44,6 +44,10 @@
                     "value": "10"
                 },
                 {
+                    "name": "CACHE_ENVIRONMENT_SEGMENTS_SECONDS",
+                    "value": "30"
+                },
+                {
                     "name": "CHARGEBEE_SITE",
                     "value": "flagsmith"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

When evaluating the flags for an identity, the Core API retrieves only those segments which have been overridden in the current environment. It seems that, when the code was updated to use this method, the caching that existed for project segments wasn't updated to handle this new method of only retrieving the segments for an environment. 

In an effort to reduce the impact on the Core API from traffic floods, this aggressively caches the segments for a given environment for 30 seconds in local memory on each of the Core API instances. 

## How did you test this code?

N/a
