### PR TITLE
fix: organisation id parsing

### DIFF
--- a/frontend/common/stores/account-store.js
+++ b/frontend/common/stores/account-store.js
@@ -310,7 +310,7 @@ const controller = {
         const orgId = parseInt(pathID || cookiedID) || undefined
         if (orgId) {
           const foundOrganisation = user.organisations.find(
-            (v) => `${v.id}` === orgId,
+            (v) => v.id === orgId,
           )
           if (foundOrganisation) {
             store.organisation = foundOrganisation


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes a regression whereby it's not selecting the right organisation id from the url.

## How did you test this code?

Refresh on an organisation settings page