### PR TITLE
ci: ensure capitalised conventional commit headers

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -32,7 +32,11 @@ jobs:
             refactor
             test
             chore
-          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: ([A-Z].*)$'
+          subjectPattern: ^([A-Z].*).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            starts with an uppercase character.
       - name: Auto-label PR with Conventional Commit title
         uses: bcoe/conventional-release-labels@v1
         with:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -32,6 +32,7 @@ jobs:
             refactor
             test
             chore
+          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: ([A-Z].*)$'
       - name: Auto-label PR with Conventional Commit title
         uses: bcoe/conventional-release-labels@v1
         with:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Conventional Commit headers go into changelogs. Varying capitalisation looks messy. This change enforces the PR headers to be capitalised.

## How did you test this code?

This is a CI change.