### PR TITLE
fix: Reload integrations on create

### DIFF
--- a/frontend/web/components/IntegrationList.js
+++ b/frontend/web/components/IntegrationList.js
@@ -290,7 +290,6 @@ class IntegrationList extends Component {
         }
       }),
     ).then((res) => {
-      console.log(res)
       this.setState({
         activeIntegrations: _.map(res, (item) =>
           !!item && item.length ? item : [],
@@ -375,7 +374,7 @@ class IntegrationList extends Component {
         }
         githubMeta={{ githubId: githubId, installationId: installationId }}
         projectId={this.props.projectId}
-        onComplete={githubId ? this.fetch : this.fetchGithubIntegration}
+        onComplete={githubId ? this.fetchGithubIntegration : this.fetch }
       />,
       'side-modal',
     )

--- a/frontend/web/components/modals/CreateEditIntegrationModal.js
+++ b/frontend/web/components/modals/CreateEditIntegrationModal.js
@@ -69,7 +69,7 @@ const CreateEditIntegration = class extends Component {
     const isEdit = this.props.data && this.props.data.id
     Utils.preventDefault(e)
     if (this.props.integration.isExternalInstallation) {
-      closeModal()
+      this.onComplete()
     }
     if (this.state.isLoading) {
       return


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes what seems like a regression in integrations, creating an integration was not refreshing the integration list. CC @novakzaballa this was a regression from the GH integration, I'm a bit unsure what the expected behaviour is?