### PR TITLE
fix: Stale connections after task processor errors

### DIFF
--- a/api/task_processor/threads.py
+++ b/api/task_processor/threads.py
@@ -1,8 +1,8 @@
 import logging
 import time
-import traceback
 from threading import Thread
 
+from django.db import close_old_connections
 from django.utils import timezone
 
 from task_processor.processor import run_recurring_tasks, run_tasks
@@ -42,8 +42,8 @@ class TaskRunner(Thread):
             # TODO: is this also what is causing tasks to get stuck as locked? Can we unlock
             #  tasks here?
 
-            logger.error("Received error retrieving tasks: %s.", e)
-            logger.debug(traceback.format_exc())
+            logger.error("Received error retrieving tasks: %s.", e, exc_info=e)
+            close_old_connections()
 
     def stop(self):
         self._stopped = True

--- a/api/tests/unit/task_processor/test_unit_task_processor_threads.py
+++ b/api/tests/unit/task_processor/test_unit_task_processor_threads.py
@@ -33,13 +33,10 @@ def test_task_runner_is_resilient_to_errors(
     task_runner.run_iteration()
 
     # Then
-    assert len(caplog.records) == 2
+    assert len(caplog.records) == 1
 
     assert caplog.records[0].levelno == logging.ERROR
     assert (
         caplog.records[0].message
         == f"Received error retrieving tasks: {exception_message}."
     )
-
-    assert caplog.records[1].levelno == logging.DEBUG
-    assert caplog.records[1].message.startswith("Traceback")


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes a problem surfaced in one of the on-prem environments when task processor wouldn't recover during database failover.

## How did you test this code?

Manually in the on-prem environment where the problem was reproduced.