### PR TITLE
refactor: Convert OAuth GitHub TestCase to a normal test function

### DIFF
--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_github.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_github.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 
@@ -6,138 +6,153 @@ from custom_auth.oauth.exceptions import GithubError
 from custom_auth.oauth.github import NON_200_ERROR_MESSAGE, GithubUser
 
 
-class GithubUserTestCase(TestCase):
-    def setUp(self) -> None:
-        self.test_client_id = "test-client-id"
-        self.test_client_secret = "test-client-secret"
+@mock.patch("custom_auth.oauth.github.requests")
+def test_get_access_token_success_with_oauth_github(
+    mock_requests: mock.MagicMock,
+) -> None:
+    # Given
+    test_code = "abc123"
+    expected_access_token = "access-token"
+    client_id = "test-client-id"
+    client_secret = "test-client-secret"
 
-        self.mock_requests = mock.patch("custom_auth.oauth.github.requests").start()
+    mock_requests.post.return_value = mock.MagicMock(
+        text=f"access_token={expected_access_token}&scope=user&token_type=bearer",
+        status_code=200,
+    )
 
-    def tearDown(self) -> None:
-        self.mock_requests.stop()
+    # When
+    github_user = GithubUser(
+        test_code,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
 
-    def test_get_access_token_success(self):
-        # Given
-        test_code = "abc123"
-        expected_access_token = "access-token"
+    # Then
+    assert github_user.access_token == expected_access_token
 
-        self.mock_requests.post.return_value = mock.MagicMock(
-            text=f"access_token={expected_access_token}&scope=user&token_type=bearer",
-            status_code=200,
+    assert mock_requests.post.call_count == 1
+    request_calls = mock_requests.post.call_args
+    assert request_calls[1]["data"]["code"] == test_code
+
+
+@mock.patch("custom_auth.oauth.github.requests")
+def test_get_access_token_fail_non_200_with_github_oauth(
+    mock_requests: mock.MagicMock,
+) -> None:
+    # Given
+    client_id = "test-client-id"
+    client_secret = "test-client-secret"
+    invalid_code = "invalid"
+    status_code = 400
+    mock_requests.post.return_value = mock.MagicMock(status_code=status_code)
+
+    # When
+    with pytest.raises(GithubError) as e:
+        GithubUser(
+            invalid_code,
+            client_id=client_id,
+            client_secret=client_secret,
         )
 
-        # When
-        github_user = GithubUser(
-            test_code,
-            client_id=self.test_client_id,
-            client_secret=self.test_client_secret,
+    # Then - exception raised
+    assert NON_200_ERROR_MESSAGE.format(status_code) in str(e)
+
+
+@mock.patch("custom_auth.oauth.github.requests")
+def test_get_access_token_fail_token_expired_with_github_oauth(
+    mock_requests: mock.MagicMock,
+) -> None:
+    # Given
+    invalid_code = "invalid"
+    client_id = "test-client-id"
+    client_secret = "test-client-secret"
+
+    error_description = "there+was+an+error"
+    mock_requests.post.return_value = mock.MagicMock(
+        text=f"error=bad_verification_code&error_description={error_description}",
+        status_code=200,
+    )
+
+    # When
+    with pytest.raises(GithubError) as e:
+        GithubUser(
+            invalid_code,
+            client_id=client_id,
+            client_secret=client_secret,
         )
 
-        # Then
-        assert github_user.access_token == expected_access_token
+    # Then
+    assert error_description.replace("+", " ") in str(e)
 
-        assert self.mock_requests.post.call_count == 1
-        request_calls = self.mock_requests.post.call_args
-        assert request_calls[1]["data"]["code"] == test_code
 
-    def test_get_access_token_fail_non_200(self):
-        # Given
-        invalid_code = "invalid"
-        status_code = 400
-        self.mock_requests.post.return_value = mock.MagicMock(status_code=status_code)
+@mock.patch("custom_auth.oauth.github.requests")
+def test_get_user_name_and_id_with_github_oauth(mock_requests: mock.MagicMock) -> None:
+    # Given
+    # mock the post to get the access token
+    mock_requests.post.return_value = mock.MagicMock(
+        status_code=200, text="access_token=123456"
+    )
+    client_id = "test-client-id"
+    client_secret = "test-client-secret"
 
-        # When
-        with pytest.raises(GithubError) as e:
-            GithubUser(
-                invalid_code,
-                client_id=self.test_client_id,
-                client_secret=self.test_client_secret,
-            )
+    # mock the get to get the user info
+    mock_response = mock.MagicMock(status_code=200)
+    mock_requests.get.return_value = mock_response
+    mock_response.json.return_value = {"name": "tommy tester", "id": 123456}
 
-        # Then - exception raised
-        assert NON_200_ERROR_MESSAGE.format(status_code) in str(e)
+    # When
+    github_user = GithubUser(
+        "test-code",
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    user_name_and_id = github_user._get_user_name_and_id()
 
-    def test_get_access_token_fail_token_expired(self):
-        # Given
-        invalid_code = "invalid"
+    # Then
+    assert user_name_and_id == {
+        "first_name": "tommy",
+        "last_name": "tester",
+        "github_user_id": 123456,
+    }
 
-        error_description = "there+was+an+error"
-        self.mock_requests.post.return_value = mock.MagicMock(
-            text=f"error=bad_verification_code&error_description={error_description}",
-            status_code=200,
-        )
 
-        # When
-        with pytest.raises(GithubError) as e:
-            GithubUser(
-                invalid_code,
-                client_id=self.test_client_id,
-                client_secret=self.test_client_secret,
-            )
+@mock.patch("custom_auth.oauth.github.requests")
+def test_get_primary_email_with_github_oauth(mock_requests: mock.MagicMock) -> None:
+    # Given
+    # mock the post to get the access token
+    mock_requests.post.return_value = mock.MagicMock(
+        status_code=200, text="access_token=123456"
+    )
+    client_id = "test-client-id"
+    client_secret = "test-client-secret"
 
-        # Then
-        assert error_description.replace("+", " ") in str(e)
+    # mock the request to get the user info
+    mock_response = mock.MagicMock(status_code=200)
+    mock_requests.get.return_value = mock_response
 
-    def test_get_user_name_and_id(self):
-        # Given
-        # mock the post to get the access token
-        self.mock_requests.post.return_value = mock.MagicMock(
-            status_code=200, text="access_token=123456"
-        )
-
-        # mock the get to get the user info
-        mock_response = mock.MagicMock(status_code=200)
-        self.mock_requests.get.return_value = mock_response
-        mock_response.json.return_value = {"name": "tommy tester", "id": 123456}
-
-        # When
-        github_user = GithubUser(
-            "test-code",
-            client_id=self.test_client_id,
-            client_secret=self.test_client_secret,
-        )
-        user_name_and_id = github_user._get_user_name_and_id()
-
-        # Then
-        assert user_name_and_id == {
-            "first_name": "tommy",
-            "last_name": "tester",
-            "github_user_id": 123456,
+    verified_emails = [
+        {
+            "email": f"tommy_tester@example_{i}.com",
+            "verified": True,
+            "visibility": None,
+            "primary": False,
         }
+        for i in range(5)
+    ]
 
-    def test_get_primary_email(self):
-        # Given
-        # mock the post to get the access token
-        self.mock_requests.post.return_value = mock.MagicMock(
-            status_code=200, text="access_token=123456"
-        )
+    # set one of the verified emails to be the primary
+    verified_emails[3]["primary"] = True
 
-        # mock the request to get the user info
-        mock_response = mock.MagicMock(status_code=200)
-        self.mock_requests.get.return_value = mock_response
+    mock_response.json.return_value = verified_emails
 
-        verified_emails = [
-            {
-                "email": f"tommy_tester@example_{i}.com",
-                "verified": True,
-                "visibility": None,
-                "primary": False,
-            }
-            for i in range(5)
-        ]
+    # When
+    github_user = GithubUser(
+        "test-code",
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    primary_email = github_user._get_primary_email()
 
-        # set one of the verified emails to be the primary
-        verified_emails[3]["primary"] = True
-
-        mock_response.json.return_value = verified_emails
-
-        # When
-        github_user = GithubUser(
-            "test-code",
-            client_id=self.test_client_id,
-            client_secret=self.test_client_secret,
-        )
-        primary_email = github_user._get_primary_email()
-
-        # Then
-        assert primary_email == verified_emails[3]["email"]
+    # Then
+    assert primary_email == verified_emails[3]["email"]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I'm working through re-writing the TestCase and APITestCase classes into normal test functions. I rewrote the existing classes and replaced with fixtures instead of recreating everything. There are other PRs that are similar to this one.

## How did you test this code?

I manually changed the tests one at a time to refactor them as I went.

