### PR TITLE
fix: Limit feature paging to 50

### DIFF
--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -29,7 +29,7 @@ import segmentOverrides from 'components/SegmentOverrides'
 import { Req } from 'common/types/requests'
 import { getVersionFeatureState } from 'common/services/useVersionFeatureState'
 let createdFirstFeature = false
-const PAGE_SIZE = 200
+const PAGE_SIZE = 50
 function recursivePageGet(url, parentRes) {
   return data.get(url).then((res) => {
     let response


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Feature list paging was set to 200 which was unnecessary since filtering has been done on the BE for a while now. Large lists optimise themselves by painting only visible rows, this was inadvertently causing issues with the feature action button.

Before: 

<img width="1365" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/cd9b8659-95d4-46f4-b4d2-8ba055d6f297">

After:
<img width="1372" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/4424997d-e7e1-43dd-b60d-00ef9e3a18a8">



## How did you test this code?

- View a project with over 50 feature flags (previously it would have been over 200)
- Tested paging and filtering
- Tested feature actions