### PR TITLE
fix: Validate if the GitHub installation is valid

### DIFF
--- a/frontend/common/services/useGithub.ts
+++ b/frontend/common/services/useGithub.ts
@@ -29,6 +29,7 @@ export const githubService = service
             query.organisation_id
           }/github/repositories/?${Utils.toParam({
             installation_id: query.installation_id,
+            is_github_installation: query.is_github_installation,
           })}`,
         }),
       }),

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -317,6 +317,7 @@ export type Req = {
   updateGithubIntegration: {
     organisation_id: string
     github_integration_id: string
+    installation_id: string
   }
   deleteGithubIntegration: {
     organisation_id: string
@@ -361,7 +362,11 @@ export type Req = {
     repo_name: string
     repo_owner: string
   }
-  getGithubRepos: { installation_id: string; organisation_id: string }
+  getGithubRepos: {
+    installation_id: string
+    organisation_id: string
+    is_github_installation: string
+  }
   getServersideEnvironmentKeys: { environmentId: string }
   deleteServersideEnvironmentKeys: { environmentId: string; id: string }
   createServersideEnvironmentKeys: {

--- a/frontend/web/components/GitHubRepositoriesSelect.tsx
+++ b/frontend/web/components/GitHubRepositoriesSelect.tsx
@@ -2,6 +2,8 @@ import React, { FC, useEffect, useState } from 'react'
 import { Repository } from 'common/types/responses'
 import Button from './base/forms/Button'
 import { useCreateGithubRepositoryMutation } from 'common/services/useGithubRepository'
+import GithubRepositoriesTable from './GithubRepositoriesTable'
+import DeleteGithubIntegracion from './DeleteGithubIntegracion'
 
 export type GitHubRepositoriesSelectType = {
   disabled?: boolean
@@ -9,6 +11,7 @@ export type GitHubRepositoriesSelectType = {
   organisationId: string
   projectId: string
   githubId: string
+  manageIntegration: () => void
 }
 
 type repoSelectValue = {
@@ -18,6 +21,7 @@ type repoSelectValue = {
 const GitHubRepositoriesSelect: FC<GitHubRepositoriesSelectType> = ({
   disabled,
   githubId,
+  manageIntegration,
   organisationId,
   projectId,
   repositories,
@@ -73,6 +77,30 @@ const GitHubRepositoriesSelect: FC<GitHubRepositoriesSelectType> = ({
           Add Repository
         </Button>
       </div>
+      <>
+        <GithubRepositoriesTable
+          githubId={githubId}
+          organisationId={organisationId}
+        />
+        <div className='text-right mt-2'>
+          <Button
+            className='mr-3'
+            id='open-github-win-installations-btn'
+            data-test='open-github-win-installations-btn'
+            onClick={manageIntegration}
+            size='small'
+          >
+            Manage available GitHub Repositories
+          </Button>
+          <DeleteGithubIntegracion
+            githubId={githubId}
+            organisationId={organisationId}
+            onConfirm={() => {
+              window.location.reload()
+            }}
+          />
+        </div>
+      </>
     </div>
   )
 }

--- a/frontend/web/components/InfoMessage.js
+++ b/frontend/web/components/InfoMessage.js
@@ -8,7 +8,11 @@ export default class InfoMessage extends PureComponent {
   static displayName = 'InfoMessage'
 
   handleOpenNewWindow = () => {
-    window.open(this.props.url, '_blank')
+    if (this.props.goToIntegrations) {
+      this.props.goToIntegrations()
+    } else {
+      window.open(this.props.url, '_blank')
+    }
   }
 
   render() {

--- a/frontend/web/components/IntegrationList.js
+++ b/frontend/web/components/IntegrationList.js
@@ -224,17 +224,21 @@ class IntegrationList extends Component {
 
   componentDidMount() {
     this.fetch()
-    if (Utils.getFlagsmithHasFeature('github_integration')) {
-      getGithubIntegration(getStore(), {
+  }
+  fetchGithubIntegration() {
+    getGithubIntegration(
+      getStore(),
+      {
         organisation_id: AccountStore.getOrganisation().id,
-      }).then((res) => {
-        this.setState({
-          githubId: res?.data?.results[0]?.id,
-          hasIntegrationWithGithub: !!res?.data?.results?.length,
-          installationId: res?.data?.results[0]?.installation_id,
-        })
+      },
+      { forceRefetch: true },
+    ).then((res) => {
+      this.setState({
+        githubId: res?.data?.results[0]?.id,
+        hasIntegrationWithGithub: !!res?.data?.results?.length,
+        installationId: res?.data?.results[0]?.installation_id,
       })
-    }
+    })
   }
 
   fetch = () => {
@@ -280,6 +284,7 @@ class IntegrationList extends Component {
       }),
     ).then((res) => {
       console.log(res)
+      this.fetchGithubIntegration()
       this.setState({
         activeIntegrations: _.map(res, (item) =>
           !!item && item.length ? item : [],

--- a/frontend/web/components/MyGitHubRepositoriesSelect.tsx
+++ b/frontend/web/components/MyGitHubRepositoriesSelect.tsx
@@ -1,31 +1,53 @@
 import { FC } from 'react'
 import { useGetGithubReposQuery } from 'common/services/useGithub'
 import GitHubRepositoriesSelect from './GitHubRepositoriesSelect'
+import InvalidGithubIntegration from './modals/InvalidGithubIntegration'
 
 type MyGitHubRepositoriesSelectType = {
   installationId: string
   organisationId: string
   projectId: string
   githubId: string
+  manageIntegration: () => void
+  onComplete: () => void
 }
 
 const MyGitHubRepositoriesSelect: FC<MyGitHubRepositoriesSelectType> = ({
   githubId,
   installationId,
+  manageIntegration,
+  onComplete,
   organisationId,
   projectId,
 }) => {
-  const { data } = useGetGithubReposQuery({
+  const { data, error, isError, isFetching } = useGetGithubReposQuery({
     installation_id: installationId,
+    is_github_installation: 'False',
     organisation_id: organisationId,
   })
   return (
-    <GitHubRepositoriesSelect
-      githubId={githubId}
-      organisationId={organisationId}
-      projectId={projectId}
-      repositories={data?.repositories}
-    />
+    <>
+      {isFetching ? (
+        <div className='text-center'>
+          <Loader />
+        </div>
+      ) : !isError && data ? (
+        <GitHubRepositoriesSelect
+          githubId={githubId}
+          organisationId={organisationId}
+          projectId={projectId}
+          repositories={data?.repositories}
+          manageIntegration={manageIntegration}
+        />
+      ) : (
+        <InvalidGithubIntegration
+          organisationId={organisationId}
+          githubIntegrationId={githubId}
+          errorMessage={error?.data?.detail}
+          onComplete={onComplete}
+        />
+      )}
+    </>
   )
 }
 

--- a/frontend/web/components/modals/CreateEditIntegrationModal.js
+++ b/frontend/web/components/modals/CreateEditIntegrationModal.js
@@ -5,11 +5,9 @@ import _data from 'common/data/base/_data'
 import ErrorMessage from 'components/ErrorMessage'
 import ModalHR from './ModalHR'
 import Button from 'components/base/forms/Button'
-import GithubRepositoriesTable from 'components/GithubRepositoriesTable'
 import classNames from 'classnames'
 import { getStore } from 'common/store'
 import { getGithubRepos } from 'common/services/useGithub'
-import DeleteGithubIntegracion from 'components/DeleteGithubIntegracion'
 
 const GITHUB_INSTALLATION_UPDATE = 'update'
 
@@ -233,29 +231,8 @@ const CreateEditIntegration = class extends Component {
                     installationId={this.props.githubMeta.installationId}
                     organisationId={AccountStore.getOrganisation().id}
                     projectId={this.props.projectId}
-                  />
-                </div>
-                <GithubRepositoriesTable
-                  githubId={this.props.githubMeta.githubId}
-                  organisationId={AccountStore.getOrganisation().id}
-                />
-                <div className='text-right mt-2'>
-                  <Button
-                    className='mr-3'
-                    type='text'
-                    id='open-github-win-installations-btn'
-                    data-test='open-github-win-installations-btn'
-                    onClick={this.openGitHubWinInstallations}
-                    size='small'
-                  >
-                    Manage available GitHub Repositories
-                  </Button>
-                  <DeleteGithubIntegracion
-                    githubId={this.props.githubMeta.githubId}
-                    organisationId={AccountStore.getOrganisation().id}
-                    onConfirm={() => {
-                      closeModal()
-                    }}
+                    manageIntegration={this.openGitHubWinInstallations}
+                    onComplete={this.onComplete}
                   />
                 </div>
               </>

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -691,7 +691,7 @@ const CreateFlag = class extends Component {
                             orgId={AccountStore.getOrganisation().id}
                             onChange={(v) =>
                               this.setState({
-                                featureExternalResource: v.value,
+                                featureExternalResource: v,
                               })
                             }
                             repoOwner={repoOwner}

--- a/frontend/web/components/modals/InvalidGithubIntegration.tsx
+++ b/frontend/web/components/modals/InvalidGithubIntegration.tsx
@@ -1,0 +1,82 @@
+import React, { FC, useState } from 'react'
+import Utils from 'common/utils/utils'
+import InputGroup from 'components/base/forms/InputGroup'
+import Button from 'components/base/forms/Button'
+import { useUpdateGithubIntegrationMutation } from 'common/services/useGithubIntegration'
+import ErrorMessage from 'components/ErrorMessage'
+
+type InvalidGithubIntegrationType = {
+  onComplete?: () => void
+  organisationId: string
+  githubIntegrationId: string
+  errorMessage: string
+}
+
+const InvalidGithubIntegration: FC<InvalidGithubIntegrationType> = ({
+  errorMessage,
+  githubIntegrationId,
+  onComplete,
+  organisationId,
+}) => {
+  const [installationId, setInstallationId] = useState<string>('')
+
+  const [updateGithubIntegration, { isLoading: updating }] =
+    useUpdateGithubIntegrationMutation()
+
+  return (
+    <form
+      onSubmit={(e) => {
+        Utils.preventDefault(e)
+        updateGithubIntegration({
+          github_integration_id: githubIntegrationId,
+          installation_id: installationId,
+          organisation_id: organisationId,
+        }).then(() => {
+          onComplete?.()
+        })
+      }}
+    >
+      <div className='modal-body'>
+        <ErrorMessage error={errorMessage} />
+        <InputGroup
+          title='New Installation ID'
+          inputProps={{
+            className: 'full-width',
+            name: 'installationId',
+          }}
+          value={installationId}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            setInstallationId(Utils.safeParseEventValue(event))
+          }}
+          type='number'
+          name='installationId'
+          id='installation-id'
+          placeholder='E.g. 12345678'
+        />
+      </div>
+      <div className='modal-footer'>
+        <Button theme='secondary' className='mr-2' onClick={closeModal}>
+          Cancel
+        </Button>
+        <Button
+          id='delete-integration'
+          className='mr-2'
+          theme='danger'
+          data-tests='delete-integration-modal'
+        >
+          {'Delete the GitHub integration'}
+        </Button>
+        <Button
+          type='submit'
+          id='update-installation-id'
+          data-tests='update-installation-id'
+          disabled={updating || installationId.length === 0}
+        >
+          {updating ? 'Updating' : 'Update'}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export default InvalidGithubIntegration

--- a/frontend/web/components/pages/GitHubSetupPage.tsx
+++ b/frontend/web/components/pages/GitHubSetupPage.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState, useEffect } from 'react'
 import OrganisationSelect from 'components/OrganisationSelect'
+import AppActions from 'common/dispatcher/app-actions'
 import Input from 'components/base/forms/Input'
 import Icon from 'components/Icon'
 import InputGroup from 'components/base/forms/InputGroup'
@@ -45,9 +46,10 @@ const GitHubSetupPage: FC<GitHubSetupPageType> = ({ location }) => {
   const { data: repos, isSuccess: reposLoaded } = useGetGithubReposQuery(
     {
       installation_id: installationId,
+      is_github_installation: 'True',
       organisation_id: organisation,
     },
-    { skip: !installationId },
+    { skip: !installationId || !organisation },
   )
 
   const [createGithubIntegration] = useCreateGithubIntegrationMutation()
@@ -72,6 +74,7 @@ const GitHubSetupPage: FC<GitHubSetupPageType> = ({ location }) => {
     ) {
       window.location.href = `${baseUrl}/`
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSuccessCreatedGithubRepository])
 
   useEffect(() => {
@@ -124,7 +127,9 @@ const GitHubSetupPage: FC<GitHubSetupPageType> = ({ location }) => {
             <label>Select your Flagsmith Organisation</label>
             <OrganisationSelect
               onChange={(organisationId: string) => {
-                setOrganisation(organisationId)
+                setOrganisation(`${organisationId}`)
+                AppActions.selectOrganisation(organisationId)
+                AppActions.getOrganisation(organisationId)
               }}
               showSettings={false}
               firstOrganisation
@@ -170,7 +175,13 @@ const GitHubSetupPage: FC<GitHubSetupPageType> = ({ location }) => {
             </div>
             <Button
               theme='primary'
-              disabled={!project || !installationId || !repositoryName}
+              disabled={
+                !(
+                  Object.entries(project).length &&
+                  installationId &&
+                  repositoryName
+                )
+              }
               onClick={() => {
                 {
                   const newProjects = [...projects]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Add an infoMessage if the GitHub installation is invalid.
- Add the option to update the installation id or delete the integration, if it is invalid.
- Correct issue when try link a GitHub PR.
- Add extra logic in the GitHubSetupPage

## How did you test this code?

- Create an integration with GH in the Flagsmith App.
- Uninstall the app in GitHub
- Go to integration option in the side menu -> GitHub Integration -> Manage integration
