### PR TITLE
fix: For Hubspot make the switch to unique org id

### DIFF
--- a/api/integrations/lead_tracking/hubspot/client.py
+++ b/api/integrations/lead_tracking/hubspot/client.py
@@ -103,20 +103,14 @@ class HubspotClient:
         organisation_id: int = None,
         domain: str | None = None,
     ) -> dict:
-        properties = {
-            "name": name,
-            "active_subscription": active_subscription,
-            "orgid": str(organisation_id),
-        }
+        properties = {"name": name}
 
         if domain:
             properties["domain"] = domain
         if active_subscription:
             properties["active_subscription"] = active_subscription
-
-        # hubspot doesn't allow null values for numeric fields, so we
-        # set this to -1 for auto generated organisations.
-        properties["orgid"] = organisation_id or -1
+        if organisation_id:
+            properties["orgid_unique"] = organisation_id
 
         simple_public_object_input_for_create = SimplePublicObjectInputForCreate(
             properties=properties,

--- a/api/tests/unit/integrations/lead_tracking/hubspot/_hubspot_responses.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/_hubspot_responses.py
@@ -72,7 +72,7 @@ def generate_get_company_by_domain_response_no_results() -> FakeHubspotResponse:
 
 
 def generate_create_company_response(
-    name: str, domain: str | None = None, organisation_id: int = -1
+    name: str, domain: str | None = None, organisation_id: None | int = None
 ) -> FakeHubspotResponse:
     """
     Generate a sample response given by the Hubspot API when creating a company.
@@ -81,25 +81,29 @@ def generate_create_company_response(
     properties dynamically.
     """
 
+    properties = {
+        "active_subscription": None,
+        "createdate": "2024-04-23T17:36:50.158Z",
+        "domain": domain,
+        "hs_lastmodifieddate": "2024-04-23T17:36:50.158Z",
+        "hs_object_id": "11349198823",
+        "hs_object_source": "INTEGRATION",
+        "hs_object_source_id": "2902325",
+        "hs_object_source_label": "INTEGRATION",
+        "name": name,
+        "website": domain,
+    }
+
+    if organisation_id:
+        properties["orgid_unique"] = organisation_id
+
     return FakeHubspotResponse(
         data={
             "archived": False,
             "archived_at": None,
             "created_at": datetime(2024, 4, 23, 17, 36, 50, 158000, tzinfo=tzlocal()),
             "id": "11349198823",
-            "properties": {
-                "active_subscription": None,
-                "createdate": "2024-04-23T17:36:50.158Z",
-                "domain": domain,
-                "hs_lastmodifieddate": "2024-04-23T17:36:50.158Z",
-                "hs_object_id": "11349198823",
-                "hs_object_source": "INTEGRATION",
-                "hs_object_source_id": "2902325",
-                "hs_object_source_label": "INTEGRATION",
-                "name": name,
-                "orgid": organisation_id,
-                "website": domain,
-            },
+            "properties": properties,
             "properties_with_history": None,
             "updated_at": datetime(2024, 4, 23, 17, 36, 50, 158000, tzinfo=tzlocal()),
         }

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
@@ -78,8 +78,6 @@ def test_create_company_without_organisation_information(
     hubspot_client.client.crm.companies.basic_api.create.assert_called_once()
     call_args = hubspot_client.client.crm.companies.basic_api.create.call_args
     assert call_args.kwargs["simple_public_object_input_for_create"].properties == {
-        "active_subscription": None,
         "domain": domain,
         "name": name,
-        "orgid": -1,
     }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

We need to switch to a new field called `orgid_unique` for Hubspot. This change introduces that behavior and at the same time removes an extraneous `None` property at the same time.

## How did you test this code?

Connected directly to Hubspot and tried different options, including without an `organisation_id`, with one, etc. The rest of the test suite is suitable for coverage.
