### PR TITLE
chore: Use category for Trivy reports

### DIFF
--- a/.github/workflows/.reusable-docker-build.yml
+++ b/.github/workflows/.reusable-docker-build.yml
@@ -153,6 +153,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         if: inputs.scan && (success() || failure())
         with:
+          category: ${{ inputs.image-name }}
           sarif_file: trivy-results.sarif
 
       - name: Render scan results URL


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes the outdated security reports in the GitHub Security tab. I already did this in the past but it seems to be swallowed by a bad merge.
## How did you test this code?

This is a CI change.