### PR TITLE
docs: Add new Edge Proxy logging settings

### DIFF
--- a/docs/docs/deployment/hosting/locally-edge-proxy.md
+++ b/docs/docs/deployment/hosting/locally-edge-proxy.md
@@ -151,6 +151,84 @@ Set a name used for human-readable log entry field when logging events in JSON. 
 "logging": {"log_event_field_name": "event"}
 ```
 
+### `logging.colour`
+
+:::note
+
+- Added in [2.13.0](https://github.com/Flagsmith/edge-proxy/releases/tag/v2.13.0).
+- This setting is optional.
+
+:::
+
+Set to `false` to disable coloured output. Useful when outputting the log to a file.
+
+### `logging.override`
+
+:::note
+
+- Added in [2.13.0](https://github.com/Flagsmith/edge-proxy/releases/tag/v2.13.0).
+- This setting is optional.
+
+:::
+
+Accepts
+[Python-compatible logging settings](https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema)
+in JSON format. You're able to define custom formatters, handlers and logger configurations. For example, to log
+everything a file, one can set up own file handler and assign it to the root logger:
+
+```json
+"logging": {
+  "override": {
+      "handlers": {
+          "file": {
+              "level": "INFO",
+              "class": "logging.FileHandler",
+              "filename": "edge-proxy.log",
+              "formatter": "json"
+          }
+      },
+      "loggers": {
+          "": {
+              "handlers": ["file"],
+              "level": "INFO",
+              "propagate": true
+          }
+      }
+  }
+}
+```
+
+Or, log access logs to file in generic format while logging everything else to stdout in json:
+
+```json
+"logging": {
+  "override": {
+      "handlers": {
+          "file": {
+              "level": "INFO",
+              "class": "logging.FileHandler",
+              "filename": "edge-proxy.log",
+              "formatter": "generic"
+          }
+      },
+      "loggers": {
+          "": {
+              "handlers": ["default"],
+              "level": "INFO"
+          },
+          "uvicorn.access": {
+              "handlers": ["file"],
+              "level": "INFO",
+              "propagate": false
+          }
+      }
+  }
+}
+```
+
+When adding logger configurations, you can use the `"default"` handler which writes to stdout and uses formatter
+specified by the [`"logging.log_format"`](#logginglog_format) setting.
+
 ### `config.json` example
 
 Here's an example of a minimal working Edge Proxy configuration:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds latest Edge Proxy settings.

## How did you test this code?

Ran `npm run build / npm run serve` locally and observed the docs in browser.