### PR TITLE
chore: Workaround for Pydantic misbehaving with FreezeGun

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -62,6 +62,7 @@ from projects.permissions import VIEW_PROJECT
 from projects.tags.models import Tag
 from segments.models import Condition, Segment, SegmentRule
 from task_processor.task_run_method import TaskRunMethod
+from tests.test_helpers import fix_issue_3869
 from tests.types import (
     WithEnvironmentPermissionsCallable,
     WithOrganisationPermissionsCallable,
@@ -77,6 +78,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Enable CI mode",
     )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    fix_issue_3869()
 
 
 @pytest.hookimpl(trylast=True)

--- a/api/tests/test_helpers.py
+++ b/api/tests/test_helpers.py
@@ -32,3 +32,14 @@ def generate_segment_data(
             }
         ],
     }
+
+
+def fix_issue_3869():
+    """
+    Hack to get around Pydantic issue with Freeze Gun.
+
+    https://github.com/Flagsmith/flagsmith/issues/3869
+    """
+    from environments.sdk.schemas import (  # noqa: F401
+        SDKEnvironmentDocumentModel,
+    )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Introduce a pytest hook that runs before all the tests and runs an import which disables a typing error that Pydantic has with FreezeGun.

## How did you test this code?

Watched a sample test fail. Added the workaround. Watched the sample test pass.
