### PR TITLE
fix: Add support for versioning v2 on GitHub resource linking

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -563,7 +563,7 @@ def feature_with_value_segment(
 
 
 @pytest.fixture()
-def segment_featurestate_and_feature_with_value(
+def segment_override_for_feature_with_value(
     feature_with_value_segment: FeatureSegment,
     feature_with_value: Feature,
     environment: Environment,

--- a/api/integrations/github/client.py
+++ b/api/integrations/github/client.py
@@ -73,7 +73,7 @@ def post_comment_to_github(
     url = f"{GITHUB_API_URL}repos/{owner}/{repo}/issues/{issue}/comments"
     headers = build_request_headers(installation_id)
     payload = {"body": body}
-    response = response = requests.post(
+    response = requests.post(
         url, json=payload, headers=headers, timeout=GITHUB_API_CALLS_TIMEOUT
     )
     response.raise_for_status()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [X] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [X] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Add support for versioning v2 on GitHub integration

## How did you test this code?
There are unit tests already in place

