### PR TITLE
fix: Create a check for billing started at in API usage task helper

### DIFF
--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -106,6 +106,14 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
         subscription_cache = organisation.subscription_information_cache
         billing_starts_at = subscription_cache.current_billing_term_starts_at
 
+        if billing_starts_at is None:
+            # Since the calling code is a list of many organisations
+            # log the error and return without raising an exception.
+            logger.error(
+                f"Paid organisation {organisation.id} is missing billing_starts_at datetime"
+            )
+            return
+
         # Truncate to the closest active month to get start of current period.
         month_delta = relativedelta(now, billing_starts_at).months
         period_starts_at = relativedelta(months=month_delta) + billing_starts_at


### PR DESCRIPTION
## Changes

Check when `billing_starts_at` is `None` and log it and return from the function.

## How did you test this code?

One new test which checks the error behaviour. Existing tests can cover normal operation.
