### PR TITLE
fix: Set error value from validation exception properly for feature seralizer

### DIFF
--- a/api/features/serializers.py
+++ b/api/features/serializers.py
@@ -434,7 +434,7 @@ class FeatureStateSerializerBasic(WritableNestedModelSerializer):
         try:
             return super().save(**kwargs)
         except django.core.exceptions.ValidationError as e:
-            raise serializers.ValidationError(e.message)
+            raise serializers.ValidationError(str(e))
 
     def validate_feature(self, feature):
         if self.instance and self.instance.feature_id != feature.id:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

To access the string value of an exception the proper way is to call `str()` on the exception itself, not referencing `.message` so this code updates the call.

## How did you test this code?

I manually tested a try and except prototype to mimic the behaviour. 
