### PR TITLE
fix(versioning): multiple versioned segment overrides added to environment document

### DIFF
--- a/api/tests/unit/util/mappers/test_unit_mappers_engine.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_engine.py
@@ -630,6 +630,9 @@ def test_map_environment_to_engine_v2_versioning_segment_overrides(
     v3 = EnvironmentFeatureVersion.objects.create(
         feature=feature, environment=environment_v2_versioning
     )
+    v3_segment_override = FeatureState.objects.get(
+        feature_segment__segment=segment, environment_feature_version=v3
+    )
     v3.publish(staff_user)
 
     # When
@@ -637,3 +640,7 @@ def test_map_environment_to_engine_v2_versioning_segment_overrides(
 
     # Then
     assert len(environment_model.project.segments[0].feature_states) == 1
+    assert (
+        environment_model.project.segments[0].feature_states[0].django_id
+        == v3_segment_override.id
+    )

--- a/api/util/mappers/engine.py
+++ b/api/util/mappers/engine.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from itertools import chain
 from typing import TYPE_CHECKING, Dict, List, Optional
+from uuid import UUID
 
 from flag_engine.environments.integrations.models import IntegrationModel
 from flag_engine.environments.models import (
@@ -430,7 +431,7 @@ def _get_prioritised_feature_states(
 def _get_segment_feature_states(
     segments: Iterable["Segment"],
     environment_id: int,
-    latest_environment_feature_version_uuids: Iterable["EnvironmentFeatureVersion"],
+    latest_environment_feature_version_uuids: Iterable[UUID],
 ) -> Dict[int, List["FeatureState"]]:
     feature_states_by_segment_id = {}
 

--- a/api/util/mappers/engine.py
+++ b/api/util/mappers/engine.py
@@ -423,9 +423,18 @@ def _get_segment_feature_states(
     feature_states_by_segment_id = {}
     for segment in segments:
         segment_feature_states = feature_states_by_segment_id.setdefault(segment.pk, [])
+
+        # TODO: this is the issue - we're iterating over the feature segments
+        #  which we now have one of per environment feature version so we're
+        #  adding all the versions' feature states.
+        #  ---
+        #  some thoughts:
+        #   - each segment might have feature segments for multiple features
+        #   - each of these features might have multiple feature versions
         for feature_segment in segment.feature_segments.all():
             if feature_segment.environment_id != environment_id:
                 continue
+
             segment_feature_states += _get_prioritised_feature_states(
                 feature_segment.feature_states.all()
             )

--- a/api/util/mappers/engine.py
+++ b/api/util/mappers/engine.py
@@ -435,13 +435,6 @@ def _get_segment_feature_states(
     for segment in segments:
         segment_feature_states = feature_states_by_segment_id.setdefault(segment.pk, [])
 
-        # TODO: this is the issue - we're iterating over the feature segments
-        #  which we now have one of per environment feature version so we're
-        #  adding all the versions' feature states.
-        #  ---
-        #  some thoughts:
-        #   - each segment might have feature segments for multiple features
-        #   - each of these features might have multiple feature versions
         for feature_segment in segment.feature_segments.all():
             if feature_segment.environment_id != environment_id:
                 continue
@@ -456,4 +449,5 @@ def _get_segment_feature_states(
             segment_feature_states += _get_prioritised_feature_states(
                 feature_segment.feature_states.all()
             )
+
     return feature_states_by_segment_id


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR fixes an issue found in testing where we were previously adding all versions of a given segment override to the environment document. It achieves this by (unfortunately) adding an extra query to the mapping function to grab the latest versions for an environment and then filtering out any segment overrides that don't have a matching version. 

## How did you test this code?

Added an explicit unit test on the mapper function to test it. 
