### PR TITLE
docs: Add GitHub Integration docs for self-hosted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,11 +53,6 @@ services:
       # EMAIL_HOST_PASSWORD: smtp_account_password
       # EMAIL_PORT: 587 # optional
       # EMAIL_USE_TLS: 'true' # optional
-      # Env vars for GitHub Integration
-      # GITHUB_CLIENT_ID: '-----SOMEKEY-----'
-      # GITHUB_APP_ID: 7654321
-      # GITHUB_WEBHOOK_SECRET: 'your_github_webhook_secret'
-      # GITHUB_APP_URL: 'https://github.com/apps/yourapp/installations/select_target'
     ports:
       - 8000:8000
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,11 @@ services:
       # EMAIL_HOST_PASSWORD: smtp_account_password
       # EMAIL_PORT: 587 # optional
       # EMAIL_USE_TLS: 'true' # optional
+      # Env vars for GitHub Integration
+      # GITHUB_CLIENT_ID: '-----SOMEKEY-----'
+      # GITHUB_APP_ID: 7654321
+      # GITHUB_WEBHOOK_SECRET: 'your_github_webhook_secret'
+      # GITHUB_APP_URL: 'https://github.com/apps/yourapp/installations/select_target'
     ports:
       - 8000:8000
     healthcheck:

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -362,9 +362,11 @@ If not running our application via docker, you can find gunicorn's documentation
 
 ### GitHub Integration Environment Variables
 
-- `GITHUB_PEM`: Create a PEM in your GitHub App and paste it here.
-- `GITHUB_APP_ID`: Your GitHub App ID
-- `GITHUB_WEBHOOK_SECRET`: Your GitHub webhook secret
+- `GITHUB_PEM`: In the 'Private keys' section of your GitHub App, you can create a PEM file within your GitHub App and
+  then paste it here.
+- `GITHUB_APP_ID`: You can find the App ID in the 'About' section -> 'App ID' of your GitHub app.
+- `GITHUB_WEBHOOK_SECRET`: You should choose the same random string of text with high entropy that you put in your
+  GitHub App.
 
 ## Caching
 

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -362,9 +362,9 @@ If not running our application via docker, you can find gunicorn's documentation
 
 ### GitHub Integration Environment Variables
 
-- `GITHUB_PEM`: create an PEM in your GitHub App, copy and paste it.
-- `GITHUB_APP_ID`: your GitHub App Id
-- `GITHUB_WEBHOOK_SECRET`: your GitHub webhook secret
+- `GITHUB_PEM`: Create an PEM in your GitHub App, copy and paste it.
+- `GITHUB_APP_ID`: Your GitHub App ID
+- `GITHUB_WEBHOOK_SECRET`: Your GitHub webhook secret
 
 ## Caching
 

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -362,7 +362,7 @@ If not running our application via docker, you can find gunicorn's documentation
 
 ### GitHub Integration Environment Variables
 
-- `GITHUB_PEM`: Create an PEM in your GitHub App, copy and paste it.
+- `GITHUB_PEM`: Create a PEM in your GitHub App and paste it here.
 - `GITHUB_APP_ID`: Your GitHub App ID
 - `GITHUB_WEBHOOK_SECRET`: Your GitHub webhook secret
 

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -360,6 +360,12 @@ services:
 If not running our application via docker, you can find gunicorn's documentation on statsd instrumentation
 [here](https://docs.gunicorn.org/en/stable/instrumentation.html)
 
+### GitHub Integration Environment Variables
+
+- `GITHUB_PEM`: create an PEM in your GitHub App, copy and paste it.
+- `GITHUB_APP_ID`: your GitHub App Id
+- `GITHUB_WEBHOOK_SECRET`: your GitHub webhook secret
+
 ## Caching
 
 The application makes use of caching in a couple of locations:

--- a/docs/docs/deployment/hosting/locally-frontend.md
+++ b/docs/docs/deployment/hosting/locally-frontend.md
@@ -101,6 +101,10 @@ Current variables used between 'frontend/environment.js' and 'frontend/common/pr
   Further reading on this value is available [here](https://web.dev/articles/samesite-cookies-explained). Default:
   'none'.
 
+### GitHub Integration Environment Variables
+
+- `GITHUB_APP_URL`: the URL from your GitHub App
+
 ## E2E testing
 
 This project uses [Test Cafe](https://testcafe.io/) for automated end to end testing with Chromedriver.

--- a/docs/docs/deployment/hosting/locally-frontend.md
+++ b/docs/docs/deployment/hosting/locally-frontend.md
@@ -103,7 +103,8 @@ Current variables used between 'frontend/environment.js' and 'frontend/common/pr
 
 ### GitHub Integration Environment Variables
 
-- `GITHUB_APP_URL`: The URL from your GitHub App
+- `GITHUB_APP_URL`: You can obtain the URL of your GitHub App in the 'About' section -> 'public link' and append
+  '/installations/select_target' to it.
 
 ## E2E testing
 

--- a/docs/docs/deployment/hosting/locally-frontend.md
+++ b/docs/docs/deployment/hosting/locally-frontend.md
@@ -104,7 +104,7 @@ Current variables used between 'frontend/environment.js' and 'frontend/common/pr
 ### GitHub Integration Environment Variables
 
 - `GITHUB_APP_URL`: You can obtain the URL of your GitHub App in the 'About' section -> 'public link' and append
-  '/installations/select_target' to it.
+  '/installations/select_target' to it. E.g. `https://github.com/apps/my-github-app/installations/select_target`
 
 ## E2E testing
 

--- a/docs/docs/deployment/hosting/locally-frontend.md
+++ b/docs/docs/deployment/hosting/locally-frontend.md
@@ -103,7 +103,7 @@ Current variables used between 'frontend/environment.js' and 'frontend/common/pr
 
 ### GitHub Integration Environment Variables
 
-- `GITHUB_APP_URL`: the URL from your GitHub App
+- `GITHUB_APP_URL`: The URL from your GitHub App
 
 ## E2E testing
 

--- a/docs/docs/integrations/project-management/github.md
+++ b/docs/docs/integrations/project-management/github.md
@@ -31,6 +31,43 @@ You can either set up the integration from the Flagsmith side or from the Github
 6. Select the Flagsmith Project you want to associate with the repository where the app was installed to create the
    Integration.
 
+## Integration Setup (Self-Hosted)
+
+You have to set the [API Env variables](/deployment/hosting/locally-api.md#github-integration-environment-variables) and
+the [Frontend Env variables](/deployment/hosting/locally-frontend.md#github-integration-environment-variables) for your
+GitHub to use your own GitHub App.
+
+### Configure you GitHub App
+
+You can create your own GitHub App follow the
+[next steps](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
+
+In the Permissions and Events section, configure the following permissions and events:
+
+**Repository permissions**
+
+- **Issues:** Read and write.
+- **Metadata:** Read only (Mandatory)
+- **Pull requests:** Read and write.
+
+**Subscribe to events**
+
+- **Pull Request**
+- **Issues**
+
+In the Post Installation section, you need to add the Setup URL and check the option 'Redirect on update':
+
+**The setup URL:** Is a combination of your Flagsmith dashboard's base URL with the following string
+`login?github-redirect=true`.
+
+E.g. `http://localhost:8000/login?github-redirect=true`
+
+In the Webhook section, you need to check the 'active' option and add the webhook URL:
+
+**The webhook URL:** Is a combination of your API base URL with the following string `github-webhook/`.
+
+E.g. `http://localhost:8000/api/v1/github-webhook/`
+
 ## Adding a Flagsmith Flag to a GitHub issue or pull request
 
 1. Create or select a Feature Flag.
@@ -42,9 +79,3 @@ You can either set up the integration from the Flagsmith side or from the Github
 
 1. From Flagsmith, click 'Integrations', find the GitHub integration and click on 'Manage Integration'.
 2. Click on 'Delete Integration' button, and confirm.
-
-## Integration Setup (Self-Hosted)
-
-You have to set the [API Env variables](/deployment/hosting/locally-api.md#github-integration-environment-variables) and
-the [Frontend Env variables](/deployment/hosting/locally-frontend.md#github-integration-environment-variables) for your
-GitHub to use your own GitHub App.

--- a/docs/docs/integrations/project-management/github.md
+++ b/docs/docs/integrations/project-management/github.md
@@ -53,13 +53,13 @@ In the Permissions and Events section, configure the following permissions and e
 
 In the Post Installation section, you need to add the Setup URL and check the option 'Redirect on update':
 
-**The setup URL:** Is your Flagsmith dashboard's base URL foolowed by `login?github-redirect=true`.
+**The setup URL:** This is the base URL of your Flagsmith dashboard, followed by `login?github-redirect=true`.
 
 E.g. `https://flagsmith.example.com/login?github-redirect=true`
 
 In the Webhook section, you need to check the 'active' option and add the webhook URL:
 
-**The webhook URL:** Is your API base URL followed by `github-webhook/`.
+**The webhook URL:** This is the base URL of your Flagsmith API, followed by `github-webhook/`.
 
 E.g. `https://flagsmith-api.example.com/api/v1/github-webhook/`
 
@@ -68,6 +68,10 @@ E.g. `https://flagsmith-api.example.com/api/v1/github-webhook/`
 You must set the [API Env variables](/deployment/hosting/locally-api.md#github-integration-environment-variables) and
 the [Frontend Env variables](/deployment/hosting/locally-frontend.md#github-integration-environment-variables) to use
 your own GitHub App.
+
+In the 'Webhook' section:
+
+**Webhook secret:** Generate a random string of text with high entropy and put it in the field
 
 ## Adding a Flagsmith Flag to a GitHub issue or pull request
 

--- a/docs/docs/integrations/project-management/github.md
+++ b/docs/docs/integrations/project-management/github.md
@@ -33,14 +33,10 @@ You can either set up the integration from the Flagsmith side or from the Github
 
 ## Integration Setup (Self-Hosted)
 
-You have to set the [API Env variables](/deployment/hosting/locally-api.md#github-integration-environment-variables) and
-the [Frontend Env variables](/deployment/hosting/locally-frontend.md#github-integration-environment-variables) for your
-GitHub to use your own GitHub App.
+### Creating and Configuring your GitHub App
 
-### Configure you GitHub App
-
-You can create your own GitHub App follow the
-[next steps](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
+You can create your own GitHub App by following these
+[steps from GitHub Docs](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
 
 In the Permissions and Events section, configure the following permissions and events:
 
@@ -57,16 +53,21 @@ In the Permissions and Events section, configure the following permissions and e
 
 In the Post Installation section, you need to add the Setup URL and check the option 'Redirect on update':
 
-**The setup URL:** Is a combination of your Flagsmith dashboard's base URL with the following string
-`login?github-redirect=true`.
+**The setup URL:** Is your Flagsmith dashboard's base URL foolowed by `login?github-redirect=true`.
 
-E.g. `http://localhost:8000/login?github-redirect=true`
+E.g. `https://flagsmith.example.com/login?github-redirect=true`
 
 In the Webhook section, you need to check the 'active' option and add the webhook URL:
 
-**The webhook URL:** Is a combination of your API base URL with the following string `github-webhook/`.
+**The webhook URL:** Is your API base URL followed by `github-webhook/`.
 
-E.g. `http://localhost:8000/api/v1/github-webhook/`
+E.g. `https://flagsmith-api.example.com/api/v1/github-webhook/`
+
+### Configuring Flagsmith
+
+You must set the [API Env variables](/deployment/hosting/locally-api.md#github-integration-environment-variables) and
+the [Frontend Env variables](/deployment/hosting/locally-frontend.md#github-integration-environment-variables) to use
+your own GitHub App.
 
 ## Adding a Flagsmith Flag to a GitHub issue or pull request
 

--- a/docs/docs/integrations/project-management/github.md
+++ b/docs/docs/integrations/project-management/github.md
@@ -9,13 +9,7 @@ hide_title: true
 
 View your Flagsmith Flags inside GitHub Issues and Pull Requests.
 
-:::tip
-
-The GitHub integration is currently only supported with our hosted Flagsmith SaaS service.
-
-:::
-
-## Integration Setup
+## Integration Setup (SaaS)
 
 You can either set up the integration from the Flagsmith side or from the Github side.
 
@@ -48,3 +42,9 @@ You can either set up the integration from the Flagsmith side or from the Github
 
 1. From Flagsmith, click 'Integrations', find the GitHub integration and click on 'Manage Integration'.
 2. Click on 'Delete Integration' button, and confirm.
+
+## Integration Setup (Self-Hosted)
+
+You have to set the [API Env variables](/deployment/hosting/locally-api.md#github-integration-environment-variables) and
+the [Frontend Env variables](/deployment/hosting/locally-frontend.md#github-integration-environment-variables) for your
+GitHub to use your own GitHub App.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Add GitHub Integration docs for self-hosted 

## How did you test this code?

- See the docs
