### PR TITLE
feat: Support transient identities and traits

### DIFF
--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -1,4 +1,5 @@
 import typing
+from itertools import chain
 
 from django.db import models
 from django.db.models import Prefetch, Q
@@ -243,7 +244,7 @@ class Identity(models.Model):
         for trait_data_item in trait_data_items:
             trait_key = trait_data_item["trait_key"]
             trait_value = trait_data_item["trait_value"]
-            transient = trait_data_item["transient"]
+            transient = trait_data_item.get("transient")
 
             if trait_value is None:
                 # build a list of trait keys to delete having been nulled by the
@@ -296,6 +297,6 @@ class Identity(models.Model):
         return [
             *{
                 trait.trait_key: trait
-                for trait in (self.identity_traits.all() + transient_traits)
+                for trait in chain(self.identity_traits.all(), transient_traits)
             }.values()
         ]

--- a/api/environments/identities/serializers.py
+++ b/api/environments/identities/serializers.py
@@ -65,6 +65,7 @@ class SDKIdentitiesResponseSerializer(serializers.Serializer):
 
 class SDKIdentitiesQuerySerializer(serializers.Serializer):
     identifier = serializers.CharField(required=True)
+    transient = serializers.BooleanField(default=False)
 
 
 class IdentityAllFeatureStatesFeatureSerializer(serializers.Serializer):

--- a/api/environments/identities/traits/serializers.py
+++ b/api/environments/identities/traits/serializers.py
@@ -26,7 +26,7 @@ class TraitSerializerBasic(serializers.ModelSerializer):
 
     class Meta:
         model = Trait
-        fields = ("id", "trait_key", "trait_value")
+        fields = ("id", "trait_key", "trait_value", "transient")
         read_only_fields = ("id",)
 
 

--- a/api/environments/identities/traits/serializers.py
+++ b/api/environments/identities/traits/serializers.py
@@ -22,7 +22,7 @@ class TraitSerializerFull(serializers.ModelSerializer):
 
 class TraitSerializerBasic(serializers.ModelSerializer):
     trait_value = TraitValueField(allow_null=True)
-    transient = serializers.BooleanField(default=False)
+    transient = serializers.BooleanField(default=False, write_only=True)
 
     class Meta:
         model = Trait

--- a/api/environments/identities/traits/serializers.py
+++ b/api/environments/identities/traits/serializers.py
@@ -22,6 +22,7 @@ class TraitSerializerFull(serializers.ModelSerializer):
 
 class TraitSerializerBasic(serializers.ModelSerializer):
     trait_value = TraitValueField(allow_null=True)
+    transient = serializers.BooleanField(default=False)
 
     class Meta:
         model = Trait

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -5,6 +5,7 @@ from core.constants import FLAGSMITH_UPDATED_AT_HEADER
 from core.request_origin import RequestOrigin
 from django.conf import settings
 from django.db.models import Q
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from drf_yasg.utils import swagger_auto_schema
@@ -175,6 +176,7 @@ class SDKIdentities(SDKAPIView):
 
         if request.query_params.get("transient"):
             identity = Identity(
+                created_date=timezone.now(),
                 identifier=identifier,
                 environment=request.environment,
             )

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -173,11 +173,17 @@ class SDKIdentities(SDKAPIView):
                 {"detail": "Missing identifier"}
             )  # TODO: add 400 status - will this break the clients?
 
-        identity, _ = Identity.objects.get_or_create_for_sdk(
-            identifier=identifier,
-            environment=request.environment,
-            integrations=IDENTITY_INTEGRATIONS,
-        )
+        if request.query_params.get("transient"):
+            identity = Identity(
+                identifier=identifier,
+                environment=request.environment,
+            )
+        else:
+            identity, _ = Identity.objects.get_or_create_for_sdk(
+                identifier=identifier,
+                environment=request.environment,
+                integrations=IDENTITY_INTEGRATIONS,
+            )
         self.identity = identity
 
         if settings.EDGE_API_URL and request.environment.project.enable_dynamo_db:

--- a/api/environments/sdk/serializers.py
+++ b/api/environments/sdk/serializers.py
@@ -2,6 +2,7 @@ import typing
 from collections import defaultdict
 
 from core.constants import BOOLEAN, FLOAT, INTEGER, STRING
+from django.utils import timezone
 from rest_framework import serializers
 
 from environments.identities.models import Identity
@@ -143,6 +144,7 @@ class IdentifyWithTraitsSerializer(
 
         if transient:
             identity = Identity(
+                created_date=timezone.now(),
                 identifier=self.validated_data["identifier"],
                 environment=environment,
             )

--- a/api/environments/sdk/serializers.py
+++ b/api/environments/sdk/serializers.py
@@ -125,6 +125,7 @@ class IdentifyWithTraitsSerializer(
     HideSensitiveFieldsSerializerMixin, serializers.Serializer
 ):
     identifier = serializers.CharField(write_only=True, required=True)
+    transient = serializers.BooleanField(write_only=True, default=False)
     traits = TraitSerializerBasic(required=False, many=True)
     flags = SDKFeatureStateSerializer(read_only=True, many=True)
 
@@ -136,22 +137,32 @@ class IdentifyWithTraitsSerializer(
         (optionally store traits if flag set on org)
         """
         environment = self.context["environment"]
-        identity, created = Identity.objects.get_or_create(
-            identifier=self.validated_data["identifier"], environment=environment
-        )
 
+        transient = self.validated_data["transient"]
         trait_data_items = self.validated_data.get("traits", [])
 
-        if not created and environment.project.organisation.persist_trait_data:
-            # if this is an update and we're persisting traits, then we need to
-            # partially update any traits and return the full list
-            trait_models = identity.update_traits(trait_data_items)
-        else:
-            # generate traits for the identity and store them if configured to do so
-            trait_models = identity.generate_traits(
-                trait_data_items,
-                persist=environment.project.organisation.persist_trait_data,
+        if transient:
+            identity = Identity(
+                identifier=self.validated_data["identifier"],
+                environment=environment,
             )
+            trait_models = identity.generate_traits(trait_data_items, persist=False)
+
+        else:
+            identity, created = Identity.objects.get_or_create(
+                identifier=self.validated_data["identifier"], environment=environment
+            )
+
+            if not created and environment.project.organisation.persist_trait_data:
+                # if this is an update and we're persisting traits, then we need to
+                # partially update any traits and return the full list
+                trait_models = identity.update_traits(trait_data_items)
+            else:
+                # generate traits for the identity and store them if configured to do so
+                trait_models = identity.generate_traits(
+                    trait_data_items,
+                    persist=environment.project.organisation.persist_trait_data,
+                )
 
         all_feature_states = identity.get_all_feature_states(
             traits=trait_models,

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -342,6 +342,8 @@ def segment_featurestate(
     feature_segment: int,
 ) -> int:
     data = {
+        "enabled": True,
+        "feature_state_value": {"type": "unicode", "string_value": "segment override"},
         "feature": feature,
         "environment": environment,
         "feature_segment": feature_segment,

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from features.feature_types import MULTIVARIATE
 from tests.integration.helpers import (
@@ -221,3 +222,103 @@ def test_get_feature_states_for_identity_only_makes_one_query_to_get_mv_feature_
 
     second_identity_response_json = second_identity_response.json()
     assert len(second_identity_response_json["flags"]) == 3
+
+
+def test_get_feature_states_for_identity__transient_identity__segment_match_expected(
+    sdk_client: APIClient,
+    feature: int,
+    segment: int,
+    segment_condition_property: str,
+    segment_condition_value: str,
+    segment_featurestate: int,
+) -> None:
+    # Given
+    url = reverse("api-v1:sdk-identities")
+
+    # When
+    # flags are requested for a new transient identity
+    # that matches the segment
+    response = sdk_client.post(
+        url,
+        data=json.dumps(
+            {
+                "identifier": "unseen",
+                "traits": [
+                    {
+                        "trait_key": segment_condition_property,
+                        "trait_value": segment_condition_value,
+                    }
+                ],
+                "transient": True,
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    response_json = response.json()
+    assert (
+        flag_data := next(
+            (
+                flag
+                for flag in response_json["flags"]
+                if flag["feature"]["id"] == feature
+            ),
+            None,
+        )
+    )
+    assert flag_data["enabled"] is True
+    assert flag_data["feature_state_value"] == "segment override"
+
+
+def test_get_feature_states_for_identity__transient_trait__segment_match_expected(
+    sdk_client: APIClient,
+    feature: int,
+    segment: int,
+    segment_condition_property: str,
+    segment_condition_value: str,
+    segment_featurestate: int,
+) -> None:
+    # Given
+    url = reverse("api-v1:sdk-identities")
+
+    # When
+    # flags are requested for a new transient identity
+    # that matches the segment
+    response = sdk_client.post(
+        url,
+        data=json.dumps(
+            {
+                "identifier": "unseen",
+                "traits": [
+                    {
+                        "trait_key": segment_condition_property,
+                        "trait_value": segment_condition_value,
+                        "transient": True,
+                    },
+                    {
+                        "trait_key": "persistent",
+                        "trait_value": "trait value",
+                    },
+                ],
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    response_json = response.json()
+    assert (
+        flag_data := next(
+            (
+                flag
+                for flag in response_json["flags"]
+                if flag["feature"]["id"] == feature
+            ),
+            None,
+        )
+    )
+    assert flag_data["enabled"] is True
+    assert flag_data["feature_state_value"] == "segment override"

--- a/api/tests/unit/environments/identities/helpers.py
+++ b/api/tests/unit/environments/identities/helpers.py
@@ -5,9 +5,15 @@ from environments.identities.traits.models import Trait
 
 
 def generate_trait_data_item(
-    trait_key: str = "trait_key", trait_value: typing.Any = "trait_value"
+    trait_key: str = "trait_key",
+    trait_value: typing.Any = "trait_value",
+    transient: bool = False,
 ):
-    return {"trait_key": trait_key, "trait_value": trait_value}
+    return {
+        "trait_key": trait_key,
+        "trait_value": trait_value,
+        "transient": transient,
+    }
 
 
 def create_trait_for_identity(

--- a/api/tests/unit/environments/identities/test_unit_identities_models.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_models.py
@@ -662,19 +662,33 @@ def test_update_traits(environment: Environment) -> None:
     new_trait_1_value = 5
     trait_3_key = "trait_3"
     trait_3_value = 3
+
+    # and one transient trait that is evaluated against but not persisted
+    transient_trait_key = "transient"
+    transient_trait_value = "not persisted"
+
     trait_data_items = [
         generate_trait_data_item(
             trait_key=trait_1.trait_key, trait_value=new_trait_1_value
         ),
         generate_trait_data_item(trait_key=trait_3_key, trait_value=trait_3_value),
+        generate_trait_data_item(trait_key=trait_3_key, trait_value=trait_3_value),
+        generate_trait_data_item(
+            trait_key=transient_trait_key,
+            trait_value=transient_trait_value,
+            transient=True,
+        ),
     ]
 
     # When
     updated_traits = identity.update_traits(trait_data_items)
 
     # Then
-    # 3 traits are returned
-    assert len(updated_traits) == 3
+    # 3 traits are persisted
+    assert identity.identity_traits.count() == 3
+
+    # 4 traits are returned
+    assert len(updated_traits) == 4
 
     # and the first trait has it's value updated correctly
     updated_trait_1 = get_trait_from_list_by_key(trait_1_key, updated_traits)
@@ -687,6 +701,10 @@ def test_update_traits(environment: Environment) -> None:
     # and the third trait is created correctly
     updated_trait_3 = get_trait_from_list_by_key(trait_3_key, updated_traits)
     assert updated_trait_3.trait_value == trait_3_value
+
+    # and the transient trait is returned among others
+    transient_trait = get_trait_from_list_by_key(transient_trait_key, updated_traits)
+    assert transient_trait.trait_value == transient_trait_value
 
 
 def test_update_traits_deletes_when_nulled_out(environment: Environment) -> None:

--- a/api/tests/unit/environments/identities/test_unit_identities_models.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_models.py
@@ -672,7 +672,6 @@ def test_update_traits(environment: Environment) -> None:
             trait_key=trait_1.trait_key, trait_value=new_trait_1_value
         ),
         generate_trait_data_item(trait_key=trait_3_key, trait_value=trait_3_value),
-        generate_trait_data_item(trait_key=trait_3_key, trait_value=trait_3_value),
         generate_trait_data_item(
             trait_key=transient_trait_key,
             trait_value=transient_trait_value,

--- a/api/tests/unit/environments/identities/test_unit_identities_models.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_models.py
@@ -604,17 +604,21 @@ def test_generate_traits_with_persistence(environment: Environment) -> None:
         generate_trait_data_item("string_trait", "string_value"),
         generate_trait_data_item("integer_trait", 1),
         generate_trait_data_item("boolean_value", True),
+        generate_trait_data_item("transient_trait", "string_value", transient=True),
     ]
 
     # When
     trait_models = identity.generate_traits(trait_data_items, persist=True)
 
     # Then
-    # the response from the method has 3 traits
-    assert len(trait_models) == 3
+    # the response from the method has 4 traits
+    assert len(trait_models) == 4
 
-    # and the database matches it
+    # and 3 were persisted
     assert Trait.objects.filter(identity=identity).count() == 3
+    assert not Trait.objects.filter(
+        identity=identity, trait_key="transient_trait"
+    ).exists()
 
 
 def test_generate_traits_without_persistence(environment: Environment) -> None:

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -1033,6 +1033,23 @@ def test_get_identities_with_hide_sensitive_data(
     assert response.json()["traits"] == []
 
 
+def test_get_identities__transient__no_persistence(
+    environment: Environment,
+    api_client: APIClient,
+) -> None:
+    # Given
+    identifier = "transient"
+    api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
+    url = reverse("api-v1:sdk-identities") + f"?identifier={identifier}&transient=true"
+
+    # When
+    response = api_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert not Identity.objects.filter(identifier=identifier).count()
+
+
 def test_post_identities_with_hide_sensitive_data(
     environment, feature, identity, api_client
 ):
@@ -1124,6 +1141,59 @@ def test_post_identities__server_key_only_feature__server_key_auth__return_expec
     # Then
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["flags"]
+
+
+def test_post_identities__transient__no_persistence(
+    environment: Environment,
+    api_client: APIClient,
+) -> None:
+    # Given
+    identifier = "transient"
+    trait_key = "trait_key"
+
+    api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
+    url = reverse("api-v1:sdk-identities")
+    data = {
+        "identifier": identifier,
+        "traits": [{"trait_key": "foo", "trait_value": "bar"}],
+        "transient": True,
+    }
+
+    # When
+    response = api_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert not Identity.objects.filter(identifier=identifier).count()
+    assert not Trait.objects.filter(trait_key=trait_key).count()
+
+
+def test_post_identities__transient_traits__no_persistence(
+    environment: Environment,
+    api_client: APIClient,
+) -> None:
+    # Given
+    identifier = "transient"
+    trait_key = "trait_key"
+
+    api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
+    url = reverse("api-v1:sdk-identities")
+    data = {
+        "identifier": identifier,
+        "traits": [{"trait_key": "foo", "trait_value": "bar", "transient": True}],
+    }
+
+    # When
+    response = api_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert Identity.objects.filter(identifier=identifier).count()
+    assert not Trait.objects.filter(trait_key=trait_key).count()
 
 
 def test_user_with_view_identities_permission_can_retrieve_identity(

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -1155,7 +1155,7 @@ def test_post_identities__transient__no_persistence(
     url = reverse("api-v1:sdk-identities")
     data = {
         "identifier": identifier,
-        "traits": [{"trait_key": "foo", "trait_value": "bar"}],
+        "traits": [{"trait_key": trait_key, "trait_value": "bar"}],
         "transient": True,
     }
 
@@ -1166,8 +1166,8 @@ def test_post_identities__transient__no_persistence(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert not Identity.objects.filter(identifier=identifier).count()
-    assert not Trait.objects.filter(trait_key=trait_key).count()
+    assert not Identity.objects.filter(identifier=identifier).exists()
+    assert not Trait.objects.filter(trait_key=trait_key).exists()
 
 
 def test_post_identities__transient_traits__no_persistence(
@@ -1182,7 +1182,7 @@ def test_post_identities__transient_traits__no_persistence(
     url = reverse("api-v1:sdk-identities")
     data = {
         "identifier": identifier,
-        "traits": [{"trait_key": "foo", "trait_value": "bar", "transient": True}],
+        "traits": [{"trait_key": trait_key, "trait_value": "bar", "transient": True}],
     }
 
     # When
@@ -1192,8 +1192,8 @@ def test_post_identities__transient_traits__no_persistence(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert Identity.objects.filter(identifier=identifier).count()
-    assert not Trait.objects.filter(trait_key=trait_key).count()
+    assert Identity.objects.filter(identifier=identifier).exists()
+    assert not Trait.objects.filter(trait_key=trait_key).exists()
 
 
 def test_user_with_view_identities_permission_can_retrieve_identity(

--- a/api/tests/unit/environments/identities/traits/test_unit_traits_serializers.py
+++ b/api/tests/unit/environments/identities/traits/test_unit_traits_serializers.py
@@ -48,7 +48,7 @@ def test_bulk_create_update_serializer_save_many(
     mocked_request = mocker.MagicMock(environment=identity.environment)
 
     # When
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(5):
         serializer = SDKBulkCreateUpdateTraitSerializer(
             data=data,
             many=True,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes #4279.
Contributes to #4278.

This adds support for
- Top-level `transient` parameter
- `transient` attribute for traits

for the `/api/v1/identities` SDK endpoint (GET, POST).

When including top-level `transient: true`, identity is evaluated against segments but is not persisted at all.
When calling the endpoint with traits marked as transient, these traits get evaluated against segments but do not get persisted.

Additionally, `Identity.update_traits` does not perform two `SELECT` queries anymore.

## How did you test this code?

Added unit tests for views and serializers.