### PR TITLE
fix: not serializable arguments when calling environment feature version webhooks

### DIFF
--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -132,7 +132,7 @@ def trigger_update_version_webhooks(environment_feature_version_uuid: str) -> No
     call_environment_webhooks(
         environment=environment_feature_version.environment_id,
         data=data,
-        event_type=WebhookEventType.NEW_VERSION_PUBLISHED,
+        event_type=WebhookEventType.NEW_VERSION_PUBLISHED.value,
     )
 
 

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -170,7 +170,7 @@ def test_trigger_update_version_webhooks(
                 }
             ],
         },
-        event_type=WebhookEventType.NEW_VERSION_PUBLISHED,
+        event_type=WebhookEventType.NEW_VERSION_PUBLISHED.value,
     )
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes an issue with non-serializable arguments passed to the call_environment_webhooks function. 

## How did you test this code?

Updated the existing unit test. 
