### PR TITLE
fix: frontend fails to load when announcement flag isn't set

### DIFF
--- a/frontend/web/components/Announcement.tsx
+++ b/frontend/web/components/Announcement.tsx
@@ -20,6 +20,11 @@ const Announcement: FC<AnnouncementType> = () => {
   }
 
   const announcementValue = Utils.getFlagsmithJSONValue('announcement', null)
+
+  if (!announcementValue) {
+    return null
+  }
+
   const { buttonText, description, id, isClosable, title, url } =
     announcementValue as AnnouncementValueType
   const dismissed = flagsmith.getTrait('dismissed_announcement')


### PR DESCRIPTION
## Changes

Fixes an error which prevents the FE from loading when the `announcement` flag isn't set. 

## How did you test this code?

Ran the FE locally pointing to a flagsmith on flagsmith environment that doesn't have the `announcement` flag set. 
