### PR TITLE
docs: remove superfluous 'Feature Flags' from link titles

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -123,55 +123,55 @@ const config = {
                         title: 'How-to guides',
                         items: [
                             {
-                                label: 'Angular Feature Flags',
+                                label: 'Angular',
                                 href: 'https://www.flagsmith.com/blog/angular-feature-flag',
                             },
                             {
-                                label: 'Flutter Feature Flags',
+                                label: 'Flutter',
                                 href: 'https://www.flagsmith.com/blog/flutter-feature-flags',
                             },
                             {
-                                label: 'Golang Feature Flags',
+                                label: 'Golang',
                                 href: 'https://www.flagsmith.com/blog/golang-feature-flag',
                             },
                             {
-                                label: 'Java Feature Flags',
+                                label: 'Java',
                                 href: 'https://www.flagsmith.com/blog/java-feature-toggle',
                             },
                             {
-                                label: 'JavaScript Feature Flags',
+                                label: 'JavaScript',
                                 href: 'https://www.flagsmith.com/blog/javascript-feature-flags',
                             },
                             {
-                                label: 'Kotlin/Android Feature Flags',
+                                label: 'Kotlin/Android',
                                 href: 'https://www.flagsmith.com/blog/feature-flags-android',
                             },
                             {
-                                label: 'Node.js Feature Flags',
+                                label: 'Node.js',
                                 href: 'https://www.flagsmith.com/blog/nodejs-feature-flags',
                             },
                             {
-                                label: 'PHP Feature Flags',
+                                label: 'PHP',
                                 href: 'https://www.flagsmith.com/blog/php-feature-flags',
                             },
                             {
-                                label: 'Python Feature Flags',
+                                label: 'Python',
                                 href: 'https://www.flagsmith.com/blog/python-feature-flag',
                             },
                             {
-                                label: 'React Native Feature Flags',
+                                label: 'React Native',
                                 href: 'https://www.flagsmith.com/blog/update-your-react-native-app-using-remote-config',
                             },
                             {
-                                label: 'Ruby Feature Flags',
+                                label: 'Ruby',
                                 href: 'https://www.flagsmith.com/blog/ruby-feature-flags',
                             },
                             {
-                                label: 'Spring Boot Feature Flags',
+                                label: 'Spring Boot',
                                 href: 'https://www.flagsmith.com/blog/spring-boot-feature-flags',
                             },
                             {
-                                label: 'Swift/iOS Feature Flags',
+                                label: 'Swift/iOS',
                                 href: 'https://www.flagsmith.com/blog/swift-ios-feature-flags',
                             },
                         ],


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Remove superfluous 'Feature Flags' copy from How-to guide link titles. 

## How did you test this code?

Ran docs locally and confirmed change has correct effect. 
