### PR TITLE
fix: Set early return when influxdb range is empty

### DIFF
--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -83,6 +83,10 @@ class InfluxDBWrapper:
         extra: str = "",
         bucket: str = read_bucket,
     ):
+        # Influx throws an error for an empty range, so just return a list.
+        if date_start == "-0d" and date_stop == "now()":
+            return []
+
         query_api = influxdb_client.query_api()
         drop_columns_input = str(list(drop_columns)).replace("'", '"')
 

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
@@ -440,3 +440,14 @@ def test_get_top_organisations_value_error(
     # The wrongly typed data does not stop the remaining data
     # from being returned.
     assert dataset == {456: 43}
+
+
+def test_early_return_for_empty_range_for_influx_query_manager() -> None:
+    # When
+    results = InfluxDBWrapper.influx_query_manager(
+        date_start="-0d",
+        date_stop="now()",
+    )
+
+    # Then
+    assert results == []


### PR DESCRIPTION
## Changes

The API usage related refactor cropped up a new issue when the set range is effectively empty. Before this change users were getting the right results due to a broad try / except, but we were spamming Sentry with pointless logged errors. This fix early returns to avoid the empty set causing an issue.

## How did you test this code?

Wrote a simple unit test.
