### PR TITLE
chore: test trimmed value when determining type

### DIFF
--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -357,7 +357,11 @@ const controller = {
               `${Project.api}environments/${environmentId}/featurestates/${environmentFlag.id}/`,
               Object.assign({}, environmentFlag, {
                 enabled: flag.default_enabled,
-                feature_state_value: flag.initial_value,
+                feature_state_value: Utils.getTypedValue(
+                  flag.initial_value,
+                  undefined,
+                  true,
+                ),
               }),
             )
           })

--- a/frontend/common/stores/identity-store.js
+++ b/frontend/common/stores/identity-store.js
@@ -1,4 +1,5 @@
 import Constants from 'common/constants'
+import Utils from 'common/utils/utils'
 
 const Dispatcher = require('../dispatcher/dispatcher')
 const BaseStore = require('./base/_store')
@@ -95,7 +96,11 @@ const controller = {
               {
                 enabled: identityFlag.enabled,
                 feature: projectFlag.id,
-                feature_state_value: identityFlag.feature_state_value,
+                feature_state_value: Utils.getTypedValue(
+                  identityFlag.feature_state_value,
+                  undefined,
+                  true,
+                ),
                 id: identityFlag.id || identityFlag.featurestate_uuid,
                 multivariate_feature_state_values:
                   identityFlag.multivariate_options,
@@ -109,7 +114,11 @@ const controller = {
             {
               enabled: identityFlag.enabled,
               feature: projectFlag.id,
-              feature_state_value: identityFlag.feature_state_value,
+              feature_state_value: Utils.getTypedValue(
+                identityFlag.feature_state_value,
+                undefined,
+                true,
+              ),
               multivariate_feature_state_values:
                 identityFlag.multivariate_options,
             },

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -462,7 +462,11 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     return id ? 'put' : 'post'
   },
 
-  getTypedValue(str: FlagsmithValue, boolToString?: boolean) {
+  getTypedValue(
+    str: FlagsmithValue,
+    boolToString?: boolean,
+    testWithTrim?: boolean,
+  ) {
     if (typeof str === 'undefined') {
       return ''
     }
@@ -470,26 +474,27 @@ const Utils = Object.assign({}, require('./base/_utils'), {
       return str
     }
 
-    const isNum = /^\d+$/.test(str.trim())
+    const typedValue = testWithTrim ? str.trim() : str
+    const isNum = /^\d+$/.test(typedValue)
 
-    if (isNum && parseInt(str.trim()) > Number.MAX_SAFE_INTEGER) {
+    if (isNum && parseInt(typedValue) > Number.MAX_SAFE_INTEGER) {
       return `${str}`
     }
 
-    if (str.trim() === 'true') {
+    if (typedValue === 'true') {
       if (boolToString) return 'true'
       return true
     }
-    if (str.trim() === 'false') {
+    if (typedValue === 'false') {
       if (boolToString) return 'false'
       return false
     }
 
     if (isNum) {
       if (str.indexOf('.') !== -1) {
-        return parseFloat(str)
+        return parseFloat(typedValue)
       }
-      return parseInt(str)
+      return parseInt(typedValue)
     }
 
     return str
@@ -668,7 +673,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     }
   },
   valueToFeatureState(value: FlagsmithValue) {
-    const val = Utils.getTypedValue(value)
+    const val = Utils.getTypedValue(value, undefined, true)
 
     if (typeof val === 'boolean') {
       return {

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -470,17 +470,17 @@ const Utils = Object.assign({}, require('./base/_utils'), {
       return str
     }
 
-    const isNum = /^\d+$/.test(str)
+    const isNum = /^\d+$/.test(str.trim())
 
-    if (isNum && parseInt(str) > Number.MAX_SAFE_INTEGER) {
+    if (isNum && parseInt(str.trim()) > Number.MAX_SAFE_INTEGER) {
       return `${str}`
     }
 
-    if (str === 'true') {
+    if (str.trim() === 'true') {
       if (boolToString) return 'true'
       return true
     }
-    if (str === 'false') {
+    if (str.trim() === 'false') {
       if (boolToString) return 'false'
       return false
     }

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -672,8 +672,8 @@ const Utils = Object.assign({}, require('./base/_utils'), {
         )
     }
   },
-  valueToFeatureState(value: FlagsmithValue) {
-    const val = Utils.getTypedValue(value, undefined, true)
+  valueToFeatureState(value: FlagsmithValue, trimSpaces = true) {
+    const val = Utils.getTypedValue(value, undefined, trimSpaces)
 
     if (typeof val === 'boolean') {
       return {

--- a/frontend/web/components/Highlight.js
+++ b/frontend/web/components/Highlight.js
@@ -102,6 +102,7 @@ class Highlight extends React.Component {
 
   onBlur = () => {
     this.setState({ focus: false })
+    this.props.onBlur?.()
   }
 
   render() {

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -217,6 +217,7 @@ class ValueEditor extends Component {
             data-test={rest['data-test']}
             disabled={rest.disabled}
             onChange={rest.disabled ? null : rest.onChange}
+            onBlur={rest.disabled ? null : rest.onBlur}
             className={this.state.language}
           >
             {typeof rest.value !== 'undefined' && rest.value != null

--- a/frontend/web/components/mv/VariationValue.js
+++ b/frontend/web/components/mv/VariationValue.js
@@ -22,10 +22,20 @@ const VariationValue = ({
             className='full-width code-medium'
             value={Utils.getTypedValue(Utils.featureStateToValue(value))}
             disabled={disabled || readOnlyValue}
+            onBlur={() => {
+              onChange({
+                ...value,
+                // Trim spaces and do conversion on blur
+                ...Utils.valueToFeatureState(Utils.featureStateToValue(value)),
+              })
+            }}
             onChange={(e) => {
               onChange({
                 ...value,
-                ...Utils.valueToFeatureState(Utils.safeParseEventValue(e)),
+                ...Utils.valueToFeatureState(
+                  Utils.safeParseEventValue(e),
+                  false,
+                ),
               })
             }}
             placeholder="e.g. 'big' "

--- a/frontend/web/components/mv/VariationValue.js
+++ b/frontend/web/components/mv/VariationValue.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ValueEditor from 'components/ValueEditor' // we need this to make JSX compile
 import Constants from 'common/constants'
 import Icon from 'components/Icon'
+import shallowEqual from 'fbjs/lib/shallowEqual'
 
 const VariationValue = ({
   disabled,
@@ -23,11 +24,15 @@ const VariationValue = ({
             value={Utils.getTypedValue(Utils.featureStateToValue(value))}
             disabled={disabled || readOnlyValue}
             onBlur={() => {
-              onChange({
+              const newValue = {
                 ...value,
                 // Trim spaces and do conversion on blur
                 ...Utils.valueToFeatureState(Utils.featureStateToValue(value)),
-              })
+              }
+              if (!shallowEqual(newValue, value)) {
+                //occurs if we converted a trimmed value
+                onChange(newValue)
+              }
             }}
             onChange={(e) => {
               onChange({


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

When saving a feature state, the frontend will now attempt to trim the value to detect boolean/int/float. If it parses a value it'll use that.

For example, editing remote config with `" true"` will now send the following 

![image](https://github.com/Flagsmith/flagsmith/assets/8608314/e37d214d-9a2e-4915-8d0d-2019aad17168)


It's important the frontend only does this when determining data to send to the API so that typing new values doesn't prevent spaces.
