### PR TITLE
docs: standardise offline handler in js

### DIFF
--- a/docs/docs/clients/client-side/javascript.md
+++ b/docs/docs/clients/client-side/javascript.md
@@ -118,11 +118,11 @@ try {
 ### Default Flag Offline Handler
 
 You can automatically set default flags for your frontend application as part of your CI/CD process by using our
-[CLI](/clients/cli) and offline hander in your build pipelines.
+[CLI](/clients/CLI) and offline hander in your build pipelines.
 
 The main steps to achieving this are as follows:
 
-1. Install the [CLI](/clients/cli) `npm i flagsmith-cli --save-dev`
+1. Install the [CLI](/clients/CLI) `npm i flagsmith-cli --save-dev`
 2. Call the CLI as part of npm postinstall to create a `flagsmith.json` file each time you run `npm install`. This can
    be done by either:
 

--- a/docs/docs/clients/client-side/javascript.md
+++ b/docs/docs/clients/client-side/javascript.md
@@ -115,21 +115,21 @@ try {
 }
 ```
 
-### Providing Default Flags as part of CI/CD
+### Default Flag Offline Handler
 
-You can automatically set default flags for your frontend application in CI/CD by using our
-[CLI](https://github.com/Flagsmith/flagsmith-cli) in your build pipelines.
+You can automatically set default flags for your frontend application as part of your CI/CD process by using our
+[CLI](/clients/cli) and offline hander in your build pipelines.
 
 The main steps to achieving this are as follows:
 
-1. Install the CLI `npm i flagsmith-cli --save-dev`
-2. Call the CLI as part of npm postinstall to create a `flagsmith.json` each time you run `npm install`. This can be
-   done by either:
+1. Install the [CLI](/clients/cli) `npm i flagsmith-cli --save-dev`
+2. Call the CLI as part of npm postinstall to create a `flagsmith.json` file each time you run `npm install`. This can
+   be done by either:
 
    - Using an environment variable `export FLAGSMITH_ENVIRONMENT=<YOUR_CLIENT_SIDE_ENVIRONMENT_KEY> flagsmith get`
    - Manually specifying your environment key `flagsmith get <YOUR_CLIENT_SIDE_ENVIRONMENT_KEY>`.
 
-3. In your application, initialise Flagsmith with the resulting JSON, this will set default flags before attempting to
+3. In your application, initialise Flagsmith with the resulting JSON. This will set default flags before attempting to
    use local storage or call the API. `flagsmith.init({environmentID: json.environmentID, state:json})`
 
 A working example of this can be found [here](https://github.com/Flagsmith/flagsmith-cli/tree/main/example). A list of


### PR DESCRIPTION
Brings the JS docs into line with https://docs.flagsmith.com/clients/server-side#using-an-offline-handler