### PR TITLE
fix: Set billing starts at to reasonable default for API usage notifications

### DIFF
--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import logging
+from datetime import timedelta
 
 from app_analytics.influxdb_wrapper import (
     get_events_for_organisation,
@@ -323,6 +324,10 @@ class OrganisationAPIUsageNotificationView(ListAPIView):
         subscription_cache = organisation.subscription_information_cache
         billing_starts_at = subscription_cache.current_billing_term_starts_at
         now = timezone.now()
+
+        # Handle case where billing dates are not set by
+        # defaulting to something as a reasonable default.
+        billing_starts_at = billing_starts_at or now - timedelta(days=30)
 
         month_delta = relativedelta(now, billing_starts_at).months
         period_starts_at = relativedelta(months=month_delta) + billing_starts_at


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x ] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Set billing starts at to reasonable default for API usage notifications. This shouldn't be common in practice since most subscriptions set a billing period. Solves [this Sentry issue](https://flagsmith.sentry.io/issues/5424660386/?environment=staging&project=5544478&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=2).

## How did you test this code?

N/A
