### PR TITLE
fix: Non-admin users cannot link a feature to a GH Issue/PR

### DIFF
--- a/api/organisations/permissions/permissions.py
+++ b/api/organisations/permissions/permissions.py
@@ -8,6 +8,7 @@ from django.views import View
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.request import Request
+from rest_framework.viewsets import GenericViewSet
 
 from organisations.models import Organisation
 from users.models import FFAdminUser
@@ -189,7 +190,7 @@ class NestedIsOrganisationAdminPermission(BasePermission):
 
 
 class GithubIsAdminOrganisation(NestedIsOrganisationAdminPermission):
-    def has_permission(self, request, view) -> bool:
+    def has_permission(self, request: Request, view: GenericViewSet) -> bool:
         organisation_pk = view.kwargs.get("organisation_pk")
 
         with suppress(ObjectDoesNotExist):
@@ -202,7 +203,9 @@ class GithubIsAdminOrganisation(NestedIsOrganisationAdminPermission):
             else:
                 return request.user.is_master_api_key_user
 
-    def has_object_permission(self, request, view, obj) -> bool:
+    def has_object_permission(
+        self, request: Request, view: GenericViewSet, obj
+    ) -> bool:
         organisation_pk = view.kwargs.get("organisation_pk")
         if isinstance(request.user, FFAdminUser):
             return request.user.is_organisation_admin(

--- a/api/organisations/permissions/permissions.py
+++ b/api/organisations/permissions/permissions.py
@@ -189,10 +189,12 @@ class NestedIsOrganisationAdminPermission(BasePermission):
 
 
 class GithubIsAdminOrganisation(NestedIsOrganisationAdminPermission):
-    def has_permission(self, request, view):
+    def has_permission(self, request, view) -> bool:
         organisation_pk = view.kwargs.get("organisation_pk")
 
         with suppress(ObjectDoesNotExist):
+            if hasattr(view, "action") and view.action == "list":
+                return True
             if isinstance(request.user, FFAdminUser):
                 return request.user.is_organisation_admin(
                     Organisation.objects.get(pk=organisation_pk)
@@ -200,7 +202,7 @@ class GithubIsAdminOrganisation(NestedIsOrganisationAdminPermission):
             else:
                 return request.user.is_master_api_key_user
 
-    def has_object_permission(self, request, view, obj):
+    def has_object_permission(self, request, view, obj) -> bool:
         organisation_pk = view.kwargs.get("organisation_pk")
         if isinstance(request.user, FFAdminUser):
             return request.user.is_organisation_admin(

--- a/api/tests/unit/integrations/github/test_unit_github_views.py
+++ b/api/tests/unit/integrations/github/test_unit_github_views.py
@@ -57,6 +57,7 @@ def test_get_github_configuration(
 def test_non_admin_user_get_github_configuration(
     staff_client: APIClient,
     organisation: Organisation,
+    github_configuration: GithubConfiguration,
 ) -> None:
     # Given
     url = reverse(
@@ -66,7 +67,10 @@ def test_non_admin_user_get_github_configuration(
     # When
     response = staff_client.get(url)
     # Then
+    github_configuration_res = response.json()["results"][0]
     assert response.status_code == status.HTTP_200_OK
+    assert github_configuration_res["installation_id"] == "1234567"
+    assert github_configuration_res["id"] == 1
 
 
 def test_create_github_configuration(

--- a/api/tests/unit/integrations/github/test_unit_github_views.py
+++ b/api/tests/unit/integrations/github/test_unit_github_views.py
@@ -54,6 +54,21 @@ def test_get_github_configuration(
     assert response.status_code == status.HTTP_200_OK
 
 
+def test_non_admin_user_get_github_configuration(
+    staff_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:organisations:integrations-github-list",
+        kwargs={"organisation_pk": organisation.id},
+    )
+    # When
+    response = staff_client.get(url)
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+
 def test_create_github_configuration(
     admin_client_new: APIClient,
     organisation: Organisation,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Granting a non-admin user permission to view the repositories integrated with Flagsmith allows them to link issues/PRs with features in the UI
## How did you test this code?

Unit test added
