### PR TITLE
fix: Create GitHub comment as table

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -553,6 +553,29 @@ def segment_featurestate(feature_segment, feature, environment):
 
 
 @pytest.fixture()
+def feature_with_value_segment(
+    feature_with_value: Feature, segment: Segment, environment: Environment
+) -> FeatureSegment:
+    return FeatureSegment.objects.create(
+        feature=feature_with_value, segment=segment, environment=environment
+    )
+
+
+@pytest.fixture()
+def segment_featurestate_and_feature_with_value(
+    feature_with_value_segment: FeatureSegment,
+    feature_with_value: Feature,
+    environment: Environment,
+) -> FeatureState:
+    return FeatureState.objects.create(
+        feature_segment=feature_with_value_segment,
+        feature=feature_with_value,
+        environment=environment,
+        updated_at="2024-01-01 00:00:00",
+    )
+
+
+@pytest.fixture()
 def environment_api_key(environment):
     return EnvironmentAPIKey.objects.create(
         environment=environment, name="Test API Key"

--- a/api/features/feature_external_resources/models.py
+++ b/api/features/feature_external_resources/models.py
@@ -61,11 +61,12 @@ class FeatureExternalResource(LifecycleModelMixin, models.Model):
                 feature_id=self.feature_id, identity_id__isnull=True
             )
             feature_data: GithubData = generate_data(
-                github_configuration,
-                self.feature_id,
-                self.feature.name,
-                WebhookEventType.FEATURE_EXTERNAL_RESOURCE_ADDED.value,
-                feature_states,
+                github_configuration=github_configuration,
+                feature_id=self.feature_id,
+                feature_name=self.feature.name,
+                type=WebhookEventType.FEATURE_EXTERNAL_RESOURCE_ADDED.value,
+                feature_states=feature_states,
+                project_id=self.feature.project_id,
             )
 
             call_github_app_webhook_for_feature_state.delay(

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -1005,7 +1005,6 @@ class FeatureState(
 
         if (
             not self.identity_id
-            and not self.feature_segment
             and self.feature.external_resources.exists()
             and self.environment.project.github_project.exists()
             and self.environment.project.organisation.github_config.exists()
@@ -1023,6 +1022,7 @@ class FeatureState(
                     feature_name=self.feature.name,
                     type=WebhookEventType.FLAG_UPDATED.value,
                     feature_states=feature_states,
+                    project_id=self.environment.project_id,
                 )
 
             if self.deleted_at is not None:

--- a/api/integrations/github/constants.py
+++ b/api/integrations/github/constants.py
@@ -3,12 +3,11 @@ GITHUB_API_VERSION = "2022-11-28"
 
 LINK_FEATURE_TITLE = """**Flagsmith feature linked:** `%s`
 Default Values:\n"""
-FEATURE_TABLE_HEADER = """| Environment | Enabled | Value | Type | Updated (UTC) |
-| :--- | :----- | :------ | :------- | :------ |\n"""
-FEATURE_TABLE_ROW = "| [%s](%s) | %s | `%s` | %s | %s |\n"
+FEATURE_TABLE_HEADER = """| Environment | Enabled | Value | Last Updated (UTC) |
+| :--- | :----- | :------ | :------ |\n"""
+FEATURE_TABLE_ROW = "| [%s](%s) | %s | %s | %s |\n"
 LINK_SEGMENT_TITLE = "Segment `%s` values:\n"
 UNLINKED_FEATURE_TEXT = "### The feature flag `%s` was unlinked from the issue/PR"
 UPDATED_FEATURE_TEXT = "Flagsmith Feature `%s` has been updated:\n"
-LAST_UPDATED_FEATURE_TEXT = "Last Updated %s"
 DELETED_FEATURE_TEXT = "### The Feature Flag `%s` was deleted"
 FEATURE_ENVIRONMENT_URL = "%s/project/%s/environment/%s/features?feature=%s&tab=%s"

--- a/api/integrations/github/constants.py
+++ b/api/integrations/github/constants.py
@@ -1,8 +1,18 @@
+from core.helpers import get_current_site_url
+
 GITHUB_API_URL = "https://api.github.com/"
 GITHUB_API_VERSION = "2022-11-28"
 
-LINK_FEATURE_TEXT = "### This pull request is linked to a Flagsmith Feature (`%s`):\n"
+LINK_FEATURE_TITLE = """**Flagsmith feature linked:** `%s`
+Default Values:\n"""
+FEATURE_TABLE_HEADER = """| Environment | Enabled | Value | Type | Updated (UTC) |
+| :--- | :----- | :------ | :------- | :------ |\n"""
+FEATURE_TABLE_ROW = "| [%s](%s) | %s | `%s` | %s | %s |\n"
+LINK_SEGMENT_TITLE = "Segment `%s` values:\n"
 UNLINKED_FEATURE_TEXT = "### The feature flag `%s` was unlinked from the issue/PR"
-UPDATED_FEATURE_TEXT = "### The Flagsmith Feature `%s` was updated in the environment "
+UPDATED_FEATURE_TEXT = "Flagsmith Feature `%s` has been updated:\n"
 LAST_UPDATED_FEATURE_TEXT = "Last Updated %s"
 DELETED_FEATURE_TEXT = "### The Feature Flag `%s` was deleted"
+FEATURE_ENVIRONMENT_URL = (
+    get_current_site_url() + "/project/%s/environment/%s/features?feature=%s&tab=%s"
+)

--- a/api/integrations/github/constants.py
+++ b/api/integrations/github/constants.py
@@ -1,5 +1,3 @@
-from core.helpers import get_current_site_url
-
 GITHUB_API_URL = "https://api.github.com/"
 GITHUB_API_VERSION = "2022-11-28"
 
@@ -13,6 +11,4 @@ UNLINKED_FEATURE_TEXT = "### The feature flag `%s` was unlinked from the issue/P
 UPDATED_FEATURE_TEXT = "Flagsmith Feature `%s` has been updated:\n"
 LAST_UPDATED_FEATURE_TEXT = "Last Updated %s"
 DELETED_FEATURE_TEXT = "### The Feature Flag `%s` was deleted"
-FEATURE_ENVIRONMENT_URL = (
-    get_current_site_url() + "/project/%s/environment/%s/features?feature=%s&tab=%s"
-)
+FEATURE_ENVIRONMENT_URL = "%s/project/%s/environment/%s/features?feature=%s&tab=%s"

--- a/api/integrations/github/github.py
+++ b/api/integrations/github/github.py
@@ -10,9 +10,13 @@ from features.models import FeatureState, FeatureStateValue
 from integrations.github.client import generate_token
 from integrations.github.constants import (
     DELETED_FEATURE_TEXT,
+    FEATURE_ENVIRONMENT_URL,
+    FEATURE_TABLE_HEADER,
+    FEATURE_TABLE_ROW,
     GITHUB_API_URL,
     LAST_UPDATED_FEATURE_TEXT,
-    LINK_FEATURE_TEXT,
+    LINK_FEATURE_TITLE,
+    LINK_SEGMENT_TITLE,
     UNLINKED_FEATURE_TEXT,
     UPDATED_FEATURE_TEXT,
 )
@@ -28,8 +32,9 @@ class GithubData:
     feature_id: int
     feature_name: str
     type: str
-    feature_states: typing.List[dict[str, typing.Any]] = None
-    url: str = None
+    feature_states: typing.List[dict[str, typing.Any]] | None = None
+    url: str | None = None
+    project_id: int | None = None
 
     @classmethod
     def from_dict(cls, data_dict: dict) -> "GithubData":
@@ -65,6 +70,8 @@ def post_comment_to_github(
 def generate_body_comment(
     name: str,
     event_type: str,
+    project_id: int,
+    feature_id: int,
     feature_states: typing.List[typing.Dict[str, typing.Any]],
 ) -> str:
 
@@ -81,22 +88,36 @@ def generate_body_comment(
     last_updated_string = LAST_UPDATED_FEATURE_TEXT % (
         datetime.datetime.now().strftime("%dth %b %Y %I:%M%p")
     )
-    updated_text = UPDATED_FEATURE_TEXT % (name)
 
-    result = updated_text if is_update else LINK_FEATURE_TEXT % (name)
+    result = UPDATED_FEATURE_TEXT % (name) if is_update else LINK_FEATURE_TITLE % (name)
+    last_segment_name = ""
+    if len(feature_states) > 0 and not feature_states[0].get("segment_name"):
+        result += FEATURE_TABLE_HEADER
 
-    # if feature_states is None:
     for v in feature_states:
         feature_value = v.get("feature_state_value")
         feature_value_type = v.get("feature_state_value_type")
+        tab = "segment-overrides" if v.get("segment_name") is not None else "value"
+        environment_link_url = FEATURE_ENVIRONMENT_URL % (
+            project_id,
+            v.get("environment_api_key"),
+            feature_id,
+            tab,
+        )
+        if v.get("segment_name") is not None and v["segment_name"] != last_segment_name:
+            result += "\n" + LINK_SEGMENT_TITLE % (v["segment_name"])
+            last_segment_name = v["segment_name"]
+            result += FEATURE_TABLE_HEADER
+        table_row = FEATURE_TABLE_ROW % (
+            v["environment_name"],
+            environment_link_url,
+            "✅ Enabled" if v["feature_value"] else "❌ Disabled",
+            feature_value if feature_value else "",
+            feature_value_type,
+            last_updated_string,
+        )
+        result += table_row
 
-        feature_value_string = f"\n{feature_value_type}\n```{feature_value if feature_value else 'No value.'}```\n\n"
-
-        result += f"**{v['environment_name']}{' - ' + v['segment_name'] if v.get('segment_name') else ''}**\n"
-        result += f"- [{'x' if v['feature_value'] else ' '}] {'Enabled' if v['feature_value'] else 'Disabled'}"
-        result += feature_value_string
-
-    result += last_updated_string
     return result
 
 
@@ -109,8 +130,11 @@ def generate_data(
     feature_id: int,
     feature_name: str,
     type: str,
-    feature_states: typing.Union[list[FeatureState], list[FeatureStateValue]] = None,
-    url: str = None,
+    feature_states: (
+        typing.Union[list[FeatureState], list[FeatureStateValue]] | None
+    ) = None,
+    url: str | None = None,
+    project_id: int | None = None,
 ) -> GithubData:
 
     if feature_states:
@@ -127,6 +151,9 @@ def generate_data(
             if type is not WebhookEventType.FEATURE_EXTERNAL_RESOURCE_REMOVED.value:
                 feature_env_data["environment_name"] = feature_state.environment.name
                 feature_env_data["feature_value"] = feature_state.enabled
+                feature_env_data["environment_api_key"] = (
+                    feature_state.environment.api_key
+                )
             if (
                 hasattr(feature_state, "feature_segment")
                 and feature_state.feature_segment is not None
@@ -147,4 +174,5 @@ def generate_data(
             else None
         ),
         feature_states=feature_states_list if feature_states else None,
+        project_id=project_id,
     )

--- a/api/integrations/github/github.py
+++ b/api/integrations/github/github.py
@@ -4,6 +4,7 @@ import typing
 from dataclasses import dataclass
 
 import requests
+from core.helpers import get_current_site_url
 from django.conf import settings
 
 from features.models import FeatureState, FeatureStateValue
@@ -99,6 +100,7 @@ def generate_body_comment(
         feature_value_type = v.get("feature_state_value_type")
         tab = "segment-overrides" if v.get("segment_name") is not None else "value"
         environment_link_url = FEATURE_ENVIRONMENT_URL % (
+            get_current_site_url(),
             project_id,
             v.get("environment_api_key"),
             feature_id,

--- a/api/integrations/github/github.py
+++ b/api/integrations/github/github.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import typing
 from dataclasses import dataclass
@@ -6,7 +5,6 @@ from dataclasses import dataclass
 import requests
 from core.helpers import get_current_site_url
 from django.conf import settings
-from django.utils.formats import get_format
 
 from features.models import FeatureState, FeatureStateValue
 from integrations.github.client import generate_token
@@ -86,10 +84,6 @@ def generate_body_comment(
     if is_removed:
         return delete_text
 
-    last_updated_string = datetime.datetime.now().strftime(
-        get_format("DATETIME_INPUT_FORMATS")[0]
-    )
-
     result = UPDATED_FEATURE_TEXT % (name) if is_update else LINK_FEATURE_TITLE % (name)
     last_segment_name = ""
     if len(feature_states) > 0 and not feature_states[0].get("segment_name"):
@@ -114,7 +108,7 @@ def generate_body_comment(
             environment_link_url,
             "✅ Enabled" if v["enabled"] else "❌ Disabled",
             f"`{feature_value}`" if feature_value else "",
-            last_updated_string,
+            v["last_updated"],
         )
         result += table_row
 
@@ -151,6 +145,7 @@ def generate_data(
             if type is not WebhookEventType.FEATURE_EXTERNAL_RESOURCE_REMOVED.value:
                 feature_env_data["environment_name"] = feature_state.environment.name
                 feature_env_data["enabled"] = feature_state.enabled
+                feature_env_data["last_updated"] = feature_state.updated_at
                 feature_env_data["environment_api_key"] = (
                     feature_state.environment.api_key
                 )

--- a/api/integrations/github/tasks.py
+++ b/api/integrations/github/tasks.py
@@ -24,12 +24,16 @@ class CallGithubData:
 
 def send_post_request(data: CallGithubData) -> None:
     feature_name = data.github_data.feature_name
+    feature_id = data.github_data.feature_id
+    project_id = data.github_data.project_id
     event_type = data.event_type
     feature_states = feature_states = (
         data.github_data.feature_states if data.github_data.feature_states else None
     )
     installation_id = data.github_data.installation_id
-    body = generate_body_comment(feature_name, event_type, feature_states)
+    body = generate_body_comment(
+        feature_name, event_type, project_id, feature_id, feature_states
+    )
 
     if (
         event_type == WebhookEventType.FLAG_UPDATED.value

--- a/api/tests/unit/features/test_unit_feature_external_resources_views.py
+++ b/api/tests/unit/features/test_unit_feature_external_resources_views.py
@@ -59,11 +59,11 @@ def test_create_feature_external_resource(
     expected_comment_body = (
         "**Flagsmith feature linked:** `feature_with_value`\n"
         + "Default Values:\n"
-        + "| Environment | Enabled | Value | Type | Updated (UTC) |\n"
-        + "| :--- | :----- | :------ | :------- | :------ |\n"
+        + "| Environment | Enabled | Value | Last Updated (UTC) |\n"
+        + "| :--- | :----- | :------ | :------ |\n"
         + f"| [Test Environment](https://example.com/project/{project.id}/"
         + f"environment/{environment.api_key}/features?feature={feature_with_value.id}&tab=value) "
-        + "| ❌ Disabled | `value` | unicode | Last Updated 01th Jan 2024 12:00AM |\n"
+        + "| ❌ Disabled | `value` | 2024-01-01 00:00:00 |\n"
     )
 
     feature_external_resource_data = {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Improve GitHub comment to look like a table

![image](https://github.com/Flagsmith/flagsmith/assets/41410593/31d29c42-0371-4785-ae82-0bf02ecbd31d)


## How did you test this code?

- Some unit tests updated.
- Link an external resource manually.
