### PR TITLE
feat: Keep segment modal open on create / edit, add segment name to modal

### DIFF
--- a/frontend/e2e/helpers.cafe.ts
+++ b/frontend/e2e/helpers.cafe.ts
@@ -458,6 +458,7 @@ export const createSegment = async (
   await click(byId('create-segment'))
   await waitForElementVisible(byId(`segment-${index}-name`))
   await assertTextContent(byId(`segment-${index}-name`), id)
+  await closeModal()
 }
 
 export const waitAndRefresh = async (waitFor = 3000) => {

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -647,7 +647,6 @@ class TheComponent extends Component {
                   <CreateSegmentModal
                     className='my-2'
                     segment={this.state.segmentEditId}
-                    isEdit
                     condensed
                     onComplete={() => {
                       this.setState({

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -52,7 +52,7 @@ import AddMetadataToEntity, {
   CustomMetadataField,
 } from 'components/metadata/AddMetadataToEntity'
 import { useGetSupportedContentTypeQuery } from 'common/services/useSupportedContentType'
-import { setInterceptClose } from './base/ModalDefault'
+import { setInterceptClose, setModalTitle } from './base/ModalDefault'
 
 type PageType = {
   number: number
@@ -90,7 +90,6 @@ const CreateSegment: FC<CreateSegmentType> = ({
   identities,
   identitiesLoading,
   identity,
-  isEdit,
   onCancel,
   onComplete,
   page,
@@ -119,7 +118,8 @@ const CreateSegment: FC<CreateSegmentType> = ({
       },
     ],
   }
-  const segment = _segment || defaultSegment
+  const [segment, setSegment] = useState(_segment || defaultSegment)
+  const isEdit = !!segment.id
   const [
     createSegment,
     {
@@ -267,6 +267,7 @@ const CreateSegment: FC<CreateSegmentType> = ({
   }, [])
   useEffect(() => {
     if (createSuccess && createSegmentData) {
+      setSegment(createSegmentData)
       onComplete?.(createSegmentData)
     }
     //eslint-disable-next-line
@@ -740,7 +741,8 @@ type LoadingCreateSegmentType = {
   environmentId: string
   isEdit?: boolean
   readOnly?: boolean
-  onComplete?: () => void
+  onSegmentRetrieved?: (segment: Segment) => void
+  onComplete?: (segment: Segment) => void
   projectId: string
   segment?: number
 }
@@ -772,6 +774,11 @@ const LoadingCreateSegment: FC<LoadingCreateSegmentType> = (props) => {
     },
   )
 
+  useEffect(() => {
+    if (segmentData) {
+      props.onSegmentRetrieved?.(segmentData)
+    }
+  }, [segmentData])
   const isEdge = Utils.getIsEdge()
 
   const { data: identities, isLoading: identitiesLoading } =

--- a/frontend/web/components/pages/SegmentsPage.tsx
+++ b/frontend/web/components/pages/SegmentsPage.tsx
@@ -23,6 +23,7 @@ import Icon from 'components/Icon'
 import PageTitle from 'components/PageTitle'
 import Switch from 'components/Switch'
 import Panel from 'components/base/grid/Panel'
+import { setModalTitle } from 'components/modals/base/ModalDefault'
 
 const CodeHelp = require('../../components/CodeHelp')
 type SegmentsPageType = {
@@ -91,10 +92,10 @@ const SegmentsPage: FC<SegmentsPageType> = (props) => {
     openModal(
       'New Segment',
       <CreateSegmentModal
-        onComplete={() => {
+        onComplete={(segment) => {
           //todo: remove when CreateSegment uses hooks
-          closeModal()
-          refetch()
+          setModalTitle(`Edit Segment: ${segment.name}`)
+          toast('Created segment')
         }}
         environmentId={environmentId}
         projectId={projectId}
@@ -124,11 +125,13 @@ const SegmentsPage: FC<SegmentsPageType> = (props) => {
       `Edit Segment`,
       <CreateSegmentModal
         segment={id}
-        isEdit
+        onSegmentRetrieved={(segment) =>
+          setModalTitle(`Edit Segment: ${segment.name}`)
+        }
         readOnly={readOnly}
         onComplete={() => {
           refetch()
-          closeModal()
+          toast('Updated Segment')
         }}
         environmentId={environmentId}
         projectId={projectId}

--- a/frontend/web/components/pages/UserPage.js
+++ b/frontend/web/components/pages/UserPage.js
@@ -143,7 +143,6 @@ const UserPage = class extends Component {
       <CreateSegmentModal
         segment={segment.id}
         readOnly
-        isEdit
         environmentId={this.props.match.params.environmentId}
         projectId={this.props.match.params.projectId}
       />,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Creating/updating a segment keeps the modal open
- Creating a segment updates the modal title and shows as edit segment
- Edit segment now has the name in the title 