### PR TITLE
fix(build): Incorrect package used for GPG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,7 +184,7 @@ FROM api-runtime-private as saas-api
 
 # Install GnuPG and import private key
 RUN --mount=type=secret,id=sse_pgp_pkey \
-  apk add gnupg && \
+  apk add gpg && \
   gpg --import /run/secrets/sse_pgp_pkey && \
   mv /root/.gnupg/ /app/ && \
   chown -R nobody /app/.gnupg/


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes `gpg` not being available to the SaaS Docker image build:

```
 > [saas-api 1/4] RUN --mount=type=secret,id=sse_pgp_pkey   apk add gnupg &&   gpg --import /run/secrets/sse_pgp_pkey &&   mv /root/.gnupg/ /app/ &&   chown -R nobody /app/.gnupg/:
#0 0.745 (1/1) Installing gnupg (2.2.41-r2)
#0 0.934 OK: 76 MiB in 32 packages
#0 0.976 /bin/sh: gpg: not found
------

```

https://github.com/Flagsmith/flagsmith/actions/runs/9990074115/job/27609995476 

## How did you test this code?

Ran `docker build --target saas-api .` locally.