### PR TITLE
fix: announcement width

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -381,21 +381,23 @@ const App = class extends Component {
                       />
                     )}
                     {user && showBanner && (
-                      <Row className={'px-3 mt-4'}>
-                        <InfoMessage
-                          title={announcementValue.title}
-                          isClosable={announcementValue.isClosable}
-                          close={() =>
-                            this.closeAnnouncement(announcementValue.id)
-                          }
-                          buttonText={announcementValue.buttonText}
-                          url={announcementValue.url}
-                        >
-                          <div>
-                            <div>{announcementValue.description}</div>
-                          </div>
-                        </InfoMessage>
-                      </Row>
+                      <div className='container mt-4'>
+                        <div className='row'>
+                          <InfoMessage
+                            title={announcementValue.title}
+                            isClosable={announcementValue.isClosable}
+                            close={() =>
+                              this.closeAnnouncement(announcementValue.id)
+                            }
+                            buttonText={announcementValue.buttonText}
+                            url={announcementValue.url}
+                          >
+                            <div>
+                              <div>{announcementValue.description}</div>
+                            </div>
+                          </InfoMessage>
+                        </div>
+                      </div>
                     )}
                     {this.props.children}
                   </Fragment>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The announcement banner was full width rather than using a standard container size.

Before / after

<img width="1973" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/8608314/09c0dadb-657c-4a0c-8fc3-48d430e6e85e">
