### PR TITLE
fix(versioning): use version live from

### DIFF
--- a/frontend/web/components/pages/ChangeRequestPage.js
+++ b/frontend/web/components/pages/ChangeRequestPage.js
@@ -151,9 +151,10 @@ const ChangeRequestsPage = class extends Component {
   publishChangeRequest = () => {
     const id = this.props.match.params.id
     const changeRequest = ChangeRequestStore.model[id]
-    const scheduledDate = changeRequest.environment_feature_versions
-      ? moment(changeRequest.environment_feature_versions[0].live_from)
-      : moment(changeRequest.feature_states[0].live_from)
+    const scheduledDate =
+      changeRequest.environment_feature_versions.length > 0
+        ? moment(changeRequest.environment_feature_versions[0].live_from)
+        : moment(changeRequest.feature_states[0].live_from)
     const isScheduled = scheduledDate > moment()
 
     openConfirm({
@@ -252,9 +253,10 @@ const ChangeRequestsPage = class extends Component {
         orgUsers &&
         orgUsers.find((v) => v.id === changeRequest.committed_by)) ||
       {}
-    const scheduledDate = changeRequest.environment_feature_versions
-      ? moment(changeRequest.environment_feature_versions[0].live_from)
-      : moment(changeRequest.feature_states[0].live_from)
+    const scheduledDate =
+      changeRequest.environment_feature_versions.length > 0
+        ? moment(changeRequest.environment_feature_versions[0].live_from)
+        : moment(changeRequest.feature_states[0].live_from)
 
     const isScheduled = scheduledDate > moment()
 

--- a/frontend/web/components/pages/ChangeRequestPage.js
+++ b/frontend/web/components/pages/ChangeRequestPage.js
@@ -148,13 +148,16 @@ const ChangeRequestsPage = class extends Component {
     AppActions.actionChangeRequest(this.props.match.params.id, 'approve')
   }
 
+  getScheduledDate = (changeRequest) => {
+    return changeRequest.environment_feature_versions.length > 0
+      ? moment(changeRequest.environment_feature_versions[0].live_from)
+      : moment(changeRequest.feature_states[0].live_from)
+  }
+
   publishChangeRequest = () => {
     const id = this.props.match.params.id
     const changeRequest = ChangeRequestStore.model[id]
-    const scheduledDate =
-      changeRequest.environment_feature_versions.length > 0
-        ? moment(changeRequest.environment_feature_versions[0].live_from)
-        : moment(changeRequest.feature_states[0].live_from)
+    const scheduledDate = this.getScheduledDate(changeRequest)
     const isScheduled = scheduledDate > moment()
 
     openConfirm({
@@ -253,11 +256,8 @@ const ChangeRequestsPage = class extends Component {
         orgUsers &&
         orgUsers.find((v) => v.id === changeRequest.committed_by)) ||
       {}
-    const scheduledDate =
-      changeRequest.environment_feature_versions.length > 0
-        ? moment(changeRequest.environment_feature_versions[0].live_from)
-        : moment(changeRequest.feature_states[0].live_from)
 
+    const scheduledDate = this.getScheduledDate(changeRequest)
     const isScheduled = scheduledDate > moment()
 
     const approval =

--- a/frontend/web/components/pages/ChangeRequestPage.js
+++ b/frontend/web/components/pages/ChangeRequestPage.js
@@ -151,12 +151,10 @@ const ChangeRequestsPage = class extends Component {
   publishChangeRequest = () => {
     const id = this.props.match.params.id
     const changeRequest = ChangeRequestStore.model[id]
-    const isScheduled =
-      new Date(changeRequest.feature_states[0].live_from).valueOf() >
-      new Date().valueOf()
-    const scheduledDate = changeRequest.feature_states
-      ? moment(changeRequest.feature_states[0].live_from)
-      : moment(changeRequest.environment_feature_versions[0].live_from)
+    const scheduledDate = changeRequest.environment_feature_versions
+      ? moment(changeRequest.environment_feature_versions[0].live_from)
+      : moment(changeRequest.feature_states[0].live_from)
+    const isScheduled = scheduledDate > moment()
 
     openConfirm({
       body: (
@@ -254,13 +252,11 @@ const ChangeRequestsPage = class extends Component {
         orgUsers &&
         orgUsers.find((v) => v.id === changeRequest.committed_by)) ||
       {}
-    const isScheduled =
-      new Date(changeRequest.feature_states[0].live_from).valueOf() >
-      new Date().valueOf()
+    const scheduledDate = changeRequest.environment_feature_versions
+      ? moment(changeRequest.environment_feature_versions[0].live_from)
+      : moment(changeRequest.feature_states[0].live_from)
 
-    const scheduledDate = changeRequest.feature_states
-      ? moment(changeRequest.feature_states[0].live_from)
-      : moment(changeRequest.environment_feature_versions[0].live_from)
+    const isScheduled = scheduledDate > moment()
 
     const approval =
       changeRequest &&

--- a/frontend/web/components/pages/ChangeRequestPage.js
+++ b/frontend/web/components/pages/ChangeRequestPage.js
@@ -154,7 +154,9 @@ const ChangeRequestsPage = class extends Component {
     const isScheduled =
       new Date(changeRequest.feature_states[0].live_from).valueOf() >
       new Date().valueOf()
-    const scheduledDate = moment(changeRequest.feature_states[0].live_from)
+    const scheduledDate = changeRequest.feature_states
+      ? moment(changeRequest.feature_states[0].live_from)
+      : moment(changeRequest.environment_feature_versions[0].live_from)
 
     openConfirm({
       body: (
@@ -256,7 +258,9 @@ const ChangeRequestsPage = class extends Component {
       new Date(changeRequest.feature_states[0].live_from).valueOf() >
       new Date().valueOf()
 
-    const scheduledDate = moment(changeRequest.feature_states[0].live_from)
+    const scheduledDate = changeRequest.feature_states
+      ? moment(changeRequest.feature_states[0].live_from)
+      : moment(changeRequest.environment_feature_versions[0].live_from)
 
     const approval =
       changeRequest &&


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Use the live_from value from the first environment feature version instead of the feature state if it exists. 

## How did you test this code?

Need to first merge the code in #4117, then we can test this using the preview URL. 
