### PR TITLE
fix: send all users on paid subscriptions to hubspot

### DIFF
--- a/api/integrations/lead_tracking/hubspot/lead_tracker.py
+++ b/api/integrations/lead_tracking/hubspot/lead_tracker.py
@@ -42,12 +42,6 @@ class HubspotLeadTracker(LeadTracker):
         ):
             return False
 
-        if any(
-            org.is_paid
-            for org in user.organisations.select_related("subscription").all()
-        ):
-            return False
-
         return True
 
     def create_lead(self, user: FFAdminUser, organisation: Organisation = None) -> None:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Previously we filtered out users that were part of an organisation that had a paid subscription before sending them to hubspot. This PR removes that filtering. 

## How did you test this code?

I haven't, but it's just removing a few lines of trivial code which gets called in a single location. 
