### PR TITLE
fix: Add multivariate values when cloning identities

### DIFF
--- a/api/edge_api/identities/models.py
+++ b/api/edge_api/identities/models.py
@@ -256,5 +256,6 @@ class EdgeIdentity:
                 feature=feature_in_source.feature,
                 feature_state_value=feature_in_source.feature_state_value,
                 enabled=feature_in_source.enabled,
+                multivariate_feature_state_values=feature_in_source.multivariate_feature_state_values,
             )
             self.add_feature_override(feature_state_target)

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -981,12 +981,17 @@ class FeatureState(
                 source_feature_id
             ].enabled
 
-            # Copy feature state value from source feature_state
-            target_feature_state.feature_state_value.copy_from(
-                source_feature_state.feature_state_value
-            )
+            if source_feature_state.feature.type == MULTIVARIATE:
+                mv_values = [
+                    mv_value.clone(feature_state=target_feature_state, persist=False)
+                    for mv_value in source_feature_state.multivariate_feature_state_values.all()
+                ]
+                MultivariateFeatureStateValue.objects.bulk_create(mv_values)
+            else:
+                target_feature_state.feature_state_value.copy_from(
+                    source_feature_state.feature_state_value
+                )
 
-            # Save changes to target feature_state
             target_feature_state.save()
 
 

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -987,10 +987,10 @@ class FeatureState(
                     for mv_value in source_feature_state.multivariate_feature_state_values.all()
                 ]
                 MultivariateFeatureStateValue.objects.bulk_create(mv_values)
-            else:
-                target_feature_state.feature_state_value.copy_from(
-                    source_feature_state.feature_state_value
-                )
+
+            target_feature_state.feature_state_value.copy_from(
+                source_feature_state.feature_state_value
+            )
 
             target_feature_state.save()
 

--- a/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from core.constants import STRING
 from django.test import Client
 from django.urls import reverse
 from rest_framework import status
@@ -12,6 +13,10 @@ from environments.permissions.constants import (
     VIEW_ENVIRONMENT,
 )
 from features.models import Feature, FeatureState, FeatureStateValue
+from features.multivariate.models import (
+    MultivariateFeatureOption,
+    MultivariateFeatureStateValue,
+)
 from projects.models import Project
 from tests.unit.environments.helpers import get_environment_user_client
 
@@ -136,6 +141,20 @@ def test_identity_clone_flag_states_from(
         project
     )
 
+    mv_feature = Feature.objects.create(
+        type="MULTIVARIATE",
+        name="mv_feature",
+        initial_value="foo",
+        project=project,
+    )
+
+    mv_variant_1 = MultivariateFeatureOption.objects.create(
+        feature=mv_feature,
+        default_percentage_allocation=0,
+        type=STRING,
+        string_value="bar",
+    )
+
     source_identity: Identity = Identity.objects.create(
         identifier="source_identity", environment=environment
     )
@@ -163,6 +182,18 @@ def test_identity_clone_flag_states_from(
     source_feature_state_2_value = "Source Identity for feature value 2"
     FeatureStateValue.objects.filter(feature_state=source_feature_state_2).update(
         string_value=source_feature_state_2_value
+    )
+
+    source_mv_feature_state: FeatureState = FeatureState.objects.create(
+        feature=mv_feature,
+        environment=environment,
+        identity=source_identity,
+        enabled=True,
+    )
+    MultivariateFeatureStateValue.objects.create(
+        feature_state=source_mv_feature_state,
+        multivariate_feature_option=mv_variant_1,
+        percentage_allocation=100,
     )
 
     target_feature_state_2: FeatureState = FeatureState.objects.create(
@@ -201,7 +232,7 @@ def test_identity_clone_flag_states_from(
     response = clone_identity_feature_states_response.json()
 
     # Target identity contains only the 2 cloned overridden features states and 1 environment feature state
-    assert len(response) == 3
+    assert len(response) == 4
 
     # Assert cloned data is correct
     assert response[0]["feature"]["id"] == feature_1.id
@@ -218,6 +249,17 @@ def test_identity_clone_flag_states_from(
     assert response[2]["enabled"] == feature_3.default_enabled
     assert response[2]["feature_state_value"] == feature_3.initial_value
     assert response[2]["overridden_by"] is None
+
+    assert response[3]["feature"]["id"] == mv_feature.id
+    assert response[3]["enabled"] == source_mv_feature_state.enabled
+    assert response[3]["feature_state_value"] == mv_variant_1.string_value
+    assert (
+        response[3]["multivariate_feature_state_values"][0][
+            "multivariate_feature_option"
+        ]["value"]
+        == mv_variant_1.value
+    )
+    assert response[3]["overridden_by"] == "IDENTITY"
 
     # Target identity feature 3 override has been removed
     assert not FeatureState.objects.filter(

--- a/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
@@ -252,7 +252,7 @@ def test_identity_clone_flag_states_from(
 
     assert response[3]["feature"]["id"] == mv_feature.id
     assert response[3]["enabled"] == source_mv_feature_state.enabled
-    assert response[3]["feature_state_value"] == mv_variant_1.string_value
+    assert response[3]["feature_state_value"] == mv_variant_1.value
     assert (
         response[3]["multivariate_feature_state_values"][0][
             "multivariate_feature_option"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Change the clone identities endpoints in Core and Edge APIs to clone also multivariate values for overriden feature states having that configuration.

## How did you test this code?

Unit tests updated to consider this case