### PR TITLE
docs: fix Edge Proxy docker compose ports definition

### DIFF
--- a/docs/docs/deployment/hosting/locally-edge-proxy.md
+++ b/docs/docs/deployment/hosting/locally-edge-proxy.md
@@ -204,8 +204,7 @@ services:
      source: ./config.json
      target: /app/config.json
   ports:
-   - target: 8000
-     published: 8000
+    - "8000:8000"
 ```
 
 The Proxy is now running and available on port 8000.

--- a/docs/docs/deployment/hosting/locally-edge-proxy.md
+++ b/docs/docs/deployment/hosting/locally-edge-proxy.md
@@ -205,8 +205,7 @@ services:
      source: ./config.json
      target: /app/config.json
   ports:
-   - target: 8000
-   - published: 8000
+   - "8000:8000"
 ```
 
 The Proxy is now running and available on port 8000.

--- a/docs/docs/deployment/hosting/locally-edge-proxy.md
+++ b/docs/docs/deployment/hosting/locally-edge-proxy.md
@@ -196,7 +196,6 @@ docker run \
 ### With docker compose
 
 ```yml
-version: '3.9'
 services:
  edge_proxy:
   image: flagsmith/edge-proxy:latest
@@ -205,7 +204,8 @@ services:
      source: ./config.json
      target: /app/config.json
   ports:
-   - "8000:8000"
+   - target: 8000
+     published: 8000
 ```
 
 The Proxy is now running and available on port 8000.


### PR DESCRIPTION
## Changes

Fixes the ports definition in the example docker compose for hosting the edge proxy. Note that I've also removed the deprecated `version` attribute. 

## How did you test this code?

Ran the docker compose locally and confirmed it runs as expected and exposes the correct port. 
