### PR TITLE
refactor: reduce DB updates by traits update requests without real changes in the data

### DIFF
--- a/api/environments/identities/traits/views.py
+++ b/api/environments/identities/traits/views.py
@@ -1,14 +1,14 @@
-from typing import Set, Any
+from typing import Any, Set
 
 from django.conf import settings
 from django.core.exceptions import BadRequest
 from django.db.models import Q
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework.request import Request
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from edge_api.identities.edge_request_forwarder import (

--- a/api/environments/identities/traits/views.py
+++ b/api/environments/identities/traits/views.py
@@ -260,6 +260,8 @@ class SDKTraits(mixins.CreateModelMixin, viewsets.GenericViewSet):
             trait_key = trait.get("trait_key")
             identifier = trait["identity"]["identifier"]
 
+            # endpoint allows users to delete existing traits by sending null values
+            # for the trait value so we need to filter those out here
             if trait.get("trait_value") is None:
                 delete_filter_query = delete_filter_query | Q(
                     trait_key=trait_key,
@@ -297,9 +299,6 @@ class SDKTraits(mixins.CreateModelMixin, viewsets.GenericViewSet):
             if not request.environment.trait_persistence_allowed(request):
                 raise BadRequest("Unable to set traits with client key.")
 
-            # endpoint allows users to delete existing traits by sending null values
-            # for the trait value so we need to filter those out here
-
             self._update_traits(request)
 
             identities = {trait["identity"]["identifier"] for trait in request.data}
@@ -310,12 +309,7 @@ class SDKTraits(mixins.CreateModelMixin, viewsets.GenericViewSet):
             )
 
             return Response(
-                [
-                    *SDKCreateUpdateTraitSerializer(
-                        instance=all_traits, many=True
-                    ).data,
-                ],
-                status=status.HTTP_200_OK,
+                SDKCreateUpdateTraitSerializer(instance=all_traits, many=True).data,
             )
 
         except (TypeError, AttributeError) as excinfo:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

It is common case for mobile app to set traits on the app start, because some properties can be changed offline or by request from another device with the same account etc. However in this case db is update even if no changes in the data. This change should reduce updates by getting list of traits from db than compares the existing and incoming data, and only add/update when the data actually changes. This strategy drastically reduces unnecessary UPDATE operations in case when the clients send requests with the same data.


## How did you test this code?

manually

_Please describe._
