### PR TITLE
fix(versioning): prevent FeatureSegment from writing audit log on delete when v2 versioning enabled

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -389,6 +389,11 @@ class FeatureSegment(
     def get_audit_log_related_object_id(self, history_instance) -> int:
         return self.feature_id
 
+    def get_skip_create_audit_log(self) -> bool:
+        # Don't create audit logs when deleting feature segments using versioning
+        # v2 as we rely on the version history instead.
+        return self.environment_feature_version_id is not None
+
     def get_delete_log_message(self, history_instance) -> typing.Optional[str]:
         return SEGMENT_FEATURE_STATE_DELETED_MESSAGE % (
             self.feature.name,

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -6,6 +6,9 @@ from pytest_lazyfixture import lazy_fixture
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from audit.constants import SEGMENT_FEATURE_STATE_DELETED_MESSAGE
+from audit.models import AuditLog
+from audit.related_object_type import RelatedObjectType
 from environments.models import Environment
 from environments.permissions.constants import (
     MANAGE_SEGMENT_OVERRIDES,
@@ -596,3 +599,43 @@ def test_get_feature_segments_only_returns_latest_version(
     response_json = response.json()
     assert response_json["count"] == 1
     assert response_json["results"][0]["id"] == feature_segment_v2.id
+
+
+def test_delete_feature_segment_does_not_create_audit_log_for_versioning_v2(
+    feature: Feature,
+    segment: Segment,
+    feature_segment: FeatureSegment,
+    segment_featurestate: FeatureState,
+    environment_v2_versioning: Environment,
+    staff_client: APIClient,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+    with_project_permissions: WithProjectPermissionsCallable,
+) -> None:
+    # Given
+    with_project_permissions([VIEW_PROJECT])
+    with_environment_permissions([MANAGE_SEGMENT_OVERRIDES, VIEW_ENVIRONMENT])
+
+    # we first need to create a new version so that we can modify the feature segment
+    # that is generated as part of the new version
+    version_2 = EnvironmentFeatureVersion.objects.create(
+        environment=environment_v2_versioning, feature=feature
+    )
+    version_2_feature_segment = FeatureSegment.objects.get(
+        feature=feature, segment=segment, environment_feature_version=version_2
+    )
+
+    url = reverse(
+        "api-v1:features:feature-segment-detail", args=[version_2_feature_segment.id]
+    )
+
+    # When
+    response = staff_client.delete(url)
+
+    # Then
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    assert not AuditLog.objects.filter(
+        related_object_type=RelatedObjectType.FEATURE.name,
+        related_object_id=feature.id,
+        log=SEGMENT_FEATURE_STATE_DELETED_MESSAGE % (feature.name, segment.name),
+    ).exists()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Prevents the application from writing an AuditLog record when a feature segment is deleted if v2 versioning is enabled. 

## How did you test this code?

Added a new unit test. 