### PR TITLE
fix(e2e): Pass `GITHUB_ACTION_URL` to Docker E2E test runs

### DIFF
--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -48,6 +48,7 @@ services:
       DISABLE_ANALYTICS_FEATURES: 'true'
       FLAGSMITH_API: flagsmith-api:8000/api/v1/
       SLACK_TOKEN: ${SLACK_TOKEN}
+      GITHUB_ACTION_URL: ${GITHUB_ACTION_URL}
     ports:
       - 8080:8080
     depends_on:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This makes sure `GITHUB_ACTION_URL` is passed during dockerised E2E runs, making the workflow run log available in the Slack reports.

## How did you test this code?

Added a purposefully failing test to test the change in CI.