### PR TITLE
infra: run influxdb feature evaluation in thread

### DIFF
--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -150,7 +150,7 @@ class SDKAnalyticsFlags(GenericAPIView):
                 )
             )
         elif settings.INFLUXDB_TOKEN:
-            track_feature_evaluation_influxdb.delay(
+            track_feature_evaluation_influxdb.run_in_thread(
                 args=(
                     request.environment.id,
                     request.data,

--- a/api/app_analytics/views.py
+++ b/api/app_analytics/views.py
@@ -150,6 +150,10 @@ class SDKAnalyticsFlags(GenericAPIView):
                 )
             )
         elif settings.INFLUXDB_TOKEN:
+            # Due to load issues on the task processor, we
+            # explicitly run this task in a separate thread.
+            # TODO: batch influx data to prevent large amounts
+            #  of tasks.
             track_feature_evaluation_influxdb.run_in_thread(
                 args=(
                     request.environment.id,

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -99,7 +99,7 @@ class TaskHandler(typing.Generic[P]):
     def run_in_thread(
         self,
         *,
-        args: tuple[typing.Any] = (),
+        args: tuple[typing.Any, ...] = (),
         kwargs: dict[str, typing.Any] | None = None,
     ) -> None:
         _validate_inputs(*args, **kwargs)

--- a/api/task_processor/decorators.py
+++ b/api/task_processor/decorators.py
@@ -102,6 +102,7 @@ class TaskHandler(typing.Generic[P]):
         args: tuple[typing.Any, ...] = (),
         kwargs: dict[str, typing.Any] | None = None,
     ) -> None:
+        kwargs = kwargs or {}
         _validate_inputs(*args, **kwargs)
         thread = Thread(target=self.unwrapped, args=args, kwargs=kwargs, daemon=True)
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Due to large amounts of throughput from tracking feature evaluation requests in influx db, we're reverting this task to run in thread. 

## How did you test this code?

Updated some unit tests to verify that the call to run_in_thread is happening correctly
