### PR TITLE
fix: Organisation/Project dropdown not reset after closing

### DIFF
--- a/frontend/web/components/BreadcrumbSeparator.tsx
+++ b/frontend/web/components/BreadcrumbSeparator.tsx
@@ -26,11 +26,9 @@ import { getStore } from 'common/store'
 import { getEnvironments } from 'common/services/useEnvironment'
 import classNames from 'classnames'
 import Button from './base/forms/Button'
-import { Link } from 'react-router-dom'
 import CreateOrganisationModal from './modals/CreateOrganisation'
 import { useHasPermission } from 'common/providers/Permission'
 import Constants from 'common/constants'
-import CreateProjectModal from './modals/CreateProject'
 
 type BreadcrumbSeparatorType = {
   hideDropdown?: boolean
@@ -305,6 +303,7 @@ const BreadcrumbSeparator: FC<BreadcrumbSeparatorType> = ({
           setOpen(false)
           setProjectSearch('')
           setOrganisationSearch('')
+          setHoveredOrganisation(AccountStore.getOrganisation())
         }}
         containerClassName={'p-0'}
         className={


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fix https://github.com/Flagsmith/flagsmith/issues/4257

Before:

https://github.com/Flagsmith/flagsmith/assets/829698/bb24c945-fb51-4c5b-bc4b-475d809d3566

After:

https://github.com/user-attachments/assets/4f1fbd50-5b66-4f44-bf71-091f6c76638b


## How did you test this code?

1. Open the Organisation/Project dropdown.
2. Hover over an Organisation and a project with the mouse.
3. Close the dropdown.
4. Reopen it (now it returns to the selected organization/project).
