### PR TITLE
docs: Add missing deployment overview redirect

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -34,7 +34,7 @@
         },
         {
             "source": "/deployment-overview/",
-            "destination": "/deployment/overview"
+            "destination": "/deployment"
         },
         {
             "source": "/hosted-service/",
@@ -323,6 +323,10 @@
         {
             "source": "/basic-features/integrations",
             "destination": "/integrations"
+        },
+        {
+            "source": "/deployment/overview",
+            "destination": "/deployment"
         }
     ]
 }


### PR DESCRIPTION
Failed to add this in https://github.com/Flagsmith/flagsmith/commit/fd989d3af2bd6a73227abcd92ead6bdc43b0da14#diff-8ff557997d89dde94881c0dbda2f41b19e3be5501fe5fa86aef781faf909bc02

Validated redirect is working in preview environment here: https://docs-git-docs-fix-deployment-overview-redirect-flagsmith.vercel.app/deployment/overview