### PR TITLE
fix: users with `CREATE_FEATURE` permission cannot assign feature users / groups

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -611,11 +611,11 @@ const CreateFlag = class extends Component {
         {!identity && projectFlag && (
           <Permission
             level='project'
-            permission='ADMIN'
+            permission='CREATE_FEATURE'
             id={this.props.projectId}
           >
-            {({ permission: projectAdmin }) =>
-              projectAdmin && (
+            {({ permission }) =>
+              permission && (
                 <>
                   <FormGroup className='mb-5 setting'>
                     <FlagOwners


### PR DESCRIPTION
## Changes

Fixes a mismatch in the permissions between the FE and the BE. The FE was requiring project admin to assign users / groups to a feature whereas it should let anyone with CREATE_FEATURE.

One thing that would be good to add to this (but beyond my expertise) is to show these data read only to all users. 

## How did you test this code?

Tested the following scenarios locally: 

 * User without CREATE_FEATURE cannot assign users / groups
 * User with CREATE_FEATURE can assign users / groups
 * User with Project Admin can assign users / groups
