### PR TITLE
fix: scarf image formatting

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -202,16 +202,6 @@ const config = {
         swaggerURL: '/api-static/edge-api.yaml',
     },
 
-    headTags: [
-        {
-            tagName: 'img',
-            attributes: {
-                src: 'https://static.scarf.sh/a.png?x-pxid=3bd13eaa-d37d-454b-b503-322643e72574',
-                referrerpolicy: 'no-referrer-when-downgrade',
-            },
-        },
-    ],
-
     presets: [
         [
             'classic',

--- a/docs/src/theme/Footer/Copyright/index.js
+++ b/docs/src/theme/Footer/Copyright/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+export default function FooterCopyright({ copyright }) {
+    return (
+        <div>
+            <div
+                className="footer__copyright"
+                // Developer provided the HTML, so assume it's safe.
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: copyright }}
+            />
+            <img
+                referrerpolicy="no-referrer-when-downgrade"
+                src="https://static.scarf.sh/a.png?x-pxid=3bd13eaa-d37d-454b-b503-322643e72574"
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
the image was blowing out the top padding

Broken:

<img width="1218" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/173290/5d6a9e25-8e5c-4a66-83a6-8abd3d560f21">

Fixed:

<img width="1218" alt="image" src="https://github.com/Flagsmith/flagsmith/assets/173290/f7abd0fb-b122-49eb-bb3a-f5f11cdfc554">
