### PR TITLE
fix: odd behaviour seen when using REPLICA_DATABASE_URLS

### DIFF
--- a/api/core/signals.py
+++ b/api/core/signals.py
@@ -30,7 +30,7 @@ def create_audit_log_from_historical_record(
         else None
     )
 
-    environment, project = history_instance.instance.get_environment_and_project()
+    environment, project = instance.get_environment_and_project()
     if project != history_instance.instance and (
         (project and project.deleted_at)
         or (environment and environment.project.deleted_at)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes https://github.com/Flagsmith/flagsmith/issues/3681. 

## How did you test this code?

Ran the API locally with `REPLICA_DATABASE_URLS` set up to point to the same database as `DATABASE_URL` and observed that, without this change, I received an exception when trying to create a Feature. 

Once I made this change, I no longer received the exception. 
