### PR TITLE
docs(footer): add .NET guide link

### DIFF
--- a/docs/docs/advanced-use/real-time-flags.md
+++ b/docs/docs/advanced-use/real-time-flags.md
@@ -63,8 +63,8 @@ but are happy to take pull requests!
 
 ## Things you should know
 
-* Per-identity overrides do not trigger an update
-* Identity Trait updates do not trigger an update
+- Per-identity overrides do not trigger an update
+- Identity Trait updates do not trigger an update
 
 ## How it works under the hood
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -124,6 +124,10 @@ const config = {
                         title: 'How-to guides',
                         items: [
                             {
+                                label: '.NET',
+                                href: 'https://www.flagsmith.com/blog/net-feature-flag',
+                            },
+                            {
                                 label: 'Angular',
                                 href: 'https://www.flagsmith.com/blog/angular-feature-flag',
                             },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add link to the .NET how-to guide to the docs footer. 

## How did you test this code?

Ran docs locally and confirmed link was added correctly. 
