### PR TITLE
chore: revert "chore: add --dist=worksteal to pytest opts"

### DIFF
--- a/api/.env-ci
+++ b/api/.env-ci
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 ANALYTICS_DATABASE_URL=postgres://postgres:postgres@localhost:5432/analytics
-PYTEST_ADDOPTS=--cov . --cov-report xml --ci
+PYTEST_ADDOPTS=--cov . --cov-report xml -n auto --dist worksteal --ci
 GUNICORN_LOGGER_CLASS=util.logging.GunicornJsonCapableLogger
 COVERAGE_CORE=sysmon

--- a/api/.env-local
+++ b/api/.env-local
@@ -1,3 +1,3 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/flagsmith
 DJANGO_SETTINGS_MODULE=app.settings.local
-PYTEST_ADDOPTS=--cov . --cov-report html
+PYTEST_ADDOPTS=--cov . --cov-report html -n auto

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -96,7 +96,7 @@ known_third_party = [
 skip = ['migrations', '.venv', '.direnv']
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '--dist=worksteal', '-n=auto', '-vvvv', '-p', 'no:warnings']
+addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings']
 console_output_style = 'count'
 
 [tool.poetry]


### PR DESCRIPTION
Reverts Flagsmith/flagsmith#4380.

We need to roll those changes back as they enforce `xdist` to every Pytest invocation, which is not desirable for some debugging setups.

A proper solution would be to add `--dist=worksteal` to `.env-local`.

