### PR TITLE
chore: restrict external HTTP calls in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         exclude: migrations
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         name: flake8

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -123,6 +123,13 @@ def django_db_setup(request: pytest.FixtureRequest) -> None:
 
 @pytest.fixture(autouse=True)
 def restrict_http_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    This fixture prevents all tests from performing HTTP requests to
+    any host than `localhost`.
+
+    Any external request attempt leads to `RuntimeError` with a helpful message
+    pointing developers to the `responses` fixture.
+    """
     allowed_hosts = {"localhost"}
     original_urlopen = HTTPConnectionPool.urlopen
 

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -13,6 +13,7 @@ from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 from pytest_django.plugin import blocking_manager_key
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
+from urllib3.connectionpool import HTTPConnectionPool
 from xdist import get_xdist_worker_id
 
 from api_keys.models import MasterAPIKey
@@ -118,6 +119,31 @@ def django_db_setup(request: pytest.FixtureRequest) -> None:
     for db_settings in settings.DATABASES.values():
         test_db_name = f'{TEST_DATABASE_PREFIX}{db_settings["NAME"]}_{test_db_suffix}'
         db_settings["NAME"] = test_db_name
+
+
+@pytest.fixture(autouse=True)
+def restrict_http_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    allowed_hosts = {"localhost"}
+    original_urlopen = HTTPConnectionPool.urlopen
+
+    def urlopen_mock(
+        self,
+        method: str,
+        url: str,
+        *args,
+        **kwargs,
+    ) -> HTTPConnectionPool.ResponseCls:
+        if self.host in allowed_hosts:
+            return original_urlopen(self, method, url, *args, **kwargs)
+
+        raise RuntimeError(
+            f"Blocked {method} request to {self.scheme}://{self.host}{url}. "
+            "Use `responses` fixture to mock the response!"
+        )
+
+    monkeypatch.setattr(
+        "urllib3.connectionpool.HTTPConnectionPool.urlopen", urlopen_mock
+    )
 
 
 trait_key = "key1"

--- a/api/tests/unit/users/utils/test_unit_users_mailer_lite.py
+++ b/api/tests/unit/users/utils/test_unit_users_mailer_lite.py
@@ -82,7 +82,7 @@ def test_batch_subscribe__subscribe_populates_batch_correctly(mocker):
     )
     users = [user1, user2]
     # When
-    with BatchSubscribe() as batch:
+    with BatchSubscribe(mocker.MagicMock()) as batch:
         for user in users:
             batch.subscribe(user)
         # Then


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR adds a global restriction of HTTP requests in unit tests.
When an external HTTP call is detected, the test trying to perform it fails with a notice/instruction to developers.

This PR will also add fixes to the current offending tests. 

## How did you test this code?

Ran the test suite.