### PR TITLE
fix(hubspot): create hubspot company with domain

### DIFF
--- a/api/integrations/lead_tracking/hubspot/lead_tracker.py
+++ b/api/integrations/lead_tracking/hubspot/lead_tracker.py
@@ -119,7 +119,7 @@ class HubspotLeadTracker(LeadTracker):
     def _get_or_create_company_by_domain(self, domain: str) -> dict:
         company = self.client.get_company_by_domain(domain)
         if not company:
-            company = self.client.create_company(name=domain)
+            company = self.client.create_company(name=domain, domain=domain)
 
         return company
 

--- a/api/integrations/lead_tracking/hubspot/lead_tracker.py
+++ b/api/integrations/lead_tracking/hubspot/lead_tracker.py
@@ -119,6 +119,9 @@ class HubspotLeadTracker(LeadTracker):
     def _get_or_create_company_by_domain(self, domain: str) -> dict:
         company = self.client.get_company_by_domain(domain)
         if not company:
+            # Since we don't know the company's name, we pass the domain as
+            # both the name and the domain. This can then be manually
+            # updated in Hubspot if needed.
             company = self.client.create_company(name=domain, domain=domain)
 
         return company

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_tasks.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_tasks.py
@@ -36,10 +36,12 @@ def test_track_hubspot_lead_without_organisation(
     # Given
     hubspot_company_id = "company-id"
     hubspot_contact_id = "contact-id"
+    domain = "example.com"
+    email = f"test@{domain}"
 
     settings.ENABLE_HUBSPOT_LEAD_TRACKING = True
 
-    user = FFAdminUser.objects.create(email="test@example.com")
+    user = FFAdminUser.objects.create(email=email)
 
     mock_hubspot_client = mocker.MagicMock(spec=HubspotClient)
     mocker.patch(
@@ -56,5 +58,8 @@ def test_track_hubspot_lead_without_organisation(
     track_hubspot_lead_without_organisation(user_id=user.id)
 
     # Then
+    mock_hubspot_client.create_company.assert_called_once_with(
+        name=domain, domain=domain
+    )
     mock_hubspot_client.create_contact.assert_called_once_with(user, hubspot_company_id)
     assert HubspotLead.objects.filter(user=user).exists()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ensure that companies created when a user doesn't join an organisation are created with their domain. 

## How did you test this code?

Updated a unit test. 
