### PR TITLE
fix: annual plan ids and refreshing

### DIFF
--- a/frontend/env/project_dev.js
+++ b/frontend/env/project_dev.js
@@ -17,5 +17,9 @@ module.exports = global.Project = {
   // This is used for Sentry tracking
   maintenance: false,
   useSecureCookies: true,
+  plans: {
+    scaleUp: { annual: 'scale-up-annual-v2', monthly: 'scale-up-v2' },
+    startup: { annual: 'startup-annual-v2', monthly: 'startup-v2' },
+  },
   ...(globalThis.projectOverrides || {}),
 }

--- a/frontend/env/project_prod.js
+++ b/frontend/env/project_prod.js
@@ -23,5 +23,9 @@ module.exports = global.Project = {
   // This is used for Sentry tracking
   maintenance: false,
   useSecureCookies: true,
+  plans: {
+    scaleUp: { annual: 'scale-up-12-months-v2', monthly: 'scale-up-v2' },
+    startup: { annual: 'start-up-12-months-v2', monthly: 'startup-v2' },
+  },
   ...(globalThis.projectOverrides || {}),
 }

--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -161,23 +161,28 @@ const Payment = class extends Component {
                           Billed Monthly
                         </div>
                         {!viewOnly ? (
-                          this.state.yearly ? (
+                          <>
                             <PaymentButton
-                              data-cb-plan-id='startup-annual-v2'
-                              className='btn btn-primary full-width mt-3'
+                              data-cb-plan-id={Project.plans.startup.annual}
+                              className={classNames(
+                                'btn btn-primary full-width mt-3',
+                                { 'd-none': !this.state.yearly },
+                              )}
                               isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('startup') ? 'Purchased' : 'Buy'}
                             </PaymentButton>
-                          ) : (
                             <PaymentButton
-                              data-cb-plan-id='startup-v2'
-                              className='btn btn-primary full-width mt-3'
+                              data-cb-plan-id={Project.plans.startup.monthly}
+                              className={classNames(
+                                'btn btn-primary full-width mt-3',
+                                { 'd-none': this.state.yearly },
+                              )}
                               isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('startup') ? 'Purchased' : 'Buy'}
                             </PaymentButton>
-                          )
+                          </>
                         ) : null}
                       </div>
                       <div className='panel-footer mt-3'>
@@ -380,23 +385,28 @@ const Payment = class extends Component {
                           Billed Monthly
                         </div>
                         {!viewOnly ? (
-                          this.state.yearly ? (
+                          <>
                             <PaymentButton
-                              data-cb-plan-id='scale-up-annual-v2'
-                              className='btn btn-success full-width mt-3'
+                              data-cb-plan-id={Project.plans.scaleUp.annual}
+                              className={classNames(
+                                'btn btn-success full-width mt-3',
+                                { 'd-none': !this.state.yearly },
+                              )}
                               isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('scale-up') ? 'Purchased' : 'Buy'}
                             </PaymentButton>
-                          ) : (
                             <PaymentButton
-                              data-cb-plan-id='scale-up-v2'
-                              className='btn btn-success full-width mt-3'
+                              data-cb-plan-id={Project.plans.scaleUp.monthly}
+                              className={classNames(
+                                'btn btn-success full-width mt-3',
+                                { 'd-none': this.state.yearly },
+                              )}
                               isDisableAccount={this.props.isDisableAccountText}
                             >
                               {plan.includes('scale-up') ? 'Purchased' : 'Buy'}
                             </PaymentButton>
-                          )
+                          </>
                         ) : null}
                       </div>
                       <div className='panel-footer mt-3'>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the following issues from #4110
- There was a missmatch in plan ids between staging and production, this moves the plan ids to project_x
- Switching between annual and monthly did not update the selected plan


## How to test

- Go to the production preview url and attempt to purchase all plans, ensure they are the correct plan
