### PR TITLE
fix: Catch full exception instead of runtime error in API usage task

### DIFF
--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -123,7 +123,7 @@ def handle_api_usage_notifications() -> None:
 
         try:
             handle_api_usage_notification_for_organisation(organisation)
-        except RuntimeError:
+        except Exception:
             logger.error(
                 f"Error processing api usage for organisation {organisation.id}",
                 exc_info=True,


### PR DESCRIPTION
## Changes

When there were failures for individual organisations in the `handle_api_usage_notifications` task the catching code was too restrictive to allow for continued processing after failure. This change simply catches all `Exception` classes.

## How did you test this code?

I ran the test suite but I decided against writing a test for this since the logic is simple.

Edit: It looks like it's failing the code cov check, so I will bite the bullet and write out the test anyway.