### PR TITLE
fix(build): Use a pre-created user for the frontend image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,7 @@ EXPOSE 8080
 
 CMD ["node",  "./api/index.js"]
 
-USER node
+USER nobody
 
 # * oss-unified [api-runtime, build-python, build-node-django]
 FROM api-runtime as oss-unified


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes the following user-reported error when running the frontend container:

```
Error: failed to create containerd container: mount callback failed on /var/lib/containerd/tmpmounts/containerd-mount675064683: no users found
```

An alternative solution would be to add a `RUN useradd node` layer to the target stage.
 
## How did you test this code?

The user in question tested the PR image on their premises and reported success.