### PR TITLE
fix: Styling alert for API usage banner

### DIFF
--- a/frontend/web/components/OrganisationLimit.tsx
+++ b/frontend/web/components/OrganisationLimit.tsx
@@ -36,7 +36,7 @@ const OrganisationLimit: FC<OrganisationLimitType> = ({
     totalApiCalls?.totals.total,
   )}/${Format.shortenNumber(maxApiCalls?.max_api_calls)}`
 
-  const alertMaxApiCallsText = `You have used ${apiUsageMessageText} of your allowed requests.`
+  const alertMaxApiCallsText = `You have used ${apiUsageMessageText} of your allowed requests`
 
   const QuotaExceededMessage = () => {
     return (
@@ -44,26 +44,33 @@ const OrganisationLimit: FC<OrganisationLimitType> = ({
         className={'alert alert-danger announcement'}
         style={{ display: 'initial' }}
       >
-        <span className='icon-alert'>
-          <Icon name='close-circle' />
-        </span>
-        <>
-          Your organisation has exceeded its API usage quota{' '}
-          {`(${alertMaxApiCallsText}).`}{' '}
-          {Utils.getPlanName(organisationPlan) === 'Free' ? (
-            <b>Please upgrade your plan to continue receiving service.</b>
-          ) : (
-            <b>Automated billing for the overages may apply.</b>
-          )}
-        </>
-        <Button
-          className='btn ml-3'
-          onClick={() => {
-            document.location.replace(Constants.upgradeURL)
-          }}
-        >
-          Upgrade plan
-        </Button>
+        <Row>
+          <span className='icon-alert'>
+            <Icon name='close-circle' />
+          </span>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            Your organisation has exceeded its API usage quota{' '}
+            {`(${alertMaxApiCallsText}).`}{' '}
+            {Utils.getPlanName(organisationPlan) === 'Free' ? (
+              <b>Please upgrade your plan to continue receiving service.</b>
+            ) : (
+              <b>Automated billing for the overages may apply.</b>
+            )}
+          </div>
+          <Button
+            className='btn ml-3'
+            onClick={() => {
+              document.location.replace(Constants.upgradeURL)
+            }}
+          >
+            Upgrade plan
+          </Button>
+        </Row>
       </div>
     )
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Adjust styles in the API usage banner, fixing this issue: https://github.com/Flagsmith/flagsmith/issues/4230
<img width="1347" alt="Screenshot 2024-07-18 at 1 54 29 PM" src="https://github.com/user-attachments/assets/5cac1d67-5508-4864-9647-a130158d2371">


## How did you test this code?

- Force display the api usage Banner
