### PR TITLE
feat(api-usage): add `subscription.plan` trait to `flagsmith.get_identity_flags`

### DIFF
--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -211,7 +211,10 @@ def handle_api_usage_notifications() -> None:
     ):
         feature_enabled = flagsmith_client.get_identity_flags(
             organisation.flagsmith_identifier,
-            traits={"organisation_id": organisation.id},
+            traits={
+                "organisation_id": organisation.id,
+                "subscription.plan": organisation.subscription.plan,
+            },
         ).is_feature_enabled("api_usage_alerting")
         if not feature_enabled:
             continue

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -272,7 +272,11 @@ def test_handle_api_usage_notifications_when_feature_flag_is_off(
     mock_api_usage.assert_not_called()
 
     client_mock.get_identity_flags.assert_called_once_with(
-        organisation.flagsmith_identifier, traits={"organisation_id": organisation.id}
+        organisation.flagsmith_identifier,
+        traits={
+            "organisation_id": organisation.id,
+            "subscription.plan": organisation.subscription.plan,
+        },
     )
 
     assert len(mailoutbox) == 0


### PR DESCRIPTION
## Changes

Adds the `subscription.plan` trait to the call to `flagsmith.get_identity_flags` so that we can segment on only free plan users for example. 

## How did you test this code?

Updated existing unit test to assert correct traits are added. 
