### PR TITLE
feat: Report database errors when waiting for database in entrypoint

### DIFF
--- a/api/core/management/commands/waitfordb.py
+++ b/api/core/management/commands/waitfordb.py
@@ -63,11 +63,8 @@ class Command(BaseCommand):
                 logger.info("Successfully connected to the database.")
                 break
             except OperationalError as e:
-                logger.warning(
-                    "Database not yet ready for connections. Error was: %s",
-                    str(e),
-                    exc_info=e,
-                )
+                logger.warning("Database not yet ready for connections.")
+                logger.warning("Error was: %s: %s", e.__class__.__name__, e)
 
             time.sleep(wait_between_checks)
 

--- a/api/core/management/commands/waitfordb.py
+++ b/api/core/management/commands/waitfordb.py
@@ -62,8 +62,9 @@ class Command(BaseCommand):
                     cursor.execute("SELECT 1")
                 logger.info("Successfully connected to the database.")
                 break
-            except OperationalError:
+            except OperationalError as e:
                 logger.warning("Database not yet ready for connections.")
+                logger.debug("Connection error was: %s", str(e), exc_info=e)
 
             time.sleep(wait_between_checks)
 

--- a/api/core/management/commands/waitfordb.py
+++ b/api/core/management/commands/waitfordb.py
@@ -63,8 +63,11 @@ class Command(BaseCommand):
                 logger.info("Successfully connected to the database.")
                 break
             except OperationalError as e:
-                logger.warning("Database not yet ready for connections.")
-                logger.debug("Connection error was: %s", str(e), exc_info=e)
+                logger.warning(
+                    "Database not yet ready for connections. Error was: %s",
+                    str(e),
+                    exc_info=e,
+                )
 
             time.sleep(wait_between_checks)
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Based on a debugging session with a customer, it would be useful to be able to see the actual error message that occurs when waitfordb fails. This PR adds the relevant information as a secondary log message. 

## How did you test this code?

```
❯ DATABASE_URL=postgres://invalid-role:password@127.0.0.1:5432/flagsmith LOG_LEVEL=WARNING python manage.py waitfordb --waitfor 1
core.management.commands.waitfordb WARNING  Database not yet ready for connections.
core.management.commands.waitfordb WARNING  Error was: OperationalError: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "invalid-role" does not exist

core.management.commands.waitfordb WARNING  Database not yet ready for connections.
core.management.commands.waitfordb WARNING  Error was: OperationalError: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "invalid-role" does not exist

core.management.commands.waitfordb WARNING  Database not yet ready for connections.
core.management.commands.waitfordb WARNING  Error was: OperationalError: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "invalid-role" does not exist

core.management.commands.waitfordb WARNING  Database not yet ready for connections.
core.management.commands.waitfordb WARNING  Error was: OperationalError: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "invalid-role" does not exist

core.management.commands.waitfordb ERROR    Failed to connect to DB within 1 seconds.
Failed to connect to DB within 1 seconds.
```
