### PR TITLE
feat: Support blank identifiers, assume transient

### DIFF
--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -199,7 +199,7 @@ class Identity(models.Model):
     def generate_traits(
         self,
         trait_data_items: list[SDKTraitData],
-        persist=False,
+        persist: bool = False,
     ) -> list[Trait]:
         """
         Given a list of trait data items, validated by TraitSerializerFull, generate

--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -4,12 +4,12 @@ from itertools import chain
 from django.db import models
 from django.db.models import Prefetch, Q
 from django.utils import timezone
-from flag_engine.identities.traits.types import TraitValue
 from flag_engine.segments.evaluator import evaluate_identity_in_segment
 
 from environments.identities.managers import IdentityManager
 from environments.identities.traits.models import Trait
 from environments.models import Environment
+from environments.sdk.types import SDKTraitData
 from features.models import FeatureState
 from features.multivariate.models import MultivariateFeatureStateValue
 from segments.models import Segment
@@ -196,7 +196,11 @@ class Identity(models.Model):
     def __str__(self):
         return "Account %s" % self.identifier
 
-    def generate_traits(self, trait_data_items, persist=False):
+    def generate_traits(
+        self,
+        trait_data_items: list[SDKTraitData],
+        persist=False,
+    ) -> list[Trait]:
         """
         Given a list of trait data items, validated by TraitSerializerFull, generate
         a list of TraitModel objects for the given identity.
@@ -232,7 +236,7 @@ class Identity(models.Model):
 
     def update_traits(
         self,
-        trait_data_items: list[dict[str, TraitValue]],
+        trait_data_items: list[SDKTraitData],
     ) -> list[Trait]:
         """
         Given a list of traits, update any that already exist and create any new ones.

--- a/api/environments/identities/serializers.py
+++ b/api/environments/identities/serializers.py
@@ -59,6 +59,7 @@ class SDKIdentitiesResponseSerializer(serializers.Serializer):
             help_text="Can be of type string, boolean, float or integer."
         )
 
+    identifier = serializers.CharField()
     flags = serializers.ListField(child=SDKFeatureStateSerializer())
     traits = serializers.ListSerializer(child=_TraitSerializer())
 

--- a/api/environments/identities/traits/fields.py
+++ b/api/environments/identities/traits/fields.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from rest_framework import serializers
 
@@ -6,6 +7,7 @@ from environments.identities.traits.constants import (
     ACCEPTED_TRAIT_VALUE_TYPES,
     TRAIT_STRING_VALUE_MAX_LENGTH,
 )
+from environments.sdk.types import SDKTraitValueData
 from features.value_types import STRING
 
 logger = logging.getLogger(__name__)
@@ -16,7 +18,7 @@ class TraitValueField(serializers.Field):
     Custom field to extract the type of the field on deserialization.
     """
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> SDKTraitValueData:
         data_type = type(data).__name__
 
         if data_type not in ACCEPTED_TRAIT_VALUE_TYPES:
@@ -28,7 +30,7 @@ class TraitValueField(serializers.Field):
             )
         return {"type": data_type, "value": data}
 
-    def to_representation(self, value):
+    def to_representation(self, value: Any) -> Any:
         return_value = value.get("value") if isinstance(value, dict) else value
 
         if return_value is None:

--- a/api/environments/identities/views.py
+++ b/api/environments/identities/views.py
@@ -309,6 +309,7 @@ class SDKIdentities(SDKAPIView):
         serializer = serializer_class(
             {
                 "flags": all_feature_states,
+                "identifier": identity.identifier,
                 "traits": identity.identity_traits.all(),
             },
             context=self.get_serializer_context(),

--- a/api/environments/sdk/serializers.py
+++ b/api/environments/sdk/serializers.py
@@ -131,7 +131,6 @@ class IdentifyWithTraitsSerializer(
     HideSensitiveFieldsSerializerMixin, serializers.Serializer
 ):
     identifier = serializers.CharField(
-        write_only=True,
         required=False,
         allow_blank=True,
         allow_null=True,
@@ -185,6 +184,7 @@ class IdentifyWithTraitsSerializer(
 
         return {
             "identity": identity,
+            "identifier": identity.identifier,
             "traits": traits,
             "flags": all_feature_states,
         }

--- a/api/environments/sdk/serializers.py
+++ b/api/environments/sdk/serializers.py
@@ -159,8 +159,8 @@ class IdentifyWithTraitsSerializer(
             )
 
         elif transient:
-            # Get presently stored traits and identity overrides
-            # but don't persist incoming data.
+            # Don't persist incoming data but load presently stored
+            # overrides and traits, if any.
             identity, traits = get_identified_transient_identity_and_traits(
                 environment=environment,
                 identifier=identifier,
@@ -168,8 +168,8 @@ class IdentifyWithTraitsSerializer(
             )
 
         else:
-            # Persist the identity in accordance with non-local settings
-            # and individual trait transiency.
+            # Persist the identity in accordance with individual trait transiency
+            # and persistence settings outside of request context.
             identity, traits = get_persisted_identity_and_traits(
                 environment=environment,
                 identifier=identifier,

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -1,0 +1,86 @@
+import uuid
+from itertools import chain
+from typing import TypeAlias
+
+from django.utils import timezone
+
+from environments.identities.models import Identity
+from environments.identities.traits.models import Trait
+from environments.models import Environment
+from environments.sdk.types import SDKTraitData
+
+IdentityAndTraits: TypeAlias = tuple[Identity, list[Trait]]
+
+
+def _get_transient_identity(
+    environment: Environment,
+    identifier: str,
+) -> Identity:
+    return Identity(
+        created_date=timezone.now(),
+        environment=environment,
+        identifier=identifier,
+    )
+
+
+def get_transient_identity_and_traits(
+    environment: Environment,
+    sdk_trait_data: list[SDKTraitData],
+) -> IdentityAndTraits:
+    return (
+        (
+            identity := _get_transient_identity(
+                environment=environment,
+                identifier=str(uuid.uuid4()),
+            )
+        ),
+        identity.generate_traits(sdk_trait_data, persist=False),
+    )
+
+
+def get_identified_transient_identity_and_traits(
+    environment: Environment,
+    identifier: str,
+    sdk_trait_data: list[SDKTraitData],
+) -> IdentityAndTraits:
+    if identity := Identity.objects.filter(
+        environment=environment,
+        identifier=identifier,
+    ).first():
+        for sdk_trait_data_item in sdk_trait_data:
+            sdk_trait_data_item["transient"] = True
+        return identity, identity.update_traits(sdk_trait_data)
+    return (
+        identity := _get_transient_identity(
+            environment=environment,
+            identifier=identifier,
+        )
+    ), identity.generate_traits(sdk_trait_data, persist=False)
+
+
+def get_persisted_identity_and_traits(
+    environment: Environment,
+    identifier: str,
+    sdk_trait_data: list[SDKTraitData],
+) -> IdentityAndTraits:
+    identity, created = Identity.objects.get_or_create(
+        environment=environment,
+        identifier=identifier,
+    )
+    persist_trait_data = environment.project.organisation.persist_trait_data
+    if created:
+        return identity, identity.generate_traits(
+            sdk_trait_data,
+            persist=persist_trait_data,
+        )
+    if persist_trait_data:
+        return identity, identity.update_traits(sdk_trait_data)
+    return identity, list(
+        {
+            trait.trait_key: trait
+            for trait in chain(
+                identity.identity_traits.all(),
+                identity.generate_traits(sdk_trait_data, persist=False),
+            )
+        }.values()
+    )

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -1,4 +1,5 @@
 import hashlib
+import uuid
 from itertools import chain
 from operator import itemgetter
 from typing import TypeAlias
@@ -91,13 +92,15 @@ def get_persisted_identity_and_traits(
 
 
 def get_transient_identifier(sdk_trait_data: list[SDKTraitData]) -> str:
-    return hashlib.sha256(
-        "".join(
-            f'{trait["trait_key"]}{trait["trait_value"]["value"]}'
-            for trait in sorted(sdk_trait_data, key=itemgetter("trait_key"))
-        ).encode(),
-        usedforsecurity=False,
-    ).hexdigest()
+    if sdk_trait_data:
+        return hashlib.sha256(
+            "".join(
+                f'{trait["trait_key"]}{trait["trait_value"]["value"]}'
+                for trait in sorted(sdk_trait_data, key=itemgetter("trait_key"))
+            ).encode(),
+            usedforsecurity=False,
+        ).hexdigest()
+    return uuid.uuid4().hex
 
 
 def _get_transient_identity(

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -12,17 +12,6 @@ from environments.sdk.types import SDKTraitData
 IdentityAndTraits: TypeAlias = tuple[Identity, list[Trait]]
 
 
-def _get_transient_identity(
-    environment: Environment,
-    identifier: str,
-) -> Identity:
-    return Identity(
-        created_date=timezone.now(),
-        environment=environment,
-        identifier=identifier,
-    )
-
-
 def get_transient_identity_and_traits(
     environment: Environment,
     sdk_trait_data: list[SDKTraitData],
@@ -97,4 +86,15 @@ def get_persisted_identity_and_traits(
                 identity.generate_traits(sdk_trait_data, persist=False),
             )
         }.values()
+    )
+
+
+def _get_transient_identity(
+    environment: Environment,
+    identifier: str,
+) -> Identity:
+    return Identity(
+        created_date=timezone.now(),
+        environment=environment,
+        identifier=identifier,
     )

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -63,8 +63,8 @@ def get_persisted_identity_and_traits(
 ) -> IdentityAndTraits:
     """
     Retrieve a previously persisted `Identity` instance or persist a new one.
-    Traits are persisted based on the `"transient"` attribute
-    provided with each individual trait.
+    Traits are persisted based on the organisation-level setting or a
+    `"transient"` attribute provided with each individual trait.
     """
     identity, created = Identity.objects.get_or_create(
         environment=environment,

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -27,6 +27,9 @@ def get_transient_identity_and_traits(
     environment: Environment,
     sdk_trait_data: list[SDKTraitData],
 ) -> IdentityAndTraits:
+    """
+    Get a transient `Identity` instance with a randomly generated identifier.
+    """
     return (
         (
             identity := _get_transient_identity(
@@ -43,12 +46,18 @@ def get_identified_transient_identity_and_traits(
     identifier: str,
     sdk_trait_data: list[SDKTraitData],
 ) -> IdentityAndTraits:
+    """
+    Get a transient `Identity` instance.
+    If present in storage, it's a previously persisted identity with its traits,
+    combined with incoming traits provided to `sdk_trait_data` argument.
+    All traits constructed from `sdk_trait_data` are marked as transient.
+    """
+    for sdk_trait_data_item in sdk_trait_data:
+        sdk_trait_data_item["transient"] = True
     if identity := Identity.objects.filter(
         environment=environment,
         identifier=identifier,
     ).first():
-        for sdk_trait_data_item in sdk_trait_data:
-            sdk_trait_data_item["transient"] = True
         return identity, identity.update_traits(sdk_trait_data)
     return (
         identity := _get_transient_identity(
@@ -63,6 +72,11 @@ def get_persisted_identity_and_traits(
     identifier: str,
     sdk_trait_data: list[SDKTraitData],
 ) -> IdentityAndTraits:
+    """
+    Retrieve a previously persisted `Identity` instance or persist a new one.
+    Traits are persisted based on the `"transient"` attribute
+    provided with each individual trait.
+    """
     identity, created = Identity.objects.get_or_create(
         environment=environment,
         identifier=identifier,

--- a/api/environments/sdk/types.py
+++ b/api/environments/sdk/types.py
@@ -3,7 +3,12 @@ import typing
 from typing_extensions import NotRequired
 
 
+class SDKTraitValueData(typing.TypedDict):
+    type: str
+    value: str
+
+
 class SDKTraitData(typing.TypedDict):
     trait_key: str
-    trait_value: typing.Any
+    trait_value: SDKTraitValueData
     transient: NotRequired[bool]

--- a/api/environments/sdk/types.py
+++ b/api/environments/sdk/types.py
@@ -1,0 +1,9 @@
+import typing
+
+from typing_extensions import NotRequired
+
+
+class SDKTraitData(typing.TypedDict):
+    trait_key: str
+    trait_value: typing.Any
+    transient: NotRequired[bool]

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -250,6 +250,7 @@ def existing_identity_identifier_data(
             id="existing-identifier",
         ),
         pytest.param({"identifier": "unseen"}, id="new-identifier"),
+        pytest.param({"identifier": ""}, id="blank-identifier"),
         pytest.param({"identifier": None}, id="null-identifier"),
         pytest.param({}, id="missing-identifier"),
     ],

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -328,6 +328,29 @@ def test_get_feature_states_for_identity__segment_match_expected(
     assert flag_data["feature_state_value"] == "segment override"
 
 
+def test_get_feature_states_for_identity__empty_traits__random_identifier_expected(
+    sdk_client: APIClient,
+    environment: int,
+) -> None:
+    # Given
+    url = reverse("api-v1:sdk-identities")
+
+    # When
+    response_1 = sdk_client.post(
+        url,
+        data=json.dumps({"traits": []}),
+        content_type="application/json",
+    )
+    response_2 = sdk_client.post(
+        url,
+        data=json.dumps({"traits": []}),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response_1.json()["identifier"] != response_2.json()["identifier"]
+
+
 def test_get_feature_states_for_identity__transient_trait__segment_match_expected(
     sdk_client: APIClient,
     feature: int,

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -1225,10 +1225,16 @@ def test_post_identities__existing__transient__no_persistence(
     assert response.status_code == status.HTTP_200_OK
     response_json = response.json()
 
+    # identity overrides are correctly loaded
     assert response_json["flags"][0]["feature_state_value"] == feature_state_value
+
+    # previously persisted traits not provided in the request
+    # are not marked as transient in the response
     assert response_json["traits"][0]["trait_key"] == trait.trait_key
     assert not response_json["traits"][0].get("transient")
 
+    # every trait provided in the request for a transient identity
+    # is marked as transient
     assert response_json["traits"][1]["trait_key"] == trait_key
     assert response_json["traits"][1]["transient"]
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes #4448.

This PR adds the following for `POST` `/api/v1/identities`:
- Allow users to provide null/blank identifiers. The identity is assigned a UUID identifier to evaluate against and is not persisted in this case.
- If an identity is provided with `"transient": true`, all provided traits are automatically considered transient.
- If an identifier is provided, the existing persisted traits and overrides are loaded for evaluation. In case of collisions, transient traits take precedence during evaluation but are not persisted.
- Identifiers are returned to keep consistency with Edge API.

## How did you test this code?

Updated integration and unit tests with new cases.