### PR TITLE
chore: Ignore `TYPE_CHECKING` in coverage by default

### DIFF
--- a/api/integrations/launch_darkly/models.py
+++ b/api/integrations/launch_darkly/models.py
@@ -7,7 +7,7 @@ from typing_extensions import NotRequired
 from audit.related_object_type import RelatedObjectType
 from projects.models import Project
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from users.models import FFAdminUser
 
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -24,6 +24,13 @@ exclude = '''
 )/
 '''
 
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_also = [
+  'if TYPE_CHECKING:',
+  '@(abc\\.)?abstractmethod',
+]
+
 [tool.isort]
 use_parentheses = true
 multi_line_output = 3

--- a/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_dynamodb.py
@@ -8,7 +8,7 @@ from environments.dynamodb.constants import (
 from util.mappers import dynamodb
 from util.mappers.engine import map_feature_state_to_engine
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from environments.identities.models import Identity

--- a/api/tests/unit/util/mappers/test_unit_mappers_engine.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_engine.py
@@ -40,7 +40,7 @@ from integrations.webhook.models import WebhookConfiguration
 from segments.models import Segment, SegmentRule
 from util.mappers import engine
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from environments.identities import Identity, Trait
     from environments.models import EnvironmentAPIKey
     from features.models import Feature

--- a/api/util/mappers/dynamodb.py
+++ b/api/util/mappers/dynamodb.py
@@ -22,7 +22,7 @@ from util.mappers.engine import (
     map_identity_to_engine,
 )
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from flag_engine.identities.models import IdentityModel
 
     from environments.identities.models import Identity

--- a/api/util/mappers/engine.py
+++ b/api/util/mappers/engine.py
@@ -24,7 +24,7 @@ from flag_engine.segments.models import (
     SegmentRuleModel,
 )
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from environments.identities.models import Identity, Trait
     from environments.models import Environment, EnvironmentAPIKey
     from features.models import Feature, FeatureSegment, FeatureState


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

After merging this PR, we won't have to manually mark imports under `if TYPE_CHECKING:` and abstract methods with `# pragma: no cover`.

## How did you test this code?

This is a CI change.