### PR TITLE
chore(build): Fix Docker Hub rate limiting for Postgres image

### DIFF
--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -6,7 +6,7 @@
 version: '3'
 services:
   db:
-    image: postgres:15.5-alpine
+    image: public.ecr.aws/docker/library/postgres:15.5-alpine
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: flagsmith


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This uses the ECR image for Postgres service in the E2E Compose file. It helps to avoid Docker Hub pull rate limiting for ARM64 runners.

## How did you test this code?

A green E2E workflow on ARM64 run should be evident that the solution works.