### PR TITLE
ci: Enable E2E tests for external contributors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ Dockerfile
 .ebignore
 .ebextensions
 .direnv
+.github

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -27,6 +27,10 @@ on:
         description: The runner label to use. Defaults to `ubuntu-latest`
         required: false
         default: ubuntu-latest
+    secrets:
+      gcr-token:
+        description: A token to use for logging into Github Container Registry. If not provided, login does not occur.
+        required: false
 
 jobs:
   run-e2e:
@@ -38,16 +42,20 @@ jobs:
       packages: read
       id-token: write
 
+    env:
+      GCR_TOKEN: ${{ secrets.gcr-token }}
+
     steps:
       - name: Cloning repo
         uses: actions/checkout@v4
 
       - name: Login to Github Container Registry
+        if: ${{ env.GCR_TOKEN }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ env.GCR_TOKEN }}
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -3,14 +3,11 @@ name: Conventional Commit
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches-ignore:
-      - release-please-*
+
 jobs:
   conventional-commit:
     name: Conventional Commit
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Check PR Conventional Commit title
         uses: amannn/action-semantic-pull-request@v5
@@ -28,20 +25,3 @@ jobs:
             refactor
             test
             chore
-      - name: Auto-label PR with Conventional Commit title
-        uses: kramen22/conventional-release-labels@v1
-        with:
-          type_labels: |
-            {
-              "feat": "feature",
-              "fix": "fix",
-              "infra": "infrastructure",
-              "ci": "ci-cd",
-              "docs": "docs",
-              "deps": "dependencies",
-              "perf": "performance",
-              "refactor": "refactor",
-              "test": "testing",
-              "chore": "chore"
-            }
-          ignored_types: '[]'

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -43,9 +43,9 @@ jobs:
     name: Build Unified Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       target: oss-unified
       image-name: flagsmith
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-api:
@@ -56,9 +56,9 @@ jobs:
     name: Build API Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       target: oss-api
       image-name: flagsmith-api
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-frontend:
@@ -69,9 +69,9 @@ jobs:
     name: Build Frontend Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       target: oss-frontend
       image-name: flagsmith-frontend
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-api-test:
@@ -84,8 +84,9 @@ jobs:
     with:
       target: api-test
       image-name: flagsmith-api-test
-      scan: false
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
+      scan: false
 
   docker-build-e2e:
     if: |
@@ -95,11 +96,11 @@ jobs:
     name: Build E2E Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       file: frontend/Dockerfile.e2e
       image-name: flagsmith-e2e
-      scan: false
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
+      scan: false
 
   docker-build-private-cloud:
     if: github.event.pull_request.draft == false && needs.permissions-check.outputs.can-write == 'true'

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
   docker-build-unified:
     if: |
       github.event.pull_request.draft == false &&
-      (needs.permissions-check.outputs.can-write == 'true' || needs.docker-prepare-report-comment.result == 'skipped')
+      (always() && needs.docker-prepare-report-comment.result == 'skipped')
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build Unified Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -51,7 +51,7 @@ jobs:
   docker-build-api:
     if: |
       github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+      (always() && needs.docker-prepare-report-comment.result == 'skipped')
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build API Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -64,7 +64,7 @@ jobs:
   docker-build-frontend:
     if: |
       github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+      (always() && needs.docker-prepare-report-comment.result == 'skipped')
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build Frontend Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
   docker-build-api-test:
     if: |
       github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+      (always() && needs.docker-prepare-report-comment.result == 'skipped')
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build API Test Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -91,7 +91,7 @@ jobs:
   docker-build-e2e:
     if: |
       github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+      (always() && needs.docker-prepare-report-comment.result == 'skipped')
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build E2E Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -116,7 +116,7 @@ jobs:
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
   run-e2e-tests:
-    needs: [docker-build-api, docker-build-e2e]
+    needs: [permissions-check, docker-build-api, docker-build-e2e]
     uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -124,7 +124,8 @@ jobs:
       api-image: ${{ needs.docker-build-api.outputs.image }}
       concurrency: ${{ matrix.args.concurrency }}
       tests: ${{ matrix.args.tests }}
-    secrets: inherit
+    secrets:
+      gcr-token: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
 
     strategy:
       matrix:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -6,8 +6,6 @@ on:
     paths-ignore:
       - docs/**
       - infrastructure/**
-    branches-ignore:
-      - release-please-*
 
 jobs:
   permissions-check:
@@ -20,6 +18,32 @@ jobs:
         id: check
         with:
           require: write
+
+  conventional-commit-label:
+    if: needs.permissions-check.outputs.can-write == 'true'
+    name: Add Conventional Commit labels
+    needs: permissions-check
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Auto-label PR with Conventional Commit title
+        uses: kramen22/conventional-release-labels@v1
+        with:
+          type_labels: |
+            {
+              "feat": "feature",
+              "fix": "fix",
+              "infra": "infrastructure",
+              "ci": "ci-cd",
+              "docs": "docs",
+              "deps": "dependencies",
+              "perf": "performance",
+              "refactor": "refactor",
+              "test": "testing",
+              "chore": "chore"
+            }
+          ignored_types: '[]'
 
   docker-prepare-report-comment:
     if: github.event.pull_request.draft == false && needs.permissions-check.outputs.can-write == 'true'

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -10,7 +10,7 @@ on:
       - release-please-*
 
 jobs:
-  check-permissions:
+  permissions-check:
     name: Check actor permissions
     runs-on: ubuntu-latest
     outputs:
@@ -22,9 +22,9 @@ jobs:
           require: write
 
   docker-prepare-report-comment:
-    if: needs.check-permissions.outputs.can-write == 'true'
+    if: github.event.pull_request.draft == false && needs.permissions-check.outputs.can-write == 'true'
     name: Prepare Docker report comment
-    needs: check-permissions
+    needs: permissions-check
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -36,64 +36,74 @@ jobs:
       - uses: ./.github/actions/docker-build-report-to-pr
 
   docker-build-unified:
-    if: github.event.pull_request.draft == false
-    needs: [check-permissions, docker-prepare-report-comment]
+    if: |
+      github.event.pull_request.draft == false &&
+      (needs.permissions-check.outputs.can-write == 'true' || needs.docker-prepare-report-comment.result == 'skipped')
+    needs: [permissions-check, docker-prepare-report-comment]
     name: Build Unified Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.check-permissions.outputs.can-write == 'false' }}
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       target: oss-unified
       image-name: flagsmith
-      comment: ${{ needs.check-permissions.outputs.can-write == 'true' }}
+      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-api:
-    if: github.event.pull_request.draft == false
-    needs: [check-permissions, docker-prepare-report-comment]
+    if: |
+      github.event.pull_request.draft == false &&
+      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+    needs: [permissions-check, docker-prepare-report-comment]
     name: Build API Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.check-permissions.outputs.can-write == 'false' }}
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       target: oss-api
       image-name: flagsmith-api
-      comment: ${{ needs.check-permissions.outputs.can-write == 'true' }}
+      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-frontend:
-    if: github.event.pull_request.draft == false
-    needs: [check-permissions, docker-prepare-report-comment]
+    if: |
+      github.event.pull_request.draft == false &&
+      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+    needs: [permissions-check, docker-prepare-report-comment]
     name: Build Frontend Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.check-permissions.outputs.can-write == 'false' }}
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       target: oss-frontend
       image-name: flagsmith-frontend
-      comment: ${{ needs.check-permissions.outputs.can-write == 'true' }}
+      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-api-test:
-    if: github.event.pull_request.draft == false
-    needs: [check-permissions, docker-prepare-report-comment]
+    if: |
+      github.event.pull_request.draft == false &&
+      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+    needs: [permissions-check, docker-prepare-report-comment]
     name: Build API Test Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
       target: api-test
       image-name: flagsmith-api-test
       scan: false
-      comment: ${{ needs.check-permissions.outputs.can-write == 'true' }}
+      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-e2e:
-    if: github.event.pull_request.draft == false
-    needs: [check-permissions, docker-prepare-report-comment]
+    if: |
+      github.event.pull_request.draft == false &&
+      (always() && needs.docker-prepare-report-comment.result == 'skipped' || needs.permissions-check.outputs.can-write == 'true')
+    needs: [permissions-check, docker-prepare-report-comment]
     name: Build E2E Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:
-      ephemeral: ${{ needs.check-permissions.outputs.can-write == 'false' }}
+      ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
       file: frontend/Dockerfile.e2e
       image-name: flagsmith-e2e
       scan: false
-      comment: ${{ needs.check-permissions.outputs.can-write == 'true' }}
+      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
 
   docker-build-private-cloud:
-    if: github.event.pull_request.draft == false && needs.check-permissions.outputs.can-write == 'true'
-    needs: [check-permissions, docker-prepare-report-comment]
+    if: github.event.pull_request.draft == false && needs.permissions-check.outputs.can-write == 'true'
+    needs: [permissions-check, docker-prepare-report-comment]
     name: Build Private Cloud Image
     uses: ./.github/workflows/.reusable-docker-build.yml
     with:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -140,6 +140,7 @@ jobs:
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
   run-e2e-tests:
+    if: '!cancelled()'
     needs: [permissions-check, docker-build-api, docker-build-e2e]
     uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
     with:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -60,9 +60,7 @@ jobs:
       - uses: ./.github/actions/docker-build-report-to-pr
 
   docker-build-unified:
-    if: |
-      github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped')
+    if: github.event.pull_request.draft == false && !cancelled()
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build Unified Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -70,12 +68,10 @@ jobs:
       target: oss-unified
       image-name: flagsmith
       ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
-      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
+      comment: ${{ needs.docker-prepare-report-comment.result == 'success' }}
 
   docker-build-api:
-    if: |
-      github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped')
+    if: github.event.pull_request.draft == false && !cancelled()
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build API Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -83,12 +79,10 @@ jobs:
       target: oss-api
       image-name: flagsmith-api
       ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
-      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
+      comment: ${{ needs.docker-prepare-report-comment.result == 'success' }}
 
   docker-build-frontend:
-    if: |
-      github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped')
+    if: github.event.pull_request.draft == false && !cancelled()
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build Frontend Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -96,12 +90,10 @@ jobs:
       target: oss-frontend
       image-name: flagsmith-frontend
       ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
-      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
+      comment: ${{ needs.docker-prepare-report-comment.result == 'success' }}
 
   docker-build-api-test:
-    if: |
-      github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped')
+    if: github.event.pull_request.draft == false && !cancelled()
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build API Test Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -109,13 +101,11 @@ jobs:
       target: api-test
       image-name: flagsmith-api-test
       ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
-      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
+      comment: ${{ needs.docker-prepare-report-comment.result == 'success' }}
       scan: false
 
   docker-build-e2e:
-    if: |
-      github.event.pull_request.draft == false &&
-      (always() && needs.docker-prepare-report-comment.result == 'skipped')
+    if: github.event.pull_request.draft == false && !cancelled()
     needs: [permissions-check, docker-prepare-report-comment]
     name: Build E2E Image
     uses: ./.github/workflows/.reusable-docker-build.yml
@@ -123,7 +113,7 @@ jobs:
       file: frontend/Dockerfile.e2e
       image-name: flagsmith-e2e
       ephemeral: ${{ needs.permissions-check.outputs.can-write == 'false' }}
-      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
+      comment: ${{ needs.docker-prepare-report-comment.result == 'success' }}
       scan: false
 
   docker-build-private-cloud:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This PR introduces a number of improvements for the PR workflow:
- Enable Docker builds (and, consequently, E2E tests) when the PR author lacks permissions to create/update PR comments.
- Unified job naming.
- Ignore `.github` directory when calculating Docker build context cache. 
 
## How did you test this code?

Tested in #4443.