### PR TITLE
fix: Move call to GitHub integration tasks out from trigger_feature_state_change_webhooks

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -74,7 +74,7 @@ from features.value_types import (
     STRING,
 )
 from features.versioning.models import EnvironmentFeatureVersion
-from organisations.models import Organisation
+from integrations.github.models import GithubConfiguration
 from projects.models import Project
 from projects.tags.models import Tag
 
@@ -1007,10 +1007,8 @@ class FeatureState(
             and self.environment.project.github_project.exists()
             and self.environment.project.organisation.github_config.exists()
         ):
-            github_configuration = (
-                Organisation.objects.prefetch_related("github_config")
-                .get(id=self.environment.project.organisation_id)
-                .github_config.first()
+            github_configuration = GithubConfiguration.objects.get(
+                organisation_id=self.environment.project.organisation_id
             )
             feature_states = []
             feature_states.append(self)

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -1013,13 +1013,23 @@ class FeatureState(
             feature_states = []
             feature_states.append(self)
 
-            feature_data: GithubData = generate_data(
-                github_configuration=github_configuration,
-                feature_id=self.feature.id,
-                feature_name=self.feature.name,
-                type=WebhookEventType.FLAG_UPDATED.value,
-                feature_states=feature_states,
-            )
+            if self.deleted_at is None:
+                feature_data: GithubData = generate_data(
+                    github_configuration=github_configuration,
+                    feature_id=self.feature.id,
+                    feature_name=self.feature.name,
+                    type=WebhookEventType.FLAG_UPDATED.value,
+                    feature_states=feature_states,
+                )
+
+            if self.deleted_at is not None:
+                feature_data: GithubData = generate_data(
+                    github_configuration=github_configuration,
+                    feature_id=self.feature.id,
+                    feature_name=self.feature.name,
+                    type=WebhookEventType.FLAG_DELETED.value,
+                    feature_states=feature_states,
+                )
 
             call_github_app_webhook_for_feature_state.delay(
                 args=(asdict(feature_data),),

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -5,6 +5,7 @@ import logging
 import typing
 import uuid
 from copy import deepcopy
+from dataclasses import asdict
 
 from core.models import (
     AbstractBaseExportableModel,
@@ -22,6 +23,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from django_lifecycle import (
     AFTER_CREATE,
+    AFTER_SAVE,
     BEFORE_CREATE,
     BEFORE_SAVE,
     LifecycleModelMixin,
@@ -72,6 +74,7 @@ from features.value_types import (
     STRING,
 )
 from features.versioning.models import EnvironmentFeatureVersion
+from organisations.models import Organisation
 from projects.models import Project
 from projects.tags.models import Tag
 
@@ -988,6 +991,41 @@ class FeatureState(
 
             # Save changes to target feature_state
             target_feature_state.save()
+
+    @hook(AFTER_SAVE)
+    def create_github_comment(self) -> None:
+        from integrations.github.github import GithubData, generate_data
+        from integrations.github.tasks import (
+            call_github_app_webhook_for_feature_state,
+        )
+        from webhooks.webhooks import WebhookEventType
+
+        if (
+            not self.identity_id
+            and not self.feature_segment
+            and self.feature.external_resources.exists()
+            and self.environment.project.github_project.exists()
+            and self.environment.project.organisation.github_config.exists()
+        ):
+            github_configuration = (
+                Organisation.objects.prefetch_related("github_config")
+                .get(id=self.environment.project.organisation_id)
+                .github_config.first()
+            )
+            feature_states = []
+            feature_states.append(self)
+
+            feature_data: GithubData = generate_data(
+                github_configuration=github_configuration,
+                feature_id=self.feature.id,
+                feature_name=self.feature.name,
+                type=WebhookEventType.FLAG_UPDATED.value,
+                feature_states=feature_states,
+            )
+
+            call_github_app_webhook_for_feature_state.delay(
+                args=(asdict(feature_data),),
+            )
 
 
 class FeatureStateValue(

--- a/api/features/signals.py
+++ b/api/features/signals.py
@@ -1,13 +1,7 @@
 import logging
-from dataclasses import asdict
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-
-from integrations.github.github import GithubData, generate_data
-from integrations.github.tasks import call_github_app_webhook_for_feature_state
-from organisations.models import Organisation
-from webhooks.webhooks import WebhookEventType
 
 # noinspection PyUnresolvedReferences
 from .models import FeatureState
@@ -18,34 +12,6 @@ logger = logging.getLogger(__name__)
 
 @receiver(post_save, sender=FeatureState)
 def trigger_feature_state_change_webhooks_signal(instance, **kwargs):
-    # Enqueue Github integration tasks if feature has GitHub external resources
-    if (
-        not instance.identity_id
-        and not instance.feature_segment
-        and instance.feature.external_resources.exists()
-        and instance.environment.project.github_project.exists()
-        and hasattr(instance.environment.project.organisation, "github_config")
-    ):
-        github_configuration = (
-            Organisation.objects.prefetch_related("github_config")
-            .get(id=instance.environment.project.organisation_id)
-            .github_config.first()
-        )
-        feature_states = []
-        feature_states.append(instance)
-
-        feature_data: GithubData = generate_data(
-            github_configuration=github_configuration,
-            feature_id=instance.feature.id,
-            feature_name=instance.feature.name,
-            type=WebhookEventType.FLAG_UPDATED.value,
-            feature_states=feature_states,
-        )
-
-        call_github_app_webhook_for_feature_state.delay(
-            args=(asdict(feature_data),),
-        )
-
     if instance.environment_feature_version_id:
         return
     trigger_feature_state_change_webhooks(instance)

--- a/api/features/signals.py
+++ b/api/features/signals.py
@@ -1,7 +1,13 @@
 import logging
+from dataclasses import asdict
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+
+from integrations.github.github import GithubData, generate_data
+from integrations.github.tasks import call_github_app_webhook_for_feature_state
+from organisations.models import Organisation
+from webhooks.webhooks import WebhookEventType
 
 # noinspection PyUnresolvedReferences
 from .models import FeatureState
@@ -12,6 +18,34 @@ logger = logging.getLogger(__name__)
 
 @receiver(post_save, sender=FeatureState)
 def trigger_feature_state_change_webhooks_signal(instance, **kwargs):
+    # Enqueue Github integration tasks if feature has GitHub external resources
+    if (
+        not instance.identity_id
+        and not instance.feature_segment
+        and instance.feature.external_resources.exists()
+        and instance.environment.project.github_project.exists()
+        and hasattr(instance.environment.project.organisation, "github_config")
+    ):
+        github_configuration = (
+            Organisation.objects.prefetch_related("github_config")
+            .get(id=instance.environment.project.organisation_id)
+            .github_config.first()
+        )
+        feature_states = []
+        feature_states.append(instance)
+
+        feature_data: GithubData = generate_data(
+            github_configuration=github_configuration,
+            feature_id=instance.feature.id,
+            feature_name=instance.feature.name,
+            type=WebhookEventType.FLAG_UPDATED.value,
+            feature_states=feature_states,
+        )
+
+        call_github_app_webhook_for_feature_state.delay(
+            args=(asdict(feature_data),),
+        )
+
     if instance.environment_feature_version_id:
         return
     trigger_feature_state_change_webhooks(instance)

--- a/api/features/tasks.py
+++ b/api/features/tasks.py
@@ -1,11 +1,7 @@
 import logging
-from dataclasses import asdict
 
 from environments.models import Webhook
 from features.models import Feature, FeatureState
-from integrations.github.github import GithubData, generate_data
-from integrations.github.tasks import call_github_app_webhook_for_feature_state
-from organisations.models import Organisation
 from task_processor.decorators import register_task_handler
 from webhooks.constants import WEBHOOK_DATETIME_FORMAT
 from webhooks.webhooks import (
@@ -58,39 +54,6 @@ def trigger_feature_state_change_webhooks(
             event_type.value,
         )
     )
-
-    if (
-        not instance.identity_id
-        and not instance.feature_segment
-        and instance.feature.external_resources.exists()
-        and instance.environment.project.github_project.exists()
-        and hasattr(instance.environment.project.organisation, "github_config")
-    ):
-        github_configuration = (
-            Organisation.objects.prefetch_related("github_config")
-            .get(id=instance.environment.project.organisationn_id)
-            .github_config.first()
-        )
-        feature_state = {
-            "environment_name": new_state["environment"]["name"],
-            "feature_value": new_state["enabled"],
-        }
-        feature_states = []
-        feature_states.append(instance)
-
-        feature_data: GithubData = generate_data(
-            github_configuration=github_configuration,
-            feature_id=history_instance.feature.id,
-            feature_name=history_instance.feature.name,
-            type=WebhookEventType.FLAG_UPDATED.value,
-            feature_states=feature_states,
-        )
-
-        feature_data.feature_states.append(feature_state)
-
-        call_github_app_webhook_for_feature_state.delay(
-            args=(asdict(feature_data),),
-        )
 
 
 def _get_previous_state(

--- a/api/integrations/github/constants.py
+++ b/api/integrations/github/constants.py
@@ -1,7 +1,8 @@
 GITHUB_API_URL = "https://api.github.com/"
 GITHUB_API_VERSION = "2022-11-28"
 
-LINK_FEATURE_TEXT = "### This pull request is linked to a Flagsmith Feature (%s):\n"
-UNLINKED_FEATURE_TEXT = "### The feature flag %s was unlinked from the issue/PR"
-UPDATED_FEATURE_TEXT = "### The Flagsmith Feature %s was updated in the environment "
+LINK_FEATURE_TEXT = "### This pull request is linked to a Flagsmith Feature (`%s`):\n"
+UNLINKED_FEATURE_TEXT = "### The feature flag `%s` was unlinked from the issue/PR"
+UPDATED_FEATURE_TEXT = "### The Flagsmith Feature `%s` was updated in the environment "
 LAST_UPDATED_FEATURE_TEXT = "Last Updated %s"
+DELETED_FEATURE_TEXT = "### The Feature Flag `%s` was deleted"

--- a/api/integrations/github/github.py
+++ b/api/integrations/github/github.py
@@ -55,7 +55,7 @@ def post_comment_to_github(
             url, json=payload, headers=headers, timeout=10
         )
 
-        return response.json() if response.status_code == 200 else None
+        return response.json() if response.status_code == 201 else None
     except requests.RequestException as e:
         logger.error(f" {e}")
         return None

--- a/api/integrations/github/github.py
+++ b/api/integrations/github/github.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from features.models import FeatureState, FeatureStateValue
 from integrations.github.client import generate_token
 from integrations.github.constants import (
+    DELETED_FEATURE_TEXT,
     GITHUB_API_URL,
     LAST_UPDATED_FEATURE_TEXT,
     LINK_FEATURE_TEXT,
@@ -70,6 +71,9 @@ def generate_body_comment(
     is_update = event_type == WebhookEventType.FLAG_UPDATED.value
     is_removed = event_type == WebhookEventType.FEATURE_EXTERNAL_RESOURCE_REMOVED.value
     delete_text = UNLINKED_FEATURE_TEXT % (name,)
+
+    if event_type == WebhookEventType.FLAG_DELETED.value:
+        return DELETED_FEATURE_TEXT % (name,)
 
     if is_removed:
         return delete_text

--- a/api/integrations/github/tasks.py
+++ b/api/integrations/github/tasks.py
@@ -31,7 +31,10 @@ def send_post_request(data: CallGithubData) -> None:
     installation_id = data.github_data.installation_id
     body = generate_body_comment(feature_name, event_type, feature_states)
 
-    if event_type == WebhookEventType.FLAG_UPDATED.value:
+    if (
+        event_type == WebhookEventType.FLAG_UPDATED.value
+        or event_type == WebhookEventType.FLAG_DELETED.value
+    ):
         for resource in data.feature_external_resources:
             url = resource.get("url")
             pathname = urlparse(url).path
@@ -61,7 +64,36 @@ def send_post_request(data: CallGithubData) -> None:
 @register_task_handler()
 def call_github_app_webhook_for_feature_state(event_data: dict[str, Any]) -> None:
 
+    from features.feature_external_resources.models import (
+        FeatureExternalResource,
+    )
+
     github_event_data = GithubData.from_dict(event_data)
+
+    def generate_feature_external_resources(
+        feature_external_resources: FeatureExternalResource,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": resource.type,
+                "url": resource.url,
+            }
+            for resource in feature_external_resources
+        ]
+
+    if github_event_data.type == WebhookEventType.FLAG_DELETED.value:
+        feature_external_resources = generate_feature_external_resources(
+            FeatureExternalResource.objects.filter(
+                feature_id=github_event_data.feature_id
+            )
+        )
+        data = CallGithubData(
+            event_type=github_event_data.type,
+            github_data=github_event_data,
+            feature_external_resources=feature_external_resources,
+        )
+        send_post_request(data)
+        return
 
     if (
         github_event_data.type
@@ -76,14 +108,9 @@ def call_github_app_webhook_for_feature_state(event_data: dict[str, Any]) -> Non
         return
 
     feature = Feature.objects.get(id=github_event_data.feature_id)
-    feature_external_resources = feature.external_resources.all()
-    feature_external_resources = [
-        {
-            "type": resource.type,
-            "url": resource.url,
-        }
-        for resource in feature_external_resources
-    ]
+    feature_external_resources = generate_feature_external_resources(
+        feature.external_resources.all()
+    )
     data = CallGithubData(
         event_type=github_event_data.type,
         github_data=github_event_data,

--- a/api/tests/unit/features/test_unit_feature_external_resources_views.py
+++ b/api/tests/unit/features/test_unit_feature_external_resources_views.py
@@ -409,20 +409,20 @@ def test_create_github_comment_on_feature_state_updated(  # noqa: C901
             },
             timeout=10,
         )
-        if event_type == "update":
-            mock_generate_data.assert_called_with(
-                github_configuration=github_configuration,
-                feature_id=feature.id,
-                feature_name=feature.name,
-                type=WebhookEventType.FLAG_UPDATED.value,
-                feature_states=[feature_state],
-            )
+    if event_type == "update":
+        mock_generate_data.assert_called_with(
+            github_configuration=github_configuration,
+            feature_id=feature.id,
+            feature_name=feature.name,
+            type=WebhookEventType.FLAG_UPDATED.value,
+            feature_states=[feature_state],
+        )
 
-        elif event_type == "update":
-            mock_generate_data.assert_called_with(
-                github_configuration=github_configuration,
-                feature_id=feature.id,
-                feature_name=feature.name,
-                type=WebhookEventType.FLAG_UPDATED.value,
-                feature_states=[feature_state],
-            )
+    elif event_type == "delete":
+        mock_generate_data.assert_called_with(
+            github_configuration=github_configuration,
+            feature_id=feature.id,
+            feature_name=feature.name,
+            type=WebhookEventType.FLAG_DELETED.value,
+            feature_states=[feature_state],
+        )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Move call to GitHub integration tasks out from trigger_feature_state_change_webhooks_signal for compatibility with versioning v2

## How did you test this code?
- Create a GitHub integration, add any repository, link a feature with a GH issue, and update the feature values, show the comment in your GH issue
