### PR TITLE
fix(build): Avoid E2E rate limiting by swithing to Postgres image hosted on GHCR

### DIFF
--- a/frontend/docker-compose-e2e-tests.yml
+++ b/frontend/docker-compose-e2e-tests.yml
@@ -6,7 +6,7 @@
 version: '3'
 services:
   db:
-    image: public.ecr.aws/docker/library/postgres:15.5-alpine
+    image: ghcr.io/cloudnative-pg/postgresql:15
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: flagsmith


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Same as https://github.com/Flagsmith/flagsmith/pull/4292, but using a GHCR-based image.

## How did you test this code?

This is a CI change