### PR TITLE
feat: Introduce the SDK Evaluation Context schema

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -66,9 +66,7 @@
                     "title": "Transient"
                 }
             },
-            "required": [
-                "traits"
-            ],
+            "required": [],
             "title": "IdentityEvaluationContext",
             "type": "object"
         },

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -69,42 +69,19 @@
         "TraitEvaluationContext": {
             "properties": {
                 "value": {
-                    "title": "Value",
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/$defs/TraitValueType"
+                    "title": "Value"
                 },
                 "transient": {
-                    "anyOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
+                    "type": "boolean",
+                    "default": false,
                     "title": "Transient"
                 }
             },
             "required": [
-                "value",
-                "type"
+                "value"
             ],
             "title": "TraitEvaluationContext",
             "type": "object"
-        },
-        "TraitValueType": {
-            "enum": [
-                "String",
-                "SemverString",
-                "Integer",
-                "Float",
-                "Boolean"
-            ],
-            "title": "TraitValueType",
-            "type": "string"
         }
     },
     "properties": {

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -77,10 +77,7 @@
                             "type": "string"
                         },
                         {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "float"
+                            "type": "number"
                         }
                     ],
                     "title": "Value"

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -109,7 +109,15 @@
     },
     "properties": {
         "environment": {
-            "$ref": "#/$defs/EnvironmentEvaluationContext"
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/EnvironmentEvaluationContext"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null
         },
         "identity": {
             "anyOf": [
@@ -134,9 +142,6 @@
             "default": null
         }
     },
-    "required": [
-        "environment"
-    ],
     "title": "FlagsmithEvaluationContext",
     "type": "object"
 }

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -69,6 +69,20 @@
         "TraitEvaluationContext": {
             "properties": {
                 "value": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "float"
+                        }
+                    ],
                     "title": "Value"
                 },
                 "transient": {

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -29,8 +29,15 @@
         "IdentityEvaluationContext": {
             "properties": {
                 "identifier": {
-                    "title": "Identifier",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "title": "Identifier"
                 },
                 "traits": {
                     "additionalProperties": {
@@ -60,7 +67,6 @@
                 }
             },
             "required": [
-                "identifier",
                 "traits"
             ],
             "title": "IdentityEvaluationContext",

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -68,20 +68,7 @@
         },
         "TraitEvaluationContext": {
             "properties": {
-                "value": {
-                    "anyOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "number"
-                        }
-                    ],
-                    "title": "Value"
-                },
+                "value": {},
                 "transient": {
                     "type": "boolean",
                     "default": false,

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -1,0 +1,142 @@
+{
+    "$defs": {
+        "EnvironmentEvaluationContext": {
+            "properties": {
+                "api_key": {
+                    "title": "Api Key",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "api_key"
+            ],
+            "title": "EnvironmentEvaluationContext",
+            "type": "object"
+        },
+        "FeatureEvaluationContext": {
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "title": "FeatureEvaluationContext",
+            "type": "object"
+        },
+        "IdentityEvaluationContext": {
+            "properties": {
+                "identifier": {
+                    "title": "Identifier",
+                    "type": "string"
+                },
+                "traits": {
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/TraitEvaluationContext"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "title": "Traits",
+                    "type": "object"
+                },
+                "transient": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Transient"
+                }
+            },
+            "required": [
+                "identifier",
+                "traits"
+            ],
+            "title": "IdentityEvaluationContext",
+            "type": "object"
+        },
+        "TraitEvaluationContext": {
+            "properties": {
+                "value": {
+                    "title": "Value",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/$defs/TraitValueType"
+                },
+                "transient": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Transient"
+                }
+            },
+            "required": [
+                "value",
+                "type"
+            ],
+            "title": "TraitEvaluationContext",
+            "type": "object"
+        },
+        "TraitValueType": {
+            "enum": [
+                "String",
+                "SemverString",
+                "Integer",
+                "Float",
+                "Boolean"
+            ],
+            "title": "TraitValueType",
+            "type": "string"
+        }
+    },
+    "properties": {
+        "environment": {
+            "$ref": "#/$defs/EnvironmentEvaluationContext"
+        },
+        "identity": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/IdentityEvaluationContext"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null
+        },
+        "feature": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/FeatureEvaluationContext"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null
+        }
+    },
+    "required": [
+        "environment"
+    ],
+    "title": "FlagsmithEvaluationContext",
+    "type": "object"
+}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

Contributes to #4413.

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The following is a proposed Flagsmith Evaluation Context schema JSON Schema definition.

### Notes

- `IdentityEvaluationContext.traits` is a mapping of trait keys to a `TraitEvaluationContext | null` union. In case a `null` is provided, we assume intent to delete the previously persisted trait.
- `TraitEvaluationContext.value` can only be a `string` now.
- We now have a `TraitEvaluationContext.type` enum field designating the trait value type. For now it will support an SDK-side mapping layer. It's expected that the v2 SDK API should support it in the future.

## How did you test this code?

This is a documentation change, but I'm verifying the schema against a validator.