### PR TITLE
fix(versioning): ensure get_previous_version returns previous version, not latest version

### DIFF
--- a/api/features/versioning/models.py
+++ b/api/features/versioning/models.py
@@ -123,7 +123,7 @@ class EnvironmentFeatureVersion(
             self.__class__.objects.filter(
                 environment=self.environment,
                 feature=self.feature,
-                live_from__lt=timezone.now(),
+                live_from__lt=self.live_from or timezone.now(),
                 published_at__isnull=False,
             )
             .order_by("-live_from")

--- a/api/tests/unit/features/versioning/test_unit_versioning_models.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_models.py
@@ -159,6 +159,36 @@ def test_get_previous_version_ignores_unpublished_version(
     assert version_3.get_previous_version() == version_1
 
 
+def test_get_previous_version_returns_previous_version_if_there_is_a_more_recent_previous_version(
+    feature: "Feature",
+    environment_v2_versioning: Environment,
+    admin_user: "FFAdminUser",
+) -> None:
+    # Given
+    # The initial version created when enabling versioning_v2
+    version_0 = EnvironmentFeatureVersion.objects.get(
+        environment=environment_v2_versioning, feature=feature
+    )
+
+    # Now, let's create (and publish) 2 new versions
+    version_1 = EnvironmentFeatureVersion.objects.create(
+        environment=environment_v2_versioning, feature=feature
+    )
+    version_1.publish(admin_user)
+    version_2 = EnvironmentFeatureVersion.objects.create(
+        environment=environment_v2_versioning, feature=feature
+    )
+    version_2.publish(admin_user)
+
+    # When
+    previous_version = version_1.get_previous_version()
+
+    # Then
+    # The previous version for the first version we created should be the
+    # original version created when enabling versioning_v2
+    assert previous_version == version_0
+
+
 def test_publish(
     feature: "Feature",
     project: "Project",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Previously, the `get_previous_version` method incorrectly returned the latest live version. For example, calling get_previous_version on version 2 if versions 1, 2, 3 were published in that order would previously return version 3. Thie PR corrects the logic to correctly return version 1. 

## How did you test this code?

Added a new unit test. 
