### PR TITLE
infra: add REPLICA_DATABASE_URLS to ECS task definition

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -202,6 +202,10 @@
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:DATABASE_URL::"
                 },
                 {
+                    "name": "REPLICA_DATABASE_URLS",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:REPLICA_DATABASE_URLS::"
+                },
+                {
                     "name": "DJANGO_SECRET_KEY",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:DJANGO_SECRET_KEY::"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -198,6 +198,10 @@
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:DATABASE_URL::"
                 },
                 {
+                    "name": "REPLICA_DATABASE_URLS",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:REPLICA_DATABASE_URLS::"
+                },
+                {
                     "name": "ANALYTICS_DATABASE_URL",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:ANALYTICS_DATABASE_URL::"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds a new reference to the `REPLICA_DATABASE_URLS` secret in the task definition so that we can add the Aurora reader endpoint to it. 

## How did you test this code?

I updated the task definition in staging manually and ran a reader instance in the aurora cluster. I then ran a basic test, spamming 3 of our main SDK endpoints and confirmed that the performance improved with the additional reader logic. 
