### PR TITLE
fix: add logic to handle subscriptions in trial

### DIFF
--- a/api/organisations/chargebee/webhook_handlers.py
+++ b/api/organisations/chargebee/webhook_handlers.py
@@ -134,7 +134,7 @@ def process_subscription(request: Request) -> Response:  # noqa: C901
         )
         return Response(status=status.HTTP_200_OK)
 
-    if subscription["status"] != "active":
+    if subscription["status"] not in ("active", "in_trial"):
         # Nothing to do, so return early.
         return Response(status=status.HTTP_200_OK)
 

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -559,12 +559,14 @@ def test_get_my_permissions_for_admin(
     assert response.data["admin"] is True
 
 
+@pytest.mark.parametrize("subscription_status", ("active", "in_trial"))
 @mock.patch("organisations.chargebee.webhook_handlers.extract_subscription_metadata")
 def test_chargebee_webhook(
     mock_extract_subscription_metadata: MagicMock,
     staff_user: FFAdminUser,
     staff_client: APIClient,
     subscription: Subscription,
+    subscription_status: str,
 ) -> None:
     # Given
     seats = 3
@@ -580,7 +582,7 @@ def test_chargebee_webhook(
     data = {
         "content": {
             "subscription": {
-                "status": "active",
+                "status": subscription_status,
                 "id": subscription.subscription_id,
                 "current_term_start": 1699630389,
                 "current_term_end": 1702222389,


### PR DESCRIPTION
## Changes

API component for #604 

This PR handles the subscription status `"in_trial"`. When the trial switches to `"active"`, `"non_renewing"` or `"cancelled"`, the rest of the logic / tests should cover that behaviour. 

## How did you test this code?

Updated existing unit test. 
