### PR TITLE
fix: tests using `has_calls` instead of `assert_has_calls`

### DIFF
--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -153,7 +153,7 @@ class ProjectFeatureTestCase(TestCase):
         mock_calls = [
             mock.call(fs, WebhookEventType.FLAG_DELETED) for fs in feature_states
         ]
-        mocked_trigger_fs_change_webhook.has_calls(mock_calls)
+        mocked_trigger_fs_change_webhook.assert_has_calls(mock_calls)
 
     def test_remove_owners_only_remove_specified_owners(self):
         # Given

--- a/api/tests/unit/sse/test_tasks.py
+++ b/api/tests/unit/sse/test_tasks.py
@@ -36,23 +36,26 @@ def test_send_environment_update_message_for_project_make_correct_request(
     send_environment_update_message_for_project(realtime_enabled_project.id)
 
     # Then
-    mocked_requests.post.has_calls(
-        mocker.call(
-            f"{base_url}/sse/environments/{realtime_enabled_project_environment_one.api_key}/queue-change",
-            headers={"Authorization": f"Token {token}"},
-            json={
-                "updated_at": realtime_enabled_project_environment_one.updated_at.isoformat()
-            },
-            timeout=2,
-        ),
-        mocker.call(
-            f"{base_url}/sse/environments/{realtime_enabled_project_environment_two.api_key}/queue-change",
-            headers={"Authorization": f"Token {token}"},
-            json={
-                "updated_at": realtime_enabled_project_environment_two.updated_at.isoformat()
-            },
-            timeout=2,
-        ),
+    mocked_requests.post.assert_has_calls(
+        calls=[
+            mocker.call(
+                f"{base_url}/sse/environments/{realtime_enabled_project_environment_one.api_key}/queue-change",
+                headers={"Authorization": f"Token {token}"},
+                json={
+                    "updated_at": realtime_enabled_project_environment_one.updated_at.isoformat()
+                },
+                timeout=2,
+            ),
+            mocker.call(
+                f"{base_url}/sse/environments/{realtime_enabled_project_environment_two.api_key}/queue-change",
+                headers={"Authorization": f"Token {token}"},
+                json={
+                    "updated_at": realtime_enabled_project_environment_two.updated_at.isoformat()
+                },
+                timeout=2,
+            ),
+        ],
+        any_order=True,
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Update tests to correctly use `assert_has_calls` instead of `has_calls` (which does nothing). 

## How did you test this code?

Ran the updated unit tests and confirmed they passed. 
