### PR TITLE
fix: Organisation ID is an object calling useHasPermission at organisation level

### DIFF
--- a/frontend/web/components/BreadcrumbSeparator.tsx
+++ b/frontend/web/components/BreadcrumbSeparator.tsx
@@ -255,7 +255,7 @@ const BreadcrumbSeparator: FC<BreadcrumbSeparatorType> = ({
   }
   const [hoveredSection, setHoveredSection] = useState(focus)
   const { permission: canCreateProject } = useHasPermission({
-    id: hoveredOrganisation,
+    id: hoveredOrganisation?.id,
     level: 'organisation',
     permission: Utils.getCreateProjectPermission(hoveredOrganisation),
   })


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Send organisation ID instead of organisation object to `useHasPermission` in BreadcrumbSeparator.

## How did you test this code?

Manually tested by runing the APP and navigating to the home page and feature page and observing that requests to the my-permissions endpoint are OK at organisation level.