### PR TITLE
fix: edge API not updated when versioned change request committed

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -35,11 +35,11 @@ from audit.tasks import (
     create_feature_state_updated_by_change_request_audit_log,
     create_feature_state_went_live_audit_log,
 )
+from environments.tasks import rebuild_environment_document
 from features.models import FeatureState
+from features.versioning.models import EnvironmentFeatureVersion
 from features.versioning.tasks import trigger_update_version_webhooks
-
-from ...versioning.models import EnvironmentFeatureVersion
-from .exceptions import (
+from features.workflows.core.exceptions import (
     CannotApproveOwnChangeRequest,
     ChangeRequestDeletionError,
     ChangeRequestNotApprovedError,
@@ -163,6 +163,10 @@ class ChangeRequest(
                             environment_feature_version.uuid
                         )
                     },
+                    delay_until=environment_feature_version.live_from,
+                )
+                rebuild_environment_document.delay(
+                    kwargs={"environment_id": self.environment_id},
                     delay_until=environment_feature_version.live_from,
                 )
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds logic to trigger the `rebuild_environment_task` when a change request containing environment feature version objects is committed.  

This PR also includes some minor tidying up of imports to remove ugly relative imports. 

## How did you test this code?

Updated existing unit test. 
