### PR TITLE
chore(tests): Retry E2E on error

### DIFF
--- a/.github/actions/e2e-bake-compose/action.yml
+++ b/.github/actions/e2e-bake-compose/action.yml
@@ -30,6 +30,10 @@ runs:
         password: ${{ inputs.github_token }}
 
     - name: Bake Compose
-      working-directory: frontend
-      run: depot bake -f docker-compose-e2e-tests.yml --load
-      shell: bash
+      uses: nick-fields/retry@v3
+      with:
+        shell: bash
+        command: cd frontend && depot bake -f docker-compose-e2e-tests.yml --load
+        max_attempts: 2
+        retry_on: error
+        timeout_minutes: 10

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -33,16 +33,20 @@ runs:
       shell: bash
 
     - name: Test with Chromedriver
-      working-directory: frontend
+      uses: nick-fields/retry@v3
+      with:
+        shell: bash
+        command: |
+          cd frontend
+          node -v
+          npm run env
+          npm run test -- ${{ inputs.tests }}
+        max_attempts: 2
+        retry_on: error
+        timeout_minutes: 10
       env:
         E2E_TEST_TOKEN: ${{ inputs.e2e_test_token }}
         SLACK_TOKEN: ${{ inputs.slack_token }}
         STATIC_ASSET_CDN_URL: /
         ENV: ${{ inputs.environment }}
         GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      run: |
-        node -v
-        npm run env
-        npm run test -- ${{ inputs.tests }}
-      shell: bash


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

After merging this, E2E jobs will retry once on failure.
Hopefully, this will make flaky E2E tests slightly less painful.

## How did you test this code?

This is a CI change.