### PR TITLE
fix: changed the error message from custom_auth serializer

### DIFF
--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -40,7 +40,7 @@ class CustomUserCreateSerializer(UserCreateSerializer):
                     UniqueValidator(
                         queryset=FFAdminUser.objects.all(),
                         lookup="iexact",
-                        message="Invalid email address.",
+                        message="Email already exists. Please log in.",
                     )
                 ]
             }

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
@@ -28,7 +28,7 @@ def test_CustomUserCreateSerializer_does_case_insensitive_lookup_with_email(db):
 
     # When
     assert serializer.is_valid() is False
-    assert serializer.errors["email"][0] == "Invalid email address."
+    assert serializer.errors["email"][0] == "Email already exists. Please log in."
 
 
 def test_CustomUserCreateSerializer_calls_is_authentication_method_valid_correctly_if_auth_controller_is_installed(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Changed the error message of custom_auth serializer from "Invalid Email Address" to "Email already exists. Please log in."

Solves #3886 
_Please describe._

## How did you test this code?
Manually

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
1. Run the api and frontend locally
2. Signup using an email and then logout and try to signup again.
3. The error message shows "Invalid email address" which is confusing to the user.