### PR TITLE
feat: Announcement per page FF accept params

### DIFF
--- a/frontend/web/components/AnnouncementPerPage.tsx
+++ b/frontend/web/components/AnnouncementPerPage.tsx
@@ -36,18 +36,6 @@ const AnnouncementPerPage: FC<AnnouncementPerPageType> = ({ pathname }) => {
     Utils.getFlagsmithHasFeature('announcement_per_page') &&
     announcementPerPageValue?.pages?.length > 0
 
-  const convertObjectValuesToStrings = (
-    obj: AnnouncementPerPageValueType['params'],
-  ) => {
-    const newObj = {}
-    for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        newObj[key] = String(obj[key])
-      }
-    }
-    return newObj
-  }
-
   const announcementInPage = announcementPerPageValue?.pages?.some((page) => {
     if (Object.keys(routes).includes(page)) {
       const match = matchPath(pathname, {
@@ -57,15 +45,14 @@ const AnnouncementPerPage: FC<AnnouncementPerPageType> = ({ pathname }) => {
       })
 
       if (match) {
-        const annParams =
-          convertObjectValuesToStrings(announcementPerPageValue?.params) || {}
-        const matchParams = convertObjectValuesToStrings(match?.params) || {}
+        const annParams = announcementPerPageValue?.params || {}
+        const matchParams = match?.params || {}
         const objectsMatch = (
           obj1: AnnouncementPerPageValueType['params'],
           obj2: AnnouncementPerPageValueType['params'],
         ) => {
           return Object.keys(obj1).every((key) => {
-            return obj2.hasOwnProperty(key) && obj1[key] === obj2[key]
+            return `${obj1[key]}` === `${obj2[key]}`
           })
         }
         const annParamsMatch = objectsMatch(annParams, matchParams)

--- a/frontend/web/components/AnnouncementPerPage.tsx
+++ b/frontend/web/components/AnnouncementPerPage.tsx
@@ -1,3 +1,4 @@
+import { get } from 'lodash'
 import React, { FC } from 'react'
 import InfoMessage from './InfoMessage'
 import flagsmith from 'flagsmith'
@@ -8,9 +9,12 @@ import { routes } from 'web/routes'
 
 type AnnouncementPerPageValueType = AnnouncementValueType & {
   pages: string[]
+  projectId: number
 }
 
-type AnnouncementPerPageType = { pathname: string }
+type AnnouncementPerPageType = {
+  pathname: string
+}
 
 const AnnouncementPerPage: FC<AnnouncementPerPageType> = ({ pathname }) => {
   const closeAnnouncement = (id: string) => {
@@ -33,11 +37,20 @@ const AnnouncementPerPage: FC<AnnouncementPerPageType> = ({ pathname }) => {
 
   const announcementInPage = announcementPerPageValue?.pages?.some((page) => {
     if (Object.keys(routes).includes(page)) {
-      return !!matchPath(pathname, {
+      const match = matchPath(pathname, {
         exact: false,
         path: routes[page],
         strict: false,
       })
+      if (match) {
+        if (
+          parseInt(get(match, 'params.projectId')!) !==
+          announcementPerPageValue?.projectId
+        ) {
+          return false
+        }
+        return true
+      }
     }
     return false
   })

--- a/frontend/web/components/AnnouncementPerPage.tsx
+++ b/frontend/web/components/AnnouncementPerPage.tsx
@@ -10,6 +10,7 @@ import { routes } from 'web/routes'
 type AnnouncementPerPageValueType = AnnouncementValueType & {
   pages: string[]
   projectId: number
+  params: { [key: string]: string }
 }
 
 type AnnouncementPerPageType = {
@@ -35,6 +36,18 @@ const AnnouncementPerPage: FC<AnnouncementPerPageType> = ({ pathname }) => {
     Utils.getFlagsmithHasFeature('announcement_per_page') &&
     announcementPerPageValue?.pages?.length > 0
 
+  const convertObjectValuesToStrings = (
+    obj: AnnouncementPerPageValueType['params'],
+  ) => {
+    const newObj = {}
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        newObj[key] = String(obj[key])
+      }
+    }
+    return newObj
+  }
+
   const announcementInPage = announcementPerPageValue?.pages?.some((page) => {
     if (Object.keys(routes).includes(page)) {
       const match = matchPath(pathname, {
@@ -42,18 +55,32 @@ const AnnouncementPerPage: FC<AnnouncementPerPageType> = ({ pathname }) => {
         path: routes[page],
         strict: false,
       })
+
       if (match) {
-        if (
-          parseInt(get(match, 'params.projectId')!) !==
-          announcementPerPageValue?.projectId
-        ) {
-          return false
+        const annParams =
+          convertObjectValuesToStrings(announcementPerPageValue?.params) || {}
+        const matchParams = convertObjectValuesToStrings(match?.params) || {}
+        const objectsMatch = (
+          obj1: AnnouncementPerPageValueType['params'],
+          obj2: AnnouncementPerPageValueType['params'],
+        ) => {
+          return Object.keys(obj1).every((key) => {
+            return obj2.hasOwnProperty(key) && obj1[key] === obj2[key]
+          })
         }
-        return true
+        const annParamsMatch = objectsMatch(annParams, matchParams)
+        const matchParamsMatch = objectsMatch(matchParams, annParams)
+        if (annParamsMatch || matchParamsMatch) {
+          return true
+        }
+
+        return false
       }
     }
+
     return false
   })
+
   return (
     <>
       {showAnnouncementPerPage && announcementInPage && (

--- a/frontend/web/components/InfoMessage.js
+++ b/frontend/web/components/InfoMessage.js
@@ -21,7 +21,7 @@ export default class InfoMessage extends PureComponent {
           <div className='title'>{this.props.title || 'NOTE'}</div>
           <div className='flex-fill'>{this.props.children}</div>
         </div>
-        {this.props.url && (
+        {this.props.url && this.props.buttonText && (
           <Button
             size='small'
             className='btn my-2 ml-2'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- The feature flag Announcement_per_page can have a projectId, and the UI validates that it matches the one from the dashboard to display the announcement.


## How did you test this code?

- Add a key `params` to the value of your feature flag `Announcement_per_page`, and set the value to the IDs of the project, environment, or organisation, where you want the announcement to be displayed.

The params key can have the following values: projectId, environmentId, and organisationId.(They are not mandatory)

This is an example of how the flag's value should appear with the params key.
 
```
{ 
"id":"announcement-per-page-3",
"title":"This is a custom announcement for some pages",
"description":"Announcement Page 1",
"buttonText":"Go your page",
"isClosable": true,
"url":"https://app.flagsmith.com/",
"pages":["users","segments","integrations","features"],
"params":{"projectId": 1}
}
```
