### PR TITLE
fix: Preserve selected environment

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -103,15 +103,20 @@ const App = class extends Component {
     this.listenTo(AccountStore, 'change', this.getOrganisationUsage)
     this.getOrganisationUsage()
     window.addEventListener('scroll', this.handleScroll)
-    AsyncStorage.getItem('lastEnv').then((res) => {
-      if (res) {
-        const lastEnv = JSON.parse(res)
-        this.setState({
-          lastEnvironmentId: lastEnv.environmentId,
-          lastProjectId: lastEnv.projectId,
-        })
-      }
-    })
+    const updateLastViewed = () => {
+      debugger
+      AsyncStorage.getItem('lastEnv').then((res) => {
+        if (res) {
+          const lastEnv = JSON.parse(res)
+          this.setState({
+            lastEnvironmentId: lastEnv.environmentId,
+            lastProjectId: lastEnv.projectId,
+          })
+        }
+      })
+    }
+    this.props.history.listen(updateLastViewed)
+    updateLastViewed()
   }
 
   getOrganisationUsage = () => {

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -104,7 +104,6 @@ const App = class extends Component {
     this.getOrganisationUsage()
     window.addEventListener('scroll', this.handleScroll)
     const updateLastViewed = () => {
-      debugger
       AsyncStorage.getItem('lastEnv').then((res) => {
         if (res) {
           const lastEnv = JSON.parse(res)

--- a/frontend/web/components/pages/HomeAside.tsx
+++ b/frontend/web/components/pages/HomeAside.tsx
@@ -113,11 +113,20 @@ const HomeAside: FC<HomeAsideType> = ({
                           }}
                           onChange={(newEnvironmentId) => {
                             if (newEnvironmentId !== environmentId) {
-                              history.push(
-                                `${document.location.pathname}${
-                                  document.location.search || ''
-                                }`.replace(environmentId, newEnvironmentId),
-                              )
+                              AsyncStorage.setItem(
+                                'lastEnv',
+                                JSON.stringify({
+                                  environmentId: newEnvironmentId,
+                                  orgId: AccountStore.getOrganisation().id,
+                                  projectId: projectId,
+                                }),
+                              ).finally(() => {
+                                history.push(
+                                  `${document.location.pathname}${
+                                    document.location.search || ''
+                                  }`.replace(environmentId, newEnvironmentId),
+                                )
+                              })
                             }
                           }}
                         />
@@ -262,19 +271,6 @@ const HomeAside: FC<HomeAsideType> = ({
                   projectId={projectId}
                   environmentId={environmentId}
                   clearableValue={false}
-                  onChange={(environment: string) => {
-                    history.push(
-                      `/project/${projectId}/environment/${environment}/features`,
-                    )
-                    AsyncStorage.setItem(
-                      'lastEnv',
-                      JSON.stringify({
-                        environmentId: environment,
-                        orgId: AccountStore.getOrganisation().id,
-                        projectId: projectId,
-                      }),
-                    )
-                  }}
                 />
               </div>
             )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Fixes 2 issues:

- Clicking features in the nav switches the environment to the first in the list
- Going to a link like segments then back to features doesn't preserve the last selected environment

## How did you test this code?

- Click the features nav item after switching environment, it preserves the same url
- Navigate from features to segments then back, it preserves the environment