### PR TITLE
feat: Implement GitHub Webhook

### DIFF
--- a/api/api/urls/v1.py
+++ b/api/api/urls/v1.py
@@ -10,6 +10,7 @@ from environments.identities.traits.views import SDKTraits
 from environments.identities.views import SDKIdentities
 from environments.sdk.views import SDKEnvironmentAPIView
 from features.views import SDKFeatureStates
+from integrations.github.views import github_webhook
 from organisations.views import chargebee_webhook
 
 schema_view = get_schema_view(
@@ -44,6 +45,8 @@ urlpatterns = [
     url(r"^metadata/", include("metadata.urls")),
     # Chargebee webhooks
     url(r"cb-webhook/", chargebee_webhook, name="chargebee-webhook"),
+    # GitHub integration webhook
+    url(r"github-webhook/", github_webhook, name="github-webhook"),
     # Client SDK urls
     url(r"^flags/$", SDKFeatureStates.as_view(), name="flags"),
     url(r"^identities/$", SDKIdentities.as_view(), name="sdk-identities"),

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -893,7 +893,7 @@ SLACK_CLIENT_SECRET = env.str("SLACK_CLIENT_SECRET", default="")
 # GitHub integrations
 GITHUB_PEM = env.str("GITHUB_PEM", default="")
 GITHUB_APP_ID: int = env.int("GITHUB_APP_ID", default=0)
-
+GITHUB_WEBHOOK_SECRET = env.str("GITHUB_WEBHOOK_SECRET", default="")
 
 # MailerLite
 MAILERLITE_BASE_URL = env.str(

--- a/api/integrations/github/helpers.py
+++ b/api/integrations/github/helpers.py
@@ -1,0 +1,20 @@
+import hashlib
+import hmac
+
+
+def github_webhook_payload_is_valid(
+    payload_body: bytes, secret_token: str, signature_header: str
+) -> bool:
+    """Verify that the payload was sent from GitHub by validating SHA256.
+    Raise and return 403 if not authorized.
+    """
+    if not signature_header:
+        return False
+    hash_object = hmac.new(
+        secret_token.encode("utf-8"), msg=payload_body, digestmod=hashlib.sha1
+    )
+    expected_signature = "sha1=" + hash_object.hexdigest()
+    if not hmac.compare_digest(expected_signature, signature_header):
+        return False
+
+    return True

--- a/api/integrations/github/views.py
+++ b/api/integrations/github/views.py
@@ -1,5 +1,3 @@
-import hashlib
-import hmac
 import json
 import re
 from functools import wraps
@@ -16,6 +14,7 @@ from rest_framework.response import Response
 from integrations.github.client import generate_token
 from integrations.github.constants import GITHUB_API_URL, GITHUB_API_VERSION
 from integrations.github.exceptions import DuplicateGitHubIntegration
+from integrations.github.helpers import github_webhook_payload_is_valid
 from integrations.github.models import GithubConfiguration, GithubRepository
 from integrations.github.permissions import HasPermissionToGithubConfiguration
 from integrations.github.serializers import (
@@ -25,24 +24,6 @@ from integrations.github.serializers import (
 )
 from organisations.models import Organisation
 from organisations.permissions.permissions import GithubIsAdminOrganisation
-
-
-def github_webhook_payload_is_valid(
-    payload_body: bytes, secret_token: str, signature_header: str
-) -> bool:
-    """Verify that the payload was sent from GitHub by validating SHA256.
-    Raise and return 403 if not authorized.
-    """
-    if not signature_header:
-        return False
-    hash_object = hmac.new(
-        secret_token.encode("utf-8"), msg=payload_body, digestmod=hashlib.sha1
-    )
-    expected_signature = "sha1=" + hash_object.hexdigest()
-    if not hmac.compare_digest(expected_signature, signature_header):
-        return False
-
-    return True
 
 
 def github_auth_required(func):

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -246,6 +246,10 @@
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:SSE_AUTHENTICATION_TOKEN::"
                 },
                 {
+                    "name": "GITHUB_WEBHOOK_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:GITHUB_WEBHOOK_SECRET::"
+                },
+                {
                     "name": "GITHUB_PEM",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:GITHUB_PEM-E1Ot8p"
                 }

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -242,6 +242,10 @@
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:SSE_AUTHENTICATION_TOKEN::"
                 },
                 {
+                    "name": "GITHUB_WEBHOOK_SECRET",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:ECS-API-heAdoB:GITHUB_WEBHOOK_SECRET::"
+                },
+                {
                     "name": "GITHUB_PEM",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:302456015006:secret:GITHUB_PEM-Bfoaql"
                 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Implement GitHub Webhook to receive events from GitHub App.
Initially we only handle the Integration Delete action. We delete the configuration and any related object in the DB when an installation is removed from GitHub.

Also, the env var `GITHUB_WEBHOOK_SECRET` was added to ECS task definition web secrets. This env var is not used by the tasks executed by the task processor. It is only used by the GitHub webhook.

Once we generate the `GITHUB_WEBHOOK_SECRET` we need to update our GitHub App to use it as shown here
![image](https://github.com/Flagsmith/flagsmith/assets/41410593/9178cf49-5e91-4703-9e4a-1331a30a46d1)

https://github.com/organizations/Flagsmith/settings/apps/flagsmith

## How did you test this code?

Unit tests added.
