### PR TITLE
fix(ci): Secrets unavailable to Docker publish jobs

### DIFF
--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -62,14 +62,25 @@ jobs:
     needs: [docker-build-api, docker-build-private-cloud-api, docker-build-e2e]
     uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
     with:
-      api-image: ${{ matrix.api-image }}
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
+      api-image: ${{ matrix.api-image }}
+      concurrency: ${{ matrix.args.concurrency }}
+      tests: ${{ matrix.args.tests }}
 
     strategy:
       matrix:
         api-image:
           - ${{ needs.docker-build-api.outputs.image }}
           - ${{ needs.docker-build-private-cloud-api.outputs.image }}
+        args:
+          - tests: segment-part-1 environment
+            concurrency: 1
+          - tests: segment-part-2
+            concurrency: 1
+          - tests: segment-part-3 signup flag invite project
+            concurrency: 2
+          - tests: versioning
+            concurrency: 1
 
   docker-publish-api:
     needs: [docker-build-api, run-e2e-tests]

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -78,6 +78,7 @@ jobs:
     with:
       source-images: ${{ needs.docker-build-api.outputs.image }}
       target-images: flagsmith/flagsmith-api
+    secrets: inherit
 
   docker-publish-frontend:
     needs: [docker-build-frontend, run-e2e-tests]
@@ -86,6 +87,7 @@ jobs:
     with:
       source-images: ${{ needs.docker-build-frontend.outputs.image }}
       target-images: flagsmith/flagsmith-frontend
+    secrets: inherit
 
   docker-publish-unified:
     needs: [docker-build-unified, run-e2e-tests]
@@ -94,6 +96,7 @@ jobs:
     with:
       source-images: ${{ needs.docker-build-unified.outputs.image }}
       target-images: flagsmith/flagsmith
+    secrets: inherit
 
   docker-publish-private-cloud-api:
     needs: [docker-build-private-cloud-api, run-e2e-tests]
@@ -102,6 +105,7 @@ jobs:
     with:
       source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
       target-images: flagsmith/flagsmith-private-cloud-api
+    secrets: inherit
 
   docker-publish-private-cloud:
     needs: [docker-build-private-cloud, run-e2e-tests]
@@ -110,6 +114,7 @@ jobs:
     with:
       source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
       target-images: flagsmith/flagsmith-private-cloud
+    secrets: inherit
 
   update-charts:
     needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes the Docker Publish actions unable to run because of insufficient access to repo secrets.
This also adds args to the E2E run performed on merge to main and release. 

## How did you test this code?

This is a CI change.