### PR TITLE
fix: Ensure flags are set in code example

### DIFF
--- a/frontend/common/code-help/init/init-ruby.js
+++ b/frontend/common/code-help/init/init-ruby.js
@@ -8,6 +8,9 @@ $flagsmith = Flagsmith::Client.new(
     environment_key: '${envId}'
 )
 
+// Load the environment's flags locally
+$flags = $flagsmith.get_environment_flags
+
 // Check for a feature
 $is_enabled = $flags.is_feature_enabled('${customFeature || FEATURE_NAME}')
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ensure flags are set in code example for the ruby client.

## How did you test this code?

Checked it out in Vercel