### PR TITLE
fix(versioning): prevent task from deleting all unrelated feature states / feature segments

### DIFF
--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -47,10 +47,10 @@ def disable_v2_versioning(environment_id: int) -> None:
     latest_feature_state_ids = [fs.id for fs in latest_feature_states]
 
     # delete any feature states and feature segments associated with older versions
-    FeatureState.objects.filter(identity_id__isnull=True).exclude(
-        id__in=latest_feature_state_ids
-    ).delete()
-    FeatureSegment.objects.exclude(
+    FeatureState.objects.filter(
+        identity_id__isnull=True, environment=environment
+    ).exclude(id__in=latest_feature_state_ids).delete()
+    FeatureSegment.objects.filter(environment=environment).exclude(
         feature_states__id__in=latest_feature_state_ids
     ).delete()
 
@@ -60,7 +60,7 @@ def disable_v2_versioning(environment_id: int) -> None:
         version=1, live_from=timezone.now(), environment_feature_version=None
     )
     FeatureSegment.objects.filter(
-        feature_states__id__in=latest_feature_state_ids
+        environment=environment, feature_states__id__in=latest_feature_state_ids
     ).update(environment_feature_version=None)
 
     EnvironmentFeatureVersion.objects.filter(environment=environment).delete()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Previously the endpoint to revert feature versioning attempted to delete all feature states in the platform. This PR resolves that by ensuring that we filter everything on the environment. 

## How did you test this code?

Updated the unit test after first confirming that it failed with the current code. 
