### PR TITLE
fix(docker): Run Task Processor entrypoint with PID 1

### DIFF
--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -34,7 +34,7 @@ function run_task_processor() {
     if [[ -n "$ANALYTICS_DATABASE_URL" || -n "$DJANGO_DB_NAME_ANALYTICS" ]]; then
         python manage.py waitfordb --waitfor 30 --migrations --database analytics
     fi
-    RUN_BY_PROCESSOR=1 python manage.py runprocessor \
+    RUN_BY_PROCESSOR=1 exec python manage.py runprocessor \
       --sleepintervalms ${TASK_PROCESSOR_SLEEP_INTERVAL:-500} \
       --graceperiodms ${TASK_PROCESSOR_GRACE_PERIOD_MS:-20000} \
       --numthreads ${TASK_PROCESSOR_NUM_THREADS:-5} \


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This ensures the task processor is ran with PID 1, which is a matter of common courtesy in the containerised world.

## How did you test this code?

Built and ran the image locally, ensuring task processor is ran as expected.
