### PR TITLE
feat: Return transient traits explicitly

### DIFF
--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -280,12 +280,13 @@ class Identity(models.Model):
                 updated_traits.append(current_trait)
                 continue
 
-            trait = Trait(
-                **Trait.generate_trait_value_data(trait_value),
-                trait_key=trait_key,
-                identity=self,
+            new_traits.append(
+                Trait(
+                    **Trait.generate_trait_value_data(trait_value),
+                    trait_key=trait_key,
+                    identity=self,
+                )
             )
-            new_traits.append(trait)
 
         # delete the traits that had their keys set to None
         # (except the transient ones)

--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -219,9 +219,11 @@ class Identity(models.Model):
                 identity=self,
                 **Trait.generate_trait_value_data(trait_value),
             )
-            trait_models.append(trait)
-            if not trait_data_item.get("transient"):
+            if trait_data_item.get("transient"):
+                trait.transient = True
+            else:
                 trait_models_to_persist.append(trait)
+            trait_models.append(trait)
 
         if persist:
             Trait.objects.bulk_create(trait_models_to_persist)
@@ -252,13 +254,13 @@ class Identity(models.Model):
             transient = trait_data_item.get("transient")
 
             if transient:
-                transient_traits.append(
-                    Trait(
-                        **Trait.generate_trait_value_data(trait_value),
-                        trait_key=trait_key,
-                        identity=self,
-                    )
+                trait = Trait(
+                    **Trait.generate_trait_value_data(trait_value),
+                    trait_key=trait_key,
+                    identity=self,
                 )
+                trait.transient = True
+                transient_traits.append(trait)
                 continue
 
             if trait_value is None:
@@ -283,9 +285,6 @@ class Identity(models.Model):
                 trait_key=trait_key,
                 identity=self,
             )
-            # We're persisting new traits via `bulk_create` with `ignore_conflicts=True`,
-            # and those don't get their pks or ModelState updated. Populate the private attribute for them.
-            trait._is_transient = False
             new_traits.append(trait)
 
         # delete the traits that had their keys set to None

--- a/api/environments/identities/traits/models.py
+++ b/api/environments/identities/traits/models.py
@@ -58,8 +58,11 @@ class Trait(models.Model):
         return self.get_trait_value()
 
     @property
-    def transient(self):
-        return not self.pk
+    def transient(self) -> bool:
+        try:
+            return self._is_transient
+        except AttributeError:
+            return self.pk is None
 
     def get_trait_value(self):
         try:

--- a/api/environments/identities/traits/models.py
+++ b/api/environments/identities/traits/models.py
@@ -59,10 +59,11 @@ class Trait(models.Model):
 
     @property
     def transient(self) -> bool:
-        try:
-            return self._is_transient
-        except AttributeError:
-            return self.pk is None
+        return getattr(self, "_transient", False)
+
+    @transient.setter
+    def transient(self, transient: bool) -> None:
+        self._transient = transient
 
     def get_trait_value(self):
         try:

--- a/api/environments/identities/traits/models.py
+++ b/api/environments/identities/traits/models.py
@@ -57,6 +57,10 @@ class Trait(models.Model):
     def trait_value(self):
         return self.get_trait_value()
 
+    @property
+    def transient(self):
+        return not self.pk
+
     def get_trait_value(self):
         try:
             value_type = self.value_type

--- a/api/environments/identities/traits/serializers.py
+++ b/api/environments/identities/traits/serializers.py
@@ -22,7 +22,7 @@ class TraitSerializerFull(serializers.ModelSerializer):
 
 class TraitSerializerBasic(serializers.ModelSerializer):
     trait_value = TraitValueField(allow_null=True)
-    transient = serializers.BooleanField(default=False, write_only=True)
+    transient = serializers.BooleanField(default=False)
 
     class Meta:
         model = Trait

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -1182,7 +1182,10 @@ def test_post_identities__transient_traits__no_persistence(
     url = reverse("api-v1:sdk-identities")
     data = {
         "identifier": identifier,
-        "traits": [{"trait_key": trait_key, "trait_value": "bar", "transient": True}],
+        "traits": [
+            {"trait_key": trait_key, "trait_value": "bar", "transient": True},
+            {"trait_key": "not_transient", "trait_value": "value"},
+        ],
     }
 
     # When
@@ -1192,6 +1195,20 @@ def test_post_identities__transient_traits__no_persistence(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
+    assert response.json()["traits"] == [
+        {
+            "id": mock.ANY,
+            "trait_key": trait_key,
+            "trait_value": "bar",
+            "transient": True,
+        },
+        {
+            "id": mock.ANY,
+            "trait_key": "not_transient",
+            "trait_value": "value",
+            "transient": False,
+        },
+    ]
     assert Identity.objects.filter(identifier=identifier).exists()
     assert not Trait.objects.filter(trait_key=trait_key).exists()
 

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -1176,15 +1176,16 @@ def test_post_identities__transient_traits__no_persistence(
 ) -> None:
     # Given
     identifier = "transient"
-    trait_key = "trait_key"
+    transient_trait_key = "trait_key"
+    non_transient_trait_key = "other"
 
     api_client.credentials(HTTP_X_ENVIRONMENT_KEY=environment.api_key)
     url = reverse("api-v1:sdk-identities")
     data = {
         "identifier": identifier,
         "traits": [
-            {"trait_key": trait_key, "trait_value": "bar", "transient": True},
-            {"trait_key": "not_transient", "trait_value": "value"},
+            {"trait_key": transient_trait_key, "trait_value": "bar", "transient": True},
+            {"trait_key": non_transient_trait_key, "trait_value": "value"},
         ],
     }
 
@@ -1195,22 +1196,9 @@ def test_post_identities__transient_traits__no_persistence(
 
     # Then
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["traits"] == [
-        {
-            "id": mock.ANY,
-            "trait_key": trait_key,
-            "trait_value": "bar",
-            "transient": True,
-        },
-        {
-            "id": mock.ANY,
-            "trait_key": "not_transient",
-            "trait_value": "value",
-            "transient": False,
-        },
-    ]
     assert Identity.objects.filter(identifier=identifier).exists()
-    assert not Trait.objects.filter(trait_key=trait_key).exists()
+    assert Trait.objects.filter(trait_key=non_transient_trait_key).exists()
+    assert not Trait.objects.filter(trait_key=transient_trait_key).exists()
 
 
 def test_user_with_view_identities_permission_can_retrieve_identity(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/platform/contributing#pre-commit) to check linting
- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

As discussed offline, this makes the `/api/v1/identities` SDK route return transient traits explicitly. This helps simplify SDK caching logic — i.e. see [this commit](https://github.com/Flagsmith/flagsmith-js-client/pull/240/commits/628e45b3afe9cc06b80c3059b54c907b8a34382e#diff-0b9b511548a3e7571b5371b6ad98facf6955df9dfa855af7107b182e04bc524bL114-L115) to JS SDK.

Contributes to #4278.

## How did you test this code?

Modified an existing unit test.
