### PR TITLE
ci: update workflow to give correct permissions

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -31,6 +31,12 @@ jobs:
             test
             chore
 
+  add-labels:
+    name: Add labels based on Conventional Commit title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Auto-label PR with Conventional Commit title
         uses: bcoe/conventional-release-labels@v1
         with:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Updates the workflow definition for adding labels based on conventional commit title to ensure that external contributors (e.g. dependabot) can correctly add labels to their PRs. 

Resolves issue seen [here](https://github.com/Flagsmith/flagsmith/actions/runs/9472515814/job/26174200566?pr=4149)

<img width="433" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/14089968/2e98f460-0132-4ccd-bae8-19ff6fccb1bf">

Reference articles: 
 1. https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac
 2. https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

## How did you test this code?

This PR will test to confirm that there is no regression in the workflow file, but I'll need to merge and then rebase the dependabot PR to confirm if it resolves the issue it's trying to fix. 
