### PR TITLE
fix: Organisation id not numeric in organisation settings

### DIFF
--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -302,11 +302,13 @@ const controller = {
       store.model = user
       if (user && user.organisations) {
         store.organisation = user.organisations[0]
-        const cookiedID = API.getCookie('organisation')
-        const pathID = matchPath(document.location.pathname, {
-          path: '/organisation/:organisationId',
-          strict: false,
-        })?.params?.organisationId
+        const cookiedID = parseInt(API.getCookie('organisation'))
+        const pathID = parseInt(
+          matchPath(document.location.pathname, {
+            path: '/organisation/:organisationId',
+            strict: false,
+          })?.params?.organisationId,
+        )
         const orgId = pathID || cookiedID
         if (orgId) {
           const foundOrganisation = user.organisations.find(

--- a/frontend/web/components/ProjectsPage.tsx
+++ b/frontend/web/components/ProjectsPage.tsx
@@ -16,7 +16,9 @@ const ProjectsPage: FC<ProjectsPageType> = ({ match }) => {
       {() => {
         return (
           <div className='app-container container'>
-            <ProjectManageWidget organisationId={match.params.organisationId} />
+            <ProjectManageWidget
+              organisationId={parseInt(match.params.organisationId)}
+            />
           </div>
         )
       }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Number of seats displayed in the Organisation Settings page is wrong because we are not calling the right endpoint. This is because we are receiving a string as parameter in the URL when we expect an integer.

## How did you test this code?

Tested locally and manually by navigating to the organisation settings page and veifying the seats data displayed and that the calls to the API are correct.