### PR TITLE
chore: Add a confirmation modal when closing create/edit segment with changes

### DIFF
--- a/frontend/web/components/base/forms/TabItem.tsx
+++ b/frontend/web/components/base/forms/TabItem.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from 'react' // we need this to make JSX compile
 
 type TabItemType = {
+  tabLabelString?: string
   tabLabel: ReactNode
   children: ReactNode
 }


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Adds a confirmation modal when segment details are entered and user attempts to close the modal

## How did you test this code?

- Create / edit a segment, editing name, description or any rules
- Attempt to close the modal