### PR TITLE
fix: use ENABLE_FLAGSMITH_REALTIME environment var

### DIFF
--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -166,7 +166,7 @@ Once you have created the project, you need to set the following
   - The Flagsmith Client-side Environment Key we use to manage features - Flagsmith runs on Flagsmith. This will be the
     API key for the project you created as instructed above.
 - `ENABLE_FLAGSMITH_REALTIME`
-  -  Determines whether the Flagsmith on Flagsmith SDK uses Realtime.
+  - Determines whether the Flagsmith on Flagsmith SDK uses Realtime.
 - `FLAGSMITH_ON_FLAGSMITH_API_URL`
   - The API URL which the Flagsmith front end dashboard should communicate with. This will most likely be the domain
     name of the Flagsmith API you are self hosting: Flagsmith runs on Flagsmith. E.g. For our SaaS hosted platform, the

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -165,6 +165,8 @@ Once you have created the project, you need to set the following
 - `FLAGSMITH_ON_FLAGSMITH_API_KEY`
   - The Flagsmith Client-side Environment Key we use to manage features - Flagsmith runs on Flagsmith. This will be the
     API key for the project you created as instructed above.
+- `ENABLE_FLAGSMITH_REALTIME`
+  -  Determines whether the Flagsmith on Flagsmith SDK uses Realtime.
 - `FLAGSMITH_ON_FLAGSMITH_API_URL`
   - The API URL which the Flagsmith front end dashboard should communicate with. This will most likely be the domain
     name of the Flagsmith API you are self hosting: Flagsmith runs on Flagsmith. E.g. For our SaaS hosted platform, the

--- a/frontend/common/stores/config-store.js
+++ b/frontend/common/stores/config-store.js
@@ -50,7 +50,7 @@ flagsmith
     enableDynatrace,
     environmentID: Project.flagsmith,
     onChange: controller.loaded,
-    realtime: true,
+    realtime: Project.flagsmithRealtime,
   })
   .catch(() => {
     controller.onError()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
ENABLE_FLAGSMITH_REALTIME was setup to determine if the SDK initialised with the realtime boolean. For some reason this was not used in the admin panel.

Demo and production Vercel environments already provide this to the FE.



## How did you test this code?
- Check that ``Project.flagsmithRealtime`` is being set.
<img width="545" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/51c36c86-8103-4682-84ac-da15b0c66de2">
