### PR TITLE
chore: remove deprecated functions url and ugettext_lazy

### DIFF
--- a/api/api/urls/deprecated.py
+++ b/api/api/urls/deprecated.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from environments.identities.traits.views import SDKTraitsDeprecated
 from environments.identities.views import SDKIdentitiesDeprecated
@@ -7,10 +7,12 @@ from features.views import SDKFeatureStates
 app_name = "deprecated"
 
 urlpatterns = [
-    url(
+    re_path(
         r"^identities/(?P<identifier>[-\w@%.]+)/traits/(?P<trait_key>[-\w.]+)$",
         SDKTraitsDeprecated.as_view(),
     ),
-    url(r"^identities/(?P<identifier>[-\w@%.]+)/", SDKIdentitiesDeprecated.as_view()),
-    url(r"^flags/(?P<identifier>[-\w@%.]+)$", SDKFeatureStates.as_view()),
+    re_path(
+        r"^identities/(?P<identifier>[-\w@%.]+)/", SDKIdentitiesDeprecated.as_view()
+    ),
+    re_path(r"^flags/(?P<identifier>[-\w@%.]+)$", SDKFeatureStates.as_view()),
 ]

--- a/api/api/urls/v1.py
+++ b/api/api/urls/v1.py
@@ -1,7 +1,6 @@
 from app_analytics.views import SDKAnalyticsFlags, SelfHostedTelemetryAPIView
 from django.conf import settings
-from django.conf.urls import url
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import authentication, permissions, routers
@@ -32,44 +31,43 @@ traits_router.register(r"", SDKTraits, basename="sdk-traits")
 app_name = "v1"
 
 urlpatterns = [
-    url(r"^organisations/", include("organisations.urls"), name="organisations"),
-    url(r"^projects/", include("projects.urls"), name="projects"),
-    url(r"^environments/", include("environments.urls"), name="environments"),
-    url(r"^features/", include("features.urls"), name="features"),
-    url(r"^multivariate/", include("features.multivariate.urls"), name="multivariate"),
-    url(r"^segments/", include("segments.urls"), name="segments"),
-    url(r"^users/", include("users.urls")),
-    url(r"^e2etests/", include("e2etests.urls")),
-    url(r"^audit/", include("audit.urls")),
-    url(r"^auth/", include("custom_auth.urls")),
-    url(r"^metadata/", include("metadata.urls")),
-    # Chargebee webhooks
-    url(r"cb-webhook/", chargebee_webhook, name="chargebee-webhook"),
-    # GitHub integration webhook
-    url(r"github-webhook/", github_webhook, name="github-webhook"),
-    # Client SDK urls
-    url(r"^flags/$", SDKFeatureStates.as_view(), name="flags"),
-    url(r"^identities/$", SDKIdentities.as_view(), name="sdk-identities"),
-    url(r"^traits/", include(traits_router.urls), name="traits"),
-    url(r"^analytics/flags/$", SDKAnalyticsFlags.as_view(), name="analytics-flags"),
-    url(
-        r"^analytics/telemetry/$",
-        SelfHostedTelemetryAPIView.as_view(),
-        name="analytics-telemetry",
+    re_path(r"^organisations/", include("organisations.urls"), name="organisations"),
+    re_path(r"^projects/", include("projects.urls"), name="projects"),
+    re_path(r"^environments/", include("environments.urls"), name="environments"),
+    re_path(r"^features/", include("features.urls"), name="features"),
+    re_path(
+        r"^multivariate/", include("features.multivariate.urls"), name="multivariate"
     ),
-    url(
+    re_path(r"^segments/", include("segments.urls"), name="segments"),
+    re_path(r"^users/", include("users.urls")),
+    re_path(r"^e2etests/", include("e2etests.urls")),
+    re_path(r"^audit/", include("audit.urls")),
+    re_path(r"^auth/", include("custom_auth.urls")),
+    re_path(r"^metadata/", include("metadata.urls")),
+    # Chargebee webhooks
+    re_path(r"cb-webhook/", chargebee_webhook, name="chargebee-webhook"),
+    # GitHub integration webhook
+    re_path(r"github-webhook/", github_webhook, name="github-webhook"),
+    re_path(r"cb-webhook/", chargebee_webhook, name="chargebee-webhook"),
+    # Client SDK urls
+    re_path(r"^flags/$", SDKFeatureStates.as_view(), name="flags"),
+    re_path(r"^identities/$", SDKIdentities.as_view(), name="sdk-identities"),
+    re_path(r"^traits/", include(traits_router.urls), name="traits"),
+    re_path(r"^analytics/flags/$", SDKAnalyticsFlags.as_view(), name="analytics-flags"),
+    re_path(r"^analytics/telemetry/$", SelfHostedTelemetryAPIView.as_view()),
+    re_path(
         r"^environment-document/$",
         SDKEnvironmentAPIView.as_view(),
         name="environment-document",
     ),
-    url("", include("features.versioning.urls", namespace="versioning")),
+    re_path("", include("features.versioning.urls", namespace="versioning")),
     # API documentation
-    url(
+    re_path(
         r"^swagger(?P<format>\.json|\.yaml)$",
         schema_view.without_ui(cache_timeout=0),
         name="schema-json",
     ),
-    url(
+    re_path(
         r"^docs/$",
         schema_view.with_ui("swagger", cache_timeout=0),
         name="schema-swagger-ui",
@@ -87,10 +85,10 @@ if settings.SPLIT_TESTING_INSTALLED:
     split_testing_router.register(r"", SplitTestViewSet, basename="split-tests")
 
     urlpatterns += [
-        url(
+        re_path(
             r"^split-testing/", include(split_testing_router.urls), name="split-testing"
         ),
-        url(
+        re_path(
             r"^split-testing/conversion-events/",
             CreateConversionEventView.as_view(),
             name="conversion-events",

--- a/api/api/urls/v2.py
+++ b/api/api/urls/v2.py
@@ -1,8 +1,10 @@
 from app_analytics.views import SDKAnalyticsFlagsV2
-from django.conf.urls import url
+from django.urls import re_path
 
 app_name = "v2"
 
 urlpatterns = [
-    url(r"^analytics/flags/$", SDKAnalyticsFlagsV2.as_view(), name="analytics-flags")
+    re_path(
+        r"^analytics/flags/$", SDKAnalyticsFlagsV2.as_view(), name="analytics-flags"
+    )
 ]

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -1,9 +1,8 @@
 import importlib
 
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path, re_path
 from django.views.generic.base import TemplateView
 
 from users.views import password_reset_redirect
@@ -11,24 +10,24 @@ from users.views import password_reset_redirect
 from . import views
 
 urlpatterns = [
-    url(r"^api/v1/", include("api.urls.deprecated", namespace="api-deprecated")),
-    url(r"^api/v1/", include("api.urls.v1", namespace="api-v1")),
-    url(r"^api/v2/", include("api.urls.v2", namespace="api-v2")),
-    url(r"^admin/", admin.site.urls),
-    url(r"^health", include("health_check.urls", namespace="health")),
-    url(r"^version", views.version_info, name="version-info"),
-    url(
+    re_path(r"^api/v1/", include("api.urls.deprecated", namespace="api-deprecated")),
+    re_path(r"^api/v1/", include("api.urls.v1", namespace="api-v1")),
+    re_path(r"^api/v2/", include("api.urls.v2", namespace="api-v2")),
+    re_path(r"^admin/", admin.site.urls),
+    re_path(r"^health", include("health_check.urls", namespace="health")),
+    re_path(r"^version", views.version_info, name="version-info"),
+    re_path(
         r"^sales-dashboard/",
         include("sales_dashboard.urls", namespace="sales_dashboard"),
     ),
     # this url is used to generate email content for the password reset workflow
-    url(
+    re_path(
         r"^password-reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,"
         r"13}-[0-9A-Za-z]{1,20})/$",
         password_reset_redirect,
         name="password_reset_confirm",
     ),
-    url(
+    re_path(
         r"^config/project-overrides",
         views.project_overrides,
         name="project_overrides",
@@ -44,7 +43,7 @@ if settings.DEBUG:
     import debug_toolbar
 
     urlpatterns = [
-        url(r"^__debug__/", include(debug_toolbar.urls)),
+        re_path(r"^__debug__/", include(debug_toolbar.urls)),
     ] + urlpatterns
 
 if settings.SAML_INSTALLED:
@@ -70,4 +69,4 @@ if settings.WORKFLOWS_LOGIC_INSTALLED:
 
 if settings.SERVE_FE_ASSETS:
     # add route to serve FE assets for any unrecognised paths
-    urlpatterns.append(url(r"^.*$", views.index, name="index"))
+    urlpatterns.append(re_path(r"^.*$", views.index, name="index"))

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -67,6 +67,6 @@ if settings.WORKFLOWS_LOGIC_INSTALLED:
         ]
     )
 
-if settings.SERVE_FE_ASSETS:
+if settings.SERVE_FE_ASSETS:  # pragma: no cover
     # add route to serve FE assets for any unrecognised paths
     urlpatterns.append(re_path(r"^.*$", views.index, name="index"))

--- a/api/audit/urls.py
+++ b/api/audit/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from rest_framework import routers
 
 from audit.views import AllAuditLogViewSet
@@ -7,4 +7,4 @@ router = routers.DefaultRouter()
 router.register(r"", AllAuditLogViewSet, basename="audit")
 
 
-urlpatterns = [url(r"^", include(router.urls))]
+urlpatterns = [re_path(r"^", include(router.urls))]

--- a/api/e2etests/urls.py
+++ b/api/e2etests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import Teardown
 
@@ -6,5 +6,5 @@ app_name = "e2etests"
 
 
 urlpatterns = [
-    url(r"teardown/", Teardown.as_view(), name="teardown"),
+    re_path(r"teardown/", Teardown.as_view(), name="teardown"),
 ]

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -10,7 +10,6 @@ from django.core.cache import caches
 from django.db import models
 from django.db.models import Prefetch, Q
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
 from django_lifecycle import (
     AFTER_CREATE,
     AFTER_DELETE,
@@ -77,7 +76,7 @@ class Environment(
     project = models.ForeignKey(
         "projects.Project",
         related_name="environments",
-        help_text=_(
+        help_text=(
             "Changing the project selected will remove all previous Feature States for"
             " the previously associated projects Features that are related to this"
             " Environment. New default Feature States will be created for the new"

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -10,7 +10,7 @@ from django.core.cache import caches
 from django.db import models
 from django.db.models import Prefetch, Q
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_lifecycle import (
     AFTER_CREATE,
     AFTER_DELETE,

--- a/api/environments/urls.py
+++ b/api/environments/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include, url
-from django.urls import path
+from django.urls import include, path, re_path
 from rest_framework_nested import routers
 
 from edge_api.identities.views import (
@@ -129,10 +128,10 @@ environments_router.register(r"api-keys", EnvironmentAPIKeyViewSet, basename="ap
 app_name = "environments"
 
 urlpatterns = [
-    url(r"^", include(router.urls)),
-    url(r"^", include(environments_router.urls)),
-    url(r"^", include(identity_router.urls)),
-    url(r"^", include(edge_identity_router.urls)),
+    re_path(r"^", include(router.urls)),
+    re_path(r"^", include(environments_router.urls)),
+    re_path(r"^", include(identity_router.urls)),
+    re_path(r"^", include(edge_identity_router.urls)),
     path(
         "environments/<str:environment_api_key>/edge-identities-featurestates",
         EdgeIdentityWithIdentifierFeatureStateView.as_view(),

--- a/api/features/feature_external_resources/models.py
+++ b/api/features/feature_external_resources/models.py
@@ -2,7 +2,6 @@ import logging
 from dataclasses import asdict
 
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from django_lifecycle import (
     AFTER_SAVE,
     BEFORE_DELETE,
@@ -22,8 +21,8 @@ logger = logging.getLogger(__name__)
 class FeatureExternalResource(LifecycleModelMixin, models.Model):
     class ResourceType(models.TextChoices):
         # GitHub external resource types
-        GITHUB_ISSUE = "GITHUB_ISSUE", _("GitHub Issue")
-        GITHUB_PR = "GITHUB_PR", _("GitHub PR")
+        GITHUB_ISSUE = "GITHUB_ISSUE", "GitHub Issue"
+        GITHUB_PR = "GITHUB_PR", "GitHub PR"
 
     url = models.URLField()
     type = models.CharField(max_length=20, choices=ResourceType.choices)

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -21,7 +21,7 @@ from django.core.exceptions import (
 from django.db import models
 from django.db.models import Max, Q, QuerySet
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_lifecycle import (
     AFTER_CREATE,
     AFTER_SAVE,

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -21,7 +21,6 @@ from django.core.exceptions import (
 from django.db import models
 from django.db.models import Max, Q, QuerySet
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
 from django_lifecycle import (
     AFTER_CREATE,
     AFTER_SAVE,
@@ -99,7 +98,7 @@ class Feature(
     project = models.ForeignKey(
         Project,
         related_name="features",
-        help_text=_(
+        help_text=(
             "Changing the project selected will remove previous Feature States for the previously "
             "associated projects Environments that are related to this Feature. New default "
             "Feature States will be created for the new selected projects Environments for this "

--- a/api/organisations/urls.py
+++ b/api/organisations/urls.py
@@ -3,8 +3,7 @@ from app_analytics.views import (
     get_usage_data_view,
 )
 from django.conf import settings
-from django.conf.urls import include, url
-from django.urls import path
+from django.urls import include, path, re_path
 from rest_framework_nested import routers
 
 from api_keys.views import MasterAPIKeyViewSet
@@ -97,9 +96,9 @@ app_name = "organisations"
 
 
 urlpatterns = [
-    url(r"^", include(router.urls)),
-    url(r"^", include(organisations_router.urls)),
-    url(r"^", include(nested_github_router.urls)),
+    re_path(r"^", include(router.urls)),
+    re_path(r"^", include(organisations_router.urls)),
+    re_path(r"^", include(nested_github_router.urls)),
     path(
         "<int:organisation_pk>/usage-data/",
         get_usage_data_view,
@@ -211,10 +210,10 @@ if settings.IS_RBAC_INSTALLED:
     )
     urlpatterns.extend(
         [
-            url(r"^", include(organisations_router.urls)),
-            url(r"^", include(nested_roles_router.urls)),
-            url(r"^", include(nested_user_roles_routes.urls)),
-            url(r"^", include(nested_api_key_roles_routes.urls)),
-            url(r"^", include(nested_group_roles_routes.urls)),
+            re_path(r"^", include(organisations_router.urls)),
+            re_path(r"^", include(nested_roles_router.urls)),
+            re_path(r"^", include(nested_user_roles_routes.urls)),
+            re_path(r"^", include(nested_api_key_roles_routes.urls)),
+            re_path(r"^", include(nested_group_roles_routes.urls)),
         ]
     )

--- a/api/projects/urls.py
+++ b/api/projects/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include, url
-from django.urls import path
+from django.urls import include, path, re_path
 from rest_framework_nested import routers
 
 from audit.views import ProjectAuditLogViewSet
@@ -78,9 +77,9 @@ nested_features_router.register(
 app_name = "projects"
 
 urlpatterns = [
-    url(r"^", include(router.urls)),
-    url(r"^", include(projects_router.urls)),
-    url(r"^", include(nested_features_router.urls)),
+    re_path(r"^", include(router.urls)),
+    re_path(r"^", include(projects_router.urls)),
+    re_path(r"^", include(nested_features_router.urls)),
     path(
         "<int:project_pk>/all-user-permissions/<int:user_pk>/",
         get_user_project_permissions,

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -9,7 +9,6 @@ from django.core.mail import send_mail
 from django.db import models
 from django.db.models import Count, QuerySet
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
 from django_lifecycle import AFTER_CREATE, LifecycleModel, hook
 
 from integrations.lead_tracking.hubspot.tasks import (
@@ -101,8 +100,8 @@ class FFAdminUser(LifecycleModel, AbstractUser):
     email = models.EmailField(unique=True, null=False)
     objects = UserManager()
     username = models.CharField(unique=True, max_length=150, null=True, blank=True)
-    first_name = models.CharField(_("first name"), max_length=30)
-    last_name = models.CharField(_("last name"), max_length=150)
+    first_name = models.CharField("first name", max_length=30)
+    last_name = models.CharField("last name", max_length=150)
     google_user_id = models.CharField(max_length=50, null=True, blank=True)
     github_user_id = models.CharField(max_length=50, null=True, blank=True)
     marketing_consent_given = models.BooleanField(

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
-from django.urls import path
+from django.urls import path, re_path
 
 from organisations.invites.views import (
     join_organisation_from_email,
@@ -24,4 +23,4 @@ urlpatterns = [
 ]
 
 if settings.ALLOW_ADMIN_INITIATION_VIA_URL:
-    urlpatterns.insert(0, url(r"^init/", AdminInitView.as_view()))
+    urlpatterns.insert(0, re_path(r"^init/", AdminInitView.as_view()))

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -22,5 +22,5 @@ urlpatterns = [
     ),
 ]
 
-if settings.ALLOW_ADMIN_INITIATION_VIA_URL:
+if settings.ALLOW_ADMIN_INITIATION_VIA_URL:  # pragme: no cover
     urlpatterns.insert(0, re_path(r"^init/", AdminInitView.as_view()))


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Replace `django.conf.urls url` with `django.urls.re_path`
- Replace `ugettext_lazy` with `gettext_lazy`

Note: ugettext_lazy and url were deprecated in Django 3.x.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

covered by existing unit tests( :crossed_fingers: )
