### PR TITLE
feat: Add logic to API usage notification templates

### DIFF
--- a/api/organisations/templates/organisations/api_usage_notification.html
+++ b/api/organisations/templates/organisations/api_usage_notification.html
@@ -12,6 +12,12 @@
                  The API usage for {{ organisation.name }} has reached
                  {{ matched_threshold }}% within the current subscription period.
                  Please consider upgrading your organisation's account limits.
+                 {% if organisation.is_paid %}
+                 Please note that once the 100% use has been breached automated charges for your account may apply.
+                 {% else %}
+                 Please note that once the 100% use has been breached the serving of feature flags and admin access may be disabled after a grace period.
+                 {% endif %}
+
                </td>
 
 

--- a/api/organisations/templates/organisations/api_usage_notification.txt
+++ b/api/organisations/templates/organisations/api_usage_notification.txt
@@ -2,6 +2,11 @@ Hi there,
 
 The API usage for {{ organisation.name }} has reached {{ matched_threshold }}% within the current subscription period. Please consider upgrading your organisation's account limits.
 
+{% if organisation.is_paid %}
+Please note that once the 100% use has been breached automated charges for your account may apply.
+{% else %}
+Please note that once the 100% use has been breached the serving of feature flags and admin access may be disabled after a grace period.
+{% endif %}
 Thank you!
 
 The Flagsmith Team

--- a/api/organisations/templates/organisations/api_usage_notification_limit.html
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.html
@@ -11,7 +11,11 @@
                <td>
                  The API usage for {{ organisation.name }} has breached
                  {{ matched_threshold }}% within the current subscription period.
-                 Please upgrade your organisation's account to ensure continued service.
+                 {% if organisation.is_paid %}
+                 Please note that automated charges for your account may apply.
+                 {% else %}
+                 Please note that the serving of feature flags and admin access may be disabled after a grace period, so please upgrade your organisation's account to ensure continued service.
+                 {% endif %}
                </td>
 
 

--- a/api/organisations/templates/organisations/api_usage_notification_limit.txt
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.txt
@@ -1,6 +1,12 @@
 Hi there,
 
-The API usage for {{ organisation.name }} has breached {{ matched_threshold }}% within the current subscription period. Please upgrade your organisation's account to ensure continued service.
+The API usage for {{ organisation.name }} has breached {{ matched_threshold }}% within the current subscription period.
+
+{% if organisation.is_paid %}
+Please note that automated charges for your account may apply.
+{% else %}
+Please note that the serving of feature flags and admin access may be disabled after a grace period, so please upgrade your organisation's account to ensure continued service.
+{% endif %}
 
 Thank you!
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Updated the templates to include logic that is customized towards whether an organisation is a paid account or not.

## How did you test this code?

Updated existing tests which had coverage, verifying the free / paid distinction.
