### PR TITLE
chore(ci): Login to both registries for E2E

### DIFF
--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -22,12 +22,6 @@ on:
         description: The concurrent number of browsers to be used on testing
         required: false
         default: 3
-      use-depot:
-        type: boolean
-        required: false
-        default: >
-          ${{ startsWith(inputs.api-image, 'registry.depot.dev') || 
-            startsWith(inputs.e2e-image, 'registry.depot.dev') }}
 
 jobs:
   run-e2e:
@@ -44,7 +38,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to Github Container Registry
-        if: ${{ startsWith(inputs.api-image, 'ghcr.io') || startsWith(inputs.e2e-image, 'ghcr.io') }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -52,11 +45,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Depot CLI
-        if: inputs.use-depot
         uses: depot/setup-action@v1
 
       - name: Login to Depot Registry
-        if: inputs.use-depot
         run: depot pull-token | docker login -u x-token --password-stdin registry.depot.dev
 
       - name: Run tests on dockerised frontend


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR simplifies the E2E workflow to expect both types of images and logging in to both GHCR and Depot registries regardless of the input.

The conditional input I've set up earlier didn't work as expected. 

## How did you test this code?

This is a CI change.