### PR TITLE
docs: Fix link to upstream OpenFeature JS provider repository

### DIFF
--- a/docs/docs/clients/openfeature.md
+++ b/docs/docs/clients/openfeature.md
@@ -23,7 +23,7 @@ following languages:
 - [Go](https://github.com/open-feature/go-sdk-contrib/tree/main/providers/flagsmith)
 - [Java](https://github.com/open-feature/java-sdk-contrib/tree/main/providers/flagsmith)
 - [.Net](https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.Flagsmith)
-- [Javascript/Web](https://github.com/Flagsmith/js-sdk-contrib)
+- [JavaScript/Web](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/flagsmith-client)
 
 ### Beta Providers
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Our JS provider for OpenFeature is now merged into the upstream repository, making the existing link obsolete.

Also uses the correct capitalisation for JavaScript.

## How did you test this code?

Clicking on the link.
