### PR TITLE
feat(build): Debian Bookworm base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,10 @@ ARG NODE_VERSION=16
 ARG PYTHON_VERSION=3.11
 ARG PYTHON_SITE_DIR=/usr/local/lib/python${PYTHON_VERSION}/site-packages
 
-FROM node:${NODE_VERSION} as node
-FROM node:${NODE_VERSION}-slim as node-slim
-FROM python:${PYTHON_VERSION} as python
-FROM python:${PYTHON_VERSION}-slim as python-slim
+FROM node:${NODE_VERSION}-bookworm as node
+FROM node:${NODE_VERSION}-bookworm-slim as node-slim
+FROM python:${PYTHON_VERSION}-bookworm as python
+FROM python:${PYTHON_VERSION}-slim-bookworm as python-slim
 
 # - Intermediary stages
 # * build-node

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,8 @@ RUN make install opts='--without dev'
 # * build-python-private [build-python]
 FROM build-python AS build-python-private
 
-# Authenticate git with token, install SAML binary dependency,
-# private Python dependencies, and integrate private modules
+# Authenticate git with token, install private Python dependencies,
+# and integrate private modules
 ARG SAML_REVISION
 ARG RBAC_REVISION
 RUN --mount=type=secret,id=github_private_cloud_token \


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This is an attempt to use newer base Docker images which should:
1. Reduce CVEs.
2. Reduce resulting image size.

## How did you test this code?

CI will build the images and run E2E tests against them. We will also test them manually.