### PR TITLE
ci: Increase timeout for E2E jobs

### DIFF
--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -43,7 +43,7 @@ runs:
           npm run test -- ${{ inputs.tests }}
         max_attempts: 2
         retry_on: error
-        timeout_minutes: 10
+        timeout_minutes: 20
       env:
         E2E_TEST_TOKEN: ${{ inputs.e2e_test_token }}
         SLACK_TOKEN: ${{ inputs.slack_token }}

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
             make test
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 10
+          timeout_minutes: 20
         env:
           opts: ${{ inputs.tests }}
           API_IMAGE: ${{ inputs.api-image }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This accommodates for longer-running E2E jobs in case of e.g. infrastructure problems.

## How did you test this code?

This is a CI change.