### PR TITLE
chore: add Edge V2 migration read capacity budget to project admin

### DIFF
--- a/api/projects/admin.py
+++ b/api/projects/admin.py
@@ -70,6 +70,7 @@ class ProjectAdmin(admin.ModelAdmin):
         "max_features_allowed",
         "max_segment_overrides_allowed",
         "edge_v2_migration_status",
+        "edge_v2_migration_read_capacity_budget",
     )
 
     @admin.action(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds per-project Edge V2 migration read capacity budget to Django admin so it can be controlled from there.

## How did you test this code?

Checked the Django admin interface locally. 