### PR TITLE
fix: Set billing term starts at 30 days for null values

### DIFF
--- a/api/app_analytics/analytics_db_service.py
+++ b/api/app_analytics/analytics_db_service.py
@@ -43,7 +43,9 @@ def get_usage_data(
             if not getattr(organisation, "subscription_information_cache", None):
                 return []
             sub_cache = organisation.subscription_information_cache
-            starts_at = sub_cache.current_billing_term_starts_at
+            starts_at = sub_cache.current_billing_term_starts_at or now - timedelta(
+                days=30
+            )
             month_delta = relativedelta(now, starts_at).months
             period_starts_at = relativedelta(months=month_delta) + starts_at
             period_ends_at = now
@@ -54,7 +56,9 @@ def get_usage_data(
             if not getattr(organisation, "subscription_information_cache", None):
                 return []
             sub_cache = organisation.subscription_information_cache
-            starts_at = sub_cache.current_billing_term_starts_at
+            starts_at = sub_cache.current_billing_term_starts_at or now - timedelta(
+                days=30
+            )
             month_delta = relativedelta(now, starts_at).months - 1
             month_delta += relativedelta(now, starts_at).years * 12
             period_starts_at = relativedelta(months=month_delta) + starts_at


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Set billing term starts at 30 days for null values of the billing starting at date. Since this function is used to show API usage and isn't involved with calculating billing amounts, it's ok to default to a rolling thirty day period for API usage reporting. Solves [this Sentry error](https://flagsmith.sentry.io/issues/5424660367/?environment=staging&project=5544478&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=1).

## How did you test this code?

N/A
