### PR TITLE
docs: seo optimisations

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,7 +6,8 @@ sidebar_position: 1
 sidebar_label: Overview
 ---
 
-[Flagsmith](https://flagsmith.com/) lets you manage features across web, mobile and server side applications.
+[Flagsmith](https://flagsmith.com/) is a feature flag tool that lets you manage features across web, mobile and server
+side applications.
 
 [Flagsmith is Open Source](https://github.com/Flagsmith). Host yourself or let us take care of the hosting.
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -127,48 +127,48 @@ const config = {
                                 href: 'https://www.flagsmith.com/blog/angular-feature-flag',
                             },
                             {
-                                label: 'Python Feature Flags',
-                                href: 'https://www.flagsmith.com/blog/python-feature-flag',
-                            },
-                            {
-                                label: 'Java Feature Flags',
-                                href: 'https://www.flagsmith.com/blog/java-feature-toggle',
-                            },
-                            {
-                                label: 'Ruby Feature Flags',
-                                href: 'https://www.flagsmith.com/blog/ruby-feature-flags',
-                            },
-                            {
-                                label: 'JavaScript Feature Flags',
-                                href: 'https://www.flagsmith.com/blog/javascript-feature-flags',
-                            },
-                            {
                                 label: 'Flutter Feature Flags',
                                 href: 'https://www.flagsmith.com/blog/flutter-feature-flags',
-                            },
-                            {
-                                label: 'Node.js Feature Flags',
-                                href: 'https://www.flagsmith.com/blog/nodejs-feature-flags',
-                            },
-                            {
-                                label: 'Spring Boot Feature Flags',
-                                href: 'https://www.flagsmith.com/blog/spring-boot-feature-flags',
-                            },
-                            {
-                                label: 'PHP Feature Flags',
-                                href: 'https://www.flagsmith.com/blog/php-feature-flags',
                             },
                             {
                                 label: 'Golang Feature Flags',
                                 href: 'https://www.flagsmith.com/blog/golang-feature-flag',
                             },
                             {
+                                label: 'Java Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/java-feature-toggle',
+                            },
+                            {
+                                label: 'JavaScript Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/javascript-feature-flags',
+                            },
+                            {
                                 label: 'Kotlin/Android Feature Flags',
                                 href: 'https://www.flagsmith.com/blog/feature-flags-android',
                             },
                             {
+                                label: 'Node.js Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/nodejs-feature-flags',
+                            },
+                            {
+                                label: 'PHP Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/php-feature-flags',
+                            },
+                            {
+                                label: 'Python Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/python-feature-flag',
+                            },
+                            {
                                 label: 'React Native Feature Flags',
                                 href: 'https://www.flagsmith.com/blog/update-your-react-native-app-using-remote-config',
+                            },
+                            {
+                                label: 'Ruby Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/ruby-feature-flags',
+                            },
+                            {
+                                label: 'Spring Boot Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/spring-boot-feature-flags',
                             },
                             {
                                 label: 'Swift/iOS Feature Flags',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -139,7 +139,7 @@ const config = {
                                 href: 'https://www.flagsmith.com/blog/ruby-feature-flags',
                             },
                             {
-                                label: 'Javascript Feature Flags',
+                                label: 'JavaScript Feature Flags',
                                 href: 'https://www.flagsmith.com/blog/javascript-feature-flags',
                             },
                             {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -119,6 +119,63 @@ const config = {
                             },
                         ],
                     },
+                    {
+                        title: 'How-to guides',
+                        items: [
+                            {
+                                label: 'Angular Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/angular-feature-flag',
+                            },
+                            {
+                                label: 'Python Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/python-feature-flag',
+                            },
+                            {
+                                label: 'Java Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/java-feature-toggle',
+                            },
+                            {
+                                label: 'Ruby Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/ruby-feature-flags',
+                            },
+                            {
+                                label: 'Javascript Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/javascript-feature-flags',
+                            },
+                            {
+                                label: 'Flutter Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/flutter-feature-flags',
+                            },
+                            {
+                                label: 'Node.js Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/nodejs-feature-flags',
+                            },
+                            {
+                                label: 'Spring Boot Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/spring-boot-feature-flags',
+                            },
+                            {
+                                label: 'PHP Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/php-feature-flags',
+                            },
+                            {
+                                label: 'Golang Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/golang-feature-flag',
+                            },
+                            {
+                                label: 'Kotlin/Android Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/feature-flags-android',
+                            },
+                            {
+                                label: 'React Native Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/update-your-react-native-app-using-remote-config',
+                            },
+                            {
+                                label: 'Swift/iOS Feature Flags',
+                                href: 'https://www.flagsmith.com/blog/swift-ios-feature-flags',
+                            },
+                        ],
+                    },
                 ],
                 copyright: `Copyright © ${new Date().getFullYear()} Bullet Train Ltd. Built with Docusaurus.`,
             },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds 2 changes to the docs site as requested by SEO agency. 

 1. Add 'feature flag tool' to the intro statement
 2. Adds all our how-to guides as links in the footer

I don't love the aesthetic of the how-to guides in the footer, but if it's helpful for SEO then we should probably just swallow it for now. I can't see any obvious options to split the columns, so we do end up with one large column of all of the guides. 

<img width="1343" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/3516039b-2370-4d37-80e2-35a22c307c9a">

## How did you test this code?

Ran the docs site locally and verified the changes. 
