### PR TITLE
refactor: Convert OAuth serializers TestCase to a normal test function

### DIFF
--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_serializers.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_serializers.py
@@ -1,7 +1,5 @@
-from unittest import TestCase, mock
+from unittest import mock
 
-import pytest
-from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
@@ -13,95 +11,88 @@ from custom_auth.oauth.serializers import (
     GoogleLoginSerializer,
     OAuthLoginSerializer,
 )
-from users.models import SignUpType
-
-UserModel = get_user_model()
+from users.models import FFAdminUser, SignUpType
 
 
-@pytest.mark.django_db
-class OAuthLoginSerializerTestCase(TestCase):
-    def setUp(self) -> None:
-        self.test_email = "testytester@example.com"
-        self.test_first_name = "testy"
-        self.test_last_name = "tester"
-        self.test_id = "test-id"
-        self.mock_user_data = {
-            "email": self.test_email,
-            "first_name": self.test_first_name,
-            "last_name": self.test_last_name,
-            "google_user_id": self.test_id,
-        }
-        rf = RequestFactory()
-        self.request = rf.post("placeholer-login-url")
+@mock.patch("custom_auth.oauth.serializers.get_user_info")
+def test_create_oauth_login_serializer(
+    mock_get_user_info: mock.MagicMock, db: None
+) -> None:
+    # Given
+    access_token = "access-token"
+    sign_up_type = "NO_INVITE"
+    data = {"access_token": access_token, "sign_up_type": sign_up_type}
+    rf = RequestFactory()
+    request = rf.post("placeholer-login-url")
+    email = "testytester@example.com"
+    first_name = "testy"
+    last_name = "tester"
+    google_user_id = "test-id"
 
-    @mock.patch("custom_auth.oauth.serializers.get_user_info")
-    def test_create(self, mock_get_user_info):
-        # Given
-        access_token = "access-token"
-        sign_up_type = "NO_INVITE"
-        data = {"access_token": access_token, "sign_up_type": sign_up_type}
-        serializer = OAuthLoginSerializer(data=data, context={"request": self.request})
+    mock_user_data = {
+        "email": email,
+        "first_name": first_name,
+        "last_name": last_name,
+        "google_user_id": google_user_id,
+    }
+    serializer = OAuthLoginSerializer(data=data, context={"request": request})
 
-        # monkey patch the get_user_info method to return the mock user data
-        serializer.get_user_info = lambda: self.mock_user_data
+    # monkey patch the get_user_info method to return the mock user data
+    serializer.get_user_info = lambda: mock_user_data
 
-        # When
-        serializer.is_valid()
-        response = serializer.save()
+    # When
+    serializer.is_valid()
+    response = serializer.save()
 
-        # Then
-        assert UserModel.objects.filter(
-            email=self.test_email, sign_up_type=sign_up_type
-        ).exists()
-        assert isinstance(response, Token)
-        assert (timezone.now() - response.user.last_login).seconds < 5
-        assert response.user.email == self.test_email
+    # Then
+    assert FFAdminUser.objects.filter(email=email, sign_up_type=sign_up_type).exists()
+    assert isinstance(response, Token)
+    assert (timezone.now() - response.user.last_login).seconds < 5
+    assert response.user.email == email
 
 
-class GoogleLoginSerializerTestCase(TestCase):
-    def setUp(self) -> None:
-        rf = RequestFactory()
-        self.request = rf.post("placeholer-login-url")
+@mock.patch("custom_auth.oauth.serializers.get_user_info")
+def test_get_user_info_with_google_login(
+    mock_get_user_info: mock.MagicMock,
+) -> None:
+    # Given
+    rf = RequestFactory()
+    request = rf.post("placeholer-login-url")
+    access_token = "some-access-token"
+    serializer = GoogleLoginSerializer(
+        data={"access_token": access_token}, context={"request": request}
+    )
 
-    @mock.patch("custom_auth.oauth.serializers.get_user_info")
-    def test_get_user_info(self, mock_get_user_info):
-        # Given
-        access_token = "some-access-token"
-        serializer = GoogleLoginSerializer(
-            data={"access_token": access_token}, context={"request": self.request}
-        )
+    # When
+    serializer.is_valid()
+    serializer.get_user_info()
 
-        # When
-        serializer.is_valid()
-        serializer.get_user_info()
-
-        # Then
-        mock_get_user_info.assert_called_with(access_token)
+    # Then
+    mock_get_user_info.assert_called_with(access_token)
 
 
-class GithubLoginSerializerTestCase(TestCase):
-    def setUp(self) -> None:
-        rf = RequestFactory()
-        self.request = rf.post("placeholer-login-url")
+@mock.patch("custom_auth.oauth.serializers.GithubUser")
+def test_get_user_info_with_github_login(
+    mock_github_user_serializer: mock.MagicMock,
+) -> None:
+    # Given
+    rf = RequestFactory()
+    request = rf.post("placeholer-login-url")
+    access_token = "some-access-token"
+    serializer = GithubLoginSerializer(
+        data={"access_token": access_token}, context={"request": request}
+    )
 
-    @mock.patch("custom_auth.oauth.serializers.GithubUser")
-    def test_get_user_info(self, MockGithubUser):
-        # Given
-        access_token = "some-access-token"
-        serializer = GithubLoginSerializer(
-            data={"access_token": access_token}, context={"request": self.request}
-        )
+    mock_github_user = mock.MagicMock()
+    mock_github_user_serializer.return_value = mock_github_user
 
-        mock_github_user = mock.MagicMock()
-        MockGithubUser.return_value = mock_github_user
+    # When
+    serializer.is_valid()
+    serializer.get_user_info()
 
-        # When
-        serializer.is_valid()
-        serializer.get_user_info()
-
-        # Then
-        MockGithubUser.assert_called_with(code=access_token)
-        mock_github_user.get_user_info.assert_called()
+    # Then
+    mock_github_user_serializer.assert_called_with(code=access_token)
+    mock_github_user.get_user_info.assert_called()
 
 
 def test_OAuthLoginSerializer_calls_is_authentication_method_valid_correctly_if_auth_controller_is_installed(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I'm working through re-writing the TestCase and APITestCase classes into normal test functions. I rewrote the existing classes and replaced with fixtures instead of recreating everything. There are other PRs that are similar to this one.

## How did you test this code?

I manually changed the tests one at a time to refactor them as I went.

