### PR TITLE
chore(ci): Set up Depot CLI for E2E if required

### DIFF
--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -22,6 +22,12 @@ on:
         description: The concurrent number of browsers to be used on testing
         required: false
         default: 3
+      use-depot:
+        type: boolean
+        required: false
+        default: >
+          ${{ startsWith(inputs.api-image, 'registry.depot.dev') || 
+            startsWith(inputs.e2e-image, 'registry.depot.dev') }}
 
 jobs:
   run-e2e:
@@ -45,8 +51,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Depot CLI
+        if: inputs.use-depot
+        uses: depot/setup-action@v1
+
       - name: Login to Depot Registry
-        if: startsWith(inputs.api-image, 'registry.depot.dev') || startsWith(inputs.e2e-image, 'registry.depot.dev')
+        if: inputs.use-depot
         run: depot pull-token | docker login -u x-token --password-stdin registry.depot.dev
 
       - name: Run tests on dockerised frontend


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the [following failure](https://github.com/Flagsmith/flagsmith/actions/runs/9663743858/job/26656781703) when running E2E against images in ephemeral mode:

```
Run depot pull-token | docker login -u x-token --password-stdin registry.depot.dev
/home/runner/work/_temp/735[4](https://github.com/Flagsmith/flagsmith/actions/runs/9663743858/job/26656781703#step:4:5)36f3-00ef-4984-a7c6-e8c5ac5caba8.sh: line 1: depot: command not found
Error: Cannot perform an interactive login from a non TTY device
Error: Process completed with exit code 1.
```

## How did you test this code?

This is a CI change.