### PR TITLE
feat: Support Aptible deployments

### DIFF
--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -14,8 +14,8 @@ urlpatterns = [
     re_path(r"^api/v1/", include("api.urls.v1", namespace="api-v1")),
     re_path(r"^api/v2/", include("api.urls.v2", namespace="api-v2")),
     re_path(r"^admin/", admin.site.urls),
+    re_path(r"^health", include("health_check.urls", namespace="health")),
     path("healthcheck", include("health_check.urls", namespace="health")),
-    re_path(r"^health/", include("health_check.urls", namespace="health")),
     re_path(r"^version", views.version_info, name="version-info"),
     re_path(
         r"^sales-dashboard/",

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     re_path(r"^api/v2/", include("api.urls.v2", namespace="api-v2")),
     re_path(r"^admin/", admin.site.urls),
     path("healthcheck", include("health_check.urls", namespace="health")),
+    re_path(r"^health/", include("health_check.urls", namespace="health")),
     re_path(r"^version", views.version_info, name="version-info"),
     re_path(
         r"^sales-dashboard/",

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
     re_path(r"^api/v2/", include("api.urls.v2", namespace="api-v2")),
     re_path(r"^admin/", admin.site.urls),
     re_path(r"^health", include("health_check.urls", namespace="health")),
+    # Aptible health checks must be on /healthcheck and cannot redirect
+    # see https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/health-checks
     path("healthcheck", include("health_check.urls", namespace="health")),
     re_path(r"^version", views.version_info, name="version-info"),
     re_path(

--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     re_path(r"^api/v1/", include("api.urls.v1", namespace="api-v1")),
     re_path(r"^api/v2/", include("api.urls.v2", namespace="api-v2")),
     re_path(r"^admin/", admin.site.urls),
-    re_path(r"^health", include("health_check.urls", namespace="health")),
+    path("healthcheck", include("health_check.urls", namespace="health")),
     re_path(r"^version", views.version_info, name="version-info"),
     re_path(
         r"^sales-dashboard/",

--- a/api/core/management/commands/waitfordb.py
+++ b/api/core/management/commands/waitfordb.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from argparse import ArgumentParser
 from typing import Any
@@ -46,12 +45,6 @@ class Command(BaseCommand):
         database: str,
         **options: Any,
     ) -> None:
-
-        if os.getenv("SKIP_WAIT_FOR_DATABASE"):
-            logger.info(
-                "Running with SKIP_WAIT_FOR_DATABASE set - will not wait for database to be available"
-            )
-            return
 
         start = time.monotonic()
         wait_between_checks = 0.25

--- a/api/core/management/commands/waitfordb.py
+++ b/api/core/management/commands/waitfordb.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from argparse import ArgumentParser
 from typing import Any
@@ -45,6 +46,13 @@ class Command(BaseCommand):
         database: str,
         **options: Any,
     ) -> None:
+
+        if os.getenv("SKIP_WAIT_FOR_DATABASE"):
+            logger.info(
+                "Running with SKIP_WAIT_FOR_DATABASE set - will not wait for database to be available"
+            )
+            return
+
         start = time.monotonic()
         wait_between_checks = 0.25
 

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -2,7 +2,9 @@
 set -e
 
 function waitfordb() {
-    [[ -z "${SKIP_WAIT_FOR_DB}" ]] && python manage.py waitfordb "$@"
+  if [ -z "${SKIP_WAIT_FOR_DB}" ]; then
+     python manage.py waitfordb "$@"
+  fi
 }
 
 function migrate () {

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -16,7 +16,7 @@ function serve() {
     export STATSD_PORT=${STATSD_PORT:-8125}
     export STATSD_PREFIX=${STATSD_PREFIX:-flagsmith.api}
 
-    python manage.py waitfordb
+    waitfordb
 
     exec gunicorn --bind 0.0.0.0:8000 \
              --worker-tmp-dir /dev/shm \

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -e
 
+function waitfordb() {
+    [[ -z "${SKIP_WAIT_FOR_DB}"]] && python manage.py waitfordb "$@"
+}
+
 function migrate () {
-    python manage.py waitfordb && python manage.py migrate && python manage.py createcachetable
+    waitfordb && python manage.py migrate && python manage.py createcachetable
 }
 function serve() {
     # configuration parameters for statsd. Docs can be found here:
@@ -26,9 +30,9 @@ function serve() {
              app.wsgi
 }
 function run_task_processor() {
-    python manage.py waitfordb --waitfor 30 --migrations
+    waitfordb --waitfor 30 --migrations
     if [[ -n "$ANALYTICS_DATABASE_URL" || -n "$DJANGO_DB_NAME_ANALYTICS" ]]; then
-        python manage.py waitfordb --waitfor 30 --migrations --database analytics
+        waitfordb --waitfor 30 --migrations --database analytics
     fi
     RUN_BY_PROCESSOR=1 exec python manage.py runprocessor \
       --sleepintervalms ${TASK_PROCESSOR_SLEEP_INTERVAL:-500} \

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -2,7 +2,7 @@
 set -e
 
 function waitfordb() {
-    [[ -z "${SKIP_WAIT_FOR_DB}"]] && python manage.py waitfordb "$@"
+    [[ -z "${SKIP_WAIT_FOR_DB}" ]] && python manage.py waitfordb "$@"
 }
 
 function migrate () {

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -10,6 +10,8 @@ function serve() {
     export STATSD_PORT=${STATSD_PORT:-8125}
     export STATSD_PREFIX=${STATSD_PREFIX:-flagsmith.api}
 
+    python manage.py waitfordb
+
     exec gunicorn --bind 0.0.0.0:8000 \
              --worker-tmp-dir /dev/shm \
              --timeout ${GUNICORN_TIMEOUT:-30} \

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -10,8 +10,6 @@ function serve() {
     export STATSD_PORT=${STATSD_PORT:-8125}
     export STATSD_PREFIX=${STATSD_PREFIX:-flagsmith.api}
 
-    python manage.py waitfordb
-
     exec gunicorn --bind 0.0.0.0:8000 \
              --worker-tmp-dir /dev/shm \
              --timeout ${GUNICORN_TIMEOUT:-30} \

--- a/docs/docs/deployment/hosting/aptible.md
+++ b/docs/docs/deployment/hosting/aptible.md
@@ -14,32 +14,50 @@ Running Flagsmith on Aptible requires some configuration tweaks because of how A
   `SKIP_WAIT_FOR_DB` environment variable.
 - Add `containers` as an allowed host to comply with Aptible's
   [strict health checks](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/health-checks#strict-health-checks).
+- Use the `before_release` tasks from `.aptible.yml` to run database migrations
+- Use a Procfile to only start the API and not perform database migrations on startup
 
-For example, if your Aptible app is named `flagsmith`, you could set its configuration using the Aptible CLI:
+This configuration can be applied by adding the Procfile and `.aptible.yml` configuration files to a
+[Docker image](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/image/deploying-with-docker-image/overview#how-do-i-deploy-from-docker-image)
+that you build starting from a Flagsmith base image:
 
-```shell
-aptible config:set --app flagsmith \
-    DATABASE_URL=postgresql://aptible:...@db-shared-us-west-1-132662.aptible.in:23532/db \
-    SKIP_WAIT_FOR_DB=1 \
-    DJANGO_ALLOWED_HOSTS='["containers", "your_aptible_hostname"]'
+```text title="Procfile"
+cmd: serve
 ```
 
-Once Flagsmith is running in Aptible, make sure to create the first admin user by visiting `/api/v1/users/config/init/`.
+```yaml title=".aptible.yml"
+before_release:
+ - migrate
+ - bootstrap
+```
 
-## Optional: using a Procfile or `.aptible.yml`
-
-If your Aptible deployment requires a
-[configuration file](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/image/deploying-with-docker-image/procfile-aptible-yml-direct-docker-deploy),
-you can build it into a new container image by starting from a Flagsmith base image. For example, if you wanted to add a
-Procfile to the Flagsmith image, you could build it using the following Dockerfile:
-
-```dockerfile
+```dockerfile title="Dockerfile"
 # Use flagsmith/flagsmith-private-cloud for the Enterprise image
 FROM --platform=linux/amd64 flagsmith/flagsmith
+
+# Don't wait for the database to be available during startup for health checks to succeed
+ENV SKIP_WAIT_FOR_DB=1
+
+# Use root user to add Aptible files to the container
 USER root
 RUN mkdir /.aptible/
 ADD Procfile /.aptible/Procfile
+ADD .aptible.yml /.aptible/.aptible.yml
+
+# Use non-root user at runtime
+USER nobody
 ```
+
+Before deploying, set the environment variables for your database URL and allowed hosts from the Aptible dashboard, or
+using the Aptible CLI:
+
+```shell
+aptible config:set --app flagsmith \
+    DATABASE_URL=postgresql://aptible:...@...:23532/db \
+    DJANGO_ALLOWED_HOSTS='containers,YOUR_APTIBLE_HOSTNAME'
+```
+
+## Deployment
 
 After your image is built and pushed to a container registry that Aptible can access, you can deploy it using the
 Aptible CLI as you would any other application:
@@ -47,3 +65,5 @@ Aptible CLI as you would any other application:
 ```shell
 aptible deploy --app flagsmith --docker-image example/my-flagsmith-aptible-image
 ```
+
+Once Flagsmith is running in Aptible, make sure to create the first admin user by visiting `/api/v1/users/config/init/`.

--- a/docs/docs/deployment/hosting/aptible.md
+++ b/docs/docs/deployment/hosting/aptible.md
@@ -67,3 +67,9 @@ aptible deploy --app flagsmith --docker-image example/my-flagsmith-aptible-image
 ```
 
 Once Flagsmith is running in Aptible, make sure to create the first admin user by visiting `/api/v1/users/config/init/`.
+
+## Limitations
+
+The steps described in this document do not deploy the
+[asynchronous task processor](/deployment/configuration/task-processor), which may affect performance in production
+workloads.

--- a/docs/docs/deployment/hosting/aptible.md
+++ b/docs/docs/deployment/hosting/aptible.md
@@ -4,8 +4,7 @@ title: Aptible
 
 ## Prerequisites
 
-Aptible health checks must be available on the `/healthcheck` route and cannot return a redirect. This additional route
-is available from Flagsmith 2.X.
+The options and health check routes described in this document are available from Flagsmith 2.130.0.
 
 ## Configuration
 

--- a/docs/docs/deployment/hosting/aptible.md
+++ b/docs/docs/deployment/hosting/aptible.md
@@ -1,0 +1,40 @@
+---
+title: Aptible
+---
+
+## Prerequisites
+
+Aptible health checks must be available on the `/healthcheck` route and cannot return a redirect. This additional route
+is available from Flagsmith 2.X.
+
+## Configuration
+
+Running Flagsmith on Aptible requires some configuration tweaks because of how Aptible's application lifecycle works:
+
+- Don't wait for the database to be available before the Flagsmith API starts. You can do this by setting the
+  `SKIP_WAIT_FOR_DB` environment variable.
+- Add `containers` as an allowed host to comply with Aptible's
+  [strict health checks](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/health-checks#strict-health-checks).
+
+For example, if your Aptible app is named `flagsmith`, you could set this using the Aptible CLI:
+
+```shell
+aptible config:set --app flagsmith\
+    DATABASE_URL=postgresql://aptible:...@db-shared-us-west-1-132662.aptible.in:23532/db \
+    SKIP_WAIT_FOR_DB=1 \
+    DJANGO_ALLOWED_HOSTS='["containers", "your_aptible_hostname"]'
+```
+
+## Optional: using a `Procfile` or `.aptible.yml`
+
+If your Aptible deployment requires a
+[configuration file](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/image/deploying-with-docker-image/procfile-aptible-yml-direct-docker-deploy)),
+you can build it into a new container image starting from a Flagsmith base image. For example, if you wanted to add your
+Procfile to the Flagsmith Enterprise image:
+
+```dockerfile
+FROM --platform=linux/amd64 flagsmith/flagsmith-private-cloud
+USER root
+RUN mkdir /.aptible/
+ADD Procfile /.aptible/Procfile
+```

--- a/docs/docs/deployment/hosting/aptible.md
+++ b/docs/docs/deployment/hosting/aptible.md
@@ -26,12 +26,12 @@ aptible config:set --app flagsmith\
 
 Once Flagsmith is running in Aptible, make sure to create the first admin user by visiting `/api/v1/users/config/init/`.
 
-## Optional: using a `Procfile` or `.aptible.yml`
+## Optional: using a Procfile or `.aptible.yml`
 
 If your Aptible deployment requires a
 [configuration file](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/image/deploying-with-docker-image/procfile-aptible-yml-direct-docker-deploy)),
 you can build it into a new container image starting from a Flagsmith base image. For example, if you wanted to add a
-`Procfile` to the Flagsmith image:
+Procfile to the Flagsmith image, you could build it using the following Dockerfile:
 
 ```dockerfile
 # Use flagsmith/flagsmith-private-cloud for the Enterprise image
@@ -41,7 +41,7 @@ RUN mkdir /.aptible/
 ADD Procfile /.aptible/Procfile
 ```
 
-After your image is deployed and pushed to a container registry that Aptible can access, you can deploy it using the
+After your image is built and pushed to a container registry that Aptible can access, you can deploy it using the
 Aptible CLI as you would any other application:
 
 ```shell

--- a/docs/docs/deployment/hosting/aptible.md
+++ b/docs/docs/deployment/hosting/aptible.md
@@ -16,7 +16,7 @@ Running Flagsmith on Aptible requires some configuration tweaks because of how A
 - Add `containers` as an allowed host to comply with Aptible's
   [strict health checks](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/health-checks#strict-health-checks).
 
-For example, if your Aptible app is named `flagsmith`, you could set this using the Aptible CLI:
+For example, if your Aptible app is named `flagsmith`, you could set its configuration using the Aptible CLI:
 
 ```shell
 aptible config:set --app flagsmith\
@@ -25,16 +25,26 @@ aptible config:set --app flagsmith\
     DJANGO_ALLOWED_HOSTS='["containers", "your_aptible_hostname"]'
 ```
 
+Once Flagsmith is running in Aptible, make sure to create the first admin user by visiting `/api/v1/users/config/init/`.
+
 ## Optional: using a `Procfile` or `.aptible.yml`
 
 If your Aptible deployment requires a
 [configuration file](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/image/deploying-with-docker-image/procfile-aptible-yml-direct-docker-deploy)),
-you can build it into a new container image starting from a Flagsmith base image. For example, if you wanted to add your
-Procfile to the Flagsmith Enterprise image:
+you can build it into a new container image starting from a Flagsmith base image. For example, if you wanted to add a
+`Procfile` to the Flagsmith image:
 
 ```dockerfile
-FROM --platform=linux/amd64 flagsmith/flagsmith-private-cloud
+# Use flagsmith/flagsmith-private-cloud for the Enterprise image
+FROM --platform=linux/amd64 flagsmith/flagsmith
 USER root
 RUN mkdir /.aptible/
 ADD Procfile /.aptible/Procfile
+```
+
+After your image is deployed and pushed to a container registry that Aptible can access, you can deploy it using the
+Aptible CLI as you would any other application:
+
+```shell
+aptible deploy --app flagsmith --docker-image example/my-flagsmith-aptible-image
 ```

--- a/docs/docs/deployment/hosting/aptible.md
+++ b/docs/docs/deployment/hosting/aptible.md
@@ -18,7 +18,7 @@ Running Flagsmith on Aptible requires some configuration tweaks because of how A
 For example, if your Aptible app is named `flagsmith`, you could set its configuration using the Aptible CLI:
 
 ```shell
-aptible config:set --app flagsmith\
+aptible config:set --app flagsmith \
     DATABASE_URL=postgresql://aptible:...@db-shared-us-west-1-132662.aptible.in:23532/db \
     SKIP_WAIT_FOR_DB=1 \
     DJANGO_ALLOWED_HOSTS='["containers", "your_aptible_hostname"]'
@@ -29,8 +29,8 @@ Once Flagsmith is running in Aptible, make sure to create the first admin user b
 ## Optional: using a Procfile or `.aptible.yml`
 
 If your Aptible deployment requires a
-[configuration file](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/image/deploying-with-docker-image/procfile-aptible-yml-direct-docker-deploy)),
-you can build it into a new container image starting from a Flagsmith base image. For example, if you wanted to add a
+[configuration file](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/image/deploying-with-docker-image/procfile-aptible-yml-direct-docker-deploy),
+you can build it into a new container image by starting from a Flagsmith base image. For example, if you wanted to add a
 Procfile to the Flagsmith image, you could build it using the following Dockerfile:
 
 ```dockerfile


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR adds functionality to enable deploying to Aptible, which an Enterprise prospect is currently evaluating. They have been able to work around these changes by forking open-source Flagsmith and making similar changes (i.e. removing `waitfordb` instead of making it optional). They would however need the changes to be upstreamed to deploy the Flagsmith Enterprise image.

### Add `/healthcheck` as a health check route

Exposes the same health check endpoint on `/healthcheck` in addition to `/health`. Aptible (surprisingly) does not allow configuring a custom health check route and forces it to be `/healthcheck`. [Strict health checks](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/health-checks) also do not accept redirects as responses.

There are some alternatives to directly adding `/healthcheck` as an alias of `/health`:

1. Add an option to make the health check route configurable. This would require a more thorough documentation review and is potentially error prone. YAGNI also applies since we have never needed to customise the health check route at the API level (i.e. not using a proxy in front of it) until now.
2. Add an option to opt in to the `/healthcheck` route, using some sort of "Aptible mode". I don't see a downside to always aliasing `/health` so this seems like extra complexity for no benefit.
3. Add an option for additional configurable health check routes, i.e. in addition to `/health`. I believe YAGNI also applies here and we can add it later if needed.

### Add `SKIP_WAIT_FOR_DB` environment variable

When Aptible is deploying an application, it first checks for successful health checks before it is added to the same network as an Aptible-hosted database. This means that trying to deploy Flagsmith to Aptible without these changes will always fail when health checks fail while `waitfordb` is hanging.

This PR adds an environment variable that skips waiting for the database before running migrations or starting the API.

It seemed to me that an environment variable is the least intrusive and Aptible-specific way we could support this - happy to consider different approaches and variable/parameter names.

## How did you test this code?

Deployed Flagsmith to a trial Aptible account here using the steps described in the docs from this PR: https://app-76164.on-aptible.com/. I'll add a link in the docs to the actual Flagsmith release that contains these changes once ready.

_Please describe._
