### PR TITLE
fix(build): Avoid Docker Hub pull throttling by using public ECR registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,10 @@ ARG CI_COMMIT_SHA=dev
 ARG NODE_VERSION=16
 ARG PYTHON_VERSION=3.11
 
-FROM node:${NODE_VERSION}-bookworm as node
-FROM node:${NODE_VERSION}-bookworm-slim as node-slim
-FROM python:${PYTHON_VERSION}-bookworm as python
-FROM python:${PYTHON_VERSION}-slim-bookworm as python-slim
+FROM public.ecr.aws/docker/library/node:${NODE_VERSION}-bookworm as node
+FROM public.ecr.aws/docker/library/node:${NODE_VERSION}-bookworm-slim as node-slim
+FROM public.ecr.aws/docker/library/python:${PYTHON_VERSION}-bookworm as python
+FROM public.ecr.aws/docker/library/python:${PYTHON_VERSION}-slim-bookworm as python-slim
 
 # - Intermediary stages
 # * build-node


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This swaps out base images from Docker Hub to ones from Public ECR. This helps to avoid Docker Hub throttling on ARM64 runners (see https://github.com/actions/runner-images/issues/1445#issuecomment-2208581589).

## How did you test this code?

Pulled each of the new images and made sure they're identical to the ones from Docker Hub.