### PR TITLE
ci: add build script to frontend package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "kill": "kill -9 $(lsof -ti tcp:4444)",
     "test:bundle": "cross-env E2E=1 npm run bundle",
     "postinstall": "npm run env",
+    "build": "npm run bundle",
     "husky:install": "cd ../ && husky install",
     "test:bundle:staging": "cross-env E2E=1 ENV=staging npm run bundle",
     "test:dev": "cross-env NODE_ENV=production E2E=true E2E_DEV=true ts-node -T ./e2e/index.cafe",


### PR DESCRIPTION


Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Currently when deploying Flagsmith to Heroku, the frontend fails to start because the build step hasn't run.

Heroku will automatically run a build script from the package.json, so adding this alias will allow the app to be deployed to Heroku with the node.js buildpack.

https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process

## How did you test this code?

Deployed a fork with this line to Heroku, using the `heroku/nodejs` buildpack, and confirmed the build step ran and the app worked as expected.

