### PR TITLE
fix: oauth user case sensitivity

### DIFF
--- a/api/custom_auth/oauth/constants.py
+++ b/api/custom_auth/oauth/constants.py
@@ -1,0 +1,3 @@
+from users.auth_type import AuthType
+
+OAUTH_AUTH_TYPES = [AuthType.GITHUB.value, AuthType.GOOGLE.value]

--- a/api/custom_auth/oauth/constants.py
+++ b/api/custom_auth/oauth/constants.py
@@ -1,3 +1,0 @@
-from users.auth_type import AuthType
-
-OAUTH_AUTH_TYPES = [AuthType.GITHUB.value, AuthType.GOOGLE.value]

--- a/api/custom_auth/oauth/serializers.py
+++ b/api/custom_auth/oauth/serializers.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.signals import user_logged_in
@@ -107,11 +109,12 @@ class OAuthLoginSerializer(serializers.Serializer):
 
         return existing_user
 
+    @abstractmethod
     def get_user_info(self):
         raise NotImplementedError("`get_user_info()` must be implemented.")
 
     def get_auth_type(self) -> AuthType:
-        if not self.auth_type:
+        if not self.auth_type:  # pragma: no cover
             raise NotImplementedError(
                 "`auth_type` must be set, or `get_auth_type()` must be implemented."
             )

--- a/api/custom_auth/oauth/serializers.py
+++ b/api/custom_auth/oauth/serializers.py
@@ -1,11 +1,13 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.signals import user_logged_in
+from django.db.models import F
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import PermissionDenied
 
 from organisations.invites.models import Invite
+from users.auth_type import AuthType
 from users.models import SignUpType
 
 from ..constants import USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE
@@ -30,6 +32,9 @@ class OAuthLoginSerializer(serializers.Serializer):
         write_only=True,
     )
 
+    auth_type: AuthType | None = None
+    user_model_id_attribute: str = None
+
     class Meta:
         abstract = True
 
@@ -53,8 +58,16 @@ class OAuthLoginSerializer(serializers.Serializer):
         return Token.objects.get_or_create(user=user)[0]
 
     def _get_user(self, user_data: dict):
-        email = user_data.get("email")
-        existing_user = UserModel.objects.filter(email=email).first()
+        email: str = user_data.pop("email")
+
+        existing_user = (
+            UserModel.objects.filter(email__iexact=email)
+            .order_by(
+                F("google_user_id").desc(nulls_last=True),
+                F("github_user_id").desc(nulls_last=True),
+            )
+            .first()
+        )
 
         if not existing_user:
             sign_up_type = self.validated_data.get("sign_up_type")
@@ -65,20 +78,54 @@ class OAuthLoginSerializer(serializers.Serializer):
             ):
                 raise PermissionDenied(USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE)
 
-            return UserModel.objects.create(**user_data, sign_up_type=sign_up_type)
+            return UserModel.objects.create(
+                **user_data, email=email.lower(), sign_up_type=sign_up_type
+            )
+        elif existing_user.auth_type != self.get_auth_type().value:
+            # In this scenario, we're seeing a user that had previously
+            # authenticated with another authentication method and is now
+            # authenticating with a new OAuth provider.
+            user_model_id_attribute = self.get_user_model_id_attribute()
+            setattr(
+                existing_user,
+                user_model_id_attribute,
+                user_data[user_model_id_attribute],
+            )
+            existing_user.save()
 
         return existing_user
 
     def get_user_info(self):
         raise NotImplementedError("`get_user_info()` must be implemented.")
 
+    def get_auth_type(self) -> AuthType:
+        if not self.auth_type:
+            raise NotImplementedError(
+                "`auth_type` must be set, or `get_auth_type()` must be implemented."
+            )
+        return self.auth_type
+
+    def get_user_model_id_attribute(self) -> str:
+        if not self.user_model_id_attribute:
+            raise NotImplementedError(
+                "`user_model_id_attribute` must be set, "
+                "or `get_user_model_id_attribute()` must be implemented."
+            )
+        return self.user_model_id_attribute
+
 
 class GoogleLoginSerializer(OAuthLoginSerializer):
+    auth_type = AuthType.GOOGLE
+    user_model_id_attribute = "google_user_id"
+
     def get_user_info(self):
         return get_user_info(self.validated_data["access_token"])
 
 
 class GithubLoginSerializer(OAuthLoginSerializer):
+    auth_type = AuthType.GITHUB
+    user_model_id_attribute = "github_user_id"
+
     def get_user_info(self):
         github_user = GithubUser(code=self.validated_data["access_token"])
         return github_user.get_user_info()

--- a/api/custom_auth/oauth/serializers.py
+++ b/api/custom_auth/oauth/serializers.py
@@ -33,7 +33,7 @@ class OAuthLoginSerializer(serializers.Serializer):
     )
 
     auth_type: AuthType | None = None
-    user_model_id_attribute: str = None
+    user_model_id_attribute: str = "id"
 
     class Meta:
         abstract = True
@@ -76,7 +76,7 @@ class OAuthLoginSerializer(serializers.Serializer):
         existing_user = (
             UserModel.objects.filter(email__iexact=email)
             .order_by(
-                F(self.user_model_id_attribute).desc(nulls_last=True),
+                F(self.get_user_model_id_attribute()).desc(nulls_last=True),
             )
             .first()
         )
@@ -118,11 +118,6 @@ class OAuthLoginSerializer(serializers.Serializer):
         return self.auth_type
 
     def get_user_model_id_attribute(self) -> str:
-        if not self.user_model_id_attribute:
-            raise NotImplementedError(
-                "`user_model_id_attribute` must be set, "
-                "or `get_user_model_id_attribute()` must be implemented."
-            )
         return self.user_model_id_attribute
 
 

--- a/api/custom_auth/oauth/serializers.py
+++ b/api/custom_auth/oauth/serializers.py
@@ -78,7 +78,7 @@ class OAuthLoginSerializer(serializers.Serializer):
         existing_user = (
             UserModel.objects.filter(email__iexact=email)
             .order_by(
-                F(self.get_user_model_id_attribute()).desc(nulls_last=True),
+                F(self.user_model_id_attribute).desc(nulls_last=True),
             )
             .first()
         )
@@ -99,11 +99,10 @@ class OAuthLoginSerializer(serializers.Serializer):
             # In this scenario, we're seeing a user that had previously
             # authenticated with another authentication method and is now
             # authenticating with a new OAuth provider.
-            user_model_id_attribute = self.get_user_model_id_attribute()
             setattr(
                 existing_user,
-                user_model_id_attribute,
-                user_data[user_model_id_attribute],
+                self.user_model_id_attribute,
+                user_data[self.user_model_id_attribute],
             )
             existing_user.save()
 
@@ -119,9 +118,6 @@ class OAuthLoginSerializer(serializers.Serializer):
                 "`auth_type` must be set, or `get_auth_type()` must be implemented."
             )
         return self.auth_type
-
-    def get_user_model_id_attribute(self) -> str:
-        return self.user_model_id_attribute
 
 
 class GoogleLoginSerializer(OAuthLoginSerializer):

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
@@ -152,12 +152,15 @@ def test_login_with_google_updates_existing_user_case_insensitive(
 
     django_user_model.objects.create(email=email_lower)
 
-    mocker.patch("custom_auth.oauth.serializers.get_user_info", return_value={
-        "email": email_upper,
-        "first_name": "John",
-        "last_name": "Smith",
-        "google_user_id": google_user_id
-    })
+    mocker.patch(
+        "custom_auth.oauth.serializers.get_user_info",
+        return_value={
+            "email": email_upper,
+            "first_name": "John",
+            "last_name": "Smith",
+            "google_user_id": google_user_id,
+        },
+    )
 
     url = reverse("api-v1:custom_auth:oauth:google-oauth-login")
 

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
@@ -105,7 +105,12 @@ def test_can_login_with_google_if_registration_disabled(
     client = APIClient()
 
     email = "test@example.com"
-    mock_get_user_info.return_value = {"email": email}
+    mock_get_user_info.return_value = {
+        "email": email,
+        "first_name": "John",
+        "last_name": "Smith",
+        "google_user_id": "abc123",
+    }
     django_user_model.objects.create(email=email)
 
     # When
@@ -128,7 +133,12 @@ def test_can_login_with_github_if_registration_disabled(
     email = "test@example.com"
     mock_github_user = mock.MagicMock()
     MockGithubUser.return_value = mock_github_user
-    mock_github_user.get_user_info.return_value = {"email": email}
+    mock_github_user.get_user_info.return_value = {
+        "email": email,
+        "first_name": "John",
+        "last_name": "Smith",
+        "github_user_id": "abc123",
+    }
     django_user_model.objects.create(email=email)
 
     # When

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
@@ -192,12 +192,14 @@ def test_login_with_github_updates_existing_user_case_insensitive(
     django_user_model.objects.create(email=email_lower)
 
     mock_github_user = mock.MagicMock()
-    mocker.patch("custom_auth.oauth.serializers.GithubUser", return_value=mock_github_user)
+    mocker.patch(
+        "custom_auth.oauth.serializers.GithubUser", return_value=mock_github_user
+    )
     mock_github_user.get_user_info.return_value = {
         "email": email_upper,
         "first_name": "John",
         "last_name": "Smith",
-        "github_user_id": github_user_id
+        "github_user_id": github_user_id,
     }
 
     url = reverse("api-v1:custom_auth:oauth:github-oauth-login")
@@ -231,16 +233,22 @@ def test_user_with_duplicate_accounts_authenticates_as_the_correct_oauth_user(
     email_lower = "test@example.com"
     email_upper = email_lower.upper()
 
-    github_user = django_user_model.objects.create(email=email_lower, github_user_id="abc123")
-    google_user = django_user_model.objects.create(email=email_upper, google_user_id="abc123")
+    github_user = django_user_model.objects.create(
+        email=email_lower, github_user_id="abc123"
+    )
+    google_user = django_user_model.objects.create(
+        email=email_upper, google_user_id="abc123"
+    )
 
     mock_github_user = mock.MagicMock()
-    mocker.patch("custom_auth.oauth.serializers.GithubUser", return_value=mock_github_user)
+    mocker.patch(
+        "custom_auth.oauth.serializers.GithubUser", return_value=mock_github_user
+    )
     mock_github_user.get_user_info.return_value = {
         "email": email_lower,
         "first_name": "John",
         "last_name": "Smith",
-        "github_user_id": github_user.github_user_id
+        "github_user_id": github_user.github_user_id,
     }
 
     mocker.patch(
@@ -257,8 +265,12 @@ def test_user_with_duplicate_accounts_authenticates_as_the_correct_oauth_user(
     google_auth_url = reverse("api-v1:custom_auth:oauth:google-oauth-login")
 
     # When
-    auth_with_github_response = api_client.post(github_auth_url, data={"access_token": "some-token"})
-    auth_with_google_response = api_client.post(google_auth_url, data={"access_token": "some-token"})
+    auth_with_github_response = api_client.post(
+        github_auth_url, data={"access_token": "some-token"}
+    )
+    auth_with_google_response = api_client.post(
+        google_auth_url, data={"access_token": "some-token"}
+    )
 
     # Then
     github_auth_key = auth_with_github_response.json().get("key")

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
@@ -176,3 +176,93 @@ def test_login_with_google_updates_existing_user_case_insensitive(
     user = qs.first()
     assert user.email == email_lower
     assert user.google_user_id == google_user_id
+
+
+def test_login_with_github_updates_existing_user_case_insensitive(
+    db: None,
+    django_user_model: type[Model],
+    mocker: MockerFixture,
+    api_client: APIClient,
+) -> None:
+    # Given
+    email_lower = "test@example.com"
+    email_upper = email_lower.upper()
+    github_user_id = "abc123"
+
+    django_user_model.objects.create(email=email_lower)
+
+    mock_github_user = mock.MagicMock()
+    mocker.patch("custom_auth.oauth.serializers.GithubUser", return_value=mock_github_user)
+    mock_github_user.get_user_info.return_value = {
+        "email": email_upper,
+        "first_name": "John",
+        "last_name": "Smith",
+        "github_user_id": github_user_id
+    }
+
+    url = reverse("api-v1:custom_auth:oauth:github-oauth-login")
+
+    # When
+    response = api_client.post(url, data={"access_token": "some-token"})
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+    qs = django_user_model.objects.filter(email__iexact=email_lower)
+    assert qs.count() == 1
+
+    user = qs.first()
+    assert user.email == email_lower
+    assert user.github_user_id == github_user_id
+
+
+def test_user_with_duplicate_accounts_authenticates_as_the_correct_oauth_user(
+    db: None,
+    django_user_model: type[Model],
+    api_client: APIClient,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Specific test to verify the correct behaviour for users affected by
+    https://github.com/Flagsmith/flagsmith/issues/4185.
+    """
+
+    # Given
+    email_lower = "test@example.com"
+    email_upper = email_lower.upper()
+
+    github_user = django_user_model.objects.create(email=email_lower, github_user_id="abc123")
+    google_user = django_user_model.objects.create(email=email_upper, google_user_id="abc123")
+
+    mock_github_user = mock.MagicMock()
+    mocker.patch("custom_auth.oauth.serializers.GithubUser", return_value=mock_github_user)
+    mock_github_user.get_user_info.return_value = {
+        "email": email_lower,
+        "first_name": "John",
+        "last_name": "Smith",
+        "github_user_id": github_user.github_user_id
+    }
+
+    mocker.patch(
+        "custom_auth.oauth.serializers.get_user_info",
+        return_value={
+            "email": email_upper,
+            "first_name": "John",
+            "last_name": "Smith",
+            "google_user_id": google_user.google_user_id,
+        },
+    )
+
+    github_auth_url = reverse("api-v1:custom_auth:oauth:github-oauth-login")
+    google_auth_url = reverse("api-v1:custom_auth:oauth:google-oauth-login")
+
+    # When
+    auth_with_github_response = api_client.post(github_auth_url, data={"access_token": "some-token"})
+    auth_with_google_response = api_client.post(google_auth_url, data={"access_token": "some-token"})
+
+    # Then
+    github_auth_key = auth_with_github_response.json().get("key")
+    assert github_auth_key == github_user.auth_token.key
+
+    google_auth_key = auth_with_google_response.json().get("key")
+    assert google_auth_key == google_user.auth_token.key


### PR DESCRIPTION
## Changes

Resolves https://github.com/Flagsmith/flagsmith/issues/4185. 

The main goal of this PR is to ensure that users who authenticate with an OAuth provider after authenticating with email/password, another OAuth provider, or even SAML (although this use case is slim) get a consistent experience. Currently if the email differs by case, a new user will be created and the user will likely be confused as to why they can't see their projects, etc. 

As a side effect, we had to handle a few edge cases where a user might already have duplicate accounts and make sure that the user gets the same experience they do today (authenticating with method A gets them into user A, authenticating with user B gets them user B). 

We should, separate to this, get in touch with the users for whom this is an issue (~20) and try to merge their accounts. 

## How did you test this code?

Added 3 new tests to cover all scenarios. 
