### PR TITLE
chore: add --dist=worksteal to pytest opts

### DIFF
--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
-PYTEST_ADDOPTS=--cov . --cov-report xml -n auto --dist worksteal --ci
+PYTEST_ADDOPTS=--cov . --cov-report xml --ci
 GUNICORN_LOGGER_CLASS=util.logging.GunicornJsonCapableLogger
 COVERAGE_CORE=sysmon

--- a/api/.env-local
+++ b/api/.env-local
@@ -1,3 +1,3 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
 DJANGO_SETTINGS_MODULE=app.settings.local
-PYTEST_ADDOPTS=--cov . --cov-report html -n auto
+PYTEST_ADDOPTS=--cov . --cov-report html

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -96,7 +96,7 @@ known_third_party = [
 skip = ['migrations', '.venv', '.direnv']
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings', '--dist=worksteal']
+addopts = ['--ds=app.settings.test', '--dist=worksteal', '-n=auto', '-vvvv', '-p', 'no:warnings']
 console_output_style = 'count'
 
 [tool.poetry]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -96,7 +96,7 @@ known_third_party = [
 skip = ['migrations', '.venv', '.direnv']
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings']
+addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings', '--dist=worksteal']
 console_output_style = 'count'
 
 [tool.poetry]


### PR DESCRIPTION
## Changes

Adds the `--dist=worksteal` and `--n auto` flags to pytest addopts. 

## How did you test this code?

Ran `make test` locally and verified the behaviour
