### PR TITLE
fix(versioning): feature segments updated with version

### DIFF
--- a/api/tests/integration/features/versioning/test_integration_v2_versioning.py
+++ b/api/tests/integration/features/versioning/test_integration_v2_versioning.py
@@ -530,27 +530,46 @@ def test_v2_versioning_carries_existing_segment_overrides_across(
     enabling v2 versioning, feature segments were not being returned via the
     API.
     """
-
-    # Firstly, let's check the response to the feature segments list endpoint
-    # before we enable v2 versioning.
+    # Given
     feature_segments_list_url = "%s?feature=%d&environment=%d" % (
         reverse("api-v1:features:feature-segment-list"),
         feature,
         environment,
     )
-    response = admin_client.get(feature_segments_list_url)
-    feature_segments_list_response_json = response.json()
-    assert feature_segments_list_response_json["count"] == 1
+
+    # Firstly, let's check the response to the feature segments list endpoint
+    # before we enable v2 versioning.
+    feature_segment_list_pre_migrate_response = admin_client.get(
+        feature_segments_list_url
+    )
+    feature_segments_list_response_pre_migrate_json = (
+        feature_segment_list_pre_migrate_response.json()
+    )
+    assert feature_segments_list_response_pre_migrate_json["count"] == 1
+    assert (
+        feature_segments_list_response_pre_migrate_json["results"][0]["id"]
+        == feature_segment
+    )
 
     # Now, let's enable v2 versioning.
     enable_v2_versioning_url = reverse(
         "api-v1:environments:environment-enable-v2-versioning",
         args=[environment_api_key],
     )
-    response = admin_client.post(enable_v2_versioning_url)
-    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert (
+        admin_client.post(enable_v2_versioning_url).status_code
+        == status.HTTP_202_ACCEPTED
+    )
 
     # and let's check the response to the feature segments endpoint after enabling v2 versioning
-    response = admin_client.get(feature_segments_list_url)
-    feature_segments_list_response_json = response.json()
-    assert feature_segments_list_response_json["count"] == 1
+    feature_segment_list_post_migrate_response = admin_client.get(
+        feature_segments_list_url
+    )
+    feature_segment_list_post_migrate_response_json = (
+        feature_segment_list_post_migrate_response.json()
+    )
+    assert feature_segment_list_post_migrate_response_json["count"] == 1
+    assert (
+        feature_segment_list_post_migrate_response_json["results"][0]["id"]
+        == feature_segment
+    )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ensures that FeatureSegments are updated with the correct environment feature version when an environment is migrated to use v2 versioning 

## How did you test this code?

Added an integration test. 
