### PR TITLE
fix(versioning): handle mapping of environment to engine post v2 versioning migration

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -544,7 +544,10 @@ class FeatureState(
     @property
     def is_live(self) -> bool:
         if self.environment.use_v2_feature_versioning:
-            return self.environment_feature_version.is_live
+            return (
+                self.environment_feature_version is not None
+                and self.environment_feature_version.is_live
+            )
         else:
             return (
                 self.version is not None


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes issue mapping environment to engine environment post v2 versioning merge. 

Note that another option here would be to change the mapping function to use e.g. the `versioning_service.get_environment_feature_states` function, but this would result in database query issues. 

## How did you test this code?

Added a specific unit test to replicate the issue seen in production. 
