### PR TITLE
fix: Set api usage billing to 100k

### DIFF
--- a/api/organisations/chargebee/__init__.py
+++ b/api/organisations/chargebee/__init__.py
@@ -1,7 +1,7 @@
 from .chargebee import (  # noqa
-    add_1000_api_calls,
-    add_1000_api_calls_scale_up,
-    add_1000_api_calls_start_up,
+    add_100k_api_calls,
+    add_100k_api_calls_scale_up,
+    add_100k_api_calls_start_up,
     add_single_seat,
     extract_subscription_metadata,
     get_customer_id_from_subscription_id,

--- a/api/organisations/chargebee/chargebee.py
+++ b/api/organisations/chargebee/chargebee.py
@@ -209,19 +209,19 @@ def add_single_seat(subscription_id: str):
         raise UpgradeSeatsError(msg) from e
 
 
-def add_1000_api_calls_start_up(
+def add_100k_api_calls_start_up(
     subscription_id: str, count: int = 1, invoice_immediately: bool = False
 ) -> None:
-    add_1000_api_calls(ADDITIONAL_API_START_UP_ADDON_ID, subscription_id, count)
+    add_100k_api_calls(ADDITIONAL_API_START_UP_ADDON_ID, subscription_id, count)
 
 
-def add_1000_api_calls_scale_up(
+def add_100k_api_calls_scale_up(
     subscription_id: str, count: int = 1, invoice_immediately: bool = False
 ) -> None:
-    add_1000_api_calls(ADDITIONAL_API_SCALE_UP_ADDON_ID, subscription_id, count)
+    add_100k_api_calls(ADDITIONAL_API_SCALE_UP_ADDON_ID, subscription_id, count)
 
 
-def add_1000_api_calls(
+def add_100k_api_calls(
     addon_id: str,
     subscription_id: str,
     count: int = 1,

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -500,8 +500,10 @@ class OrganisationAPIBilling(models.Model):
 
     Even though api_overage is charge per thousand API calls, this
     class tracks the actual rounded count of API calls that are
-    billed for (i.e., 52000 for an account with 52233 api calls).
-    We're intentionally rounding down to the closest thousands.
+    billed for (i.e., 200000 for an account with 234323 api calls
+    and a allowed_30d_api_calls set to 100000, the overage is
+    beyond the allowed api calls).
+    We're intentionally rounding up to the closest hundred thousand.
 
     The option to set immediate_invoice means whether or not the
     API billing was processed immediately versus pushed onto the

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -498,7 +498,7 @@ class OrganisationAPIBilling(models.Model):
     limits. This model is what allows subsequent billing runs
     to not double bill an organisation for the same use.
 
-    Even though api_overage is charge per thousand API calls, this
+    Even though api_overage is charge per 100k API calls, this
     class tracks the actual rounded count of API calls that are
     billed for (i.e., 200000 for an account with 234323 api calls
     and a allowed_30d_api_calls set to 100000, the overage is

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -253,20 +253,12 @@ def charge_for_api_call_count_overages():
         subscription_cache = organisation.subscription_information_cache
         api_usage = get_current_api_usage(organisation.id, "30d")
 
-        api_billing = (
-            OrganisationAPIBilling.objects.filter(
-                billed_at__gte=subscription_cache.current_billing_term_starts_at
-            )
-            .order_by("-billed_at")
-            .first()
+        api_billings = OrganisationAPIBilling.objects.filter(
+            billed_at__gte=subscription_cache.current_billing_term_starts_at
         )
+        previous_api_overage = sum([ap.api_overage for ap in api_billings])
 
-        if api_billing:
-            previous_api_overage = api_billing.api_overage
-        else:
-            previous_api_overage = 0
         api_limit = subscription_cache.allowed_30d_api_calls + previous_api_overage
-
         api_overage = api_usage - api_limit
         if api_overage <= 0:
             logger.info("API Usage below current API limit.")

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import timedelta
 
 from app_analytics.influxdb_wrapper import get_current_api_usage
@@ -12,8 +13,8 @@ from django.utils import timezone
 from integrations.flagsmith.client import get_client
 from organisations import subscription_info_cache
 from organisations.chargebee import (
-    add_1000_api_calls_scale_up,
-    add_1000_api_calls_start_up,
+    add_100k_api_calls_scale_up,
+    add_100k_api_calls_start_up,
 )
 from organisations.models import (
     APILimitAccessBlock,
@@ -255,21 +256,35 @@ def charge_for_api_call_count_overages():
     ):
         subscription_cache = organisation.subscription_information_cache
         api_usage = get_current_api_usage(organisation.id, "30d")
-        api_usage_ratio = api_usage / subscription_cache.allowed_30d_api_calls
 
-        if api_usage_ratio < 1.0:
-            logger.warning("API Usage does not match API Notification")
+        api_billing = (
+            OrganisationAPIBilling.objects.filter(
+                billed_at__gte=subscription_cache.current_billing_term_starts_at
+            )
+            .order_by("-billed_at")
+            .first()
+        )
+
+        if api_billing:
+            previous_api_overage = api_billing.api_overage
+        else:
+            previous_api_overage = 0
+        api_limit = subscription_cache.allowed_30d_api_calls + previous_api_overage
+
+        api_overage = api_usage - api_limit
+        if api_overage <= 0:
+            logger.info("API Usage below current API limit.")
             continue
 
-        api_overage = api_usage - subscription_cache.allowed_30d_api_calls
-
         if organisation.subscription.plan in {SCALE_UP, SCALE_UP_V2}:
-            add_1000_api_calls_scale_up(
-                organisation.subscription.subscription_id, api_overage // 1000
+            add_100k_api_calls_scale_up(
+                organisation.subscription.subscription_id,
+                math.ceil(api_overage / 100_000),
             )
         elif organisation.subscription.plan in {STARTUP, STARTUP_V2}:
-            add_1000_api_calls_start_up(
-                organisation.subscription.subscription_id, api_overage // 1000
+            add_100k_api_calls_start_up(
+                organisation.subscription.subscription_id,
+                math.ceil(api_overage / 100_000),
             )
         else:
             logger.error(
@@ -281,7 +296,7 @@ def charge_for_api_call_count_overages():
         # double billing on a subsequent task run.
         OrganisationAPIBilling.objects.create(
             organisation=organisation,
-            api_overage=(1000 * (api_overage // 1000)),
+            api_overage=(100_000 * math.ceil(api_overage / 100_000)),
             immediate_invoice=False,
             billed_at=now,
         )

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -231,11 +231,7 @@ def charge_for_api_call_count_overages():
         OrganisationAPIUsageNotification.objects.filter(
             notified_at__gte=api_usage_notified_at,
             percent_usage__gte=100,
-        )
-        .exclude(
-            organisation__api_billing__billed_at__gt=api_usage_notified_at,
-        )
-        .values_list("organisation_id", flat=True)
+        ).values_list("organisation_id", flat=True)
     )
 
     for organisation in Organisation.objects.filter(

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -9,7 +9,7 @@ from pytest_mock import MockerFixture
 from pytz import UTC
 
 from organisations.chargebee import (
-    add_1000_api_calls,
+    add_100k_api_calls,
     add_single_seat,
     extract_subscription_metadata,
     get_customer_id_from_subscription_id,
@@ -605,12 +605,12 @@ def test_add_single_seat_throws_upgrade_seats_error_error_if_api_error(
     )
 
 
-def test_add_1000_api_calls_when_count_is_empty(mocker: MockerFixture) -> None:
+def test_add_100k_api_calls_when_count_is_empty(mocker: MockerFixture) -> None:
     # Given
     subscription_mock = mocker.patch("chargebee.Subscription.update")
 
     # When
-    result = add_1000_api_calls(
+    result = add_100k_api_calls(
         addon_id=ADDITIONAL_API_SCALE_UP_ADDON_ID,
         subscription_id="subscription23",
         count=0,
@@ -622,7 +622,7 @@ def test_add_1000_api_calls_when_count_is_empty(mocker: MockerFixture) -> None:
     subscription_mock.assert_not_called()
 
 
-def test_add_1000_api_calls_when_chargebee_api_error_has_error_code(
+def test_add_100k_api_calls_when_chargebee_api_error_has_error_code(
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -641,7 +641,7 @@ def test_add_1000_api_calls_when_chargebee_api_error_has_error_code(
 
     # When / Then
     with pytest.raises(UpgradeAPIUsagePaymentFailure):
-        add_1000_api_calls(
+        add_100k_api_calls(
             addon_id=ADDITIONAL_API_SCALE_UP_ADDON_ID,
             subscription_id="subscription23",
             count=1,
@@ -649,7 +649,7 @@ def test_add_1000_api_calls_when_chargebee_api_error_has_error_code(
         )
 
 
-def test_add_1000_api_calls_when_chargebee_api_error_has_no_error_code(
+def test_add_100k_api_calls_when_chargebee_api_error_has_no_error_code(
     mocker: MockerFixture,
 ) -> None:
     # Given
@@ -668,7 +668,7 @@ def test_add_1000_api_calls_when_chargebee_api_error_has_no_error_code(
 
     # When / Then
     with pytest.raises(UpgradeAPIUsageError):
-        add_1000_api_calls(
+        add_100k_api_calls(
             addon_id=ADDITIONAL_API_SCALE_UP_ADDON_ID,
             subscription_id="subscription23",
             count=1,

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -476,7 +476,7 @@ def test_charge_for_api_call_count_overages_scale_up(
         organisation=organisation,
         allowed_seats=10,
         allowed_projects=3,
-        allowed_30d_api_calls=10_000,
+        allowed_30d_api_calls=100_000,
         chargebee_email="test@example.com",
         current_billing_term_starts_at=now - timedelta(days=30),
         current_billing_term_ends_at=now + timedelta(minutes=30),
@@ -498,7 +498,7 @@ def test_charge_for_api_call_count_overages_scale_up(
     mock_api_usage = mocker.patch(
         "organisations.tasks.get_current_api_usage",
     )
-    mock_api_usage.return_value = 12_005
+    mock_api_usage.return_value = 212_005
     assert OrganisationAPIBilling.objects.count() == 0
 
     # When
@@ -511,7 +511,7 @@ def test_charge_for_api_call_count_overages_scale_up(
             "addons": [
                 {
                     "id": "additional-api-scale-up-monthly",
-                    "quantity": 2,  # Two thousand API requests.
+                    "quantity": 2,  # 200k API requests.
                 }
             ],
             "prorate": False,
@@ -522,7 +522,7 @@ def test_charge_for_api_call_count_overages_scale_up(
     assert OrganisationAPIBilling.objects.count() == 1
     api_billing = OrganisationAPIBilling.objects.first()
     assert api_billing.organisation == organisation
-    assert api_billing.api_overage == 2000
+    assert api_billing.api_overage == 200_000
     assert api_billing.immediate_invoice is False
     assert api_billing.billed_at == now
 
@@ -575,7 +575,7 @@ def test_charge_for_api_call_count_overages_with_not_covered_plan(
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
-def test_charge_for_api_call_count_overages_sub_1_api_usage_ratio(
+def test_charge_for_api_call_count_overages_under_api_limit(
     organisation: Organisation,
     mocker: MockerFixture,
 ) -> None:
@@ -629,7 +629,7 @@ def test_charge_for_api_call_count_overages_start_up(
         organisation=organisation,
         allowed_seats=10,
         allowed_projects=3,
-        allowed_30d_api_calls=10_000,
+        allowed_30d_api_calls=100_000,
         chargebee_email="test@example.com",
         current_billing_term_starts_at=now - timedelta(days=30),
         current_billing_term_ends_at=now + timedelta(minutes=30),
@@ -651,7 +651,7 @@ def test_charge_for_api_call_count_overages_start_up(
     mock_api_usage = mocker.patch(
         "organisations.tasks.get_current_api_usage",
     )
-    mock_api_usage.return_value = 12_005
+    mock_api_usage.return_value = 202_005
     assert OrganisationAPIBilling.objects.count() == 0
 
     # When
@@ -664,7 +664,7 @@ def test_charge_for_api_call_count_overages_start_up(
             "addons": [
                 {
                     "id": "additional-api-start-up-monthly",
-                    "quantity": 2,  # Two thousand API requests.
+                    "quantity": 2,  # 200k API requests.
                 }
             ],
             "prorate": False,
@@ -675,13 +675,13 @@ def test_charge_for_api_call_count_overages_start_up(
     assert OrganisationAPIBilling.objects.count() == 1
     api_billing = OrganisationAPIBilling.objects.first()
     assert api_billing.organisation == organisation
-    assert api_billing.api_overage == 2000
+    assert api_billing.api_overage == 200_000
     assert api_billing.immediate_invoice is False
     assert api_billing.billed_at == now
 
     # Now attempt to rebill the account should fail
     calls_mock = mocker.patch(
-        "organisations.tasks.add_1000_api_calls_start_up",
+        "organisations.tasks.add_100k_api_calls_start_up",
     )
     charge_for_api_call_count_overages()
     assert OrganisationAPIBilling.objects.count() == 1


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

1. Set up billing to 100k from 1000 from the Chargebee add-on code.
2. Fix a horrible bug that would have allowed customers to be billed multiple times for the same API calls.

## How did you test this code?

Updated tests and added for codecov.
