### PR TITLE
fix: select propagation

### DIFF
--- a/frontend/web/project/project-components.js
+++ b/frontend/web/project/project-components.js
@@ -113,11 +113,17 @@ global.Select = class extends PureComponent {
           ))}
       </div>
     ) : (
-      <Select
-        className={`react-select ${props.size ? props.size : ''}`}
-        classNamePrefix='react-select'
-        {...props}
-      />
+      <div
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+      >
+        <Select
+          className={`react-select ${props.size ? props.size : ''}`}
+          classNamePrefix='react-select'
+          {...props}
+        />
+      </div>
     )
   }
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Clicking a select element would propagate the event, this is an issue when the parent has a click handler. Prevents the permissions select from opening the permissions modal 

![image](https://github.com/Flagsmith/flagsmith/assets/8608314/9ab24f22-5b62-45df-89bd-15e5959fd822)


## How did you test this code?

- Clicked the permissions select.
- Tested other select elements in the app.