### PR TITLE
feat: Add command for Edge V2 migration

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = [
     "organisations.permissions",
     "projects",
     "sales_dashboard",
+    "edge_api",
     "environments",
     "environments.permissions",
     "environments.identities",

--- a/api/edge_api/apps.py
+++ b/api/edge_api/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class EdgeAPIAppConfig(AppConfig):
+    name = "edge_api"

--- a/api/edge_api/management/commands/migrate_to_edge_v2.py
+++ b/api/edge_api/management/commands/migrate_to_edge_v2.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from django.core.management import BaseCommand
+
+from projects.models import EdgeV2MigrationStatus, Project
+from projects.tasks import migrate_project_environments_to_v2
+
+
+class Command(BaseCommand):
+    def handle(self, *args: Any, **options: Any) -> str | None:
+        for project_id in Project.objects.filter(
+            edge_v2_migration_status__in=(
+                EdgeV2MigrationStatus.NOT_STARTED,
+                EdgeV2MigrationStatus.INCOMPLETE,
+            )
+        ).values_list("id", flat=True):
+            migrate_project_environments_to_v2(project_id)

--- a/api/tests/unit/edge_api/test_unit_edge_api_commands.py
+++ b/api/tests/unit/edge_api/test_unit_edge_api_commands.py
@@ -1,0 +1,38 @@
+from django.core.management import call_command
+from pytest_mock import MockerFixture
+
+from projects.models import EdgeV2MigrationStatus, Project
+
+
+def test_migrate_to_edge_v2__new_projects__dont_migrate(
+    mocker: MockerFixture, project: Project
+) -> None:
+    # Given
+    # unmigrated projects are present
+    unmigrated_projects = Project.objects.bulk_create(
+        [
+            Project(
+                name="edge_v2_not_started",
+                organisation=project.organisation,
+                edge_v2_migration_status=EdgeV2MigrationStatus.NOT_STARTED,
+            ),
+            Project(
+                name="edge_v2_incomplete",
+                organisation=project.organisation,
+                edge_v2_migration_status=EdgeV2MigrationStatus.INCOMPLETE,
+            ),
+        ],
+    )
+
+    migrate_project_environments_to_v2_mock = mocker.patch(
+        "edge_api.management.commands.migrate_to_edge_v2.migrate_project_environments_to_v2",
+        autospec=True,
+    )
+
+    # When
+    call_command("migrate_to_edge_v2")
+
+    # Then
+    migrate_project_environments_to_v2_mock.assert_has_calls(
+        [mocker.call(project.id) for project in unmigrated_projects]
+    )

--- a/api/tests/unit/edge_api/test_unit_edge_api_commands.py
+++ b/api/tests/unit/edge_api/test_unit_edge_api_commands.py
@@ -33,6 +33,9 @@ def test_migrate_to_edge_v2__new_projects__dont_migrate(
     call_command("migrate_to_edge_v2")
 
     # Then
+    # unmigrated projects were migrated
     migrate_project_environments_to_v2_mock.assert_has_calls(
         [mocker.call(project.id) for project in unmigrated_projects]
     )
+    # the migrated `project` was not redundantly migrated
+    migrate_project_environments_to_v2_mock.call_count == len(unmigrated_projects)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds a `migrate_to_edge_v2` management command that migrated all unmigrated projects to Edge V2.

## How did you test this code?

Added a unit test.