### PR TITLE
fix: add logic to set segment to lowest priority if not set

### DIFF
--- a/api/features/feature_segments/serializers.py
+++ b/api/features/feature_segments/serializers.py
@@ -56,6 +56,8 @@ class CustomCreateSegmentOverrideFeatureSegmentSerializer(
 
         if priority:
             feature_segment.to(priority)
+        else:
+            feature_segment.bottom(priority)
 
         return feature_segment
 

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_serializers.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_serializers.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 from environments.models import Environment
 from features.feature_segments.serializers import (
+    CustomCreateSegmentOverrideFeatureSegmentSerializer,
     FeatureSegmentChangePrioritiesSerializer,
 )
 from features.models import Feature, FeatureSegment, FeatureState
@@ -58,3 +59,24 @@ def test_feature_segment_change_priorities_serializer_validate_fails_if_non_uniq
     # Then
     assert is_valid is False
     assert serializer.errors
+
+
+def test_feature_segment_serializer_save_sets_lowest_priority_if_none_given(
+    feature: Feature,
+    segment_featurestate: FeatureState,
+    feature_segment: FeatureSegment,
+    another_segment: Segment,
+    environment: Environment,
+) -> None:
+    # Given
+    serializer = CustomCreateSegmentOverrideFeatureSegmentSerializer(
+        data={"segment": another_segment.id}
+    )
+    serializer.is_valid(raise_exception=True)
+
+    # When
+    new_feature_segment = serializer.save(feature=feature, environment=environment)
+
+    # Then
+    assert feature_segment.priority == 0
+    assert new_feature_segment.priority == 1


### PR DESCRIPTION
## Changes

Fix behaviour when creating a segment override to add the segment override as the lowest (i.e.. biggest number) priority when a specific priority is not provided. 

The specific use case for this is to ensure that, when 2 separate change requests are created on a new feature to add 2 different segment overrides, the second one that gets published, correctly has the priority set, and doesn't conflict with the first one. 

## How did you test this code?

Added a new unit test. 
