### PR TITLE
fix: Get current api usage InfluxDB query

### DIFF
--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -341,6 +341,7 @@ def get_current_api_usage(organisation_id: int, date_range: str) -> int:
         ),
         drop_columns=("_start", "_stop", "_time"),
         extra='|> sum() \
+               |> group() \
                |> sort(columns: ["_value"], desc: true) ',
     )
 
@@ -349,10 +350,7 @@ def get_current_api_usage(organisation_id: int, date_range: str) -> int:
         if len(result.records) == 0:
             return 0
 
-        # There should only be one matching result due to the
-        # sum part of the query.
-        assert len(result.records) == 1
-        return result.records[0].get_value()
+        return sum(r.get_value() for r in result.records)
 
     return 0
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

A month or two ago I wrote a function to get current API usage, but I was limited to testing with the developer and staging keys and the amount of records returned from the database seemed low, but still seemed reasonable given that organisations in staging could reasonably be argued to not have much API use.

While testing with real production data the difference in the returned results against what we already know should be the right result made it apparent that this function was malfunctioning. Looking at other queries in the InfluxDB wrapper module I was able to alter the function in order to produce the correct result.

## How did you test this code?

Tested against production data and verified that the total API calls were an exact match.

<img width="152" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/222715/799c1f0d-faf2-4987-b00f-99eeac01a3cd">

```python
(Pdb++) sum([r.get_value() for r in result.records])
816600
```

