### PR TITLE
docs: Tweak change request settings language

### DIFF
--- a/docs/docs/advanced-use/change-requests.md
+++ b/docs/docs/advanced-use/change-requests.md
@@ -17,8 +17,7 @@ team member. They work in a similar way to Pull Requests in git.
 ## Setting up Change Requests
 
 Change Requests are configured at the Environment level. To enable Change Requests, go to the Environment Settings Page,
-Enable 4 Eyes Change Request Approvals, and select how many approvals you would like for each Change Request to be
-applied.
+Enable the Change Request setting, and select how many approvals you would like for each Change Request to be applied.
 
 ## Creating a Change Request
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The old language was to call change requests "4 eyes" which is now deprecated. I grepped the codebase and only found this one occurrence and I've updated the language.

## How did you test this code?

N/A