### PR TITLE
fix(build): Missing gpg-agent for the SaaS build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,7 +184,7 @@ FROM api-runtime-private as saas-api
 
 # Install GnuPG and import private key
 RUN --mount=type=secret,id=sse_pgp_pkey \
-  apk add gpg && \
+  apk add gpg gpg-agent && \
   gpg --import /run/secrets/sse_pgp_pkey && \
   mv /root/.gnupg/ /app/ && \
   chown -R nobody /app/.gnupg/

--- a/Dockerfile
+++ b/Dockerfile
@@ -184,7 +184,7 @@ FROM api-runtime-private as saas-api
 
 # Install GnuPG and import private key
 RUN --mount=type=secret,id=sse_pgp_pkey \
-  apk add gnupg && \
+  apk add gpg && \
   gpg --import /run/secrets/sse_pgp_pkey && \
   mv /root/.gnupg/ /app/ && \
   chown -R nobody /app/.gnupg/


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the following build error:

```
 > [saas-api 1/4] RUN --mount=type=secret,id=sse_pgp_pkey   apk add gpg &&   gpg --import /run/secrets/sse_pgp_pkey &&   mv /root/.gnupg/ /app/ &&   chown -R nobody /app/.gnupg/:
#21 1.950 gpg: /root/.gnupg/trustdb.gpg: trustdb created
#21 1.950 gpg: key 00FA6826BD9B2E99: public key "Fastly logs (Used to encrypt/decrypt fastly logs) <gagan.trivedi@flagsmith.com>" imported
#21 1.951 gpg: failed to start agent '/usr/bin/gpg-agent': No such file or directory
#21 1.951 gpg: can't connect to the agent: No such file or directory
#21 1.951 gpg: error getting the KEK: No agent running
#21 1.951 gpg: error reading '/run/secrets/sse_pgp_pkey': No agent running
#21 1.951 gpg: import from '/run/secrets/sse_pgp_pkey' failed: No agent running
#21 1.951 gpg: Total number processed: 0
#21 1.951 gpg:               imported: 1
#21 1.951 gpg:       secret keys read: 1
```

https://github.com/Flagsmith/flagsmith/actions/runs/9990268125/job/27610616512

## How did you test this code?

This is a CI change.