### PR TITLE
docs: update README password reset URL to use http

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Superuser "admin@example.com" created successfully.
 Please go to the following page and choose a password: http://localhost:8000/password-reset/confirm/.../...
 ```
 
-Note: This setup uses http:// for local development. If you've configured SSL for your local environment, you may use https:// instead. For any production deployment, always use https://.
+Note: This setup uses http:// for local development. If you've configured SSL for your local environment, you may use
+https:// instead. For any production deployment, always use https://.
 
 ![Flagsmith Screenshot](static-files/screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ in your Compose logs:
 
 ```txt
 Superuser "admin@example.com" created successfully.
-Please go to the following page and choose a password: https://localhost:8000/password-reset/confirm/.../...
+Please go to the following page and choose a password: http://localhost:8000/password-reset/confirm/.../...
 ```
+
+Note: This setup uses http:// for local development. If you've configured SSL for your local environment, you may use https:// instead. For any production deployment, always use https://.
 
 ![Flagsmith Screenshot](static-files/screenshot.png)
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR fixes a discrepancy between the README instructions and the actual output when setting up Flagsmith locally using Docker Compose.

The current README shows a https:// URL for the password reset link, but the actual output in the Docker logs uses http://. This change updates the README to match the actual behavior, preventing confusion for new users who might try to access the HTTPS version and encounter errors.

Additionally, I've added a note to clarify that this setup is for local development, and that SSL should be configured for any production use. This helps raise awareness about security considerations when moving beyond local setup.

This small change improves the accuracy of the documentation and enhances the onboarding experience for new users of Flagsmith.

## How did you test this code?

I manually verified the correct URL by setting up Flagsmith using Docker Compose as described in the README. I confirmed that the password reset link in the Docker logs uses http:// and not https://, and that the link works correctly when accessed in a web browser.


