### PR TITLE
feat: Show organisation name in HTML title

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/base.html
+++ b/api/sales_dashboard/templates/sales_dashboard/base.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="{% static 'sales_dashboard/css/bootstrap.min.css' %}"
           integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
     <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.css">
-    <title>Flagsmith Sales Dashboard</title>
+    <title>{% block title %}{% endblock %} Flagsmith Sales Dashboard</title>
   </head>
   <body>
     <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0 shadow">

--- a/api/sales_dashboard/templates/sales_dashboard/organisation.html
+++ b/api/sales_dashboard/templates/sales_dashboard/organisation.html
@@ -1,6 +1,10 @@
 {% extends "sales_dashboard/base.html" %}
 {% load humanize %}
 
+{% block title %}
+{{organisation.name}} -
+{% endblock title %}
+
 {% block content %}
 <div class="container-fluid">
     <div class="row">


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add the organisation name to the HTML title.

This makes it easier to find URLs to specific organisations by searching for them in browser history, bookmarks, chat/email/etc, since the URLs on their own only have numbers like `/sales-dashboard/organisations/4`.

There are smarter ways to implement this but it works and YAGNI applies until we need to customise a different page's title.

## How did you test this code?

Manually, inspecting HTML titles on different pages.