### PR TITLE
feat: Add UI for configuring SAML in Flagsmith

### DIFF
--- a/docs/docs/system-administration/authentication/01-SAML/index.md
+++ b/docs/docs/system-administration/authentication/01-SAML/index.md
@@ -15,17 +15,17 @@ SAML tab, you'll be able to configure it.
 
 In the UI, you will be able to configure the following fields.
 
-**Name:** (**Requierd**) A short name for the organisation, used as the input when clicking "Single Sign-on" at login
+**Name:** (**Required**) A short name for the organisation, used as the input when clicking "Single Sign-on" at login
 (note this is unique across all tenants and will form part of the URL so should only be alphanumeric + '-,\_').
 
-**Frontend URL**: (**Requierd**) This should be the base URL of the Flagsmith dashboard.
+**Frontend URL**: (**Required**) This should be the base URL of the Flagsmith dashboard.
 
 **Allow IdP initiated**: This field determines whether logins can be initiated from the IdP.
 
 **IdP metadata xml**: The metadata from the IdP.
 
-Once Flagsmith has configured your identity provider, you can download the service provider metadata XML document whit
-the button "Download Service Provider Metadata".
+Once Flagsmith you have configured your identity provider, you can download the service provider metadata XML document
+with the button "Download Service Provider Metadata".
 
 ### Assertion Consumer Service URL
 

--- a/docs/docs/system-administration/authentication/01-SAML/index.md
+++ b/docs/docs/system-administration/authentication/01-SAML/index.md
@@ -24,8 +24,8 @@ In the UI, you will be able to configure the following fields.
 
 **IdP metadata xml**: The metadata from the IdP.
 
-Once you have configured your identity provider, you can download the service provider metadata XML document
-with the button "Download Service Provider Metadata".
+Once you have configured your identity provider, you can download the service provider metadata XML document with the
+button "Download Service Provider Metadata".
 
 ### Assertion Consumer Service URL
 

--- a/docs/docs/system-administration/authentication/01-SAML/index.md
+++ b/docs/docs/system-administration/authentication/01-SAML/index.md
@@ -8,45 +8,24 @@ SAML authentication requires an [Enterprise subscription](https://flagsmith.com/
 
 :::
 
-## Setup (SaaS)
+## Setup
 
-To enable SAML authentication for your Flagsmith organisation, you must send your identity provider metadata XML
-document to [support@flagsmith.com](mailto:support@flagsmith.com).
+To enable SAML authentication for your Flagsmith organisation, you have to go to your organisations settings, and in the
+SAML tab, you'll be able to configure it.
 
-Once Flagsmith has configured your identity provider, we will send you a service provider metadata XML document or an
-Assertion Consumer Service (ACS) URL to use with your identity provider.
+In the UI, you will be able to configure the following fields.
 
-## Setup (self-hosted)
+**Name:** (**Requierd**) A short name for the organisation, used as the input when clicking "Single Sign-on" at login
+(note this is unique across all tenants and will form part of the URL so should only be alphanumeric + '-,\_').
 
-To enable SAML for your Flagsmith organisation in a self-hosted environment, you will need access the
-[Django admin interface](/deployment/configuration/django-admin).
+**Frontend URL**: (**Requierd**) This should be the base URL of the Flagsmith dashboard.
 
-In the Django admin interface, click on the "SAML Configurations" option in the menu on the left. To create a new SAML
-configuration, click on "Add SAML Configuration" in the top right corner.
+**Allow IdP initiated**: This field determines whether logins can be initiated from the IdP.
 
-You should see a screen similar to the following:
+**IdP metadata xml**: The metadata from the IdP.
 
-![SAML Auth Setup](/img/saml-auth-setup.png)
-
-From the drop down next to **Organisation**, select the organisation that you want to configure for SAML authentication.
-
-Next to **Organisation name**, add a URI-safe name that uniquely identifies the organisation. Users will need to provide
-this name when selecting the "Single Sign-On" option at the Flagsmith login screen.
-
-Next to **Frontend URL**, add the URL where your Flagsmith frontend is running. Users will be redirected to this URL
-when they authenticate using SAML.
-
-Copy your identity provider's XML metadata document into the **IdP metadata XML** field, or leave it blank and come back
-to this step later if you do not have it.
-
-If you want to enable IdP-initiated SSO, check the box next to **Allow IdP-initiated (unsolicited) login**. If you are
-unsure, leave this box unchecked.
-
-Hit the **Save** button to create the SAML configuration.
-
-Once your SAML configuration is created, you can download your Flagsmith service provider metadata by going back to the
-list of SAML configurations in the Django admin interface and clicking "Download" on the SAML configuration you just
-created.
+Once Flagsmith has configured your identity provider, you can download the service provider metadata XML document whit
+the button "Download Service Provider Metadata".
 
 ### Assertion Consumer Service URL
 

--- a/docs/docs/system-administration/authentication/01-SAML/index.md
+++ b/docs/docs/system-administration/authentication/01-SAML/index.md
@@ -24,7 +24,7 @@ In the UI, you will be able to configure the following fields.
 
 **IdP metadata xml**: The metadata from the IdP.
 
-Once Flagsmith you have configured your identity provider, you can download the service provider metadata XML document
+Once you have configured your identity provider, you can download the service provider metadata XML document
 with the button "Download Service Provider Metadata".
 
 ### Assertion Consumer Service URL

--- a/frontend/common/services/useSamlConfiguration.ts
+++ b/frontend/common/services/useSamlConfiguration.ts
@@ -1,6 +1,7 @@
 import { Res } from 'common/types/responses'
 import { Req } from 'common/types/requests'
 import { service } from 'common/service'
+import Utils from 'common/utils/utils'
 
 export const samlConfigurationService = service
   .enhanceEndpoints({ addTagTypes: ['SamlConfiguration'] })
@@ -44,6 +45,17 @@ export const samlConfigurationService = service
         providesTags: (res) => [{ id: res?.name, type: 'SamlConfiguration' }],
         query: (query: Req['getSamlConfigurationMetadata']) => ({
           url: `auth/saml/${query.name}/metadata/`,
+        }),
+      }),
+      getSamlConfigurations: builder.query<
+        Res['samlConfiguration'],
+        Req['getSamlConfigurations']
+      >({
+        providesTags: (res) => [{ id: res?.name, type: 'SamlConfiguration' }],
+        query: (query: Req['getSamlConfigurations']) => ({
+          url: `auth/saml/configuration/?${Utils.toParam(
+            query.organisation_id,
+          )}`,
         }),
       }),
       updateSamlConfiguration: builder.mutation<
@@ -106,6 +118,20 @@ export async function getSamlConfiguration(
     ),
   )
 }
+export async function getSamlConfigurations(
+  store: any,
+  data: Req['getSamlConfigurations'],
+  options?: Parameters<
+    typeof samlConfigurationService.endpoints.getSamlConfigurations.initiate
+  >[1],
+) {
+  return store.dispatch(
+    samlConfigurationService.endpoints.getSamlConfigurations.initiate(
+      data,
+      options,
+    ),
+  )
+}
 export async function getSamlConfigurationMetadata(
   store: any,
   data: Req['getSamlConfigurationMetadata'],
@@ -141,6 +167,7 @@ export const {
   useDeleteSamlConfigurationMutation,
   useGetSamlConfigurationMetadataQuery,
   useGetSamlConfigurationQuery,
+  useGetSamlConfigurationsQuery,
   useUpdateSamlConfigurationMutation,
   // END OF EXPORTS
 } = samlConfigurationService

--- a/frontend/common/services/useSamlConfiguration.ts
+++ b/frontend/common/services/useSamlConfiguration.ts
@@ -1,0 +1,152 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const samlConfigurationService = service
+  .enhanceEndpoints({ addTagTypes: ['SamlConfiguration'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      createSamlConfiguration: builder.mutation<
+        Res['samlConfiguration'],
+        Req['createSamlConfiguration']
+      >({
+        invalidatesTags: [{ id: 'LIST', type: 'SamlConfiguration' }],
+        query: (query: Req['createSamlConfiguration']) => ({
+          body: query,
+          method: 'POST',
+          url: `auth/saml/configuration/`,
+        }),
+      }),
+      deleteSamlConfiguration: builder.mutation<
+        Res['samlConfiguration'],
+        Req['deleteSamlConfiguration']
+      >({
+        invalidatesTags: [{ id: 'LIST', type: 'SamlConfiguration' }],
+        query: (query: Req['deleteSamlConfiguration']) => ({
+          body: query,
+          method: 'DELETE',
+          url: `auth/saml/configuration/${query.name}/`,
+        }),
+      }),
+      getSamlConfiguration: builder.query<
+        Res['samlConfiguration'],
+        Req['getSamlConfiguration']
+      >({
+        providesTags: (res) => [{ id: res?.name, type: 'SamlConfiguration' }],
+        query: (query: Req['getSamlConfiguration']) => ({
+          url: `auth/saml/configuration/${query.name}/`,
+        }),
+      }),
+      getSamlConfigurationMetadata: builder.query<
+        Res['samlConfiguration'],
+        Req['getSamlConfigurationMetadata']
+      >({
+        providesTags: (res) => [{ id: res?.name, type: 'SamlConfiguration' }],
+        query: (query: Req['getSamlConfigurationMetadata']) => ({
+          url: `auth/saml/${query.name}/metadata/`,
+        }),
+      }),
+      updateSamlConfiguration: builder.mutation<
+        Res['samlConfiguration'],
+        Req['updateSamlConfiguration']
+      >({
+        invalidatesTags: (res) => [
+          { id: 'LIST', type: 'SamlConfiguration' },
+          { id: res?.name, type: 'SamlConfiguration' },
+        ],
+        query: (query: Req['updateSamlConfiguration']) => ({
+          body: query,
+          method: 'PUT',
+          url: `auth/saml/configuration/${query.name}/`,
+        }),
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function createSamlConfiguration(
+  store: any,
+  data: Req['createSamlConfiguration'],
+  options?: Parameters<
+    typeof samlConfigurationService.endpoints.createSamlConfiguration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    samlConfigurationService.endpoints.createSamlConfiguration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function deleteSamlConfiguration(
+  store: any,
+  data: Req['deleteSamlConfiguration'],
+  options?: Parameters<
+    typeof samlConfigurationService.endpoints.deleteSamlConfiguration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    samlConfigurationService.endpoints.deleteSamlConfiguration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function getSamlConfiguration(
+  store: any,
+  data: Req['getSamlConfiguration'],
+  options?: Parameters<
+    typeof samlConfigurationService.endpoints.getSamlConfiguration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    samlConfigurationService.endpoints.getSamlConfiguration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function getSamlConfigurationMetadata(
+  store: any,
+  data: Req['getSamlConfigurationMetadata'],
+  options?: Parameters<
+    typeof samlConfigurationService.endpoints.getSamlConfigurationMetadata.initiate
+  >[1],
+) {
+  return store.dispatch(
+    samlConfigurationService.endpoints.getSamlConfigurationMetadata.initiate(
+      data,
+      options,
+    ),
+  )
+}
+export async function updateSamlConfiguration(
+  store: any,
+  data: Req['updateSamlConfiguration'],
+  options?: Parameters<
+    typeof samlConfigurationService.endpoints.updateSamlConfiguration.initiate
+  >[1],
+) {
+  return store.dispatch(
+    samlConfigurationService.endpoints.updateSamlConfiguration.initiate(
+      data,
+      options,
+    ),
+  )
+}
+// END OF FUNCTION_EXPORTS
+
+export const {
+  useCreateSamlConfigurationMutation,
+  useDeleteSamlConfigurationMutation,
+  useGetSamlConfigurationMetadataQuery,
+  useGetSamlConfigurationQuery,
+  useUpdateSamlConfigurationMutation,
+  // END OF EXPORTS
+} = samlConfigurationService
+
+/* Usage examples:
+const { data, isLoading } = useGetSamlConfigurationQuery({ id: 2 }, {}) //get hook
+const [createSamlConfiguration, { isLoading, data, isSuccess }] = useCreateSamlConfigurationMutation() //create hook
+samlConfigurationService.endpoints.getSamlConfiguration.select({id: 2})(store.getState()) //access data from any function
+*/

--- a/frontend/common/services/useSamlConfiguration.ts
+++ b/frontend/common/services/useSamlConfiguration.ts
@@ -4,14 +4,19 @@ import { service } from 'common/service'
 import Utils from 'common/utils/utils'
 
 export const samlConfigurationService = service
-  .enhanceEndpoints({ addTagTypes: ['SamlConfiguration'] })
+  .enhanceEndpoints({
+    addTagTypes: ['SamlConfiguration', 'samlConfigurations'],
+  })
   .injectEndpoints({
     endpoints: (builder) => ({
       createSamlConfiguration: builder.mutation<
         Res['samlConfiguration'],
         Req['createSamlConfiguration']
       >({
-        invalidatesTags: [{ id: 'LIST', type: 'SamlConfiguration' }],
+        invalidatesTags: [
+          { id: 'LIST', type: 'SamlConfiguration' },
+          { id: 'LIST', type: 'samlConfigurations' },
+        ],
         query: (query: Req['createSamlConfiguration']) => ({
           body: query,
           method: 'POST',
@@ -22,7 +27,10 @@ export const samlConfigurationService = service
         Res['samlConfiguration'],
         Req['deleteSamlConfiguration']
       >({
-        invalidatesTags: [{ id: 'LIST', type: 'SamlConfiguration' }],
+        invalidatesTags: [
+          { id: 'LIST', type: 'SamlConfiguration' },
+          { id: 'LIST', type: 'samlConfigurations' },
+        ],
         query: (query: Req['deleteSamlConfiguration']) => ({
           body: query,
           method: 'DELETE',
@@ -39,23 +47,25 @@ export const samlConfigurationService = service
         }),
       }),
       getSamlConfigurationMetadata: builder.query<
-        Res['samlConfiguration'],
+        Res['samlMetadata'],
         Req['getSamlConfigurationMetadata']
       >({
-        providesTags: (res) => [{ id: res?.name, type: 'SamlConfiguration' }],
+        providesTags: (res) => [
+          { id: res?.entity_id, type: 'SamlConfiguration' },
+        ],
         query: (query: Req['getSamlConfigurationMetadata']) => ({
           url: `auth/saml/${query.name}/metadata/`,
         }),
       }),
       getSamlConfigurations: builder.query<
-        Res['samlConfiguration'],
+        Res['samlConfigurations'],
         Req['getSamlConfigurations']
       >({
-        providesTags: (res) => [{ id: res?.name, type: 'SamlConfiguration' }],
+        providesTags: [{ id: 'LIST', type: 'samlConfigurations' }],
         query: (query: Req['getSamlConfigurations']) => ({
-          url: `auth/saml/configuration/?${Utils.toParam(
-            query.organisation_id,
-          )}`,
+          url: `auth/saml/configuration/?${Utils.toParam({
+            organisation: query.organisation_id,
+          })}`,
         }),
       }),
       updateSamlConfiguration: builder.mutation<
@@ -64,10 +74,11 @@ export const samlConfigurationService = service
       >({
         invalidatesTags: (res) => [
           { id: 'LIST', type: 'SamlConfiguration' },
+          { id: 'LIST', type: 'samlConfigurations' },
           { id: res?.name, type: 'SamlConfiguration' },
         ],
         query: (query: Req['updateSamlConfiguration']) => ({
-          body: query,
+          body: query.body,
           method: 'PUT',
           url: `auth/saml/configuration/${query.name}/`,
         }),

--- a/frontend/common/services/useSamlConfiguration.ts
+++ b/frontend/common/services/useSamlConfiguration.ts
@@ -54,6 +54,7 @@ export const samlConfigurationService = service
           { id: res?.entity_id, type: 'SamlConfiguration' },
         ],
         query: (query: Req['getSamlConfigurationMetadata']) => ({
+          headers: { Accept: 'application/xml' },
           url: `auth/saml/${query.name}/metadata/`,
         }),
       }),

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -4,9 +4,9 @@ import {
   FeatureState,
   FeatureStateValue,
   ImportStrategy,
-  APIKey,
   Approval,
   MultivariateOption,
+  SAMLConfiguration,
   Segment,
   Tag,
   ProjectFlag,
@@ -476,5 +476,10 @@ export type Req = {
     feature?: number
   }
   getFeatureSegment: { id: string }
+  getSamlConfiguration: { name: string }
+  getSamlConfigurationMetadata: { name: string }
+  updateSamlConfiguration: { name: string; body: SAMLConfiguration }
+  deleteSamlConfiguration: { name: string }
+  createSamlConfiguration: SAMLConfiguration
   // END OF TYPES
 }

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -477,6 +477,7 @@ export type Req = {
   }
   getFeatureSegment: { id: string }
   getSamlConfiguration: { name: string }
+  getSamlConfigurations: { organisation_id: number }
   getSamlConfigurationMetadata: { name: string }
   updateSamlConfiguration: { name: string; body: SAMLConfiguration }
   deleteSamlConfiguration: { name: string }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -669,5 +669,11 @@ export type Res = {
   cloneidentityFeatureStates: IdentityFeatureState
   featureStates: PagedResponse<FeatureState>
   samlConfiguration: SAMLConfiguration
+  samlConfigurations: PagedResponse<SAMLConfiguration>
+  samlMetadata: {
+    entity_id: string
+    response_url: string
+    metadata_xml: string
+  }
   // END OF TYPES
 }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -549,6 +549,14 @@ export type MetadataModelField = {
   is_required_for: isRequiredFor[]
 }
 
+export type SAMLConfiguration = {
+  organisation: number
+  name: string
+  frontend_url: string
+  idp_metadata_xml?: string
+  allow_idp_initiated?: boolean
+}
+
 export type Res = {
   segments: PagedResponse<Segment>
   segment: Segment
@@ -660,5 +668,6 @@ export type Res = {
   identityFeatureStates: PagedResponse<FeatureState>
   cloneidentityFeatureStates: IdentityFeatureState
   featureStates: PagedResponse<FeatureState>
+  samlConfiguration: SAMLConfiguration
   // END OF TYPES
 }

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -377,6 +377,10 @@ const Utils = Object.assign({}, require('./base/_utils'), {
         valid = isEnterprise
         break
       }
+      case 'SAML': {
+        valid = isEnterprise
+        break
+      }
       default:
         valid = true
         break

--- a/frontend/web/components/SamlTab.tsx
+++ b/frontend/web/components/SamlTab.tsx
@@ -5,7 +5,10 @@ import Icon from './Icon'
 import PanelSearch from './PanelSearch'
 import PageTitle from './PageTitle'
 
-import { useDeleteSamlConfigurationMutation } from 'common/services/useSamlConfiguration'
+import {
+  useDeleteSamlConfigurationMutation,
+  useGetSamlConfigurationsQuery,
+} from 'common/services/useSamlConfiguration'
 import CreateSAML from './modals/CreateSAML'
 import Switch from './Switch'
 import { SAMLConfiguration } from 'common/types/responses'
@@ -14,30 +17,10 @@ export type SamlTabType = {
   organisationId: number
 }
 const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
+  const { data } = useGetSamlConfigurationsQuery({
+    organisation_id: organisationId,
+  })
   const [deleteSamlConfiguration] = useDeleteSamlConfigurationMutation()
-  const samlExamples = [
-    {
-      'allow_idp_initiated': true,
-      'frontend_url': 'http://localhost:8080/',
-      'idp_metadata_xml': 'string',
-      'name': 'name 1',
-      'organisation': 1,
-    },
-    {
-      'allow_idp_initiated': false,
-      'frontend_url': 'http://localhost:8080/',
-      'idp_metadata_xml': 'string',
-      'name': 'name 2',
-      'organisation': 1,
-    },
-    {
-      'allow_idp_initiated': false,
-      'frontend_url': 'http://localhost:8080/',
-      'idp_metadata_xml': 'string',
-      'name': 'name 3',
-      'organisation': 1,
-    },
-  ]
   const openCreateSAML = (organisationId: number, name?: string) => {
     openModal(
       'New SAML configuration',
@@ -80,7 +63,7 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
               <div className='table-column'>Allow IDP Initiated</div>
             </Row>
           }
-          items={samlExamples}
+          items={data}
           renderRow={(samlConf: SAMLConfiguration) => (
             <Row
               onClick={() => {

--- a/frontend/web/components/SamlTab.tsx
+++ b/frontend/web/components/SamlTab.tsx
@@ -21,9 +21,13 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
     organisation_id: organisationId,
   })
   const [deleteSamlConfiguration] = useDeleteSamlConfigurationMutation()
-  const openCreateSAML = (organisationId: number, name?: string) => {
+  const openCreateSAML = (
+    title: string,
+    organisationId: number,
+    name?: string,
+  ) => {
     openModal(
-      'New SAML configuration',
+      title,
       <CreateSAML organisationId={organisationId} samlName={name || ''} />,
       'p-0 side-modal',
     )
@@ -37,7 +41,7 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
           <Button
             className='text-right'
             onClick={() => {
-              openCreateSAML(organisationId)
+              openCreateSAML('Create SAML configuration', organisationId)
             }}
           >
             {'Create a SAML Configuration'}
@@ -63,11 +67,15 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
               <div className='table-column'>Allow IDP Initiated</div>
             </Row>
           }
-          items={data}
+          items={data?.results || []}
           renderRow={(samlConf: SAMLConfiguration) => (
             <Row
               onClick={() => {
-                openCreateSAML(organisationId, samlConf.name)
+                openCreateSAML(
+                  'Update SAML configuration',
+                  organisationId,
+                  samlConf.name,
+                )
               }}
               space
               className='list-item clickable cursor-pointer'
@@ -84,14 +92,40 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
                   id='delete-invite'
                   type='button'
                   onClick={(e) => {
+                    openModal(
+                      'Delete Github Integration',
+                      <div>
+                        <div>
+                          Are you sure you want to delete the SAML
+                          configuration?
+                        </div>
+                        <div className='text-right'>
+                          <Button
+                            className='mr-2'
+                            onClick={() => {
+                              closeModal2()
+                            }}
+                          >
+                            Cancel
+                          </Button>
+                          <Button
+                            theme='danger'
+                            onClick={() => {
+                              deleteSamlConfiguration({
+                                name: samlConf.name,
+                              }).then(() => {
+                                toast('SAML configuration deleted')
+                                closeModal()
+                              })
+                            }}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </div>,
+                    )
                     e.stopPropagation()
                     e.preventDefault()
-                    deleteSamlConfiguration({ name: samlConf.name }).then(
-                      () => {
-                        toast('SAML configuration deleted')
-                        closeModal()
-                      },
-                    )
                   }}
                   className='btn btn-with-icon'
                 >

--- a/frontend/web/components/SamlTab.tsx
+++ b/frontend/web/components/SamlTab.tsx
@@ -22,7 +22,7 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
   const [metadataXml, setMetadataXml] = useState<string>('')
   const [allowIdpInitiated, setAllowIdpInitiated] = useState<boolean>(false)
   const [createSamlConfiguration] = useCreateSamlConfigurationMutation()
-  const [editSamlCOnfiguration] = useUpdateSamlConfigurationMutation()
+  const [editSamlConfiguration] = useUpdateSamlConfigurationMutation()
   const [deleteSamlConfiguration] = useDeleteSamlConfigurationMutation()
   const { data } = useGetSamlConfigurationQuery({ name: name }, { skip: !name })
 
@@ -103,7 +103,7 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
                 body.allow_idp_initiated = allowIdpInitiated
               }
               if (data) {
-                editSamlCOnfiguration(body).then((res) => {
+                editSamlConfiguration(body).then((res) => {
                   if (res.data) {
                     setName(res.data.organisation)
                     setFrontendUrl(res.data.name)
@@ -134,7 +134,7 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
             <div className='col-md-7'>
               <h5 className='mn-2'>Delete SAML configuration</h5>
               <p className='fs-small lh-sm'>
-                This SAML configuration will be permanently deleted.s
+                This SAML configuration will be permanently deleted.
               </p>
             </div>
             <Button

--- a/frontend/web/components/SamlTab.tsx
+++ b/frontend/web/components/SamlTab.tsx
@@ -1,160 +1,124 @@
-import React, { FC, useState } from 'react'
-import Switch from './Switch'
-import InputGroup from './base/forms/InputGroup'
+import React, { FC } from 'react'
 import Button from './base/forms/Button'
-import ValueEditor from './ValueEditor'
-import Utils from 'common/utils/utils'
-import {
-  useCreateSamlConfigurationMutation,
-  useUpdateSamlConfigurationMutation,
-  useDeleteSamlConfigurationMutation,
-  useGetSamlConfigurationQuery,
-} from 'common/services/useSamlConfiguration'
-import { SAMLConfiguration } from 'common/types/responses'
+
 import Icon from './Icon'
+import PanelSearch from './PanelSearch'
+import PageTitle from './PageTitle'
+
+import { useDeleteSamlConfigurationMutation } from 'common/services/useSamlConfiguration'
+import CreateSAML from './modals/CreateSAML'
+import Switch from './Switch'
+import { SAMLConfiguration } from 'common/types/responses'
 
 export type SamlTabType = {
   organisationId: number
 }
 const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
-  const [name, setName] = useState<string>('')
-  const [frontendUrl, setFrontendUrl] = useState<string>(window.location.origin)
-  const [metadataXml, setMetadataXml] = useState<string>('')
-  const [allowIdpInitiated, setAllowIdpInitiated] = useState<boolean>(false)
-  const [createSamlConfiguration] = useCreateSamlConfigurationMutation()
-  const [editSamlConfiguration] = useUpdateSamlConfigurationMutation()
   const [deleteSamlConfiguration] = useDeleteSamlConfigurationMutation()
-  const { data } = useGetSamlConfigurationQuery({ name: name }, { skip: !name })
+  const samlExamples = [
+    {
+      'allow_idp_initiated': true,
+      'frontend_url': 'http://localhost:8080/',
+      'idp_metadata_xml': 'string',
+      'name': 'name 1',
+      'organisation': 1,
+    },
+    {
+      'allow_idp_initiated': false,
+      'frontend_url': 'http://localhost:8080/',
+      'idp_metadata_xml': 'string',
+      'name': 'name 2',
+      'organisation': 1,
+    },
+    {
+      'allow_idp_initiated': false,
+      'frontend_url': 'http://localhost:8080/',
+      'idp_metadata_xml': 'string',
+      'name': 'name 3',
+      'organisation': 1,
+    },
+  ]
+  const openCreateSAML = (organisationId: number, name?: string) => {
+    openModal(
+      'New SAML configuration',
+      <CreateSAML organisationId={organisationId} samlName={name || ''} />,
+      'p-0 side-modal',
+    )
+  }
 
   return (
-    <div className='col-md-8 mt-3'>
-      <h5 className='mb-5'>SAML Configuration</h5>
-      <InputGroup
-        className='mt-2'
-        title='Name*'
-        data-test='saml-name'
-        value={name}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-          setName(Utils.safeParseEventValue(event))
-        }}
-        inputProps={{
-          className: 'full-width',
-        }}
-        type='text'
-        name='Name*'
-      />
-      <InputGroup
-        className='mt-2 mb-4'
-        title='Frontend URL*'
-        data-test='frontend-url'
-        value={frontendUrl}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-          setFrontendUrl(Utils.safeParseEventValue(event))
-        }}
-        inputProps={{
-          className: 'full-width',
-          name: 'groupName',
-        }}
-        type='text'
-        name='Frontend URL*'
-      />
-      <InputGroup
-        className='mt-2 mb-4'
-        title='Allow idp initiated'
-        component={
-          <Switch
-            checked={allowIdpInitiated}
-            onChange={() => {
-              setAllowIdpInitiated(!allowIdpInitiated)
-            }}
-          />
-        }
-      />
-      <FormGroup className='mb-4'>
-        <InputGroup
-          component={
-            <ValueEditor
-              data-test='featureValue'
-              name='featureValue'
-              className='full-width'
-              value={metadataXml}
-              onChange={setMetadataXml}
-              placeholder="e.g. '<xml>time<xml>' "
-            />
-          }
-          title={'IPD Metadata XML'}
-        />
-      </FormGroup>
-      <form className='text-right'>
-        <div className='text-right mt-2'>
+    <div className='mt-3'>
+      <PageTitle
+        title={'SAML Configuration'}
+        cta={
           <Button
-            type='submit'
-            disabled={!name || !frontendUrl}
+            className='text-right'
             onClick={() => {
-              const body = {
-                frontend_url: frontendUrl,
-                name: name,
-                organisation: organisationId,
-              } as SAMLConfiguration
-              if (metadataXml) {
-                body.idp_metadata_xml = metadataXml
-              }
-              if (allowIdpInitiated) {
-                body.allow_idp_initiated = allowIdpInitiated
-              }
-              if (data) {
-                editSamlConfiguration(body).then((res) => {
-                  if (res.data) {
-                    setName(res.data.organisation)
-                    setFrontendUrl(res.data.name)
-                    setMetadataXml(res.data.idp_metadata_xml)
-                    setAllowIdpInitiated(res.data.allow_idp_initiated)
-                  }
-                })
-              } else {
-                createSamlConfiguration(body).then((res) => {
-                  if (res.data) {
-                    setName(res.data.organisation)
-                    setFrontendUrl(res.data.name)
-                    setMetadataXml(res.data.idp_metadata_xml)
-                    setAllowIdpInitiated(res.data.allow_idp_initiated)
-                  }
-                })
-              }
+              openCreateSAML(organisationId)
             }}
           >
-            {data ? 'Edit Configuration' : 'Create Configuration'}
+            {'Create a SAML Configuration'}
           </Button>
-        </div>
-      </form>
-      <hr className='py-0 my-4' />
-      {data && (
-        <FormGroup className='mt-4 col-md-6'>
-          <Row space>
-            <div className='col-md-7'>
-              <h5 className='mn-2'>Delete SAML configuration</h5>
-              <p className='fs-small lh-sm'>
-                This SAML configuration will be permanently deleted.
-              </p>
-            </div>
-            <Button
-              id='delete-saml-configuration'
+        }
+      ></PageTitle>
+
+      <FormGroup className='mb-4'>
+        <PanelSearch
+          className='no-pad overflow-visible'
+          id='features-list'
+          renderSearchWithNoResults
+          itemHeight={65}
+          isLoading={false}
+          filterRow={(samlConf: SAMLConfiguration, search: string) =>
+            samlConf.name.toLowerCase().indexOf(search) > -1
+          }
+          header={
+            <Row className='table-header'>
+              <Flex className='table-column'>
+                <div className='font-weight-medium mb-1'>SAML Name</div>
+              </Flex>
+              <div className='table-column'>Allow IDP Initiated</div>
+            </Row>
+          }
+          items={samlExamples}
+          renderRow={(samlConf: SAMLConfiguration) => (
+            <Row
               onClick={() => {
-                deleteSamlConfiguration({ name: name }).then((res) => {
-                  if (res.data) {
-                    setName('')
-                    setMetadataXml('')
-                    setAllowIdpInitiated(false)
-                  }
-                })
+                openCreateSAML(organisationId, samlConf.name)
               }}
-              className='btn-with-icon btn-remove'
+              space
+              className='list-item clickable cursor-pointer'
+              key={samlConf.name}
             >
-              <Icon name='trash-2' width={20} fill='#EF4D56' />
-            </Button>
-          </Row>
-        </FormGroup>
-      )}
+              <Flex className='table-column px-3'>
+                <div className='font-weight-medium mb-1'>{samlConf.name}</div>
+              </Flex>
+              <div className='table-column'>
+                <Switch checked={samlConf.allow_idp_initiated} />
+              </div>
+              <div className='table-column'>
+                <Button
+                  id='delete-invite'
+                  type='button'
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    deleteSamlConfiguration({ name: samlConf.name }).then(
+                      () => {
+                        toast('SAML configuration deleted')
+                        closeModal()
+                      },
+                    )
+                  }}
+                  className='btn btn-with-icon'
+                >
+                  <Icon name='trash-2' width={20} fill='#656D7B' />
+                </Button>
+              </div>
+            </Row>
+          )}
+        />
+      </FormGroup>
     </div>
   )
 }

--- a/frontend/web/components/SamlTab.tsx
+++ b/frontend/web/components/SamlTab.tsx
@@ -47,7 +47,7 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
             {'Create a SAML Configuration'}
           </Button>
         }
-      ></PageTitle>
+      />
 
       <FormGroup className='mb-4'>
         <PanelSearch
@@ -61,10 +61,12 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
           }
           header={
             <Row className='table-header'>
-              <Flex className='table-column'>
-                <div className='font-weight-medium mb-1'>SAML Name</div>
+              <Flex className='table-column px-3'>
+                <div className='font-weight-medium'>SAML Name</div>
               </Flex>
-              <div className='table-column'>Allow IDP Initiated</div>
+              <div className='table-column' style={{ width: '205px' }}>
+                Allow IDP Initiated
+              </div>
             </Row>
           }
           items={data?.results || []}
@@ -84,7 +86,7 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
               <Flex className='table-column px-3'>
                 <div className='font-weight-medium mb-1'>{samlConf.name}</div>
               </Flex>
-              <div className='table-column'>
+              <div className='table-column' style={{ width: '95px' }}>
                 <Switch checked={samlConf.allow_idp_initiated} />
               </div>
               <div className='table-column'>

--- a/frontend/web/components/SamlTab.tsx
+++ b/frontend/web/components/SamlTab.tsx
@@ -1,0 +1,162 @@
+import React, { FC, useState } from 'react'
+import Switch from './Switch'
+import InputGroup from './base/forms/InputGroup'
+import Button from './base/forms/Button'
+import ValueEditor from './ValueEditor'
+import Utils from 'common/utils/utils'
+import {
+  useCreateSamlConfigurationMutation,
+  useUpdateSamlConfigurationMutation,
+  useDeleteSamlConfigurationMutation,
+  useGetSamlConfigurationQuery,
+} from 'common/services/useSamlConfiguration'
+import { SAMLConfiguration } from 'common/types/responses'
+import Icon from './Icon'
+
+export type SamlTabType = {
+  organisationId: number
+}
+const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
+  const [name, setName] = useState<string>('')
+  const [frontendUrl, setFrontendUrl] = useState<string>(window.location.origin)
+  const [metadataXml, setMetadataXml] = useState<string>('')
+  const [allowIdpInitiated, setAllowIdpInitiated] = useState<boolean>(false)
+  const [createSamlConfiguration] = useCreateSamlConfigurationMutation()
+  const [editSamlCOnfiguration] = useUpdateSamlConfigurationMutation()
+  const [deleteSamlConfiguration] = useDeleteSamlConfigurationMutation()
+  const { data } = useGetSamlConfigurationQuery({ name: name }, { skip: !name })
+
+  return (
+    <div className='col-md-8 mt-3'>
+      <h5 className='mb-5'>SAML Configuration</h5>
+      <InputGroup
+        className='mt-2'
+        title='Name*'
+        data-test='saml-name'
+        value={name}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          setName(Utils.safeParseEventValue(event))
+        }}
+        inputProps={{
+          className: 'full-width',
+        }}
+        type='text'
+        name='Name*'
+      />
+      <InputGroup
+        className='mt-2 mb-4'
+        title='Frontend URL*'
+        data-test='frontend-url'
+        value={frontendUrl}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          setFrontendUrl(Utils.safeParseEventValue(event))
+        }}
+        inputProps={{
+          className: 'full-width',
+          name: 'groupName',
+        }}
+        type='text'
+        name='Frontend URL*'
+      />
+      <InputGroup
+        className='mt-2 mb-4'
+        title='Allow idp initiated'
+        component={
+          <Switch
+            checked={allowIdpInitiated}
+            onChange={() => {
+              setAllowIdpInitiated(!allowIdpInitiated)
+            }}
+          />
+        }
+      />
+      <FormGroup className='mb-4'>
+        <InputGroup
+          component={
+            <ValueEditor
+              data-test='featureValue'
+              name='featureValue'
+              className='full-width'
+              value={metadataXml}
+              onChange={setMetadataXml}
+              placeholder="e.g. '<xml>time<xml>' "
+            />
+          }
+          title={'IPD Metadata XML'}
+        />
+      </FormGroup>
+      <form className='text-right'>
+        <div className='text-right mt-2'>
+          <Button
+            type='submit'
+            disabled={!name || !frontendUrl}
+            onClick={() => {
+              const body = {
+                frontend_url: frontendUrl,
+                name: name,
+                organisation: organisationId,
+              } as SAMLConfiguration
+              if (metadataXml) {
+                body.idp_metadata_xml = metadataXml
+              }
+              if (allowIdpInitiated) {
+                body.allow_idp_initiated = allowIdpInitiated
+              }
+              if (data) {
+                editSamlCOnfiguration(body).then((res) => {
+                  if (res.data) {
+                    setName(res.data.organisation)
+                    setFrontendUrl(res.data.name)
+                    setMetadataXml(res.data.idp_metadata_xml)
+                    setAllowIdpInitiated(res.data.allow_idp_initiated)
+                  }
+                })
+              } else {
+                createSamlConfiguration(body).then((res) => {
+                  if (res.data) {
+                    setName(res.data.organisation)
+                    setFrontendUrl(res.data.name)
+                    setMetadataXml(res.data.idp_metadata_xml)
+                    setAllowIdpInitiated(res.data.allow_idp_initiated)
+                  }
+                })
+              }
+            }}
+          >
+            {data ? 'Edit Configuration' : 'Create Configuration'}
+          </Button>
+        </div>
+      </form>
+      <hr className='py-0 my-4' />
+      {data && (
+        <FormGroup className='mt-4 col-md-6'>
+          <Row space>
+            <div className='col-md-7'>
+              <h5 className='mn-2'>Delete SAML configuration</h5>
+              <p className='fs-small lh-sm'>
+                This SAML configuration will be permanently deleted.s
+              </p>
+            </div>
+            <Button
+              id='delete-saml-configuration'
+              onClick={() => {
+                deleteSamlConfiguration({ name: name }).then((res) => {
+                  if (res.data) {
+                    setName('')
+                    setMetadataXml('')
+                    setAllowIdpInitiated(false)
+                  }
+                })
+              }}
+              className='btn-with-icon btn-remove'
+            >
+              <Icon name='trash-2' width={20} fill='#EF4D56' />
+            </Button>
+          </Row>
+        </FormGroup>
+      )}
+    </div>
+  )
+}
+
+export default SamlTab

--- a/frontend/web/components/ValueEditor.js
+++ b/frontend/web/components/ValueEditor.js
@@ -118,6 +118,10 @@ class ValueEditor extends Component {
   }
 
   componentDidMount() {
+    if (this.props.language) {
+      this.setState({ language: this.props.language })
+      this.renderValidation(this.props.language)
+    }
     if (!this.props.value) return
     try {
       const v = JSON.parse(this.props.value)
@@ -143,72 +147,74 @@ class ValueEditor extends Component {
           this.props.className,
         )}
       >
-        <Row className='select-language gap-1'>
-          <span
-            onMouseDown={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              this.setState({ language: 'txt' })
-            }}
-            className={cx('txt', { active: this.state.language === 'txt' })}
-          >
-            .txt
-          </span>
-          <span
-            onMouseDown={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              this.setState({ language: 'json' })
-            }}
-            className={cx('json', { active: this.state.language === 'json' })}
-          >
-            .json {this.state.language === 'json' && this.renderValidation()}
-          </span>
-          <span
-            onMouseDown={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              this.setState({ language: 'xml' })
-            }}
-            className={cx('xml', { active: this.state.language === 'xml' })}
-          >
-            .xml {this.state.language === 'xml' && this.renderValidation()}
-          </span>
-          <span
-            onMouseDown={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
+        {!this.props.onlyOneLang && (
+          <Row className='select-language gap-1'>
+            <span
+              onMouseDown={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                this.setState({ language: 'txt' })
+              }}
+              className={cx('txt', { active: this.state.language === 'txt' })}
+            >
+              .txt
+            </span>
+            <span
+              onMouseDown={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                this.setState({ language: 'json' })
+              }}
+              className={cx('json', { active: this.state.language === 'json' })}
+            >
+              .json {this.state.language === 'json' && this.renderValidation()}
+            </span>
+            <span
+              onMouseDown={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                this.setState({ language: 'xml' })
+              }}
+              className={cx('xml', { active: this.state.language === 'xml' })}
+            >
+              .xml {this.state.language === 'xml' && this.renderValidation()}
+            </span>
+            <span
+              onMouseDown={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
 
-              this.setState({ language: 'ini' })
-            }}
-            className={cx('ini', { active: this.state.language === 'ini' })}
-          >
-            .toml {this.state.language === 'ini' && this.renderValidation()}
-          </span>
-          <span
-            onMouseDown={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              this.setState({ language: 'yaml' })
-            }}
-            className={cx('yaml', { active: this.state.language === 'yaml' })}
-          >
-            .yaml {this.state.language === 'yaml' && this.renderValidation()}
-          </span>
-          <span
-            onMouseDown={() => {
-              const res = Clipboard.setString(this.props.value)
-              toast(
-                res ? 'Clipboard set' : 'Could not set clipboard :(',
-                res ? '' : 'danger',
-              )
-            }}
-            className={cx('txt primary')}
-          >
-            <Icon name='copy-outlined' fill={'#6837fc'} />
-            copy
-          </span>
-        </Row>
+                this.setState({ language: 'ini' })
+              }}
+              className={cx('ini', { active: this.state.language === 'ini' })}
+            >
+              .toml {this.state.language === 'ini' && this.renderValidation()}
+            </span>
+            <span
+              onMouseDown={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                this.setState({ language: 'yaml' })
+              }}
+              className={cx('yaml', { active: this.state.language === 'yaml' })}
+            >
+              .yaml {this.state.language === 'yaml' && this.renderValidation()}
+            </span>
+            <span
+              onMouseDown={() => {
+                const res = Clipboard.setString(this.props.value)
+                toast(
+                  res ? 'Clipboard set' : 'Could not set clipboard :(',
+                  res ? '' : 'danger',
+                )
+              }}
+              className={cx('txt primary')}
+            >
+              <Icon name='copy-outlined' fill={'#6837fc'} />
+              copy
+            </span>
+          </Row>
+        )}
 
         {E2E ? (
           <textarea {...rest} />

--- a/frontend/web/components/XMLUpload.tsx
+++ b/frontend/web/components/XMLUpload.tsx
@@ -1,49 +1,21 @@
-import { FC, useCallback, useState } from 'react'
+import { FC, useCallback } from 'react'
 import DropIcon from './svg/DropIcon'
 import Button from './base/forms/Button'
 import { useDropzone } from 'react-dropzone'
+import { DropAreaType } from './JSONUpload'
 
-export type DropAreaType = {
-  value: File | null
-  onChange: (file: File, json: Record<string, any> | string) => void
-}
-
-const JSONUpload: FC<DropAreaType> = ({ onChange, value }) => {
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState('')
-
+const XMLUpload: FC<DropAreaType> = ({ onChange, value }) => {
   const onDrop = useCallback((acceptedFiles: File[]) => {
-    setIsLoading(true)
-    setError('')
-    // Do something with the files
     const reader = new FileReader()
 
     reader.addEventListener(
       'load',
       () => {
-        let json
         try {
-          json = JSON.parse(reader.result)
-          onChange(acceptedFiles[0], json)
+          onChange(acceptedFiles[0], reader.result as string)
         } catch (e) {
-          setError('File is not valid JSON')
+          toast('File is not valid XML')
         }
-      },
-      false,
-    )
-
-    reader.addEventListener(
-      'error',
-      () => {
-        setIsLoading(false)
-        setError('Error reading file')
-      },
-      false,
-    )
-    reader.addEventListener(
-      'abort',
-      () => {
-        setIsLoading(false)
       },
       false,
     )
@@ -51,10 +23,11 @@ const JSONUpload: FC<DropAreaType> = ({ onChange, value }) => {
     if (acceptedFiles[0]) {
       reader.readAsText(acceptedFiles[0])
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-  const { getInputProps, getRootProps, isDragActive } = useDropzone({
+  const { getInputProps, getRootProps } = useDropzone({
     accept: {
-      'application/json': [],
+      'text/xml': [],
     },
     multiple: false,
     onDrop,
@@ -85,7 +58,7 @@ const JSONUpload: FC<DropAreaType> = ({ onChange, value }) => {
             <div className='mb-2'>
               <strong>Select a file or drag and drop here</strong>
             </div>
-            <div className='text-muted fs-small mb-4'>JSON File</div>
+            <div className='text-muted fs-small mb-4'>XML File</div>
             <Button>Select File</Button>
           </div>
         </div>
@@ -94,4 +67,4 @@ const JSONUpload: FC<DropAreaType> = ({ onChange, value }) => {
   )
 }
 
-export default JSONUpload
+export default XMLUpload

--- a/frontend/web/components/XMLUpload.tsx
+++ b/frontend/web/components/XMLUpload.tsx
@@ -56,10 +56,9 @@ const XMLUpload: FC<DropAreaType> = ({ onChange, value }) => {
           <div className='droparea text-center'>
             <DropIcon />
             <div className='mb-2'>
-              <strong>Select a file or drag and drop here</strong>
+              <strong>Drag a file or click to select a file</strong>
             </div>
             <div className='text-muted fs-small mb-4'>XML File</div>
-            <Button>Select File</Button>
           </div>
         </div>
       )}

--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -14,8 +14,8 @@ import { Req } from 'common/types/requests'
 import ErrorMessage from 'components/ErrorMessage'
 import { getStore } from 'common/store'
 import XMLUpload from 'components/XMLUpload'
-import Tabs from 'components/base/forms/Tabs'
-import TabItem from 'components/base/forms/TabItem'
+import { IonIcon } from '@ionic/react'
+import { cloudDownloadOutline } from 'ionicons/icons'
 
 type CreateSAML = {
   organisationId: number
@@ -43,21 +43,31 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
     return regularExpresion.test(name)
   }
 
-  const download = () => {
+  const convetToXmlFile = (fileName: string, data: string) => {
+    const blob = new Blob([data], { type: 'application/xml' })
+    const link = document.createElement('a')
+    link.download = `${fileName}.xml`
+    link.href = window.URL.createObjectURL(blob)
+    link.click()
+  }
+
+  const downloadServiceProvider = () => {
     setIsLoading(true)
-    getSamlConfigurationMetadata(getStore(), { name: name })
+    const name = data?.name || samlName
+    getSamlConfigurationMetadata(getStore(), { name: name! })
       .then((res) => {
         if (res.error) {
-          const blob = new Blob([res.error.data], { type: 'application/xml' })
-          const link = document.createElement('a')
-          link.download = `${data?.name}.xml`
-          link.href = window.URL.createObjectURL(blob)
-          link.click()
+          convetToXmlFile(name!, res.error.data)
         }
       })
       .finally(() => {
         setIsLoading(false)
       })
+  }
+
+  const downloadIDPMetadata = () => {
+    const name = data?.name || samlName
+    convetToXmlFile(`IDP metadata ${name!}`, data?.idp_metadata_xml || '')
   }
 
   return (
@@ -114,58 +124,60 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
         }
       />
       <FormGroup className='mb-1'>
-        <InputGroup
-          component={
-            <Tabs uncontrolled theme='pill m-0'>
-              <TabItem tabLabel='Paste XML'>
-                <div className='mt-2 p-0'>
-                  <ValueEditor
-                    data-test='featureValue'
-                    name='featureValue'
-                    className='full-width'
-                    value={metadataXml || data?.idp_metadata_xml}
-                    onChange={setMetadataXml}
-                    placeholder="e.g. '<xml>time<xml>' "
-                    onlyOneLang
-                    language='xml'
-                  />
-                </div>
-              </TabItem>
-              <TabItem tabLabel={'Upload file'}>
-                <div className='mt-2 p-0'>
-                  {uploadMetadataXml && (
-                    <ValueEditor
-                      data-test='featureValue'
-                      name='featureValue'
-                      className='full-width'
-                      value={uploadMetadataXml}
-                      placeholder="e.g. '<xml>time<xml>' "
-                      onlyOneLang
-                      language='xml'
+        <div className='mt-2 p-0'>
+          <Row>
+            <label className='form-label'>IDP Metadata XML</label>
+            {data?.idp_metadata_xml && (
+              <div className='ml-2' onClick={downloadIDPMetadata}>
+                <Tooltip
+                  title={
+                    <IonIcon
+                      className='text-primary'
+                      icon={cloudDownloadOutline}
+                      style={{ fontSize: '18px' }}
                     />
-                  )}
-                  <XMLUpload
-                    value={file}
-                    onChange={(file, data) => {
-                      setFile(file)
-                      setUploadMetadataXml(data as string)
-                      setMetadataXml(data as string)
-                    }}
-                  />
-                </div>
-              </TabItem>
-            </Tabs>
-          }
-          title={'IDP Metadata XML'}
-        />
+                  }
+                  place='right'
+                >
+                  Download IDP Metadata
+                </Tooltip>
+              </div>
+            )}
+          </Row>
+          <ValueEditor
+            data-test='featureValue'
+            name='featureValue'
+            className='full-width'
+            value={metadataXml || data?.idp_metadata_xml}
+            onChange={setMetadataXml}
+            placeholder="e.g. '<xml>time<xml>' "
+            onlyOneLang
+            language='xml'
+          />
+          <Row className='or-divider my-1'>
+            <Flex className='or-divider__line' />
+            Or
+            <Flex className='or-divider__line' />
+          </Row>
+          <XMLUpload
+            value={file}
+            onChange={(file, data) => {
+              setFile(file)
+              setUploadMetadataXml(data as string)
+              setMetadataXml(data as string)
+            }}
+          />
+        </div>
       </FormGroup>
 
       <div className='text-right py-2'>
-        {data?.idp_metadata_xml && (
-          <Button disabled={isLoading} onClick={download} className='mr-2'>
-            {isLoading ? 'Downloading' : 'Download Service Provider Metadata'}
-          </Button>
-        )}
+        <Button
+          disabled={isLoading}
+          onClick={downloadServiceProvider}
+          className='mr-2'
+        >
+          {isLoading ? 'Downloading' : 'Download Service Provider Metadata'}
+        </Button>
         <Button
           type='submit'
           disabled={!name || !frontendUrl}

--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -13,6 +13,9 @@ import Button from 'components/base/forms/Button'
 import { Req } from 'common/types/requests'
 import ErrorMessage from 'components/ErrorMessage'
 import { getStore } from 'common/store'
+import XMLUpload from 'components/XMLUpload'
+import Tabs from 'components/base/forms/Tabs'
+import TabItem from 'components/base/forms/TabItem'
 
 type CreateSAML = {
   organisationId: number
@@ -25,6 +28,8 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
   const [metadataXml, setMetadataXml] = useState<string>('')
   const [allowIdpInitiated, setAllowIdpInitiated] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [file, setFile] = useState<File | null>(null)
+  const [uploadMetadataXml, setUploadMetadataXml] = useState<string>('')
   const [createSamlConfiguration, createError] =
     useCreateSamlConfigurationMutation()
   const [editSamlConfiguration, updateError] =
@@ -111,22 +116,51 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
       <FormGroup className='mb-1'>
         <InputGroup
           component={
-            <ValueEditor
-              data-test='featureValue'
-              name='featureValue'
-              className='full-width'
-              value={metadataXml || data?.idp_metadata_xml}
-              onChange={setMetadataXml}
-              placeholder="e.g. '<xml>time<xml>' "
-              onlyOneLang
-              language='xml'
-            />
+            <Tabs uncontrolled theme='pill m-0'>
+              <TabItem tabLabel='Paste XML'>
+                <div className='mt-2 p-0'>
+                  <ValueEditor
+                    data-test='featureValue'
+                    name='featureValue'
+                    className='full-width'
+                    value={metadataXml || data?.idp_metadata_xml}
+                    onChange={setMetadataXml}
+                    placeholder="e.g. '<xml>time<xml>' "
+                    onlyOneLang
+                    language='xml'
+                  />
+                </div>
+              </TabItem>
+              <TabItem tabLabel={'Upload file'}>
+                <div className='mt-2 p-0'>
+                  {uploadMetadataXml && (
+                    <ValueEditor
+                      data-test='featureValue'
+                      name='featureValue'
+                      className='full-width'
+                      value={uploadMetadataXml}
+                      placeholder="e.g. '<xml>time<xml>' "
+                      onlyOneLang
+                      language='xml'
+                    />
+                  )}
+                  <XMLUpload
+                    value={file}
+                    onChange={(file, data) => {
+                      setFile(file)
+                      setUploadMetadataXml(data as string)
+                      setMetadataXml(data as string)
+                    }}
+                  />
+                </div>
+              </TabItem>
+            </Tabs>
           }
           title={'IDP Metadata XML'}
         />
       </FormGroup>
 
-      <div className='text-right pb-2'>
+      <div className='text-right py-2'>
         {data?.idp_metadata_xml && (
           <Button disabled={isLoading} onClick={download} className='mr-2'>
             {isLoading ? 'Downloading' : 'Download Service Provider Metadata'}

--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -1,0 +1,162 @@
+import React, { FC, useState } from 'react'
+import InputGroup from 'components/base/forms/InputGroup'
+import Utils from 'common/utils/utils'
+import Switch from 'components/Switch'
+import ValueEditor from 'components/ValueEditor'
+import {
+  useCreateSamlConfigurationMutation,
+  useUpdateSamlConfigurationMutation,
+  useGetSamlConfigurationQuery,
+} from 'common/services/useSamlConfiguration'
+import Button from 'components/base/forms/Button'
+import { Req } from 'common/types/requests'
+import ErrorMessage from 'components/ErrorMessage'
+
+type CreateSAML = {
+  organisationId: number
+  samlName?: string
+}
+
+const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
+  const [name, setName] = useState<string>(samlName || '')
+  const [frontendUrl, setFrontendUrl] = useState<string>(window.location.origin)
+  const [metadataXml, setMetadataXml] = useState<string>('')
+  const [allowIdpInitiated, setAllowIdpInitiated] = useState<boolean>(false)
+  const [createSamlConfiguration, createError] =
+    useCreateSamlConfigurationMutation()
+  const [editSamlConfiguration, updateError] =
+    useUpdateSamlConfigurationMutation()
+  const { data } = useGetSamlConfigurationQuery(
+    { name: samlName! },
+    { skip: !samlName },
+  )
+  const validateName = (name: string) => {
+    const regularExpresion = /^[a-zA-Z0-9_+-]+$/
+    return regularExpresion.test(name)
+  }
+
+  return (
+    <div className='create-feature-tab px-3'>
+      <Tooltip
+        title={
+          <InputGroup
+            className='mt-2'
+            title='Name*'
+            data-test='saml-name'
+            value={name}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              const nuevoNombre = Utils.safeParseEventValue(event)
+              if (validateName(nuevoNombre)) {
+                setName(nuevoNombre)
+              }
+            }}
+            inputProps={{
+              className: 'full-width',
+            }}
+            type='text'
+            name='Name*'
+          />
+        }
+      >
+        {
+          'A short name for the organization, used as the input when clicking "Single Sign-on" at login, should only consist of alphanumeric characters, plus (+), underscore (_), and hyphen (-).'
+        }
+      </Tooltip>
+
+      <InputGroup
+        className='mt-2 mb-4'
+        title='Frontend URL*'
+        data-test='frontend-url'
+        value={frontendUrl}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          setFrontendUrl(Utils.safeParseEventValue(event))
+        }}
+        inputProps={{
+          className: 'full-width',
+          name: 'groupName',
+        }}
+        type='text'
+        name='Frontend URL*'
+      />
+      <InputGroup
+        className='mt-2 mb-4'
+        title='Allow idp initiated'
+        component={
+          <Switch
+            checked={allowIdpInitiated}
+            onChange={() => {
+              setAllowIdpInitiated(!allowIdpInitiated)
+            }}
+          />
+        }
+      />
+      {allowIdpInitiated && (
+        <FormGroup className='mb-4'>
+          <InputGroup
+            component={
+              <ValueEditor
+                data-test='featureValue'
+                name='featureValue'
+                className='full-width'
+                value={metadataXml}
+                onChange={setMetadataXml}
+                placeholder="e.g. '<xml>time<xml>' "
+                onlyOneLang
+                language='xml'
+              />
+            }
+            title={'IPD Metadata XML'}
+          />
+        </FormGroup>
+      )}
+
+      <div className='text-right mt-2'>
+        <Button
+          type='submit'
+          disabled={!name || !frontendUrl}
+          onClick={() => {
+            const body = {
+              frontend_url: frontendUrl,
+              name: name,
+              organisation: organisationId,
+            } as Req['updateSamlConfiguration']['body']
+            if (metadataXml) {
+              body.idp_metadata_xml = metadataXml
+            }
+            if (allowIdpInitiated) {
+              body.allow_idp_initiated = allowIdpInitiated
+            }
+            if (data) {
+              editSamlConfiguration(body).then((res) => {
+                if (res.data) {
+                  setName(res.data.organisation)
+                  setFrontendUrl(res.data.name)
+                  setMetadataXml(res.data.idp_metadata_xml)
+                  setAllowIdpInitiated(res.data.allow_idp_initiated)
+                }
+              })
+            } else {
+              createSamlConfiguration(body).then((res) => {
+                if (res.data) {
+                  setName(res.data.organisation)
+                  setFrontendUrl(res.data.name)
+                  setMetadataXml(res.data.idp_metadata_xml)
+                  setAllowIdpInitiated(res.data.allow_idp_initiated)
+                }
+              })
+            }
+          }}
+        >
+          {data ? 'Edit Configuration' : 'Create Configuration'}
+        </Button>
+      </div>
+      {!!createError ||
+        (!!updateError && (
+          <div className='mt-2'>
+            <ErrorMessage error={createError || updateError} />
+          </div>
+        ))}
+    </div>
+  )
+}
+export default CreateSAML

--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -29,7 +29,6 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
   const [allowIdpInitiated, setAllowIdpInitiated] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [file, setFile] = useState<File | null>(null)
-  const [uploadMetadataXml, setUploadMetadataXml] = useState<string>('')
   const [createSamlConfiguration, createError] =
     useCreateSamlConfigurationMutation()
   const [editSamlConfiguration, updateError] =
@@ -144,16 +143,21 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
               </div>
             )}
           </Row>
-          <ValueEditor
-            data-test='featureValue'
-            name='featureValue'
-            className='full-width'
-            value={metadataXml || data?.idp_metadata_xml}
-            onChange={setMetadataXml}
-            placeholder="e.g. '<xml>time<xml>' "
-            onlyOneLang
-            language='xml'
-          />
+          {(!samlName ||
+            (data &&
+              ((data.name && !data.idp_metadata_xml) ||
+                data.idp_metadata_xml))) && (
+            <ValueEditor
+              data-test='featureValue'
+              name='featureValue'
+              className='full-width'
+              value={metadataXml || data?.idp_metadata_xml}
+              onChange={setMetadataXml}
+              placeholder="e.g. '<xml>time<xml>' "
+              onlyOneLang
+              language='xml'
+            />
+          )}
           <Row className='or-divider my-1'>
             <Flex className='or-divider__line' />
             Or
@@ -163,7 +167,6 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
             value={file}
             onChange={(file, data) => {
               setFile(file)
-              setUploadMetadataXml(data as string)
               setMetadataXml(data as string)
             }}
           />

--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -42,10 +42,10 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
     setIsLoading(true)
     getSamlConfigurationMetadata(getStore(), { name: name })
       .then((res) => {
-        if (res.data) {
-          const blob = new Blob([JSON.stringify(res.data, null, 2)])
+        if (res.error) {
+          const blob = new Blob([res.error.data], { type: 'application/xml' })
           const link = document.createElement('a')
-          link.download = `${data?.name}.json`
+          link.download = `${data?.name}.xml`
           link.href = window.URL.createObjectURL(blob)
           link.click()
         }
@@ -57,36 +57,32 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
 
   return (
     <div className='create-feature-tab px-3'>
-      <Tooltip
-        title={
-          <InputGroup
-            className='mt-2'
-            title='Name*'
-            data-test='saml-name'
-            value={name}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              const nuevoNombre = Utils.safeParseEventValue(event)
-              if (validateName(nuevoNombre)) {
-                setName(nuevoNombre)
-              }
-            }}
-            inputProps={{
-              className: 'full-width',
-            }}
-            type='text'
-            name='Name*'
-          />
-        }
-      >
-        {
-          'A short name for the organization, used as the input when clicking "Single Sign-on" at login, should only consist of alphanumeric characters, plus (+), underscore (_), and hyphen (-).'
-        }
-      </Tooltip>
+      <InputGroup
+        className='mt-2'
+        title='Name*'
+        data-test='saml-name'
+        tooltip='A short name for the organization, used as the input when clicking "Single Sign-on" at login, should only consist of alphanumeric characters, plus (+), underscore (_), and hyphen (-).'
+        tooltipPlace='right'
+        value={name}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          const nuevoNombre = Utils.safeParseEventValue(event)
+          if (validateName(nuevoNombre)) {
+            setName(nuevoNombre)
+          }
+        }}
+        inputProps={{
+          className: 'full-width',
+        }}
+        type='text'
+        name='Name*'
+      />
 
       <InputGroup
         className='mt-2 mb-4'
         title='Frontend URL*'
         data-test='frontend-url'
+        tooltip='The base URL of the Flagsmith dashboard'
+        tooltipPlace='right'
         value={frontendUrl}
         onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
           setFrontendUrl(Utils.safeParseEventValue(event))
@@ -101,6 +97,8 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
       <InputGroup
         className='mt-2 mb-4'
         title='Allow IDP initiated'
+        tooltip='Determines whether logins can be initiated from the IDP'
+        tooltipPlace='right'
         component={
           <Switch
             checked={allowIdpInitiated || data?.allow_idp_initiated}
@@ -110,7 +108,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
           />
         }
       />
-      <FormGroup className='mb-4'>
+      <FormGroup className='mb-1'>
         <InputGroup
           component={
             <ValueEditor
@@ -128,7 +126,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
         />
       </FormGroup>
 
-      <div className='text-right mt-2'>
+      <div className='text-right pb-2'>
         {data?.idp_metadata_xml && (
           <Button disabled={isLoading} onClick={download} className='mr-2'>
             {isLoading ? 'Downloading' : 'Download Service Provider Metadata'}
@@ -176,7 +174,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
             }
           }}
         >
-          {data ? 'Edit Configuration' : 'Create Configuration'}
+          {data ? 'Update Configuration' : 'Create Configuration'}
         </Button>
       </div>
       {!!createError ||

--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -128,7 +128,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
           <Row>
             <label className='form-label'>IDP Metadata XML</label>
             {data?.idp_metadata_xml && (
-              <div className='ml-2' onClick={downloadIDPMetadata}>
+              <div className='ml-2 clickable' onClick={downloadIDPMetadata}>
                 <Tooltip
                   title={
                     <IonIcon

--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -232,16 +232,18 @@ const OrganisationSettingsPage = class extends Component {
                     AccountStore.getUser() &&
                     AccountStore.getOrganisationRole() === 'ADMIN'
                   ) {
-                    const isEnterprise =
-                      Utils.getPlanName(organisation.subscription?.plan) ===
-                      'enterprise'
+                    const showSaml =
+                      Utils.getPlanPermission(
+                        organisation.subscription?.plan,
+                        'SAML',
+                      ) && Utils.getFlagsmithHasFeature('saml_configuration')
                     displayedTabs.push(
                       ...[
                         SettingsTab.General,
                         paymentsEnabled && !isAWS ? SettingsTab.Billing : null,
                         SettingsTab.Keys,
                         SettingsTab.Webhooks,
-                        isEnterprise ? SettingsTab.SAML : null,
+                        showSaml ? SettingsTab.SAML : null,
                       ].filter((v) => !!v),
                     )
                   } else {
@@ -613,12 +615,11 @@ const OrganisationSettingsPage = class extends Component {
                             </FormGroup>
                           </TabItem>
                         )}
-                        {Utils.getFlagsmithHasFeature('saml_configuration') &&
-                          displayedTabs.includes(SettingsTab.SAML) && (
-                            <TabItem tabLabel='SAML'>
-                              <SamlTab organisationId={organisation.id} />
-                            </TabItem>
-                          )}
+                        {displayedTabs.includes(SettingsTab.SAML) && (
+                          <TabItem tabLabel='SAML'>
+                            <SamlTab organisationId={organisation.id} />
+                          </TabItem>
+                        )}
                       </Tabs>
                     </div>
                   )

--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -15,11 +15,13 @@ import Icon from 'components/Icon'
 import _data from 'common/data/base/_data'
 import AccountStore from 'common/stores/account-store'
 import PageTitle from 'components/PageTitle'
+import SamlTab from 'components/SamlTab'
 
 const SettingsTab = {
   'Billing': 'billing',
   'General': 'general',
   'Keys': 'keys',
+  'SAML': 'saml',
   'Usage': 'usage',
   'Webhooks': 'webhooks',
 }
@@ -230,12 +232,16 @@ const OrganisationSettingsPage = class extends Component {
                     AccountStore.getUser() &&
                     AccountStore.getOrganisationRole() === 'ADMIN'
                   ) {
+                    const isEnterprise =
+                      Utils.getPlanName(organisation.subscription?.plan) ===
+                      'enterprise'
                     displayedTabs.push(
                       ...[
                         SettingsTab.General,
                         paymentsEnabled && !isAWS ? SettingsTab.Billing : null,
                         SettingsTab.Keys,
                         SettingsTab.Webhooks,
+                        isEnterprise ? SettingsTab.SAML : null,
                       ].filter((v) => !!v),
                     )
                   } else {
@@ -607,6 +613,12 @@ const OrganisationSettingsPage = class extends Component {
                             </FormGroup>
                           </TabItem>
                         )}
+                        {Utils.getFlagsmithHasFeature('saml_configuration') &&
+                          displayedTabs.includes(SettingsTab.SAML) && (
+                            <TabItem tabLabel='SAML'>
+                              <SamlTab organisationId={organisation.id} />
+                            </TabItem>
+                          )}
                       </Tabs>
                     </div>
                   )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Add UI for configuring SAML in Flagsmith wrapped with the `saml_configuration` flag.
## How did you test this code?

- Use an organisation with an enterprise plan
- Go to Organisation Settings -> SAML tab
- Create a SAML configuration