### PR TITLE
fix(versioning): send live from when creating versions for change requests

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -250,14 +250,14 @@ class ChangeRequest(
         # feature states, we also want to prevent it at the ORM level.
         if self.committed_at and not (
             self.environment.deleted_at
-            or (self._live_from and self._live_from > timezone.now())
+            or (self.live_from and self.live_from > timezone.now())
         ):
             raise ChangeRequestDeletionError(
                 "Cannot delete a Change Request that has been committed."
             )
 
     @property
-    def _live_from(self) -> datetime | None:
+    def live_from(self) -> datetime | None:
         # First we check if there are feature states associated with the change request
         # and, if so, we return the live_from of the feature state with the earliest
         # live_from.

--- a/frontend/common/services/useFeatureVersion.ts
+++ b/frontend/common/services/useFeatureVersion.ts
@@ -27,6 +27,7 @@ export const featureVersionService = service
             await createFeatureVersion(getStore(), {
               environmentId: query.environmentId,
               featureId: query.featureId,
+              liveFrom: query.liveFrom,
             })
 
           // Step 2: Get the feature states for the live version
@@ -161,7 +162,7 @@ export const featureVersionService = service
       >({
         invalidatesTags: [{ id: 'LIST', type: 'FeatureVersion' }],
         query: (query: Req['createFeatureVersion']) => ({
-          body: {},
+          body: { live_from: query.liveFrom },
           method: 'POST',
           url: `environments/${query.environmentId}/features/${query.featureId}/versions/`,
         }),

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -482,6 +482,7 @@ const controller = {
         featureId: projectFlag.id,
         featureStates,
         skipPublish: true,
+        liveFrom: changeRequest.live_from,
       })
       environment_feature_versions = [version.version_sha]
     }

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -311,10 +311,12 @@ export type Req = {
       | 'toRemove'
       | 'multivariate_feature_state_values'
     >[]
+    liveFrom?: string
   }
   createFeatureVersion: {
     environmentId: number
     featureId: number
+    liveFrom?: string
   }
   publishFeatureVersion: {
     sha: string


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR updates the FE code to send the `live_from` attribute when creating a new version for a change request. It also updates the property on the `ChangeRequest` from `_live_from` to `live_from` so that we can use it in the flagsmith-workflows module.  

## How did you test this code?

Ran the FE locally and confirmed that the `live_from` attribute is correctly sent when creating a version for a change request. I also regression tested it to confirm that it's _not_ sent when creating a new version that should not be scheduled. 
