### PR TITLE
fix(versioning): ensure that audit log record is created when committing versions via CR

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -38,6 +38,7 @@ from audit.tasks import (
 from environments.tasks import rebuild_environment_document
 from features.models import FeatureState
 from features.versioning.models import EnvironmentFeatureVersion
+from features.versioning.signals import environment_feature_version_published
 from features.versioning.tasks import trigger_update_version_webhooks
 from features.workflows.core.exceptions import (
     CannotApproveOwnChangeRequest,
@@ -168,6 +169,9 @@ class ChangeRequest(
                 rebuild_environment_document.delay(
                     kwargs={"environment_id": self.environment_id},
                     delay_until=environment_feature_version.live_from,
+                )
+                environment_feature_version_published.send(
+                    EnvironmentFeatureVersion, instance=environment_feature_version
                 )
 
     def get_create_log_message(self, history_instance) -> typing.Optional[str]:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR ensures that the correct `environment_feature_version_published` signal is sent when we publish a ChangeRequest that includes EnvironmentFeatureVersion objects. 

## How did you test this code?

Added new test
