### PR TITLE
fix(versioning): ensure that future scheduled changes are migrated to versioning v2

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -596,7 +596,9 @@ class FeatureState(
             )
 
         clone.environment = env
-        clone.version = None if as_draft else version or self.version
+        clone.version = (
+            None if as_draft or environment_feature_version else version or self.version
+        )
         clone.live_from = live_from
         clone.environment_feature_version = environment_feature_version
         clone.save()
@@ -703,6 +705,7 @@ class FeatureState(
     def check_for_duplicate_feature_state(self):
         if self.version is None:
             return
+
         filter_ = Q(
             environment=self.environment,
             feature=self.feature,

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -1,3 +1,7 @@
+from datetime import timedelta
+
+import freezegun
+from django.utils import timezone
 from pytest_mock import MockerFixture
 
 from environments.identities.models import Identity
@@ -12,6 +16,7 @@ from features.versioning.tasks import (
 from features.versioning.versioning_service import (
     get_environment_flags_queryset,
 )
+from features.workflows.core.models import ChangeRequest
 from projects.models import Project
 from segments.models import Segment
 from users.models import FFAdminUser
@@ -167,3 +172,72 @@ def test_trigger_update_version_webhooks(
         },
         event_type=WebhookEventType.NEW_VERSION_PUBLISHED,
     )
+
+
+def test_enable_v2_versioning_for_scheduled_changes(
+    environment: Environment, staff_user: FFAdminUser, feature: Feature
+) -> None:
+    # Given
+    now = timezone.now()
+    one_from_from_now = now + timedelta(hours=1)
+    two_hours_from_now = now + timedelta(hours=2)
+
+    # The current environment feature state for the provided feature
+    current_environment_feature_state = FeatureState.objects.get(
+        environment=environment, feature=feature
+    )
+
+    # A feature state scheduled to go live in the future that is published
+    scheduled_change_request = ChangeRequest.objects.create(
+        environment=environment, title="Scheduled Change", user=staff_user
+    )
+    scheduled_feature_state = FeatureState.objects.create(
+        feature=feature,
+        enabled=True,
+        environment=environment,
+        live_from=one_from_from_now,
+        change_request=scheduled_change_request,
+        version=None,
+    )
+    scheduled_change_request.commit(staff_user)
+
+    # and a feature state scheduled to go live in the future that is not published (and hence
+    # shouldn't affect anything)
+    unpublished_scheduled_change_request = ChangeRequest.objects.create(
+        environment=environment, title="Unpublished Scheduled Change", user=staff_user
+    )
+    FeatureState.objects.create(
+        feature=feature,
+        enabled=True,
+        environment=environment,
+        live_from=two_hours_from_now,
+        change_request=unpublished_scheduled_change_request,
+        version=None,
+    )
+
+    # When
+    enable_v2_versioning(environment.id)
+
+    # Then
+    environment_flags_queryset_now = get_environment_flags_queryset(environment)
+    assert environment_flags_queryset_now.count() == 1
+    assert environment_flags_queryset_now.first() == current_environment_feature_state
+
+    with freezegun.freeze_time(one_from_from_now):
+        environment_flags_queryset_one_hour_later = get_environment_flags_queryset(
+            environment
+        )
+        assert environment_flags_queryset_one_hour_later.count() == 1
+        assert (
+            environment_flags_queryset_one_hour_later.first() == scheduled_feature_state
+        )
+
+    with freezegun.freeze_time(two_hours_from_now):
+        environment_flags_queryset_two_hours_later = get_environment_flags_queryset(
+            environment
+        )
+        assert environment_flags_queryset_two_hours_later.count() == 1
+        assert (
+            environment_flags_queryset_two_hours_later.first()
+            == scheduled_feature_state
+        )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ensure that future scheduled change requests are correctly migrated to feature versioning v2. 

## How did you test this code?

Added comprehensive unit test. 
