### PR TITLE
docs: Add Crisp, identity overrides in local evaluation rollout info

### DIFF
--- a/docs/docs/clients/overview.md
+++ b/docs/docs/clients/overview.md
@@ -346,7 +346,10 @@ are all computed locally.
 - Identities and their Traits are **not** read from or written to the Flagsmith API, and so are not persisted in the
   datastore. This means that you have to provide the full complement of Traits when requesting the Flags for a
   particular Identity. Our SDKs all provide relevant methods to achieve this.
-- [Identity overrides](../basic-features/managing-identities#identity-overrides) do not operate at all.
+- [Identity overrides](../basic-features/managing-identities#identity-overrides) work with self-hosted Flagsmith
+  instances. We're rolling them out gradually for the SaaS version. If you are a SaaS customer,
+  <a class="open-chat" data-crisp-chat-message="Hi! I'm interested to try out identity overrides in Local Evaluation mode with Flagsmith SaaS!" href="#local-evaluation-1">contact
+  us</a> to try them out!
 - [Analytics-based Integrations](/integrations/overview#analytics-platforms) do not run.
   [Flag Analytics](/advanced-use/flag-analytics) do still work, if enabled within the
   [SDK setup](/clients/server-side#configuring-the-sdk).

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -219,6 +219,10 @@ const config = {
             }),
         ],
     ],
+
+    scripts: ['/js/crisp-chat.js'],
+
+    clientModules: [require.resolve('./plugins/crisp-chat-links.js')],
 };
 
 export default config;

--- a/docs/plugins/crisp-chat-links.js
+++ b/docs/plugins/crisp-chat-links.js
@@ -1,0 +1,32 @@
+// Plugin code based on https://stackoverflow.com/a/74736980
+
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+const enableCrispLinks = () => {
+    document.querySelectorAll('.open-chat').forEach((oc) => {
+        oc.onclick = ({ target }) => {
+            if (typeof $crisp !== 'undefined') {
+                $crisp.push(['do', 'chat:open']);
+                if (target.dataset.crispChatMessage) {
+                    $crisp.push(['set', 'message:text', [e.target.dataset.crispChatMessage]]);
+                }
+            }
+        };
+    });
+};
+
+export function onRouteDidUpdate({ location, previousLocation }) {
+    // Don't execute if we are still on the same page; the lifecycle may be fired
+    // because the hash changes (e.g. when navigating between headings)
+    if (location.pathname === previousLocation?.pathname) return;
+    enableCrispLinks();
+}
+
+if (ExecutionEnvironment.canUseDOM) {
+    // We also need to setCodeRevealTriggers when the page first loads; otherwise,
+    // after reloading the page, these triggers will not be set until the user
+    // navigates somewhere.
+    window.addEventListener('load', () => {
+        setTimeout(enableCrispLinks, 1000);
+    });
+}

--- a/docs/src/pages/api/index.js
+++ b/docs/src/pages/api/index.js
@@ -2,7 +2,6 @@ import { RedocStandalone } from 'redoc';
 import React from 'react';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 export default function Redoc() {
     const { siteConfig } = useDocusaurusContext();

--- a/docs/src/pages/api/index.js
+++ b/docs/src/pages/api/index.js
@@ -2,6 +2,7 @@ import { RedocStandalone } from 'redoc';
 import React from 'react';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 export default function Redoc() {
     const { siteConfig } = useDocusaurusContext();

--- a/docs/static/js/crisp-chat.js
+++ b/docs/static/js/crisp-chat.js
@@ -1,0 +1,9 @@
+window.$crisp = [];
+window.CRISP_WEBSITE_ID = '8857f89e-0eb5-4263-ab49-a293872b6c19';
+(function () {
+    d = document;
+    s = d.createElement('script');
+    s.src = 'https://client.crisp.chat/l.js';
+    s.async = 1;
+    d.getElementsByTagName('head')[0].appendChild(s);
+})();


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds the following to docs:
- Crisp button & chat
- Latest local evaluation information, with an invitation to contact us via Crisp

## How did you test this code?

Ran Docusaurus build locally.