### PR TITLE
refactor: Use datetimes for InfluxDB queries

### DIFF
--- a/api/app_analytics/analytics_db_service.py
+++ b/api/app_analytics/analytics_db_service.py
@@ -35,8 +35,7 @@ def get_usage_data(
 ) -> list[UsageData]:
     now = timezone.now()
 
-    date_stop = date_start = None
-    period_starts_at = period_ends_at = None
+    date_start = date_stop = None
 
     match period:
         case constants.CURRENT_BILLING_PERIOD:
@@ -47,10 +46,8 @@ def get_usage_data(
                 days=30
             )
             month_delta = relativedelta(now, starts_at).months
-            period_starts_at = relativedelta(months=month_delta) + starts_at
-            period_ends_at = now
-            date_start = f"-{(now - period_starts_at).days}d"
-            date_stop = "now()"
+            date_start = relativedelta(months=month_delta) + starts_at
+            date_stop = now
 
         case constants.PREVIOUS_BILLING_PERIOD:
             if not getattr(organisation, "subscription_information_cache", None):
@@ -61,16 +58,12 @@ def get_usage_data(
             )
             month_delta = relativedelta(now, starts_at).months - 1
             month_delta += relativedelta(now, starts_at).years * 12
-            period_starts_at = relativedelta(months=month_delta) + starts_at
-            period_ends_at = relativedelta(months=month_delta + 1) + starts_at
-            date_start = f"-{(now - period_starts_at).days}d"
-            date_stop = f"-{(now - period_ends_at).days}d"
+            date_start = relativedelta(months=month_delta) + starts_at
+            date_stop = relativedelta(months=month_delta + 1) + starts_at
 
         case constants.NINETY_DAY_PERIOD:
-            period_starts_at = now - relativedelta(days=90)
-            period_ends_at = now
-            date_start = "-90d"
-            date_stop = "now()"
+            date_start = now - relativedelta(days=90)
+            date_stop = now
 
     if settings.USE_POSTGRES_FOR_ANALYTICS:
         kwargs = {
@@ -79,10 +72,10 @@ def get_usage_data(
             "project_id": project_id,
         }
 
-        if period_starts_at:
-            assert period_ends_at
-            kwargs["date_start"] = period_starts_at
-            kwargs["date_stop"] = period_ends_at
+        if date_start:
+            assert date_stop
+            kwargs["date_start"] = date_start
+            kwargs["date_stop"] = date_stop
 
         return get_usage_data_from_local_db(**kwargs)
 

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -1,8 +1,10 @@
 import logging
 import typing
 from collections import defaultdict
+from datetime import datetime, timedelta
 
 from django.conf import settings
+from django.utils import timezone
 from influxdb_client import InfluxDBClient, Point
 from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.client.write_api import SYNCHRONOUS
@@ -20,11 +22,6 @@ token = settings.INFLUXDB_TOKEN
 influx_org = settings.INFLUXDB_ORG
 read_bucket = settings.INFLUXDB_BUCKET + "_downsampled_15m"
 
-range_bucket_mappings = {
-    "-24h": settings.INFLUXDB_BUCKET + "_downsampled_15m",
-    "-7d": settings.INFLUXDB_BUCKET + "_downsampled_15m",
-    "-30d": settings.INFLUXDB_BUCKET + "_downsampled_1h",
-}
 retries = Retry(connect=3, read=3, redirect=3)
 # Set a timeout to prevent threads being potentially stuck open due to network weirdness
 influxdb_client = InfluxDBClient(
@@ -41,6 +38,13 @@ DEFAULT_DROP_COLUMNS = (
     "environment_id",
     "host",
 )
+
+
+def get_range_bucket_mappings(date_start: datetime) -> str:
+    now = timezone.now()
+    if (now - date_start).days > 10:
+        return settings.INFLUXDB_BUCKET + "_downsampled_1h"
+    return settings.INFLUXDB_BUCKET + "_downsampled_15m"
 
 
 class InfluxDBWrapper:
@@ -76,15 +80,22 @@ class InfluxDBWrapper:
 
     @staticmethod
     def influx_query_manager(
-        date_start: str = "-30d",
-        date_stop: str = "now()",
+        date_start: datetime | None = None,
+        date_stop: datetime | None = None,
         drop_columns: typing.Tuple[str, ...] = DEFAULT_DROP_COLUMNS,
         filters: str = "|> filter(fn:(r) => r._measurement == 'api_call')",
         extra: str = "",
         bucket: str = read_bucket,
     ):
+        now = timezone.now()
+        if date_start is None:
+            date_start = now - timedelta(days=30)
+
+        if date_stop is None:
+            date_stop = now
+
         # Influx throws an error for an empty range, so just return a list.
-        if date_start == "-0d" and date_stop == "now()":
+        if date_start == date_stop:
             return []
 
         query_api = influxdb_client.query_api()
@@ -92,7 +103,7 @@ class InfluxDBWrapper:
 
         query = (
             f'from(bucket:"{bucket}")'
-            f" |> range(start: {date_start}, stop: {date_stop})"
+            f" |> range(start: {date_start.isoformat()}, stop: {date_stop.isoformat()})"
             f" {filters}"
             f" |> drop(columns: {drop_columns_input})"
             f"{extra}"
@@ -108,7 +119,9 @@ class InfluxDBWrapper:
 
 
 def get_events_for_organisation(
-    organisation_id: id, date_start: str = "-30d", date_stop: str = "now()"
+    organisation_id: id,
+    date_start: datetime | None = None,
+    date_stop: datetime | None = None,
 ) -> int:
     """
     Query influx db for usage for given organisation id
@@ -116,6 +129,13 @@ def get_events_for_organisation(
     :param organisation_id: an id of the organisation to get usage for
     :return: a number of request counts for organisation
     """
+    now = timezone.now()
+    if date_start is None:
+        date_start = now - timedelta(days=30)
+
+    if date_stop is None:
+        date_stop = now
+
     result = InfluxDBWrapper.influx_query_manager(
         filters=build_filter_string(
             [
@@ -145,7 +165,9 @@ def get_events_for_organisation(
 
 
 def get_event_list_for_organisation(
-    organisation_id: int, date_start: str = "-30d", date_stop: str = "now()"
+    organisation_id: int,
+    date_start: datetime | None = None,
+    date_stop: datetime | None = None,
 ) -> tuple[dict[str, list[int]], list[str]]:
     """
     Query influx db for usage for given organisation id
@@ -154,6 +176,13 @@ def get_event_list_for_organisation(
 
     :return: a number of request counts for organisation in chart.js scheme
     """
+    now = timezone.now()
+    if date_start is None:
+        date_start = now - timedelta(days=30)
+
+    if date_stop is None:
+        date_stop = now
+
     results = InfluxDBWrapper.influx_query_manager(
         filters=f'|> filter(fn:(r) => r._measurement == "api_call") \
                   |> filter(fn: (r) => r["organisation_id"] == "{organisation_id}")',
@@ -163,15 +192,12 @@ def get_event_list_for_organisation(
     )
     dataset = defaultdict(list)
     labels = []
+
+    date_difference = date_stop - date_start
+    required_records = date_difference.days + 1
     for result in results:
         for record in result.records:
             dataset[record["resource"]].append(record["_value"])
-            if date_stop == "now()":
-                required_records = abs(int(date_start[:-1])) + 1
-            else:
-                required_records = (
-                    abs(int(date_start[:-1])) - abs(int(date_stop[:-1])) + 1
-                )
             if len(labels) != required_records:
                 labels.append(record.values["_time"].strftime("%Y-%m-%d"))
     return dataset, labels
@@ -181,8 +207,8 @@ def get_multiple_event_list_for_organisation(
     organisation_id: int,
     project_id: int = None,
     environment_id: int = None,
-    date_start: str = "-30d",
-    date_stop: str = "now()",
+    date_start: datetime | None = None,
+    date_stop: datetime | None = None,
 ) -> list[UsageData]:
     """
     Query influx db for usage for given organisation id
@@ -193,6 +219,13 @@ def get_multiple_event_list_for_organisation(
 
     :return: a number of requests for flags, traits, identities, environment-document
     """
+    now = timezone.now()
+    if date_start is None:
+        date_start = now - timedelta(days=30)
+
+    if date_stop is None:
+        date_stop = now
+
     filters = [
         'r._measurement == "api_call"',
         f'r["organisation_id"] == "{organisation_id}"',
@@ -227,9 +260,16 @@ def get_usage_data(
     organisation_id: int,
     project_id: int | None = None,
     environment_id: int | None = None,
-    date_start: str = "-30d",
-    date_stop: str = "now()",
+    date_start: datetime | None = None,
+    date_stop: datetime | None = None,
 ) -> list[UsageData]:
+    now = timezone.now()
+    if date_start is None:
+        date_start = now - timedelta(days=30)
+
+    if date_stop is None:
+        date_stop = now
+
     events_list = get_multiple_event_list_for_organisation(
         organisation_id=organisation_id,
         project_id=project_id,
@@ -243,7 +283,7 @@ def get_usage_data(
 def get_multiple_event_list_for_feature(
     environment_id: int,
     feature_name: str,
-    date_start: str = "-30d",
+    date_start: datetime | None = None,
     aggregate_every: str = "24h",
 ) -> list[dict]:
     """
@@ -264,11 +304,14 @@ def get_multiple_event_list_for_feature(
 
     :param environment_id: an id of the environment to get usage for
     :param feature_name: the name of the feature to get usage for
-    :param date_start: the influx time period to filter on, e.g. -30d, -7d, etc.
+    :param date_start: the influx datetime period to filter on
     :param aggregate_every: the influx time period to aggregate the data by, e.g. 24h
 
     :return: a list of dicts with feature and request count in a specific environment
     """
+    now = timezone.now()
+    if date_start is None:
+        date_start = now - timedelta(days=30)
 
     results = InfluxDBWrapper.influx_query_manager(
         date_start=date_start,
@@ -297,15 +340,20 @@ def get_multiple_event_list_for_feature(
 def get_feature_evaluation_data(
     feature_name: str, environment_id: int, period: str = "30d"
 ) -> typing.List[FeatureEvaluationData]:
+    assert period.endswith("d")
+    days = int(period[:-1])
+    date_start = timezone.now() - timedelta(days=days)
     data = get_multiple_event_list_for_feature(
         feature_name=feature_name,
         environment_id=environment_id,
-        date_start=f"-{period}",
+        date_start=date_start,
     )
     return FeatureEvaluationDataSchema(many=True).load(data)
 
 
-def get_top_organisations(date_start: str, limit: str = ""):
+def get_top_organisations(
+    date_start: datetime | None = None, limit: str = ""
+) -> dict[int, int]:
     """
     Query influx db top used organisations
 
@@ -315,10 +363,14 @@ def get_top_organisations(date_start: str, limit: str = ""):
 
     :return: top organisations in descending order based on api calls.
     """
+    now = timezone.now()
+    if date_start is None:
+        date_start = now - timedelta(days=30)
+
     if limit:
         limit = f"|> limit(n:{limit})"
 
-    bucket = range_bucket_mappings[date_start]
+    bucket = get_range_bucket_mappings(date_start)
     results = InfluxDBWrapper.influx_query_manager(
         date_start=date_start,
         bucket=bucket,
@@ -333,6 +385,7 @@ def get_top_organisations(date_start: str, limit: str = ""):
     )
 
     dataset = {}
+
     for result in results:
         for record in result.records:
             try:
@@ -347,7 +400,9 @@ def get_top_organisations(date_start: str, limit: str = ""):
     return dataset
 
 
-def get_current_api_usage(organisation_id: int, date_start: str) -> int:
+def get_current_api_usage(
+    organisation_id: int, date_start: datetime | None = None
+) -> int:
     """
     Query influx db for api usage
 
@@ -356,6 +411,9 @@ def get_current_api_usage(organisation_id: int, date_start: str) -> int:
 
     :return: number of current api calls
     """
+    now = timezone.now()
+    if date_start is None:
+        date_start = now - timedelta(days=30)
 
     bucket = read_bucket
     results = InfluxDBWrapper.influx_query_manager(

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -361,7 +361,8 @@ class FeatureViewSet(viewsets.ModelViewSet):
         elif period.endswith("d"):
             date_start = now - timedelta(days=int(period[:-1]))
         else:
-            assert False, "Expecting hours or days as period input"
+            raise ValidationError("Malformed period supplied")
+
         events_list = get_multiple_event_list_for_feature(
             feature_name=feature.name,
             date_start=date_start,

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+from datetime import timedelta
 from functools import reduce
 
 from app_analytics.analytics_db_service import get_feature_evaluation_data
@@ -9,6 +10,7 @@ from core.request_origin import RequestOrigin
 from django.conf import settings
 from django.core.cache import caches
 from django.db.models import Max, Q, QuerySet
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from drf_yasg import openapi
@@ -352,8 +354,14 @@ class FeatureViewSet(viewsets.ModelViewSet):
 
         query_serializer = GetInfluxDataQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
-
-        date_start = f"-{query_serializer.data['period']}"
+        period = query_serializer.data["period"]
+        now = timezone.now()
+        if period.endswith("h"):
+            date_start = now - timedelta(hours=int(period[:-1]))
+        elif period.endswith("d"):
+            date_start = now - timedelta(days=int(period[:-1]))
+        else:
+            assert False, "Expecting hours or days as period input"
         events_list = get_multiple_event_list_for_feature(
             feature_name=feature.name,
             date_start=date_start,

--- a/api/organisations/subscription_info_cache.py
+++ b/api/organisations/subscription_info_cache.py
@@ -81,7 +81,7 @@ def _update_caches_with_influx_data(
         elif _date_start.endswith("h"):
             date_start = now - timedelta(hours=int(_date_start[1:-1]))
         else:
-            assert False, "Expecting either days (d) or hours (h)"
+            assert False, "Expecting either days (d) or hours (h)"  # pragma: no cover
 
         org_calls = get_top_organisations(date_start, limit)
 

--- a/api/organisations/subscription_info_cache.py
+++ b/api/organisations/subscription_info_cache.py
@@ -1,7 +1,9 @@
 import typing
+from datetime import timedelta
 
 from app_analytics.influxdb_wrapper import get_top_organisations
 from django.conf import settings
+from django.utils import timezone
 
 from .chargebee import get_subscription_metadata_from_id
 from .models import Organisation, OrganisationSubscriptionInformationCache
@@ -70,9 +72,19 @@ def _update_caches_with_influx_data(
     if not settings.INFLUXDB_TOKEN:
         return
 
-    for date_start, limit in (("-30d", ""), ("-7d", ""), ("-24h", "100")):
-        key = f"api_calls_{date_start[1:]}"
+    for _date_start, limit in (("-30d", ""), ("-7d", ""), ("-24h", "100")):
+        key = f"api_calls_{_date_start[1:]}"
+
+        now = timezone.now()
+        if _date_start.endswith("d"):
+            date_start = now - timedelta(days=int(_date_start[1:-1]))
+        elif _date_start.endswith("h"):
+            date_start = now - timedelta(hours=int(_date_start[1:-1]))
+        else:
+            assert False, "Expecting either days (d) or hours (h)"
+
         org_calls = get_top_organisations(date_start, limit)
+
         for org_id, calls in org_calls.items():
             subscription_info_cache = organisation_info_cache_dict.get(org_id)
             if not subscription_info_cache:

--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -118,10 +118,9 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
         month_delta = relativedelta(now, billing_starts_at).months
         period_starts_at = relativedelta(months=month_delta) + billing_starts_at
 
-        days = relativedelta(now, period_starts_at).days
         allowed_api_calls = subscription_cache.allowed_30d_api_calls
 
-    api_usage = get_current_api_usage(organisation.id, f"-{days}d")
+    api_usage = get_current_api_usage(organisation.id, period_starts_at)
 
     # For some reason the allowed API calls is set to 0 so default to the max free plan.
     allowed_api_calls = allowed_api_calls or MAX_API_CALLS_IN_FREE_PLAN

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -191,7 +191,7 @@ def charge_for_api_call_count_overages():
             continue
 
         subscription_cache = organisation.subscription_information_cache
-        api_usage = get_current_api_usage(organisation.id, "30d")
+        api_usage = get_current_api_usage(organisation.id)
 
         # Grace period for organisations < 200% of usage.
         if api_usage / subscription_cache.allowed_30d_api_calls < 2.0:
@@ -294,7 +294,7 @@ def restrict_use_due_to_api_limit_grace_period_over() -> None:
             continue
 
         subscription_cache = organisation.subscription_information_cache
-        api_usage = get_current_api_usage(organisation.id, "30d")
+        api_usage = get_current_api_usage(organisation.id)
         if api_usage / subscription_cache.allowed_30d_api_calls < 1.0:
             logger.info(
                 f"API use for organisation {organisation.id} has fallen to below limit, so not restricting use."

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
@@ -387,6 +387,7 @@ def test_get_event_list_for_organisation_with_date_stop_set_to_now_and_previousl
     assert labels == ["2023-01-18", "2023-01-17"]
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @pytest.mark.parametrize("limit", ["10", ""])
 def test_get_top_organisations(
     limit: str,
@@ -409,9 +410,11 @@ def test_get_top_organisations(
     )
 
     influx_mock.return_value = [result]
+    now = timezone.now()
+    date_start = now - timedelta(days=30)
 
     # When
-    dataset = get_top_organisations(date_start="-30d", limit=limit)
+    dataset = get_top_organisations(date_start=date_start, limit=limit)
 
     # Then
     assert dataset == {123: 23, 456: 43}
@@ -419,9 +422,10 @@ def test_get_top_organisations(
     influx_mock.assert_called_once()
     influx_query_call = influx_mock.call_args
     assert influx_query_call.kwargs["bucket"] == "test_bucket_downsampled_1h"
-    assert influx_query_call.kwargs["date_start"] == "-30d"
+    assert influx_query_call.kwargs["date_start"] == date_start
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 def test_get_top_organisations_value_error(
     mocker: MockerFixture,
 ) -> None:
@@ -442,9 +446,11 @@ def test_get_top_organisations_value_error(
     )
 
     influx_mock.return_value = [result]
+    now = timezone.now()
+    date_start = now - timedelta(days=30)
 
     # When
-    dataset = get_top_organisations(date_start="-30d")
+    dataset = get_top_organisations(date_start=date_start)
 
     # Then
     # The wrongly typed data does not stop the remaining data

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -168,8 +168,8 @@ def test_get_usage_data__current_billing_period(
         organisation_id=organisation.id,
         environment_id=None,
         project_id=None,
-        date_start="-28d",
-        date_stop="now()",
+        date_start=four_weeks_ago,
+        date_stop=now,
     )
 
 
@@ -195,6 +195,7 @@ def test_get_usage_data__previous_billing_period(
     now = timezone.now()
     week_from_now = now + timedelta(days=7)
     four_weeks_ago = now - timedelta(days=28)
+    target_start_at = now - timedelta(days=59)
 
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
@@ -229,8 +230,8 @@ def test_get_usage_data__previous_billing_period(
         organisation_id=organisation.id,
         environment_id=None,
         project_id=None,
-        date_start="-59d",
-        date_stop="-28d",
+        date_start=target_start_at,
+        date_stop=four_weeks_ago,
     )
 
 
@@ -256,7 +257,7 @@ def test_get_usage_data__ninety_day_period(
     now = timezone.now()
     week_from_now = now + timedelta(days=7)
     four_weeks_ago = now - timedelta(days=28)
-
+    ninety_days_ago = now - timedelta(days=90)
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
         current_billing_term_starts_at=four_weeks_ago,
@@ -290,8 +291,8 @@ def test_get_usage_data__ninety_day_period(
         organisation_id=organisation.id,
         environment_id=None,
         project_id=None,
-        date_start="-90d",
-        date_stop="now()",
+        date_start=ninety_days_ago,
+        date_stop=now,
     )
 
 

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -425,6 +425,7 @@ def test_put_feature_does_not_update_feature_states(
     assert all(fs.enabled is False for fs in feature.feature_states.all())
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @mock.patch("features.views.get_multiple_event_list_for_feature")
 def test_get_project_features_influx_data(
     mock_get_event_list: mock.MagicMock,
@@ -446,6 +447,7 @@ def test_get_project_features_influx_data(
             "datetime": datetime(2021, 2, 26, 12, 0, 0, tzinfo=pytz.UTC),
         }
     ]
+    one_day_ago = timezone.now() - timedelta(days=1)
 
     # When
     response = admin_client_new.get(url)
@@ -455,7 +457,7 @@ def test_get_project_features_influx_data(
     mock_get_event_list.assert_called_once_with(
         feature_name=feature.name,
         environment_id=str(environment.id),  # provided as a GET param
-        date_start="-24h",  # this is the default but can be provided as a GET param
+        date_start=one_day_ago,  # this is the default but can be provided as a GET param
         aggregate_every="24h",  # this is the default but can be provided as a GET param
     )
 

--- a/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
+++ b/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
@@ -46,7 +46,6 @@ def test_update_caches(mocker, organisation, chargebee_subscription, settings):
     update_caches(subscription_cache_entities)
 
     # Then
-    breakpoint()
     assert (
         organisation.subscription_information_cache.api_calls_24h
         == organisation_usage[day_1]

--- a/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
+++ b/api/tests/unit/organisations/test_unit_organisations_subscription_info_cache.py
@@ -1,3 +1,7 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
 from task_processor.task_run_method import TaskRunMethod
 
 from organisations.chargebee.metadata import ChargebeeObjMetadata
@@ -5,18 +9,27 @@ from organisations.subscription_info_cache import update_caches
 from organisations.subscriptions.constants import SubscriptionCacheEntity
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 def test_update_caches(mocker, organisation, chargebee_subscription, settings):
     # Given
     settings.CHARGEBEE_API_KEY = "api-key"
     settings.INFLUXDB_TOKEN = "token"
     settings.TASK_RUN_METHOD = TaskRunMethod.SYNCHRONOUSLY
 
-    organisation_usage = {"24h": 25123, "7d": 182957, "30d": 804564}
+    now = timezone.now()
+    day_1 = now - timedelta(days=1)
+    day_7 = now - timedelta(days=7)
+    day_30 = now - timedelta(days=30)
+    organisation_usage = {
+        day_1: 25123,
+        day_7: 182957,
+        day_30: 804564,
+    }
     mocked_get_top_organisations = mocker.patch(
         "organisations.subscription_info_cache.get_top_organisations"
     )
     mocked_get_top_organisations.side_effect = lambda t, _: {
-        organisation.id: organisation_usage.get(f"{t[1:]}")
+        organisation.id: organisation_usage[t]
     }
 
     chargebee_metadata = ChargebeeObjMetadata(seats=15, api_calls=1000000)
@@ -33,17 +46,18 @@ def test_update_caches(mocker, organisation, chargebee_subscription, settings):
     update_caches(subscription_cache_entities)
 
     # Then
+    breakpoint()
     assert (
         organisation.subscription_information_cache.api_calls_24h
-        == organisation_usage["24h"]
+        == organisation_usage[day_1]
     )
     assert (
         organisation.subscription_information_cache.api_calls_7d
-        == organisation_usage["7d"]
+        == organisation_usage[day_7]
     )
     assert (
         organisation.subscription_information_cache.api_calls_30d
-        == organisation_usage["30d"]
+        == organisation_usage[day_30]
     )
     assert (
         organisation.subscription_information_cache.allowed_seats
@@ -60,7 +74,7 @@ def test_update_caches(mocker, organisation, chargebee_subscription, settings):
 
     assert mocked_get_top_organisations.call_count == 3
     assert [call[0] for call in mocked_get_top_organisations.call_args_list] == [
-        ("-30d", ""),
-        ("-7d", ""),
-        ("-24h", "100"),
+        (day_30, ""),
+        (day_7, ""),
+        (day_1, "100"),
     ]

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -365,7 +365,7 @@ def test_handle_api_usage_notifications_below_100(
     handle_api_usage_notifications()
 
     # Then
-    mock_api_usage.assert_called_once_with(organisation.id, "-14d")
+    mock_api_usage.assert_called_once_with(organisation.id, now - timedelta(days=14))
 
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
@@ -451,7 +451,7 @@ def test_handle_api_usage_notifications_below_api_usage_alert_thresholds(
     handle_api_usage_notifications()
 
     # Then
-    mock_api_usage.assert_called_once_with(organisation.id, "-14d")
+    mock_api_usage.assert_called_once_with(organisation.id, now - timedelta(days=14))
 
     assert len(mailoutbox) == 0
 
@@ -501,7 +501,7 @@ def test_handle_api_usage_notifications_above_100(
     handle_api_usage_notifications()
 
     # Then
-    mock_api_usage.assert_called_once_with(organisation.id, "-14d")
+    mock_api_usage.assert_called_once_with(organisation.id, now - timedelta(days=14))
 
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
@@ -611,6 +611,7 @@ def test_handle_api_usage_notifications_for_free_accounts(
     mailoutbox: list[EmailMultiAlternatives],
 ) -> None:
     # Given
+    now = timezone.now()
     assert organisation.is_paid is False
     assert organisation.subscription.is_free_plan is True
     assert organisation.subscription.max_api_calls == MAX_API_CALLS_IN_FREE_PLAN
@@ -633,7 +634,7 @@ def test_handle_api_usage_notifications_for_free_accounts(
     handle_api_usage_notifications()
 
     # Then
-    mock_api_usage.assert_called_once_with(organisation.id, "-30d")
+    mock_api_usage.assert_called_once_with(organisation.id, now - timedelta(days=30))
 
     assert len(mailoutbox) == 1
     email = mailoutbox[0]

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -351,6 +351,7 @@ def test_user_can_get_projects_for_an_organisation(
     assert response.data[0]["name"] == project.name
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 @mock.patch("app_analytics.influxdb_wrapper.influxdb_client")
 def test_should_get_usage_for_organisation(
     mock_influxdb_client: MagicMock,
@@ -365,7 +366,7 @@ def test_should_get_usage_for_organisation(
     expected_query = (
         (
             f'from(bucket:"{read_bucket}") '
-            "|> range(start: -30d, stop: now()) "
+            "|> range(start: 2022-12-20T09:09:47.325132+00:00, stop: 2023-01-19T09:09:47.325132+00:00) "
             '|> filter(fn:(r) => r._measurement == "api_call")         '
             '|> filter(fn: (r) => r["_field"] == "request_count")         '
             f'|> filter(fn: (r) => r["organisation_id"] == "{organisation.id}") '

--- a/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
+++ b/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
@@ -1,6 +1,9 @@
+from datetime import timedelta
+
 import pytest
 from django.test import Client, RequestFactory
 from django.urls import reverse
+from django.utils import timezone
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 from rest_framework.test import APIClient
@@ -39,6 +42,7 @@ def test_organisation_subscription_get_api_call_overage(
     assert result.overage == expected_overage
 
 
+@pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")
 def test_get_organisation_info__get_event_list_for_organisation(
     organisation: Organisation,
     superuser_client: APIClient,
@@ -65,7 +69,8 @@ def test_get_organisation_info__get_event_list_for_organisation(
     # Then
     assert "label1" in str(response.content)
     assert "label2" in str(response.content)
-    event_list_mock.assert_called_once_with(organisation.id, "-180d", "now()")
+    date_start = timezone.now() - timedelta(days=180)
+    event_list_mock.assert_called_once_with(organisation.id, date_start)
 
 
 def test_list_organisations_search_by_name(


### PR DESCRIPTION
## Changes

This PR changes the former calling procedure from specifying strings for ranges to use datetimes for more exact matches. There is one function that was used by a view with serializer data sent directly to it which was avoided for the change but all other functions have been updated to the new approach. I tried to cover every caller but it is possible that something slipped through the cracks.

## How did you test this code?

I ran many, many tests as I was going through and I updated scores of them to get the coverage we need to be confident that the code will pass in production.