### PR TITLE
docs: Don't expand "Basic Features" by default

### DIFF
--- a/docs/docs/basic-features/_category_.json
+++ b/docs/docs/basic-features/_category_.json
@@ -1,5 +1,4 @@
 {
     "label": "Basic Features",
-    "position": 30,
-    "collapsed": false
+    "position": 30
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Don't expand the "Basic Features" section by default when opening the docs page.

This makes it clearer that "Basic Features" itself is a page, which was changed in https://github.com/Flagsmith/flagsmith/pull/4332. It also makes the docs page cleaner and hopefully reduces information/choice overload.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manually, see:

![image](https://github.com/user-attachments/assets/278543f1-8e67-4dd3-8bd8-e6d743972617)

