### PR TITLE
fix(sentry-FLAGSMITH-API-4FY): resolve metadata segment n+1

### DIFF
--- a/api/segments/views.py
+++ b/api/segments/views.py
@@ -50,6 +50,7 @@ class SegmentViewSet(viewsets.ModelViewSet):
                 "rules__rules",
                 "rules__rules__conditions",
                 "rules__rules__rules",
+                "metadata",
             )
 
         query_serializer = SegmentListQuerySerializer(data=self.request.query_params)

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from flag_engine.segments.constants import EQUAL
+from pytest_django import DjangoAssertNumQueries
 from pytest_django.fixtures import SettingsWrapper
 from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
@@ -343,11 +344,11 @@ def test_get_segment_by_uuid(client, project, segment):
     ],
 )
 def test_list_segments(
-    django_assert_num_queries,
-    project,
-    client,
-    num_queries,
-    required_a_segment_metadata_field,
+    django_assert_num_queries: DjangoAssertNumQueries,
+    project: Project,
+    client: APIClient,
+    num_queries: int,
+    required_a_segment_metadata_field: MetadataModelField,
 ):
     # Given
     num_segments = 5

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -3,6 +3,7 @@ import random
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from flag_engine.segments.constants import EQUAL
 from pytest_django.fixtures import SettingsWrapper
@@ -15,7 +16,7 @@ from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from environments.models import Environment
 from features.models import Feature
-from metadata.models import MetadataModelField
+from metadata.models import Metadata, MetadataModelField
 from projects.models import Project
 from projects.permissions import MANAGE_SEGMENTS, VIEW_PROJECT
 from segments.models import Condition, Segment, SegmentRule, WhitelistedSegment
@@ -337,16 +338,28 @@ def test_get_segment_by_uuid(client, project, segment):
 @pytest.mark.parametrize(
     "client, num_queries",
     [
-        (lazy_fixture("admin_master_api_key_client"), 16),
-        (lazy_fixture("admin_client"), 15),
+        (lazy_fixture("admin_master_api_key_client"), 12),
+        (lazy_fixture("admin_client"), 11),
     ],
 )
-def test_list_segments(django_assert_num_queries, project, client, num_queries):
+def test_list_segments(
+    django_assert_num_queries,
+    project,
+    client,
+    num_queries,
+    required_a_segment_metadata_field,
+):
     # Given
     num_segments = 5
     segments = []
     for i in range(num_segments):
         segment = Segment.objects.create(project=project, name=f"segment {i}")
+        Metadata.objects.create(
+            object_id=segment.id,
+            content_type=ContentType.objects.get_for_model(segment),
+            model_field=required_a_segment_metadata_field,
+            field_value="test",
+        )
         all_rule = SegmentRule.objects.create(
             segment=segment, type=SegmentRule.ALL_RULE
         )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
fixes: https://flagsmith.sentry.io/issues/5385839623/
Fix segment metadata n+1 issue by prefetching metadata

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Updated the unit test
