### PR TITLE
fix: versioning webhooks and update test to correctly test end to end

### DIFF
--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -130,7 +130,7 @@ def trigger_update_version_webhooks(environment_feature_version_uuid: str) -> No
 
     data = environment_feature_version_webhook_schema.dump(environment_feature_version)
     call_environment_webhooks(
-        environment=environment_feature_version.environment_id,
+        environment_id=environment_feature_version.environment_id,
         data=data,
         event_type=WebhookEventType.NEW_VERSION_PUBLISHED.value,
     )

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -1,11 +1,13 @@
+import json
 from datetime import timedelta
 
 import freezegun
+import responses
 from django.utils import timezone
 from pytest_mock import MockerFixture
 
 from environments.identities.models import Identity
-from environments.models import Environment
+from environments.models import Environment, Webhook
 from features.models import Feature, FeatureSegment, FeatureState
 from features.versioning.models import EnvironmentFeatureVersion
 from features.versioning.tasks import (
@@ -140,6 +142,7 @@ def test_disable_v2_versioning(
     assert unaffected_environment.feature_segments.count() == 1
 
 
+@responses.activate
 def test_trigger_update_version_webhooks(
     environment_v2_versioning: Environment, feature: Feature, mocker: MockerFixture
 ) -> None:
@@ -149,17 +152,19 @@ def test_trigger_update_version_webhooks(
     )
     feature_state = version.feature_states.first()
 
-    mock_call_environment_webhooks = mocker.patch(
-        "features.versioning.tasks.call_environment_webhooks"
-    )
+    webhook_url = "https://example.com/webhook/"
+    Webhook.objects.create(environment=environment_v2_versioning, url=webhook_url)
+
+    responses.post(url=webhook_url, status=200)
 
     # When
     trigger_update_version_webhooks(str(version.uuid))
 
     # Then
-    mock_call_environment_webhooks.assert_called_once_with(
-        environment=environment_v2_versioning.id,
-        data={
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == webhook_url
+    assert json.loads(responses.calls[0].request.body) == {
+        "data": {
             "uuid": str(version.uuid),
             "feature": {"id": feature.id, "name": feature.name},
             "published_by": None,
@@ -170,8 +175,8 @@ def test_trigger_update_version_webhooks(
                 }
             ],
         },
-        event_type=WebhookEventType.NEW_VERSION_PUBLISHED.value,
-    )
+        "event_type": WebhookEventType.NEW_VERSION_PUBLISHED.name,
+    }
 
 
 def test_enable_v2_versioning_for_scheduled_changes(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes an issue with the webhooks for environment feature versions that was supposed to be fixed in #4187 but, because the test was just mocking the call to `call_environment_webhooks`, that was not the case. This PR fixes it properly and updates the test to run the full end to end webhook flow. 

## How did you test this code?

Updated existing test. 
