### PR TITLE
fix: show audit logs url

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -399,7 +399,7 @@ class TheComponent extends Component {
             onShowAudit={() => {
               if (disableControls) return
               this.context.router.history.push(
-                `/project/${projectId}/environment/${environmentId}/audit-log?env=${environment.id}&search=${projectFlag.name}`,
+                `/project/${projectId}/audit-log?env=${environment.id}&search=${projectFlag.name}`,
               )
             }}
             onRemove={() => {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fix 'Show audit logs' option in feature actions. Currently it links to the incorrect URL path. 

## How did you test this code?

Ran the FE locally and verified that the show audit logs link works in all projects (v2 versioning and not). 
