### PR TITLE
fix(versioning): handle Master API Keys when publishing a version

### DIFF
--- a/api/features/versioning/models.py
+++ b/api/features/versioning/models.py
@@ -116,8 +116,8 @@ class EnvironmentFeatureVersion(
 
     def publish(
         self,
-        published_by: "FFAdminUser",
-        live_from: datetime.datetime = None,
+        published_by: typing.Union["FFAdminUser", None] = None,
+        live_from: datetime.datetime | None = None,
         persist: bool = True,
     ) -> None:
         now = timezone.now()

--- a/api/features/versioning/serializers.py
+++ b/api/features/versioning/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from features.serializers import CreateSegmentOverrideFeatureStateSerializer
 from features.versioning.models import EnvironmentFeatureVersion
+from users.models import FFAdminUser
 
 
 class EnvironmentFeatureVersionFeatureStateSerializer(
@@ -44,9 +45,11 @@ class EnvironmentFeatureVersionPublishSerializer(serializers.Serializer):
 
     def save(self, **kwargs):
         live_from = self.validated_data.get("live_from")
-        self.instance.publish(
-            live_from=live_from, published_by=self.context["request"].user
-        )
+
+        request = self.context["request"]
+        published_by = request.user if isinstance(request.user, FFAdminUser) else None
+
+        self.instance.publish(live_from=live_from, published_by=published_by)
         return self.instance
 
 

--- a/api/tests/unit/features/versioning/test_unit_versioning_views.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_views.py
@@ -26,10 +26,10 @@ tomorrow = now + timedelta(days=1)
 
 
 def test_get_versions_for_a_feature_and_environment(
-    admin_client: "APIClient",
-    admin_user: "FFAdminUser",
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     url = reverse(
@@ -70,10 +70,10 @@ def test_get_versions_for_a_feature_and_environment(
 
 
 def test_create_new_feature_version(
-    admin_user: "FFAdminUser",
-    admin_client: "APIClient",
+    admin_user: FFAdminUser,
+    admin_client: APIClient,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     url = reverse(
@@ -93,9 +93,9 @@ def test_create_new_feature_version(
 
 
 def test_delete_feature_version(
-    admin_client: "APIClient",
+    admin_client: APIClient,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     # an unpublished version
@@ -123,9 +123,9 @@ def test_delete_feature_version(
 
 
 def test_cannot_delete_live_feature_version(
-    admin_client: "APIClient",
+    admin_client: APIClient,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     # the initial published version
@@ -153,10 +153,10 @@ def test_cannot_delete_live_feature_version(
 
 @pytest.mark.parametrize("live_from", (None, tomorrow))
 def test_publish_feature_version(
-    admin_client: "APIClient",
-    admin_user: "FFAdminUser",
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
     live_from: typing.Optional[datetime],
 ) -> None:
     # Given
@@ -229,9 +229,9 @@ def test_publish_feature_version_using_master_api_key(
 
 
 def test_list_environment_feature_version_feature_states(
-    admin_client: "APIClient",
+    admin_client: APIClient,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     environment_feature_version = EnvironmentFeatureVersion.objects.get(
@@ -258,10 +258,10 @@ def test_list_environment_feature_version_feature_states(
 
 
 def test_add_environment_feature_version_feature_state(
-    admin_client: "APIClient",
+    admin_client: APIClient,
     environment_v2_versioning: Environment,
-    segment: "Segment",
-    feature: "Feature",
+    segment: Segment,
+    feature: Feature,
 ) -> None:
     # Given
     # an unpublished environment feature version
@@ -299,10 +299,10 @@ def test_add_environment_feature_version_feature_state(
 
 
 def test_cannot_add_feature_state_to_published_environment_feature_version(
-    admin_client: "APIClient",
+    admin_client: APIClient,
     environment_v2_versioning: Environment,
-    segment: "Segment",
-    feature: "Feature",
+    segment: Segment,
+    feature: Feature,
 ) -> None:
     # Given
     # the initial (published) environment feature version
@@ -340,9 +340,9 @@ def test_cannot_add_feature_state_to_published_environment_feature_version(
 
 
 def test_update_environment_feature_version_feature_state(
-    admin_client: "APIClient",
+    admin_client: APIClient,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     # an unpublished environment feature version
@@ -382,10 +382,10 @@ def test_update_environment_feature_version_feature_state(
 
 
 def test_cannot_update_feature_state_in_published_environment_feature_version(
-    admin_client: "APIClient",
-    admin_user: "FFAdminUser",
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     # the initial (published) environment feature version
@@ -427,11 +427,11 @@ def test_cannot_update_feature_state_in_published_environment_feature_version(
 
 
 def test_delete_environment_feature_version_feature_state(
-    admin_client: "APIClient",
-    admin_user: "FFAdminUser",
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
-    segment: "Segment",
-    feature: "Feature",
+    segment: Segment,
+    feature: Feature,
 ) -> None:
     # Given
     # an unpublished environment feature version
@@ -470,11 +470,11 @@ def test_delete_environment_feature_version_feature_state(
 
 
 def test_cannot_delete_feature_state_in_published_environment_feature_version(
-    admin_client: "APIClient",
-    admin_user: "FFAdminUser",
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
-    segment: "Segment",
-    feature: "Feature",
+    segment: Segment,
+    feature: Feature,
 ) -> None:
     # Given
     # an unpublished environment feature version
@@ -518,10 +518,10 @@ def test_cannot_delete_feature_state_in_published_environment_feature_version(
 
 
 def test_cannot_delete_environment_default_feature_state_for_unpublished_environment_feature_version(
-    admin_client: "APIClient",
-    admin_user: "FFAdminUser",
+    admin_client: APIClient,
+    admin_user: FFAdminUser,
     environment_v2_versioning: Environment,
-    feature: "Feature",
+    feature: Feature,
 ) -> None:
     # Given
     # an unpublished environment feature version
@@ -564,9 +564,9 @@ def test_cannot_delete_environment_default_feature_state_for_unpublished_environ
 
 def test_filter_versions_by_is_live(
     environment_v2_versioning: Environment,
-    feature: "Feature",
-    staff_user: "FFAdminUser",
-    staff_client: "APIClient",
+    feature: Feature,
+    staff_user: FFAdminUser,
+    staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
     with_project_permissions: WithProjectPermissionsCallable,
 ) -> None:
@@ -620,7 +620,7 @@ def test_filter_versions_by_is_live(
 
 def test_disable_v2_versioning_returns_bad_request_if_not_using_v2_versioning(
     environment: Environment,
-    staff_client: "APIClient",
+    staff_client: APIClient,
     with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given

--- a/api/tests/unit/features/versioning/test_unit_versioning_views.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_views.py
@@ -7,23 +7,19 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from environments.models import Environment
 from environments.permissions.constants import VIEW_ENVIRONMENT
-from features.models import FeatureSegment, FeatureState
+from features.models import Feature, FeatureSegment, FeatureState
 from features.versioning.models import EnvironmentFeatureVersion
 from projects.permissions import VIEW_PROJECT
+from segments.models import Segment
 from tests.types import (
     WithEnvironmentPermissionsCallable,
     WithProjectPermissionsCallable,
 )
-
-if typing.TYPE_CHECKING:
-    from rest_framework.test import APIClient
-
-    from features.models import Feature
-    from segments.models import Segment
-    from users.models import FFAdminUser
+from users.models import FFAdminUser
 
 now = timezone.now()
 tomorrow = now + timedelta(days=1)
@@ -196,10 +192,10 @@ def test_publish_feature_version(
 
 @pytest.mark.parametrize("live_from", (None, tomorrow))
 def test_publish_feature_version_using_master_api_key(
-    admin_master_api_key_client: "APIClient",
+    admin_master_api_key_client: APIClient,
     environment_v2_versioning: Environment,
-    feature: "Feature",
-    live_from: typing.Optional[datetime],
+    feature: Feature,
+    live_from: datetime | None,
 ) -> None:
     # Given
     # an unpublished version


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Allow EnvironmentFeatureVersion objects to be published using a MasterAPIKey. 

## How did you test this code?

Added a new unit test. Note that I tried using the new `admin_client_new` fixture, but I decided against it since it would have meant adding some conditional logic to the assert regarding the `published_by` attribute (which is set to `None`, and hence interpreted as 'System' when using a MasterAPIKey). 
