### PR TITLE
fix(ci): `packages:read` permission lacking for Docker publish jobs

### DIFF
--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -25,6 +25,7 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
       id-token: write
 
     steps:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes Docker publish jobs failing when trying to publish private GHCR images.  

## How did you test this code?

This is a CI change.