### PR TITLE
fix(ci): Enable Docker builds and E2E for external PRs

### DIFF
--- a/.github/workflows/.reusable-docker-build.yml
+++ b/.github/workflows/.reusable-docker-build.yml
@@ -42,7 +42,7 @@ on:
         value: ${{ jobs.build.outputs.image-tag }}
       build-id:
         description: Depot build ID (if `ephemeral` was set to `true`)
-        value: ${{ jobs.build.outputs.build-id  }}
+        value: ${{ inputs.ephemeral && jobs.build.outputs.build-id || '' }}
     secrets:
       secrets:
         description: List of secrets to expose to the build (e.g., `key=string, GIT_AUTH_TOKEN=mytoken`)

--- a/.github/workflows/.reusable-docker-build.yml
+++ b/.github/workflows/.reusable-docker-build.yml
@@ -31,10 +31,18 @@ on:
         description: Whether to scan built image for vulnerabilities
         required: false
         default: true
+      ephemeral:
+        type: boolean
+        description: Whether to skip push and use Depot's ephemeral registry
+        required: false
+        default: false
     outputs:
       image:
         description: Resulting image specifier
-        value: ${{ inputs.registry-url }}/flagsmith/${{ inputs.image-name }}:${{ jobs.build.outputs.version }}
+        value: ${{ jobs.build.outputs.image-tag }}
+      build-id:
+        description: Depot build ID (if `ephemeral` was set to `true`)
+        value: ${{ jobs.build.outputs.build-id  }}
     secrets:
       secrets:
         description: List of secrets to expose to the build (e.g., `key=string, GIT_AUTH_TOKEN=mytoken`)
@@ -45,7 +53,8 @@ jobs:
     name: Build ${{ inputs.scan && 'and verify ' || '' }}${{ inputs.image-name }} image
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.meta.outputs.version }}
+      image-tag: ${{ steps.image-tag.outputs.image-tag }}
+      build-id: ${{ steps.build.outputs.build-id }}
 
     permissions:
       packages: write
@@ -61,6 +70,7 @@ jobs:
         uses: depot/setup-action@v1
 
       - name: Login to Github Container Registry
+        if: ${{ !inputs.ephemeral }}
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.registry-url }}
@@ -81,10 +91,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push image
+        id: build
         uses: depot/build-push-action@v1
         with:
           context: .
-          push: true
+          save: ${{ inputs.ephemeral }}
+          push: ${{ !inputs.ephemeral }}
           platforms: linux/amd64,linux/arm64
           secrets: ${{ secrets.secrets }}
           target: ${{ inputs.target }}
@@ -96,12 +108,22 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
 
+      - name: Render image tag
+        id: image-tag
+        run: >
+          echo image-tag=${{ inputs.registry-url }}/flagsmith/${{ inputs.image-name}}:${{ steps.meta.outputs.version }}
+          >> $GITHUB_OUTPUT
+
+      - name: Pull image from Depot
+        if: inputs.scan && inputs.ephemeral
+        run: depot pull ${{ steps.build.outputs.build-id }} -t ${{ steps.image-tag.outputs.image-tag }}
+
       - name: Run Trivy vulnerability scanner
         id: trivy
         if: inputs.scan
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ inputs.registry-url }}/flagsmith/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
+          image-ref: ${{ steps.image-tag.outputs.image-tag }}
           format: sarif
           output: trivy-results.sarif
         env:

--- a/.github/workflows/.reusable-docker-build.yml
+++ b/.github/workflows/.reusable-docker-build.yml
@@ -39,10 +39,7 @@ on:
     outputs:
       image:
         description: Resulting image specifier
-        value: ${{ jobs.build.outputs.image-tag }}
-      build-id:
-        description: Depot build ID (if `ephemeral` was set to `true`)
-        value: ${{ inputs.ephemeral && jobs.build.outputs.build-id || '' }}
+        value: ${{ jobs.build.outputs.image }}
     secrets:
       secrets:
         description: List of secrets to expose to the build (e.g., `key=string, GIT_AUTH_TOKEN=mytoken`)
@@ -53,8 +50,7 @@ jobs:
     name: Build ${{ inputs.scan && 'and verify ' || '' }}${{ inputs.image-name }} image
     runs-on: ubuntu-latest
     outputs:
-      image-tag: ${{ steps.image-tag.outputs.image-tag }}
-      build-id: ${{ steps.build.outputs.build-id }}
+      image: ${{ steps.image-tag.outputs.image-tag }}
 
     permissions:
       packages: write
@@ -111,12 +107,13 @@ jobs:
       - name: Render image tag
         id: image-tag
         run: >
-          echo image-tag=${{ inputs.registry-url }}/flagsmith/${{ inputs.image-name}}:${{ steps.meta.outputs.version }}
-          >> $GITHUB_OUTPUT
+          echo image-tag=${{ inputs.ephemeral && format('registry.depot.dev/{0}:{1}', steps.build.outputs.project-id,
+          steps.build.outputs.build-id) || format('{0}/flagsmith/{1}:{2}', inputs.registry-url, inputs.image-name,
+          steps.meta.outputs.version) }} >> $GITHUB_OUTPUT
 
-      - name: Pull image from Depot
+      - name: Login to Depot Registry
         if: inputs.scan && inputs.ephemeral
-        run: depot pull ${{ steps.build.outputs.build-id }} -t ${{ steps.image-tag.outputs.image-tag }}
+        run: depot pull-token | docker login -u x-token --password-stdin registry.depot.dev
 
       - name: Run Trivy vulnerability scanner
         id: trivy

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -13,10 +13,18 @@ on:
         type: string
         description: Core API Docker image to use, e.g., `ghcr.io/flagsmith/flagsmith-api:main`
         required: true
+      api-image-build-id:
+        type: string
+        description: Depot build ID for the Core API Docker image
+        required: false
       e2e-image:
         type: string
         description: Frontend Docker with E2E capabilities image to use, e.g., `ghcr.io/flagsmith/flagsmith-e2e:main`
         required: true
+      e2e-image-build-id:
+        type: string
+        description: Depot build ID for the Frontend Docker with E2E capabilities
+        required: false
       tests:
         type: string
         description: Space-delimited list of E2E tests to be executed
@@ -33,11 +41,29 @@ jobs:
     name: "E2E${{ inputs.tests && format(': {0}', inputs.tests) || '' }}"
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+
     steps:
       - name: Cloning repo
         uses: actions/checkout@v4
 
+      - name: Set up Depot CLI
+        if: ${{ inputs.api-image-build-id || inputs.e2e-image-build-id }}
+        uses: depot/setup-action@v1
+
+      - name: Pull API image from Depot
+        if: inputs.api-image-build-id
+        run: depot pull ${{ inputs.api-image-build-id }} -t ${{ inputs.api-image }}
+
+      - name: Pull E2E image from Depot
+        if: inputs.e2e-image-build-id
+        run: depot pull ${{ inputs.api-image-build-id }} -t ${{ inputs.e2e-image }}
+
       - name: Login to Github Container Registry
+        if: ${{ !inputs.api-image-build-id && !inputs.e2e-image-build-id }}
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.registry-url }}
@@ -61,10 +87,3 @@ jobs:
           E2E_CONCURRENCY: ${{ inputs.concurrency }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           GITHUB_ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Output Core API container status and logs
-        if: failure()
-        working-directory: frontend
-        run: |
-          docker compose -f docker-compose-e2e-tests.yml logs flagsmith-api
-        shell: bash

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -4,27 +4,14 @@ name: Run Docker E2E tests
 on:
   workflow_call:
     inputs:
-      registry-url:
-        type: string
-        description: Github Container Registry base URL
-        required: false
-        default: ghcr.io
       api-image:
         type: string
         description: Core API Docker image to use, e.g., `ghcr.io/flagsmith/flagsmith-api:main`
         required: true
-      api-image-build-id:
-        type: string
-        description: Depot build ID for the Core API Docker image
-        required: false
       e2e-image:
         type: string
         description: Frontend Docker with E2E capabilities image to use, e.g., `ghcr.io/flagsmith/flagsmith-e2e:main`
         required: true
-      e2e-image-build-id:
-        type: string
-        description: Depot build ID for the Frontend Docker with E2E capabilities
-        required: false
       tests:
         type: string
         description: Space-delimited list of E2E tests to be executed
@@ -50,25 +37,17 @@ jobs:
       - name: Cloning repo
         uses: actions/checkout@v4
 
-      - name: Set up Depot CLI
-        if: ${{ inputs.api-image-build-id || inputs.e2e-image-build-id }}
-        uses: depot/setup-action@v1
-
-      - name: Pull API image from Depot
-        if: inputs.api-image-build-id
-        run: depot pull ${{ inputs.api-image-build-id }} -t ${{ inputs.api-image }}
-
-      - name: Pull E2E image from Depot
-        if: inputs.e2e-image-build-id
-        run: depot pull ${{ inputs.api-image-build-id }} -t ${{ inputs.e2e-image }}
-
       - name: Login to Github Container Registry
-        if: ${{ !inputs.api-image-build-id && !inputs.e2e-image-build-id }}
+        if: ${{ startsWith(inputs.api-image, 'ghcr.io') || startsWith(inputs.e2e-image, 'ghcr.io') }}
         uses: docker/login-action@v3
         with:
-          registry: ${{ inputs.registry-url }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Depot Registry
+        if: startsWith(inputs.api-image, 'registry.depot.dev') || startsWith(inputs.e2e-image, 'registry.depot.dev')
+        run: depot pull-token | docker login -u x-token --password-stdin registry.depot.dev
 
       - name: Run tests on dockerised frontend
         uses: nick-fields/retry@v3

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -66,6 +66,7 @@ jobs:
       api-image: ${{ matrix.api-image }}
       concurrency: ${{ matrix.args.concurrency }}
       tests: ${{ matrix.args.tests }}
+    secrets: inherit
 
     strategy:
       matrix:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -108,9 +108,7 @@ jobs:
     uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
     with:
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
-      e2e-image-build-id: ${{ needs.docker-build-e2e.outputs.build-id }}
       api-image: ${{ needs.docker-build-api.outputs.image }}
-      api-image-build-id: ${{ needs.docker-build-api.outputs.build-id }}
       concurrency: ${{ matrix.args.concurrency }}
       tests: ${{ matrix.args.tests }}
     secrets: inherit

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -62,6 +62,7 @@ jobs:
     with:
       target: oss-unified
       image-name: flagsmith
+      ephemeral: ${{ github.event.pull_request.author_association != 'MEMBER' }}
 
   docker-build-api:
     if: github.event.pull_request.draft == false
@@ -70,6 +71,7 @@ jobs:
     with:
       target: oss-api
       image-name: flagsmith-api
+      ephemeral: ${{ github.event.pull_request.author_association != 'MEMBER' }}
 
   docker-build-frontend:
     if: github.event.pull_request.draft == false
@@ -78,6 +80,7 @@ jobs:
     with:
       target: oss-frontend
       image-name: flagsmith-frontend
+      ephemeral: ${{ github.event.pull_request.author_association != 'MEMBER' }}
 
   docker-build-e2e:
     if: github.event.pull_request.draft == false
@@ -86,10 +89,11 @@ jobs:
     with:
       file: frontend/Dockerfile.e2e
       image-name: flagsmith-e2e
+      ephemeral: ${{ github.event.pull_request.author_association != 'MEMBER' }}
       scan: false
 
   docker-build-private-cloud:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.author_association == 'MEMBER'
     name: Build Private Cloud Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
@@ -100,19 +104,19 @@ jobs:
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
   run-e2e-tests:
-    needs: [docker-build-api, docker-build-private-cloud, docker-build-e2e]
+    needs: [docker-build-api, docker-build-e2e]
     uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
     with:
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
-      api-image: ${{ matrix.api-image }}
+      e2e-image-build-id: ${{ needs.docker-build-e2e.outputs.build-id }}
+      api-image: ${{ needs.docker-build-api.outputs.image }}
+      api-image-build-id: ${{ needs.docker-build-api.outputs.build-id }}
       concurrency: ${{ matrix.args.concurrency }}
       tests: ${{ matrix.args.tests }}
+    secrets: inherit
 
     strategy:
       matrix:
-        api-image:
-          - ${{ needs.docker-build-api.outputs.image }}
-          - ${{ needs.docker-build-private-cloud.outputs.image }}
         args:
           - tests: segment-part-1 environment
             concurrency: 1

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,5 +1,8 @@
 .EXPORT_ALL_VARIABLES:
 
+COMPOSE_FILE ?= docker-compose-e2e-tests.yml
+COMPOSE_PROJECT_NAME ?= flagsmith-e2e
+
 DOTENV_OVERRIDE_FILE ?= .env
 
 E2E_CONCURRENCY ?= 3
@@ -25,5 +28,6 @@ serve:
 
 .PHONY: test
 test:
-	docker compose -f docker-compose-e2e-tests.yml run frontend \
-		npx cross-env E2E_CONCURRENCY=${E2E_CONCURRENCY} npm run test -- $(opts)
+	docker compose run frontend \
+		npx cross-env E2E_CONCURRENCY=${E2E_CONCURRENCY} npm run test -- $(opts) \
+		|| docker compose logs flagsmith-api


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This does a few things:
- For PRs opened by external contributors, skip pushing built images to Github Container registry. Push to an ephemeral registry instead.
- For PRs opened by external contributors, skip building the Private cloud image altogether.
- Remove Private cloud E2E for PRs for now. When we have Private cloud-specific E2E scenarios, we'll be able to run them by adding a E2E job depending on `private-cloud` build.
- When running E2E, pull ephemeral Depot images if a Depot build ID was provided.
- When running E2E, display API container logs on failure as part of the Makefile target.
- Add `secrets: inherit` for the release/merge to main E2E run so errors are reported to Slack correctly.

## How did you test this code?

Tested the Makefile change locally.
The rest of the changes will be tested in CI.