### PR TITLE
docs: remove warning from IN operator in FoF flag

### DIFF
--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -475,7 +475,6 @@ The list of the flags and remote config we're currently using in production is b
  {
   "value": "IN",
   "label": "In",
-  "warning": "Check your SDK version supports the IN operator. <a href=\"https://docs.flagsmith.com/clients/overview#sdk-compatibility\">See SDK compatibility docs</a>.",
   "valuePlaceholder": "Value1,Value2"
  },
  {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Remove version warning from FoF flag for segment operators. 

## How did you test this code?

Clicked through to docs preview link and verified change. 
