### PR TITLE
fix: feature segments created with priority 0 are sent to bottom

### DIFF
--- a/api/features/feature_segments/serializers.py
+++ b/api/features/feature_segments/serializers.py
@@ -58,12 +58,20 @@ class CustomCreateSegmentOverrideFeatureSegmentSerializer(
 
         priority: int | None = self.validated_data.get("priority", None)
 
+        if kwargs["environment"].use_v2_feature_versioning:  # pragma: no cover
+            assert (
+                kwargs["environment_feature_version"] is not None
+            ), "Must provide environment_feature_version for environment using v2 versioning"
+
         if (
             priority is not None
             and (
                 collision := FeatureSegment.objects.filter(
-                    environment_id=kwargs["environment"],
+                    environment=kwargs["environment"],
                     feature=kwargs["feature"],
+                    environment_feature_version=kwargs.get(
+                        "environment_feature_version"
+                    ),
                     priority=priority,
                 ).first()
             )

--- a/api/features/feature_segments/serializers.py
+++ b/api/features/feature_segments/serializers.py
@@ -70,12 +70,7 @@ class CustomCreateSegmentOverrideFeatureSegmentSerializer(
             # given priority and early returns.
             collision.to(priority + 1)
 
-        feature_segment = super().create(validated_data)
-
-        if priority is None:
-            feature_segment.bottom()
-
-        return feature_segment
+        return super().create(validated_data)
 
     def update(
         self, instance: FeatureSegment, validated_data: dict[str, typing.Any]

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_serializers.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_serializers.py
@@ -61,7 +61,7 @@ def test_feature_segment_change_priorities_serializer_validate_fails_if_non_uniq
     assert serializer.errors
 
 
-def test_feature_segment_serializer_save_sets_lowest_priority_if_none_given(
+def test_feature_segment_serializer_save_new_feature_segment_sets_lowest_priority_if_none_given(
     feature: Feature,
     segment_featurestate: FeatureState,
     feature_segment: FeatureSegment,
@@ -78,5 +78,142 @@ def test_feature_segment_serializer_save_sets_lowest_priority_if_none_given(
     new_feature_segment = serializer.save(feature=feature, environment=environment)
 
     # Then
+    feature_segment.refresh_from_db()
     assert feature_segment.priority == 0
     assert new_feature_segment.priority == 1
+
+
+def test_feature_segment_serializer_save_new_feature_segment_sets_highest_priority_if_0_given(
+    feature: Feature,
+    segment_featurestate: FeatureState,
+    feature_segment: FeatureSegment,
+    another_segment: Segment,
+    environment: Environment,
+) -> None:
+    # Given
+    serializer = CustomCreateSegmentOverrideFeatureSegmentSerializer(
+        data={"segment": another_segment.id, "priority": 0}
+    )
+    serializer.is_valid(raise_exception=True)
+
+    # When
+    new_feature_segment = serializer.save(feature=feature, environment=environment)
+
+    # Then
+    feature_segment.refresh_from_db()
+    assert feature_segment.priority == 1
+    assert new_feature_segment.priority == 0
+
+
+def test_feature_segment_serializer_save_new_feature_segment_moves_others_if_needed(
+    feature: Feature,
+    segment_featurestate: FeatureState,
+    feature_segment: FeatureSegment,
+    another_segment: Segment,
+    environment: Environment,
+) -> None:
+    # Given
+    feature_segment.to(1)
+
+    serializer = CustomCreateSegmentOverrideFeatureSegmentSerializer(
+        data={"segment": another_segment.id, "priority": 1}
+    )
+    serializer.is_valid(raise_exception=True)
+
+    # When
+    new_feature_segment = serializer.save(feature=feature, environment=environment)
+
+    # Then
+    feature_segment.refresh_from_db()
+    assert feature_segment.priority == 2
+    assert new_feature_segment.priority == 1
+
+
+def test_feature_segment_serializer_save_existing_feature_segment_does_nothing_if_no_priority_given(
+    feature: Feature,
+    segment_featurestate: FeatureState,
+    feature_segment: FeatureSegment,
+    another_segment: Segment,
+    environment: Environment,
+) -> None:
+    # Given
+    feature_segment_to_update = FeatureSegment.objects.create(
+        environment=environment,
+        feature=feature,
+        segment=another_segment,
+        priority=1,
+    )
+
+    serializer = CustomCreateSegmentOverrideFeatureSegmentSerializer(
+        instance=feature_segment_to_update, data={"segment": another_segment.id}
+    )
+    serializer.is_valid(raise_exception=True)
+
+    # When
+    updated_feature_segment = serializer.save(feature=feature, environment=environment)
+
+    # Then
+    feature_segment.refresh_from_db()
+    assert feature_segment.priority == 0
+    assert updated_feature_segment.priority == 1
+
+
+def test_feature_segment_serializer_save_existing_feature_segment_sets_highest_priority_if_0_given(
+    feature: Feature,
+    segment_featurestate: FeatureState,
+    feature_segment: FeatureSegment,
+    another_segment: Segment,
+    environment: Environment,
+) -> None:
+    # Given
+    feature_segment_to_update = FeatureSegment.objects.create(
+        environment=environment,
+        feature=feature,
+        segment=another_segment,
+        priority=1,
+    )
+
+    serializer = CustomCreateSegmentOverrideFeatureSegmentSerializer(
+        instance=feature_segment_to_update,
+        data={"segment": another_segment.id, "priority": 0},
+    )
+    serializer.is_valid(raise_exception=True)
+
+    # When
+    updated_feature_segment = serializer.save(feature=feature, environment=environment)
+
+    # Then
+    feature_segment.refresh_from_db()
+    assert feature_segment.priority == 1
+    assert updated_feature_segment.priority == 0
+
+
+def test_feature_segment_serializer_save_existing_feature_segment_moves_others_if_needed(
+    feature: Feature,
+    segment_featurestate: FeatureState,
+    feature_segment: FeatureSegment,
+    another_segment: Segment,
+    environment: Environment,
+) -> None:
+    # Given
+    feature_segment.to(1)
+
+    feature_segment_to_update = FeatureSegment.objects.create(
+        environment=environment,
+        feature=feature,
+        segment=another_segment,
+    )
+
+    serializer = CustomCreateSegmentOverrideFeatureSegmentSerializer(
+        instance=feature_segment_to_update,
+        data={"segment": another_segment.id, "priority": 1},
+    )
+    serializer.is_valid(raise_exception=True)
+
+    # When
+    updated_feature_segment = serializer.save(feature=feature, environment=environment)
+
+    # Then
+    feature_segment.refresh_from_db()
+    assert feature_segment.priority == 2
+    assert updated_feature_segment.priority == 1


### PR DESCRIPTION
## Changes

The previous PR [here](https://github.com/Flagsmith/flagsmith/pull/4381) actually causes an issue because the FE always defaults to sending the priority as 0. 

This PR is in part accounting for that, but also accounting for the fact that the `django-ordered-model` library that we are using doesn't enforce uniqueness on the priority so, when the priority is set in the save, any subsequent calls to `to()` don't work because it early returns that it already exists at that priority. The issue is that we now likely have 2 feature segments at that priority. To resolve this, we first move the 'collision' feature segment down and out of the way before completing the save. 

## How did you test this code?

Added a bunch more tests for all scenarios. 
