### PR TITLE
fix(versioning): webhooks not triggered when new version published

### DIFF
--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -104,7 +104,7 @@ def trigger_update_version_webhooks(environment_feature_version_uuid: str) -> No
 
     data = environment_feature_version_webhook_schema.dump(environment_feature_version)
     call_environment_webhooks(
-        environment=environment_feature_version.environment,
+        environment=environment_feature_version.environment_id,
         data=data,
         event_type=WebhookEventType.NEW_VERSION_PUBLISHED,
     )

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -133,7 +133,7 @@ def test_trigger_update_version_webhooks(
 
     # Then
     mock_call_environment_webhooks.assert_called_once_with(
-        environment=environment_v2_versioning,
+        environment=environment_v2_versioning.id,
         data={
             "uuid": str(version.uuid),
             "feature": {"id": feature.id, "name": feature.name},


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes an issue calling the call_environment_webhooks function with the environment object instead of its `id` attribute. 

## How did you test this code?

Update existing unit test. 
