### PR TITLE
fix: Disable segment override diffs for non versioned environments

### DIFF
--- a/frontend/web/components/diff/DiffChangeRequest.tsx
+++ b/frontend/web/components/diff/DiffChangeRequest.tsx
@@ -7,11 +7,13 @@ type DiffChangeRequestType = {
   changeRequest: ChangeRequest | null
   feature: number
   projectId: string
+  isVersioned: boolean
 }
 
 const DiffChangeRequest: FC<DiffChangeRequestType> = ({
   changeRequest,
   feature,
+  isVersioned,
   projectId,
 }) => {
   const { data, isLoading } = useGetFeatureStatesQuery(
@@ -36,6 +38,7 @@ const DiffChangeRequest: FC<DiffChangeRequestType> = ({
     <div className='col-md-8'>
       <DiffFeature
         featureId={feature}
+        disableSegments={!isVersioned}
         projectId={projectId}
         newState={changeRequest.feature_states}
         oldState={data?.results || []}

--- a/frontend/web/components/diff/DiffFeature.tsx
+++ b/frontend/web/components/diff/DiffFeature.tsx
@@ -22,9 +22,11 @@ type FeatureDiffType = {
   featureId: number
   projectId: string
   tabTheme?: string
+  disableSegments?: boolean
 }
 
 const DiffFeature: FC<FeatureDiffType> = ({
+  disableSegments,
   featureId,
   newState,
   noChangesMessage,
@@ -47,7 +49,9 @@ const DiffFeature: FC<FeatureDiffType> = ({
     projectId,
   })
 
-  const segmentDiffs = getSegmentDiff(oldState, newState, segments?.results)
+  const segmentDiffs = disableSegments
+    ? { diffs: [], totalChanges: 0 }
+    : getSegmentDiff(oldState, newState, segments?.results)
   const variationDiffs = getVariationDiff(oldEnv, newEnv, feature)
   const totalSegmentChanges = segmentDiffs?.totalChanges
   const totalVariationChanges = variationDiffs?.totalChanges

--- a/frontend/web/components/pages/ChangeRequestPage.js
+++ b/frontend/web/components/pages/ChangeRequestPage.js
@@ -501,6 +501,7 @@ const ChangeRequestsPage = class extends Component {
                         </div>
                       </Panel>
                       <DiffChangeRequest
+                        isVersioned={isVersioned}
                         changeRequest={changeRequest}
                         feature={projectFlag.id}
                         projectId={this.props.match.params.projectId}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Disables segment override comparison in change requests when versioning is disabled.

## How did you test this code?

Viewed existing wrong change request in production demo environment