### PR TITLE
fix: don't create audit log for FeatureStateValue when not published

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -1080,6 +1080,9 @@ class FeatureStateValue(
         self.string_value = source_feature_state_value.string_value
         self.save()
 
+    def get_skip_create_audit_log(self) -> bool:
+        return self.feature_state.get_skip_create_audit_log()
+
     def get_update_log_message(self, history_instance) -> typing.Optional[str]:
         fs = self.feature_state
 

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -660,7 +660,7 @@ def test_feature_state_get_skip_create_audit_log_if_uncommitted_change_request(
 
 
 def test_feature_state_get_skip_create_audit_log_if_environment_feature_version(
-    environment_v2_versioning, feature
+    environment_v2_versioning: Environment, feature: Feature
 ):
     # Given
     environment_feature_version = EnvironmentFeatureVersion.objects.get(
@@ -674,6 +674,23 @@ def test_feature_state_get_skip_create_audit_log_if_environment_feature_version(
 
     # Then
     assert feature_state.get_skip_create_audit_log() is True
+
+
+def test_feature_state_value_get_skip_create_audit_log_if_environment_feature_version(
+    environment_v2_versioning: Environment, feature: Feature
+):
+    # Given
+    environment_feature_version = EnvironmentFeatureVersion.objects.get(
+        environment=environment_v2_versioning, feature=feature
+    )
+    feature_state = FeatureState.objects.get(
+        environment=environment_v2_versioning,
+        feature=feature,
+        environment_feature_version=environment_feature_version,
+    )
+
+    # Then
+    assert feature_state.feature_state_value.get_skip_create_audit_log() is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

We don't create audit log records for FeatureStates when they belong to an unpublished change request, or they are part of an environment feature version (see #4064 for more context on this one). Based on that logic, however, this PR updates the FeatureStateValue object to behave the same way. Currently, in an environment where versioning is enabled we see audit log records for changes to feature values, but not to their enabled state. This PR fixes that inconsistency. 

## How did you test this code?

Added a unit test. 
