### PR TITLE
docs: Use category index pages instead of separate Overview pages

### DIFF
--- a/docs/docs/advanced-use/ab-testing.md
+++ b/docs/docs/advanced-use/ab-testing.md
@@ -15,8 +15,8 @@ to put users into a particular AB testing bucket. These buckets will control the
 tested. The analytics platform will receive a stream of event data derived from the behaviour of the user. Combining
 these two concepts allows you to deliver seamless AB test.
 
-We have [integrations](integrations/overview.md) with a number of analytics platforms. If we don't integrate with the
-platform you are using, you can still manually send the test data to the downstream platform manually.
+We have [integrations](/integrations) with a number of analytics platforms. If we don't integrate with the platform you
+are using, you can still manually send the test data to the downstream platform manually.
 
 ## Overview - Testing a new Paypal button
 

--- a/docs/docs/advanced-use/custom-fields.md
+++ b/docs/docs/advanced-use/custom-fields.md
@@ -22,8 +22,7 @@ For example, you might want to:
 
 You can define **custom fields** that are shown when creating or modifying
 [**flags**](/basic-features/managing-features.md), [**segments**](/basic-features/segments.md) or
-[**environments**](/basic-features/overview.md#environments). Custom fields are defined per
-[project](/basic-features/overview.md#projects).
+[**environments**](/basic-features#environments). Custom fields are defined per [project](/basic-features#projects).
 
 ## Permissions
 

--- a/docs/docs/advanced-use/edge-api.md
+++ b/docs/docs/advanced-use/edge-api.md
@@ -6,9 +6,9 @@ The Edge API is only available with on our SaaS platform. It does not form part 
 
 :::
 
-[The Flagsmith Architecture](/clients/overview#remote-evaluation) is based around a server-side flag engine. This comes
-with a number of benefits, but it can increase latency, especially when the calls are being made from a location that is
-far from the EU; the location of our current API. It also provides a single point of failure in the event of an AWS
+[The Flagsmith Architecture](/clients#remote-evaluation) is based around a server-side flag engine. This comes with a
+number of benefits, but it can increase latency, especially when the calls are being made from a location that is far
+from the EU; the location of our current API. It also provides a single point of failure in the event of an AWS
 region-wide outage.
 
 The Edge API solves both of these issues. It provides a datastore and Edge compute API that is replicated across 8 AWS

--- a/docs/docs/advanced-use/edge-proxy.md
+++ b/docs/docs/advanced-use/edge-proxy.md
@@ -7,24 +7,23 @@ close to your servers. If you are running Flagsmith within a server-side environ
 latency flags, you have two options:
 
 1. Run the Edge Proxy within in your own infrastructure and connect to it from your server-side SDKs
-2. Run your server-side SDKs in [Local Evaluation Mode](/clients/overview#local-evaluation).
+2. Run your server-side SDKs in [Local Evaluation Mode](/clients#local-evaluation).
 
 The main benefit to running the Edge Proxy is that you reduce your polling requests against the Flagsmith API itself.
 
-The main benefit to running server side SDKs in [Local Evaluation Mode](/clients/overview#local-evaluation) is that you
-get the lowest possible latency.
+The main benefit to running server side SDKs in [Local Evaluation Mode](/clients#local-evaluation) is that you get the
+lowest possible latency.
 
 ## How does it work
 
 :::info
 
-The Edge Proxy has the same [caveats as running our SDK in Local Evaluation mode.](/clients/overview#local-evaluation).
+The Edge Proxy has the same [caveats as running our SDK in Local Evaluation mode.](/clients/#local-evaluation).
 
 :::
 
 You can think of the Edge Proxy as a copy of our Python Server Side SDK, running in
-[Local Evaluation Mode](/clients/overview#local-evaluation), with an API interface that is compatible with the Flagsmith
-SDK API.
+[Local Evaluation Mode](/clients#local-evaluation), with an API interface that is compatible with the Flagsmith SDK API.
 
 The Edge Proxy runs as a lightweight Docker container. It connects to the Flagsmith API (either powered by us at
 api.flagsmith.com or self hosted by you) to get Environment Flags and Segment rules. You can then point the Flagsmith

--- a/docs/docs/basic-features/index.md
+++ b/docs/docs/basic-features/index.md
@@ -1,6 +1,5 @@
 ---
 title: Feature Flags - An Overview
-sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/docs/docs/basic-features/managing-identities.md
+++ b/docs/docs/basic-features/managing-identities.md
@@ -85,8 +85,8 @@ This can be useful if, at runtime, your application does not have all the releva
 particular Identity; any Traits provided will be combined with the Traits stored within Flagsmith before the evaluation
 engine runs.
 
-There are some [exceptions to this rule](/clients/overview#server-side-sdks) with Server Side SDKs running in local
-evaluation mode.
+There are some [exceptions to this rule](/clients#server-side-sdks) with Server Side SDKs running in local evaluation
+mode.
 
 ### Using Traits as a data-store
 

--- a/docs/docs/basic-features/segments.md
+++ b/docs/docs/basic-features/segments.md
@@ -43,11 +43,11 @@ to read traits and flags derived from segments in this case.
 
 Segment names and definitions might include sensitive or proprietary information that you do not want to expose to your
 users. Because of this, segments are transparent to applications and are not included in API responses when using
-[remote evaluation mode](/clients/overview#remote-evaluation).
+[remote evaluation mode](/clients#remote-evaluation).
 
-Segment definitions _are_ served to clients running in [local evaluation mode](/clients/overview#local-evaluation), as
-this allows them to calculate segments without making requests to the Flagsmith API. This is only an implementation
-detail and no segment information is exposed when retrieving flags using any SDK method.
+Segment definitions _are_ served to clients running in [local evaluation mode](/clients#local-evaluation), as this
+allows them to calculate segments without making requests to the Flagsmith API. This is only an implementation detail
+and no segment information is exposed when retrieving flags using any SDK method.
 
 ## Creating project or feature-specific segments
 

--- a/docs/docs/clients/index.md
+++ b/docs/docs/clients/index.md
@@ -1,6 +1,5 @@
 ---
 description: Manage your Feature Flags and Remote Config in your REST APIs.
-sidebar_label: Overview
 sidebar_position: 1
 ---
 
@@ -350,7 +349,7 @@ are all computed locally.
   instances. We're rolling them out gradually for the SaaS version. If you are a SaaS customer,
   <a class="open-chat" data-crisp-chat-message="Hi! I'm interested to try out identity overrides in Local Evaluation mode with Flagsmith SaaS!" href="#local-evaluation-1">contact
   us</a> to try them out!
-- [Analytics-based Integrations](/integrations/overview#analytics-platforms) do not run.
+- [Analytics-based Integrations](/integrations#analytics-platforms) do not run.
   [Flag Analytics](/advanced-use/flag-analytics) do still work, if enabled within the
   [SDK setup](/clients/server-side#configuring-the-sdk).
 - In circumstances where you need to target a specific identity, you can do this by creating a segment to target that

--- a/docs/docs/clients/server-side.md
+++ b/docs/docs/clients/server-side.md
@@ -11,8 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 :::tip
 
 Server Side SDKs can run in 2 different modes: `Local Evaluation` and `Remote Evaluation`. We recommend
-[reading up about the differences](/clients/overview#server-side-sdks) first before integrating the SDKS into your
-applications.
+[reading up about the differences](/clients#server-side-sdks) first before integrating the SDKS into your applications.
 
 :::
 
@@ -554,7 +553,7 @@ secret_button_feature_value = Flagsmith.Client.get_feature_value(flags, "secret_
 </TabItem>
 </Tabs>
 
-### When running in [Remote Evaluation mode](/clients/overview#remote-evaluation)
+### When running in [Remote Evaluation mode](/clients#remote-evaluation)
 
 - When requesting Flags for an Identity, all the Traits defined in the SDK will automatically be persisted against the
   Identity within the Flagsmith API.
@@ -562,13 +561,13 @@ secret_button_feature_value = Flagsmith.Client.get_feature_value(flags, "secret_
 - This full set of Traits are then used to evaluate the Flag values for the Identity.
 - This all happens in a single request/response.
 
-### When running in [Local Evaluation mode](/clients/overview#local-evaluation)
+### When running in [Local Evaluation mode](/clients#local-evaluation)
 
 - _Only_ the Traits provided to the SDK at runtime will be used. Local Evaluation mode, by design, does not make any
   network requests to the Flagsmith API when evaluating Flags for an Identity.
   - When running in Local Evaluation Mode, the SDK requests the
-    [Environment Document](/clients/overview#the-environment-document) from the Flagsmith API. This contains all the
-    information required to make Flag Evaluations, but it does _not_ contain any Trait data.
+    [Environment Document](/clients#the-environment-document) from the Flagsmith API. This contains all the information
+    required to make Flag Evaluations, but it does _not_ contain any Trait data.
 
 ## Managing Default Flags
 
@@ -775,8 +774,8 @@ Flagsmith SDKs can be configured to include an offline handler which has 2 funct
    offline mode.
 
 To use it as a default handler, we recommend using the [flagsmith CLI](https://github.com/Flagsmith/flagsmith-cli) to
-generate the [Environment Document](/clients/overview#the-environment-document) and use our LocalFileHandler class, but
-you can also create your own offline handlers, by extending the base class.
+generate the [Environment Document](/clients#the-environment-document) and use our LocalFileHandler class, but you can
+also create your own offline handlers, by extending the base class.
 
 <Tabs groupId="language" queryString>
 <TabItem value="python" label="Python">
@@ -896,8 +895,7 @@ The Server Side SDKS share the same network behaviour across the different langu
 
 :::info
 
-When using Local Evaluation, it's important to read up on the
-[Pros, Cons and Caveats](overview.md#pros-cons-and-caveats).
+When using Local Evaluation, it's important to read up on the [Pros, Cons and Caveats](/clients/#pros-cons-and-caveats).
 
 To use Local Evaluation mode, you must use a Server Side key.
 

--- a/docs/docs/deployment/hosting/kubernetes.md
+++ b/docs/docs/deployment/hosting/kubernetes.md
@@ -281,7 +281,7 @@ By default, Flagsmith uses Postgres to store time series data. You can alternati
 - SDK API traffic
 - SDK Flag Evaluations
 
-[You need to perform some additional steps to configure InfluxDB.](/deployment/overview#time-series-data-via-influxdb).
+[You need to perform some additional steps to configure InfluxDB.](/deployment#time-series-data-via-influxdb).
 
 ### Task Processor
 

--- a/docs/docs/deployment/hosting/locally-edge-proxy.md
+++ b/docs/docs/deployment/hosting/locally-edge-proxy.md
@@ -326,8 +326,7 @@ There are 2 health check endpoints for the Edge Proxy.
 
 When making a request to `/proxy/health` the proxy will respond with a HTTP `200` and `{"status": "ok"}`. You can point
 your orchestration health checks to this endpoint. This endpoint checks that the
-[Environment Document](/clients/overview#the-environment-document) is not stale, and that the proxy is serving SDK
-requests.
+[Environment Document](/clients#the-environment-document) is not stale, and that the proxy is serving SDK requests.
 
 ### Realtime Flags/Server Sent Events Health Check
 

--- a/docs/docs/deployment/hosting/locally-frontend.md
+++ b/docs/docs/deployment/hosting/locally-frontend.md
@@ -65,7 +65,7 @@ Current variables used between 'frontend/environment.js' and 'frontend/common/pr
 
 - `FLAGSMITH_API_URL`: The API to hit for requests. E.g. `https://edge.api.flagsmith.com/api/v1/`
 - `FLAGSMITH_ON_FLAGSMITH_API_KEY`: The flagsmith environment key we use to manage features -
-  [Flagsmith runs on Flagsmith](/deployment/overview#running-flagsmith-on-flagsmith).
+  [Flagsmith runs on Flagsmith](/deployment#running-flagsmith-on-flagsmith).
 - `FLAGSMITH_ON_FLAGSMITH_API_URL`: The API URL which the flagsmith client should communicate with. Flagsmith runs on
   flagsmith. E.g. `https://edge.api.flagsmith.com/api/v1/`. If you are self hosting and using your own Flagsmith
   instance to manage its own features, you would generally point this to the same domain name as your own Flagsmith
@@ -124,4 +124,4 @@ We use Flagsmith to manage features we rollout, if you are using your own Flagsm
 project_x.js-> flagsmith) then you will need to have a replica of our flags.
 
 A list of the flags and remote config we're currently using in production can be
-[found here](/deployment/overview#current-flagsmith-feature-flags).
+[found here](/deployment#current-flagsmith-feature-flags).

--- a/docs/docs/deployment/index.md
+++ b/docs/docs/deployment/index.md
@@ -1,6 +1,5 @@
 ---
-title: Deployment Overview
-sidebar_label: Overview
+title: Deployment
 sidebar_position: 1
 ---
 
@@ -556,7 +555,7 @@ Then use this rule to override the `dark_mode` Feature Flag.
 
 ## Integrations
 
-Some [Integrations](/integrations/overview) require additional configuration
+Some [Integrations](/integrations) require additional configuration
 
 ### Slack Integration
 

--- a/docs/docs/guides-and-examples/defensive-coding.md
+++ b/docs/docs/guides-and-examples/defensive-coding.md
@@ -35,9 +35,9 @@ The solution here really depends on which of our SDKs you are using. By default 
 application thread, and are designed to work around an asynchronous callback model.
 
 Where our Server Side SDKs are being used, it really depends on if you are using them in
-[local or remote evaluation mode](/clients/overview#networking-model). When running in local evaluation mode, once the
-SDKs have received a response from the API with the Environment related data, they will keep that data in memory. In the
-event of the SDKs then not receiving an update, they will continue to function.
+[local or remote evaluation mode](/clients#networking-model). When running in local evaluation mode, once the SDKs have
+received a response from the API with the Environment related data, they will keep that data in memory. In the event of
+the SDKs then not receiving an update, they will continue to function.
 
 In the event that the SDKs aren't able to contact the API at all, they will time out and resort to
 [Default flags](#progressively-enhance-your-application-with-default-flags). When running in remote evaluation mode, you
@@ -82,9 +82,9 @@ requests for flag evaluation will happen locally in memory in fractions of a mil
 
 If you need sub-millisecond latency for end-to-end flag evaluation, for example in the event that you are running a
 multi-variate test on a landing page of your website, you can employ one of our Server Side SDKs running in
-[local evaluation mode](/clients/overview#local-evaluation) mode. This will provide sub-millisecond latency of the
-entire flag evaluation rules engine, running locally within your server infrastructure, allowing you to run multivariate
-tests with zero latency impact.
+[local evaluation mode](/clients#local-evaluation) mode. This will provide sub-millisecond latency of the entire flag
+evaluation rules engine, running locally within your server infrastructure, allowing you to run multivariate tests with
+zero latency impact.
 
 ### No proxy-server required
 

--- a/docs/docs/guides-and-examples/efficient-api-usage.md
+++ b/docs/docs/guides-and-examples/efficient-api-usage.md
@@ -50,16 +50,15 @@ significantly reduce API usage.
 
 ### Local Evaluation Mode
 
-The most efficient way of evaluating Flags on the Server is using
-[Local Evaluation mode](/clients/overview#local-evaluation). There are
-[some caveats](/clients/overview#local-evaluation), so please be aware of them!
+The most efficient way of evaluating Flags on the Server is using [Local Evaluation mode](/clients#local-evaluation).
+There are [some caveats](/clients#local-evaluation), so please be aware of them!
 
 ### CDN Usage
 
 There are 3 main API calls the Flagsmith SDK can make:
 
-1. Get the [Environment Document](/clients/overview#the-environment-document) for
-   [Local Evaluation mode](/clients/overview#local-evaluation).
+1. Get the [Environment Document](/clients#the-environment-document) for
+   [Local Evaluation mode](/clients#local-evaluation).
 2. Get the Flags for an Environment.
 3. Get the Flags for an Identity.
 

--- a/docs/docs/guides-and-examples/integration-approaches.md
+++ b/docs/docs/guides-and-examples/integration-approaches.md
@@ -73,7 +73,7 @@ The official [Javascript Client](/clients/javascript/) offers optional caching b
 
 :::tip
 
-Note that you can also [evaluate flags locally](../clients/overview.md) in our Server Side SDKs.
+Note that you can also [evaluate flags locally](/clients) in our Server Side SDKs.
 
 :::
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -17,15 +17,15 @@ If you're new to Flagsmith or Feature Flags in general we would recommend:
 
 - [Signing up for a free account on our SaaS platform](https://app.flagsmith.com/signup)
 - [Go through our 5 minute Quickstart Guide](quickstart.md)
-- [Set up an SDK for your Project](clients/overview.md)
-- [Dive into the Docs](basic-features/overview.md)
+- [Set up an SDK for your Project](clients)
+- [Dive into the Docs](basic-features)
 
 ## Digging Deeper
 
 - [View our SaaS Features and how SaaS compares to Self Hosted](version-comparison.md)
 - [Learn about our globally distributed Edge API](advanced-use/edge-api.md)
 - [Use Flagsmith to run A/B and Multivariate Tests](advanced-use/ab-testing.md)
-- [Integrate with 3rd party applications](integrations/overview.md)
+- [Integrate with 3rd party applications](integrations)
 - [Use Change Requests and Scheduled Flags to manage your workflows](advanced-use/change-requests.md)
 
 ## Check out our SDKs
@@ -41,7 +41,7 @@ If you're new to Flagsmith or Feature Flags in general we would recommend:
 
 ### Server Side SDKs
 
-Check out our [Server Side SDK architecture first!](clients/overview.md)
+Check out our [Server Side SDK architecture first!](/clients)
 
 - [Node.js](/clients/server-side?language=nodejs)
 - [Java](/clients/server-side?language=java)

--- a/docs/docs/integrations/index.md
+++ b/docs/docs/integrations/index.md
@@ -1,7 +1,6 @@
 ---
 title: Flagsmith Integrations
 description: Flagsmith Integrations
-sidebar_label: Overview
 hide_title: true
 sidebar_position: 1
 ---

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -168,4 +168,4 @@ From here, some areas of the documentation you might want to check out are:
 - A deeper overview of the application - [Features](basic-features/managing-features.md),
   [Identities](basic-features/managing-identities.md) and [Segments](basic-features/segments.md).
 - More details about our [API and SDKs](clients/rest.md).
-- How you can [run Flagsmith yourself](deployment/overview.md) or use our [Hosted API](https://flagsmith.com/).
+- How you can [run Flagsmith yourself](/deployment) or use our [Hosted API](https://flagsmith.com/).

--- a/docs/docs/system-administration/api-usage.md
+++ b/docs/docs/system-administration/api-usage.md
@@ -9,7 +9,7 @@ tracks the following request types:
 1. Get Flags
 2. Get Identity Flags
 3. Set Identity Traits
-4. Get [Environment Document](/clients/overview#the-environment-document) (for local evaluation SDKs)
+4. Get [Environment Document](/clients#the-environment-document) (for local evaluation SDKs)
 
 ![API Usage](/img/api-usage.png)
 

--- a/docs/docs/system-administration/authentication/03-OAuth.md
+++ b/docs/docs/system-administration/authentication/03-OAuth.md
@@ -7,12 +7,12 @@ title: OAuth
 To configure OAuth for Google:
 
 - [Setting up OAuth 2.0](https://support.google.com/cloud/answer/6158849?hl=en)
-- Create the Flagsmith on Flagsmith flag as it shows [here](/deployment/overview#oauth_google).
+- Create the Flagsmith on Flagsmith flag as it shows [here](/deployment#oauth_google).
 
 ### GitHub
 
 As a pre-requisite for this configuration make sure to have
-[Flagsmith on Flagsmith](/deployment/overview#running-flagsmith-on-flagsmith) set up.
+[Flagsmith on Flagsmith](/deployment#running-flagsmith-on-flagsmith) set up.
 
 Configure the following environment variables:
 
@@ -23,7 +23,7 @@ To configure OAuth for GitHub:
 
 - [Create an OAuth GitHub application](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app)
 - For the Authorization callback URL use: `https://<your flagsmith domain name>/oauth/github`
-- Create the Flagsmith on Flagsmith flag as it shows [here](/deployment/overview#oauth_github).
+- Create the Flagsmith on Flagsmith flag as it shows [here](/deployment#oauth_github).
 
 Now you would be able to see the GitHub SSO option.
 

--- a/docs/docs/system-administration/security.md
+++ b/docs/docs/system-administration/security.md
@@ -10,7 +10,7 @@ a client-side SDK, update their trait to `plan=gold` and unlock features they ha
 
 You can prevent this by disabling the "Allow client SDKs to set user traits" option. This option defaults to "On".
 Turning it "Off" will not allow client-side SDKs to write Traits to Flagsmith. In order to write traits, you will need
-to use a [server-side SDK and server-side Key](../clients/overview.md).
+to use a [server-side SDK and server-side Key](/clients).
 
 This is a per-Environment setting.
 

--- a/docs/docs/version-comparison.md
+++ b/docs/docs/version-comparison.md
@@ -57,4 +57,4 @@ organisation.
 - The Open Source version has **no** API request or Identity limits - you can run as many API instances in a cluster as
   you wish.
 - The Open Source version has **no** Dashboard User limits - you can have as many team members as you wish.
-- Deploy with one click to a number of different [IaaS and PaaS providers](/deployment/overview#one-click-installers).
+- Deploy with one click to a number of different [IaaS and PaaS providers](/deployment#one-click-installers).

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -311,6 +311,18 @@
         {
             "source": "/system-administration/metadata",
             "destination": "/system-administration/custom-fields"
+        },
+        {
+            "source": "/clients/overview",
+            "destination": "/clients"
+        },
+        {
+            "source": "/basic-features/overview",
+            "destination": "/basic-features"
+        },
+        {
+            "source": "/basic-features/integrations",
+            "destination": "/integrations"
         }
     ]
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This change moves some Overview pages to the top level of their category, so that one click into the category header opens the Overview page (and removes it from the sidebar) instead of needing to click into the category first, and then into Overview.

Before:

<img width="239" alt="image" src="https://github.com/user-attachments/assets/d0594cfe-cbc6-4bd5-993f-2823e9eabc32">

After:

<img width="297" alt="image" src="https://github.com/user-attachments/assets/427e2865-6552-4681-9b9e-71099d15a3b8">


## How did you test this code?

Manually
