### PR TITLE
chore(versioning): add feature and environment to serializer retrieve serializer

### DIFF
--- a/api/features/versioning/serializers.py
+++ b/api/features/versioning/serializers.py
@@ -62,6 +62,8 @@ class EnvironmentFeatureVersionSerializer(serializers.ModelSerializer):
             "is_live",
             "published_by",
             "created_by",
+            "feature",
+            "environment",
         )
 
 
@@ -69,7 +71,11 @@ class EnvironmentFeatureVersionRetrieveSerializer(EnvironmentFeatureVersionSeria
     previous_version_uuid = serializers.SerializerMethodField()
 
     class Meta(EnvironmentFeatureVersionSerializer.Meta):
-        _fields = ("previous_version_uuid",)
+        _fields = (
+            "previous_version_uuid",
+            "feature",
+            "environment",
+        )
 
         fields = EnvironmentFeatureVersionSerializer.Meta.fields + _fields
 

--- a/api/tests/unit/features/versioning/test_unit_versioning_views.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_views.py
@@ -171,6 +171,8 @@ def test_retrieve_feature_version_with_no_previous_version(
     response_json = response.json()
     assert response_json["uuid"] == str(environment_feature_version.uuid)
     assert response_json["previous_version_uuid"] is None
+    assert response_json["feature"] == feature.id
+    assert response_json["environment"] == environment_v2_versioning.id
 
 
 def test_retrieve_feature_version_with_previous_version(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds `feature` and `environment` attributes to retrieve response when getting an EnvironmentFeatureVersion. 

## How did you test this code?

Added extra checks to the existing test. 
