### PR TITLE
docs: fix default flags example

### DIFF
--- a/docs/docs/clients/client-side/javascript.md
+++ b/docs/docs/clients/client-side/javascript.md
@@ -99,16 +99,20 @@ the event that it [cannot receive a response from our API](/guides-and-examples/
 ```javascript
 import flagsmith from 'flagsmith or react-native-flagsmith'; //Add this line if you're using flagsmith via npm
 
-flagsmith.init({
-    environmentID: '<YOUR_CLIENT_SIDE_ENVIRONMENT_KEY>',
-    defaultFlags: {
-        feature_a: { enabled: false},
-        font_size: { enabled: true, value: 12 },
-    }
-    onChange: (oldFlags, params) => {
-        ...
-    },
-});
+try {
+    flagsmith.init({
+        environmentID: '<YOUR_CLIENT_SIDE_ENVIRONMENT_KEY>',
+        defaultFlags: {
+            feature_a: { enabled: false},
+            font_size: { enabled: true, value: 12 },
+        }
+        onChange: (oldFlags, params) => {
+            ...
+        },
+    });
+} catch (e) {
+    // if an exception is thrown the default values will be used
+}
 ```
 
 ### Providing Default Flags as part of CI/CD


### PR DESCRIPTION
closes https://github.com/Flagsmith/flagsmith-js-client/issues/237

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [ ] I have added information to `docs/` if required so people know about the feature!
- [ ] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Updated default flags example (`defaultFlags`) in the documentation to use a try/catch so the default flags are used when an exception is thrown.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Could not get the project running locally (only changes to the code block)
