### PR TITLE
chore(api-usage): update api usage email templates

### DIFF
--- a/api/organisations/templates/organisations/api_usage_notification.html
+++ b/api/organisations/templates/organisations/api_usage_notification.html
@@ -9,13 +9,18 @@
         <tr>
 
                <td>
-                 The API usage for {{ organisation.name }} has reached
-                 {{ matched_threshold }}% within the current subscription period.
-                 Please consider upgrading your organisation's account limits.
+                 This is a system generated notification related to your Flagsmith API Usage. Your company,
+                 {{ organisation.name }}, has reached {{ matched_threshold }}% of your API usage within the
+                 current subscription period.
+
                  {% if organisation.is_paid %}
-                 Please note that once the 100% use has been breached automated charges for your account may apply.
+                 If this is expected, no action is required. If you are expecting to go over, you can upgrade your
+                 organisation’s account limits by reaching out to support@flagsmith.com. We will automatically charge
+                 for overages after our first grace period of 30 days.
                  {% else %}
-                 Please note that once the 100% use has been breached the serving of feature flags and admin access may be disabled after a grace period.
+                 Please note that once 100% use has been breached, the serving of feature flags and admin access may
+                 be disabled after a 7-day grace period. Please reach out to support@flagsmith.com in order to upgrade
+                 your account.
                  {% endif %}
 
                </td>

--- a/api/organisations/templates/organisations/api_usage_notification.txt
+++ b/api/organisations/templates/organisations/api_usage_notification.txt
@@ -1,12 +1,17 @@
 Hi there,
 
-The API usage for {{ organisation.name }} has reached {{ matched_threshold }}% within the current subscription period. Please consider upgrading your organisation's account limits.
+This is a system generated notification related to your Flagsmith API Usage. Your company, {{ organisation.name }}, has
+reached {{ matched_threshold }}% of your API usage within the current subscription period.
 
 {% if organisation.is_paid %}
-Please note that once the 100% use has been breached automated charges for your account may apply.
+If this is expected, no action is required. If you are expecting to go over, you can upgrade your organisation’s account
+limits by reaching out to support@flagsmith.com. We will automatically charge for overages after our first grace period
+of 30 days.
 {% else %}
-Please note that once the 100% use has been breached the serving of feature flags and admin access may be disabled after a grace period.
+Please note that once 100% use has been breached, the serving of feature flags and admin access may be disabled after a
+7-day grace period. Please reach out to support@flagsmith.com in order to upgrade your account.
 {% endif %}
+
 Thank you!
 
 The Flagsmith Team

--- a/api/organisations/templates/organisations/api_usage_notification_limit.html
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.html
@@ -16,7 +16,7 @@
                  {% if organisation.is_paid %}
                  We will charge for overages after our first grace period of 30 days. Please see the pricing page for
                  more information. You can reach out to support@flagsmith.com if you’d like to take advantage of better
-                 contracted rates..
+                 contracted rates.
                  {% else %}
                  Please note that the serving of feature flags and admin access will be disabled after a 7 day grace
                  period until the next subscription period. If you’d like to continue service you can upgrade your

--- a/api/organisations/templates/organisations/api_usage_notification_limit.html
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.html
@@ -9,12 +9,18 @@
         <tr>
 
                <td>
-                 The API usage for {{ organisation.name }} has breached
-                 {{ matched_threshold }}% within the current subscription period.
+                 This is a system generated notification related to your Flagsmith API Usage. Your company,
+                 {{ organisation.name }}, has reached {{ matched_threshold }}% of your API usage within the
+                 current subscription period.
+
                  {% if organisation.is_paid %}
-                 Please note that automated charges for your account may apply.
+                 We will charge for overages after our first grace period of 30 days. Please see the pricing page for
+                 more information. You can reach out to support@flagsmith.com if you’d like to take advantage of better
+                 contracted rates..
                  {% else %}
-                 Please note that the serving of feature flags and admin access may be disabled after a grace period, so please upgrade your organisation's account to ensure continued service.
+                 Please note that the serving of feature flags and admin access will be disabled after a 7 day grace
+                 period until the next subscription period. If you’d like to continue service you can upgrade your
+                 organisation’s account (see pricing page).
                  {% endif %}
                </td>
 

--- a/api/organisations/templates/organisations/api_usage_notification_limit.txt
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.txt
@@ -1,11 +1,15 @@
 Hi there,
 
-The API usage for {{ organisation.name }} has breached {{ matched_threshold }}% within the current subscription period.
+This is a system generated notification related to your Flagsmith API Usage. Your company,  {{ organisation.name }},
+has reached {{ matched_threshold }}% of your API usage within the current subscription period.
 
 {% if organisation.is_paid %}
-Please note that automated charges for your account may apply.
+We will charge for overages after our first grace period of 30 days. Please see the pricing page for more information.
+You can reach out to support@flagsmith.com if you’d like to take advantage of better contracted rates.
 {% else %}
-Please note that the serving of feature flags and admin access may be disabled after a grace period, so please upgrade your organisation's account to ensure continued service.
+Please note that the serving of feature flags and admin access will be disabled after a 7 day grace period until the
+next subscription period. If you’d like to continue service you can upgrade your organisation’s account (see pricing
+page).
 {% endif %}
 
 Thank you!

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 from django.core.mail.message import EmailMultiAlternatives
+from django.template.loader import render_to_string
 from django.utils import timezone
 from freezegun.api import FrozenDateTimeFactory
 from pytest_django.fixtures import SettingsWrapper
@@ -330,33 +331,18 @@ def test_handle_api_usage_notifications_below_100(
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
     assert email.subject == "Flagsmith API use has reached 90%"
-    assert email.body == (
-        "Hi there,\n\nThe API usage for Test Org has reached "
-        "90% within the current subscription period. Please "
-        "consider upgrading your organisation's account limits.\n\n\n"
-        "Please note that once the 100% use has been breached "
-        "automated charges for your account may apply.\n\n"
-        "Thank you!\n\nThe Flagsmith Team\n"
+    assert email.body == render_to_string(
+        "organisations/api_usage_notification.txt",
+        context={"organisation": organisation, "matched_threshold": 90},
     )
 
     assert len(email.alternatives) == 1
     assert len(email.alternatives[0]) == 2
     assert email.alternatives[0][1] == "text/html"
 
-    assert email.alternatives[0][0] == (
-        "<table>\n\n        <tr>\n\n               <td>Hi "
-        "there,</td>\n\n        </tr>\n\n        <tr>\n\n       "
-        "        <td>\n                 The API usage for Test "
-        "Org has reached\n                 90% within the current "
-        "subscription period.\n                 Please consider "
-        "upgrading your organisation's account limits.\n         "
-        "        \n                 Please note that once the 100%"
-        " use has been breached automated charges for your account "
-        "may apply.\n                 \n\n               </td>\n\n"
-        "\n        </tr>\n\n        <tr>\n\n               <td>"
-        "Thank you!</td>\n\n        </tr>\n\n        <tr>\n\n    "
-        "           <td>The Flagsmith Team</td>\n\n        "
-        "</tr>\n\n</table>\n"
+    assert email.alternatives[0][0] == render_to_string(
+        "organisations/api_usage_notification.html",
+        context={"organisation": organisation, "matched_threshold": 90},
     )
 
     assert email.from_email == "noreply@flagsmith.com"
@@ -430,28 +416,18 @@ def test_handle_api_usage_notifications_above_100(
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
     assert email.subject == "Flagsmith API use has reached 100%"
-    assert email.body == (
-        "Hi there,\n\nThe API usage for Test Org has breached 100% "
-        "within the current subscription period.\n\n\nPlease note "
-        "that automated charges for your account may apply.\n\n\n"
-        "Thank you!\n\nThe Flagsmith Team\n"
+    assert email.body == render_to_string(
+        "organisations/api_usage_notification_limit.txt",
+        context={"organisation": organisation, "matched_threshold": 100},
     )
 
     assert len(email.alternatives) == 1
     assert len(email.alternatives[0]) == 2
     assert email.alternatives[0][1] == "text/html"
 
-    assert email.alternatives[0][0] == (
-        "<table>\n\n        <tr>\n\n               <td>Hi there,"
-        "</td>\n\n        </tr>\n\n        <tr>\n\n               <td>"
-        "\n                 The API usage for Test Org has breached"
-        "\n                 100% within the current subscription period."
-        "\n                 \n                 Please note that "
-        "automated charges for your account may apply.\n                 "
-        "\n               </td>\n\n\n        </tr>\n\n        <tr>"
-        "\n\n               <td>Thank you!</td>\n\n        </tr>"
-        "\n\n        <tr>\n\n               <td>The Flagsmith "
-        "Team</td>\n\n        </tr>\n\n</table>\n"
+    assert email.alternatives[0][0] == render_to_string(
+        "organisations/api_usage_notification_limit.html",
+        context={"organisation": organisation, "matched_threshold": 100},
     )
 
     assert email.from_email == "noreply@flagsmith.com"
@@ -517,33 +493,18 @@ def test_handle_api_usage_notifications_for_free_accounts(
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
     assert email.subject == "Flagsmith API use has reached 100%"
-    assert email.body == (
-        "Hi there,\n\nThe API usage for Test Org has breached "
-        "100% within the current subscription period.\n\n\nPlease "
-        "note that the serving of feature flags and admin access "
-        "may be disabled after a grace period, so please upgrade "
-        "your organisation's account to ensure continued service."
-        "\n\n\nThank you!\n\nThe Flagsmith Team\n"
+    assert email.body == render_to_string(
+        "organisations/api_usage_notification_limit.txt",
+        context={"organisation": organisation, "matched_threshold": 100},
     )
 
     assert len(email.alternatives) == 1
     assert len(email.alternatives[0]) == 2
     assert email.alternatives[0][1] == "text/html"
 
-    assert email.alternatives[0][0] == (
-        "<table>\n\n        <tr>\n\n               <td>Hi there,"
-        "</td>\n\n        </tr>\n\n        <tr>\n\n             "
-        "  <td>\n                 The API usage for Test Org has"
-        " breached\n                 100% within the current "
-        "subscription period.\n                 \n             "
-        "    Please note that the serving of feature flags and "
-        "admin access may be disabled after a grace period, so "
-        "please upgrade your organisation's account to ensure "
-        "continued service.\n                 \n               "
-        "</td>\n\n\n        </tr>\n\n        <tr>\n\n          "
-        "     <td>Thank you!</td>\n\n        </tr>\n\n        "
-        "<tr>\n\n               <td>The Flagsmith Team</td>"
-        "\n\n        </tr>\n\n</table>\n"
+    assert email.alternatives[0][0] == render_to_string(
+        "organisations/api_usage_notification_limit.html",
+        context={"organisation": organisation, "matched_threshold": 100},
     )
 
     assert email.from_email == "noreply@flagsmith.com"


### PR DESCRIPTION
## Changes

Updates the API usage alert email templates with better wording, written by a non-developer 😄 

Fixes https://github.com/Flagsmith/flagsmith/issues/4351

## How did you test this code?

Updated the tests. 

Note that I changed the tests to use `render_to_string` directly because making changes to them as strings was really painful. Arguably this is not quite as thorough a test but, equally, those strings in the test weren't readable anyway because of the formatting so I don't see that we're losing much. 
