### PR TITLE
chore: blank project Edge V2 read capacity budget field

### DIFF
--- a/api/projects/migrations/0024_add_project_edge_v2_migration_read_capacity_budget.py
+++ b/api/projects/migrations/0024_add_project_edge_v2_migration_read_capacity_budget.py
@@ -31,6 +31,7 @@ class Migration(migrations.Migration):
                 default=None,
                 help_text="[Edge V2 migration] Read capacity budget override. If project migration was finished with `INCOMPLETE` status, you can set it to a higher value than `EDGE_V2_MIGRATION_READ_CAPACITY_BUDGET` setting before restarting the migration.",
                 null=True,
+                blank=True,
             ),
         ),
         migrations.AlterField(

--- a/api/projects/models.py
+++ b/api/projects/models.py
@@ -94,6 +94,7 @@ class Project(LifecycleModelMixin, SoftDeleteExportableModel):
     )
     edge_v2_migration_read_capacity_budget = models.IntegerField(
         null=True,
+        blank=True,
         default=None,
         help_text=(
             "[Edge V2 migration] Read capacity budget override. If project migration was finished with "


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This allows inputting null as Project.edge_v2_migration_read_capacity_budget value in Django admin.

As the migration change only concerns the Python side of things I'm ok with having the existing migration modified. 

## How did you test this code?

Modified an organisation locally.