### PR TITLE
fix: code highlighting

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,7 @@
         "flux-react-dispatcher": "1.2.5",
         "free-email-domains": "^1.2.13",
         "fs-extra": "2.0.0",
-        "highlight.js": "^11.9.0",
+        "highlight.js": "11.0.1",
         "history": "4.10.1",
         "html-loader": "1.3.2",
         "html-webpack-plugin": "5.5.0",
@@ -9822,9 +9822,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
+      "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -27143,9 +27143,9 @@
       }
     },
     "highlight.js": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
+      "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ=="
     },
     "history": {
       "version": "4.10.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "flux-react-dispatcher": "1.2.5",
     "free-email-domains": "^1.2.13",
     "fs-extra": "2.0.0",
-    "highlight.js": "^11.9.0",
+    "highlight.js": "11.0.1",
     "history": "4.10.1",
     "html-loader": "1.3.2",
     "html-webpack-plugin": "5.5.0",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

A breaking change between hljs 11.0.1 and 11.9.0 caused remote config to not apply syntax highlighting. Whilst this is being diagnosed, this PR downgrades it to the original version.

Before: 

![image](https://github.com/Flagsmith/flagsmith/assets/8608314/8011dec8-7bef-4141-b9a1-45c6431688d0)

After: 

![image](https://github.com/Flagsmith/flagsmith/assets/8608314/f5597a1a-f6d7-4767-80f3-026eb51ff7ac)
