### PR TITLE
fix: Handle zero case for API usage limit

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -452,7 +452,7 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
     api_calls_30d = models.IntegerField(default=0)
 
     allowed_seats = models.IntegerField(default=1)
-    allowed_30d_api_calls = models.IntegerField(default=50000)
+    allowed_30d_api_calls = models.IntegerField(default=MAX_API_CALLS_IN_FREE_PLAN)
     allowed_projects = models.IntegerField(default=1, blank=True, null=True)
 
     chargebee_email = models.EmailField(blank=True, max_length=254, null=True)

--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -13,6 +13,7 @@ from organisations.models import (
     OrganisationAPIUsageNotification,
     OrganisationRole,
 )
+from organisations.subscriptions.constants import MAX_API_CALLS_IN_FREE_PLAN
 from users.models import FFAdminUser
 
 from .constants import API_USAGE_ALERT_THRESHOLDS
@@ -113,6 +114,9 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
         allowed_api_calls = subscription_cache.allowed_30d_api_calls
 
     api_usage = get_current_api_usage(organisation.id, f"-{days}d")
+
+    # For some reason the allowed API calls is set to 0 so default to the max free plan.
+    allowed_api_calls = allowed_api_calls or MAX_API_CALLS_IN_FREE_PLAN
 
     api_usage_percent = int(100 * api_usage / allowed_api_calls)
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/Flagsmith/flagsmith/issues/4411

During tests on staging a divide by zero condition was reached when the amount of API usage for a given customer was zero. I'm not sure if the same bad data exists on production, but either way a reasonable default to the free plan size is justified. While I was at it, I also set the default value of the field to point to the pre-existing constant so if we ever change the free default we won't have to search for the value.

## How did you test this code?

I did not test the code since it's pretty obvious.