### PR TITLE
fix: Validate feature values before saving

### DIFF
--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -93,29 +93,25 @@ class Validation extends Component {
   render() {
     const displayLanguage =
       this.props.language === 'ini' ? 'toml' : this.props.language
-    return (
+    return this.state.error ? (
       <Tooltip
         position='top'
         title={
-          !this.state.error ? (
-            <IonIcon
-              id='language-validation-success'
-              className='language-icon'
-              icon={checkmarkCircle}
-            />
-          ) : (
-            <IonIcon
-              id='language-validation-error'
-              className='language-icon'
-              icon={warning}
-            />
-          )
+          <IonIcon
+            id='language-validation-error'
+            className='language-icon text-danger'
+            icon={warning}
+          />
         }
       >
-        {!this.state.error
-          ? `${displayLanguage} validation passed`
-          : `${displayLanguage} validation error, please check your value.<br/>Error: ${this.state.error}`}
+        {`${displayLanguage} validation error, please check your value.<br/>Error: ${this.state.error}`}
       </Tooltip>
+    ) : (
+      <IonIcon
+        id='language-validation-success'
+        className='language-icon text-success'
+        icon={checkmarkCircle}
+      />
     )
   }
 }
@@ -134,7 +130,11 @@ class ValueEditor extends Component {
   }
 
   renderValidation = () => (
-    <Validation language={this.state.language} value={this.props.value} />
+    <Validation
+      key={this.state.language}
+      language={this.state.language}
+      value={this.props.value}
+    />
   )
 
   render() {

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -99,7 +99,7 @@ class Validation extends Component {
         title={
           !this.state.error ? (
             <IonIcon
-              id='language-validation-error'
+              id='language-validation-success'
               className='language-icon'
               icon={checkmarkCircle}
             />

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -4,8 +4,8 @@ import Highlight from './Highlight'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import { Clipboard } from 'polyfill-react-native'
 import Icon from './Icon'
-import { IonIcon } from '@ionic/react';
-import { warning } from 'ionicons/icons';
+import { IonIcon } from '@ionic/react'
+import { checkmarkCircle, warning } from 'ionicons/icons'
 
 const toml = require('toml')
 const yaml = require('yaml')
@@ -98,7 +98,11 @@ class Validation extends Component {
         position='top'
         title={
           !this.state.error ? (
-            <span className='language-icon ion-ios-checkmark-circle' />
+            <IonIcon
+              id='language-validation-error'
+              className='language-icon'
+              icon={checkmarkCircle}
+            />
           ) : (
             <IonIcon
               id='language-validation-error'

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -4,6 +4,8 @@ import Highlight from './Highlight'
 import ConfigProvider from 'common/providers/ConfigProvider'
 import { Clipboard } from 'polyfill-react-native'
 import Icon from './Icon'
+import { IonIcon } from '@ionic/react';
+import { warning } from 'ionicons/icons';
 
 const toml = require('toml')
 const yaml = require('yaml')
@@ -98,9 +100,10 @@ class Validation extends Component {
           !this.state.error ? (
             <span className='language-icon ion-ios-checkmark-circle' />
           ) : (
-            <span
+            <IonIcon
               id='language-validation-error'
-              className='language-icon ion-ios-warning'
+              className='language-icon'
+              icon={warning}
             />
           )
         }

--- a/frontend/web/components/modals/AssociatedSegmentOverrides.js
+++ b/frontend/web/components/modals/AssociatedSegmentOverrides.js
@@ -12,6 +12,7 @@ import EnvironmentSelect from 'components/EnvironmentSelect'
 import SegmentOverrideLimit from 'components/SegmentOverrideLimit'
 import { getStore } from 'common/store'
 import { getEnvironment } from 'common/services/useEnvironment'
+import { saveFeatureWithValidation } from 'components/saveFeatureWithValidation'
 
 class TheComponent extends Component {
   state = {
@@ -306,7 +307,7 @@ export default class SegmentOverridesInner extends Component {
     return (
       <FeatureListProvider>
         {({}, { editFeatureSegments, isSaving }) => {
-          const save = () => {
+          const save = saveFeatureWithValidation(() => {
             FeatureListStore.isSaving = true
             FeatureListStore.trigger('change')
             !isSaving &&
@@ -324,7 +325,7 @@ export default class SegmentOverridesInner extends Component {
                 },
               )
             this.setState({ isSaving: true })
-          }
+          })
           const segmentOverride =
             segmentOverrides && segmentOverrides.filter((v) => v.segment === id)
           if (!segmentOverrides) return null

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1026,9 +1026,9 @@ const CreateFlag = class extends Component {
                 }
               })
 
-              const onCreateFeature = () => {
+              const onCreateFeature = saveWithValidation(() => {
                 this.save(createFlag, isSaving)
-              }
+              })
 
               const featureLimitAlert =
                 Utils.calculateRemainingLimitsPercentage(

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -41,6 +41,21 @@ import { getGithubIntegration } from 'common/services/useGithubIntegration'
 import { removeUserOverride } from 'components/RemoveUserOverride'
 import ExternalResourcesLinkTab from 'components/ExternalResourcesLinkTab'
 
+const saveWithValidation = (cb) => {
+  return () => {
+    if (document.getElementById('language-validation-error')) {
+      openConfirm({
+        body: 'Your remote config value does not pass validation for the language you have selected. Are you sure you wish to save?',
+        noText: 'Cancel',
+        onYes: () => cb(),
+        title: 'Validation error',
+        yesText: 'Save',
+      })
+    } else {
+      cb()
+    }
+  }
+}
 const CreateFlag = class extends Component {
   static displayName = 'CreateFlag'
 
@@ -855,7 +870,7 @@ const CreateFlag = class extends Component {
                 editFeatureValue,
               },
             ) => {
-              const saveFeatureValue = (schedule) => {
+              const saveFeatureValue = saveWithValidation((schedule) => {
                 this.setState({ valueChanged: false })
                 if ((is4Eyes || schedule) && !identity) {
                   openModal2(
@@ -926,29 +941,17 @@ const CreateFlag = class extends Component {
                       }}
                     />,
                   )
-                } else if (
-                  document.getElementById('language-validation-error')
-                ) {
-                  openConfirm({
-                    body: 'Your remote config value does not pass validation for the language you have selected. Are you sure you wish to save?',
-                    noText: 'Cancel',
-                    onYes: () => {
-                      this.save(editFeatureValue, isSaving)
-                    },
-                    title: 'Validation error',
-                    yesText: 'Save',
-                  })
                 } else {
                   this.save(editFeatureValue, isSaving)
                 }
-              }
+              })
 
               const saveSettings = () => {
                 this.setState({ settingsChanged: false })
                 this.save(editFeatureSettings, isSaving)
               }
 
-              const saveFeatureSegments = () => {
+              const saveFeatureSegments = saveWithValidation(() => {
                 this.setState({ segmentsChanged: false })
 
                 if (is4Eyes && isVersioned && !identity) {
@@ -1021,7 +1024,7 @@ const CreateFlag = class extends Component {
                 } else {
                   this.save(editFeatureSegments, isSaving)
                 }
-              }
+              })
 
               const onCreateFeature = () => {
                 this.save(createFlag, isSaving)

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -40,22 +40,8 @@ import { getSupportedContentType } from 'common/services/useSupportedContentType
 import { getGithubIntegration } from 'common/services/useGithubIntegration'
 import { removeUserOverride } from 'components/RemoveUserOverride'
 import ExternalResourcesLinkTab from 'components/ExternalResourcesLinkTab'
+import { saveFeatureWithValidation } from 'components/saveFeatureWithValidation'
 
-const saveWithValidation = (cb) => {
-  return () => {
-    if (document.getElementById('language-validation-error')) {
-      openConfirm({
-        body: 'Your remote config value does not pass validation for the language you have selected. Are you sure you wish to save?',
-        noText: 'Cancel',
-        onYes: () => cb(),
-        title: 'Validation error',
-        yesText: 'Save',
-      })
-    } else {
-      cb()
-    }
-  }
-}
 const CreateFlag = class extends Component {
   static displayName = 'CreateFlag'
 
@@ -870,7 +856,7 @@ const CreateFlag = class extends Component {
                 editFeatureValue,
               },
             ) => {
-              const saveFeatureValue = saveWithValidation((schedule) => {
+              const saveFeatureValue = saveFeatureWithValidation((schedule) => {
                 this.setState({ valueChanged: false })
                 if ((is4Eyes || schedule) && !identity) {
                   openModal2(
@@ -951,7 +937,7 @@ const CreateFlag = class extends Component {
                 this.save(editFeatureSettings, isSaving)
               }
 
-              const saveFeatureSegments = saveWithValidation(() => {
+              const saveFeatureSegments = saveFeatureWithValidation(() => {
                 this.setState({ segmentsChanged: false })
 
                 if (is4Eyes && isVersioned && !identity) {
@@ -1026,7 +1012,7 @@ const CreateFlag = class extends Component {
                 }
               })
 
-              const onCreateFeature = saveWithValidation(() => {
+              const onCreateFeature = saveFeatureWithValidation(() => {
                 this.save(createFlag, isSaving)
               })
 

--- a/frontend/web/components/saveFeatureWithValidation.ts
+++ b/frontend/web/components/saveFeatureWithValidation.ts
@@ -1,0 +1,15 @@
+export const saveFeatureWithValidation = (cb: () => void) => {
+  return () => {
+    if (document.getElementById('language-validation-error')) {
+      openConfirm({
+        body: 'Your remote config value does not pass validation for the language you have selected. Are you sure you wish to save?',
+        noText: 'Cancel',
+        onYes: () => cb(),
+        title: 'Validation error',
+        yesText: 'Save',
+      })
+    } else {
+      cb()
+    }
+  }
+}

--- a/frontend/web/styles/3rdParty/_hljs.scss
+++ b/frontend/web/styles/3rdParty/_hljs.scss
@@ -69,6 +69,9 @@
       }
     }
     span {
+      display: flex;
+      align-items: center;
+      gap: 2px;
       color: $text-icon-light-grey;
       cursor: pointer;
       font-size: $font-caption-sm;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Fixes the icon for when language validation fails 
![image](https://github.com/Flagsmith/flagsmith/assets/8608314/5918054f-ab09-475a-8ac4-2ff9fc9955e9)

- Saving features, segment overrides and creating change requests will now validate values in the same way.
![image](https://github.com/Flagsmith/flagsmith/assets/8608314/8d18c16b-773a-4691-90fa-ee7b79eeccda)

## How did you test this code?

Attempted to create an invalid change request, segment override and remote config