### PR TITLE
fix: save empty segment overrides request

### DIFF
--- a/frontend/common/services/useFeatureVersion.ts
+++ b/frontend/common/services/useFeatureVersion.ts
@@ -135,11 +135,12 @@ export const featureVersionService = service
           }
 
           const ret = {
-            data: res.map((item) => ({
+            feature_states: res.map((item) => ({
               ...item,
               version_sha: versionRes.data.uuid,
             })),
             error: res.find((v) => !!v.error)?.error,
+            version_sha: versionRes.data.uuid,
           }
 
           // Step 5: Publish the feature version
@@ -151,7 +152,7 @@ export const featureVersionService = service
             })
           }
 
-          return ret as any
+          return { data: ret } as any
         },
       }),
       createFeatureVersion: builder.mutation<

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -477,13 +477,13 @@ const controller = {
         ]
       }
 
-      const version = await createAndSetFeatureVersion(getStore(), {
+      const { data: version } = await createAndSetFeatureVersion(getStore(), {
         environmentId: env.id,
         featureId: projectFlag.id,
         featureStates,
         skipPublish: true,
       })
-      environment_feature_versions = version.data.map((v) => v.version_sha)
+      environment_feature_versions = [version.version_sha]
     }
     const prom = data
       .get(
@@ -612,15 +612,15 @@ const controller = {
           environmentId: res,
           featureId: projectFlag.id,
           featureStates,
-        }).then((res) => {
-          if (res.error) {
-            throw res.error
+        }).then((version) => {
+          if (version.error) {
+            throw version.error
           }
           // Fetch and update the latest environment feature state
           return getVersionFeatureState(getStore(), {
             environmentId: ProjectStore.getEnvironmentIdFromKey(environmentId),
             featureId: projectFlag.id,
-            sha: res.data[0].version_sha,
+            sha: version.data.version_sha,
           }).then((res) => {
             const environmentFeatureState = res.data.find(
               (v) => !v.feature_segment,
@@ -669,11 +669,11 @@ const controller = {
               environmentId: res,
               featureId: projectFlag.id,
               featureStates: [data],
-            }).then((res) => {
-              if (res.error) {
-                throw res.error
+            }).then((version) => {
+              if (version.error) {
+                throw version.error
               }
-              const featureState = res.data[0].data
+              const featureState = version.data.feature_states[0].data
               store.model.keyedEnvironmentFeatures[projectFlag.id] = {
                 ...featureState,
                 feature_state_value: Utils.featureStateToValue(

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -502,9 +502,11 @@ class TheComponent extends Component {
     openConfirm({
       body: (
         <div>
-          {
-            'Are you sure you want to delete this segment override? This will be applied when you click Update Segment Overrides and cannot be undone.'
-          }
+          {`Are you sure you want to delete this segment override?${
+            this.props.is4Eyes
+              ? ''
+              : ' This will be applied when you click Update Segment Overrides and cannot be undone.'
+          }`}
         </div>
       ),
       destructive: true,

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1308,6 +1308,7 @@ const CreateFlag = class extends Component {
                                                 return (
                                                   <SegmentOverrides
                                                     readOnly={isReadOnly}
+                                                    is4Eyes={is4Eyes}
                                                     showEditSegment
                                                     showCreateSegment={
                                                       this.state


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- On an environment with versioning enabled, creating a change request with empty segment overrides was not sending the version id. This was due to it using the version id of the feature states that were used to create the version, a version now returns its id at the root level.

## How did you test this code?

- Created a change request with no segments
- Created a change request with just feature states
- Saved a feature without a change request
- Saved segment overrides without a change request