### PR TITLE
feat: Show organisation name in header

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -361,7 +361,7 @@ const App = class extends Component {
                                         fill='#9DA4AE'
                                       />
                                     </span>
-                                    {'Organisation'}
+                                    Organisation <strong>{AccountStore.getOrganisation()?.name}</strong>
                                   </NavLink>
                                 </Row>
                                 <Row>

--- a/frontend/web/styles/project/_project-nav.scss
+++ b/frontend/web/styles/project/_project-nav.scss
@@ -128,6 +128,10 @@
   }
 }
 .nav-link {
+  text-wrap: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 30em;
   img {
     max-height: 21px;
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Always show the organisation name in the header:

![Screenshot 2024-04-18 at 15-38-26 Flagsmith - Feature Flags Feature Toggles and Remote Config](https://github.com/Flagsmith/flagsmith/assets/829698/f91af945-80d3-4605-b7c2-dbee5aa6f187)

This is what it looks like with very long organisation names:

<img width="1584" alt="Screenshot 2024-04-18 at 17 35 40" src="https://github.com/Flagsmith/flagsmith/assets/829698/7c1547bd-12c7-4ca2-9cb0-a6446275229f">

This ensures users can quickly check which organisation they're working in. This is especially important for self-hosting users and Flagsmith support working within customer organisations.

It also hopefully makes this navigation element more evident as a click target - it's not immediately obvious that "Organisation" is clickable, I've seen a few users miss this.

There's probably a smarter way to implement this, but this was the least offense/effort/risk solution I came up with.

## How did you test this code?

Manually, see screenshots.
