### PR TITLE
fix: Edge V2-enabled environments are not rebuilt on feature version publish

### DIFF
--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -1,8 +1,5 @@
 from audit.models import AuditLog
-from environments.dynamodb import (
-    DynamoEnvironmentWrapper,
-    DynamoIdentityWrapper,
-)
+from environments.dynamodb import DynamoIdentityWrapper
 from environments.models import (
     Environment,
     environment_v2_wrapper,
@@ -17,11 +14,8 @@ from task_processor.models import TaskPriority
 
 
 @register_task_handler(priority=TaskPriority.HIGH)
-def rebuild_environment_document(environment_id: int):
-    wrapper = DynamoEnvironmentWrapper()
-    if wrapper.is_enabled:
-        environment = Environment.objects.get(id=environment_id)
-        wrapper.write_environment(environment)
+def rebuild_environment_document(environment_id: int) -> None:
+    Environment.write_environments_to_dynamodb(environment_id=environment_id)
 
 
 @register_task_handler(priority=TaskPriority.HIGHEST)

--- a/api/tests/unit/environments/test_unit_environments_tasks.py
+++ b/api/tests/unit/environments/test_unit_environments_tasks.py
@@ -1,6 +1,7 @@
 from pytest_mock import MockerFixture
 
 from audit.models import AuditLog
+from environments.models import Environment
 from environments.tasks import (
     delete_environment_from_dynamo,
     process_environment_update,
@@ -8,18 +9,22 @@ from environments.tasks import (
 )
 
 
-def test_rebuild_environment_document(environment, mocker):
+def test_rebuild_environment_document(
+    environment: Environment,
+    mocker: MockerFixture,
+) -> None:
     # Given
-    mock_dynamo_wrapper = mocker.MagicMock(is_enabled=True)
-    mocker.patch(
-        "environments.tasks.DynamoEnvironmentWrapper", return_value=mock_dynamo_wrapper
+    mock_write_environments_to_dynamodb = mocker.patch(
+        "environments.tasks.Environment.write_environments_to_dynamodb",
     )
 
     # When
     rebuild_environment_document(environment_id=environment.id)
 
     # Then
-    mock_dynamo_wrapper.write_environment.assert_called_once_with(environment)
+    mock_write_environments_to_dynamodb.assert_called_once_with(
+        environment_id=environment.id
+    )
 
 
 def test_process_environment_update_with_environment_audit_log(environment, mocker):


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes the issue when some environment updates don't trigger an `flagsmith_environments_v2` update.
 
## How did you test this code?

Updated the relevant unit test.