### PR TITLE
fix: don't allow bypassing `ALLOW_REGISTRATION_WITHOUT_INVITE` behaviour

### DIFF
--- a/api/custom_auth/oauth/serializers.py
+++ b/api/custom_auth/oauth/serializers.py
@@ -83,10 +83,9 @@ class OAuthLoginSerializer(InviteLinkValidationMixin, serializers.Serializer):
 
         if not existing_user:
             sign_up_type = self.validated_data.get("sign_up_type")
-            if not settings.ALLOW_REGISTRATION_WITHOUT_INVITE:
-                self._validate_registration_invite(
-                    {"email": email, **self.validated_data}
-                )
+            self._validate_registration_invite(
+                email=email, sign_up_type=self.validated_data.get("sign_up_type")
+            )
 
             return UserModel.objects.create(
                 **user_data, email=email.lower(), sign_up_type=sign_up_type

--- a/api/custom_auth/oauth/serializers.py
+++ b/api/custom_auth/oauth/serializers.py
@@ -13,6 +13,7 @@ from users.auth_type import AuthType
 from users.models import SignUpType
 
 from ..constants import USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE
+from ..serializers import InviteLinkValidationMixin
 from .github import GithubUser
 from .google import get_user_info
 
@@ -20,7 +21,7 @@ GOOGLE_URL = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json&"
 UserModel = get_user_model()
 
 
-class OAuthLoginSerializer(serializers.Serializer):
+class OAuthLoginSerializer(InviteLinkValidationMixin, serializers.Serializer):
     access_token = serializers.CharField(
         required=True,
         help_text="Code or access token returned from the FE interaction with the third party login provider.",

--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -28,14 +28,6 @@ class CustomTokenSerializer(serializers.ModelSerializer):
 class InviteLinkValidationMixin:
     invite_hash = serializers.CharField(required=False, write_only=True)
 
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        attrs = super().validate(attrs)
-
-        if not settings.ALLOW_REGISTRATION_WITHOUT_INVITE:
-            self._validate_registration_invite(attrs)
-
-        return attrs
-
     def _validate_registration_invite(self, attrs: dict[str, Any]) -> None:
         valid = False
 
@@ -87,6 +79,9 @@ class CustomUserCreateSerializer(UserCreateSerializer, InviteLinkValidationMixin
             is_authentication_method_valid(
                 self.context.get("request"), email=email, raise_exception=True
             )
+
+        if not settings.ALLOW_REGISTRATION_WITHOUT_INVITE:
+            self._validate_registration_invite(attrs)
 
         attrs["email"] = email.lower()
         return attrs

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -12,7 +12,7 @@ from rest_framework.test import APIClient, override_settings
 
 from organisations.invites.models import Invite
 from organisations.models import Organisation
-from users.models import FFAdminUser
+from users.models import FFAdminUser, SignUpType
 
 
 def test_register_and_login_workflows(db: None, api_client: APIClient) -> None:
@@ -124,6 +124,7 @@ def test_can_register_with_invite_if_registration_disabled_without_invite(
         "password": password,
         "first_name": "test",
         "last_name": "register",
+        "sign_up_type": SignUpType.INVITE_EMAIL.value,
     }
     Invite.objects.create(email=email, organisation=organisation)
 

--- a/api/tests/unit/custom_auth/conftest.py
+++ b/api/tests/unit/custom_auth/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from organisations.invites.models import InviteLink
+from organisations.models import Organisation
+
+
+@pytest.fixture()
+def invite_link(organisation: Organisation) -> InviteLink:
+    return InviteLink.objects.create(organisation=organisation)

--- a/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
+++ b/api/tests/unit/custom_auth/oauth/test_unit_oauth_views.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient
 
 from organisations.invites.models import Invite
 from organisations.models import Organisation
+from users.models import SignUpType
 
 
 @mock.patch("custom_auth.oauth.serializers.get_user_info")
@@ -66,7 +67,13 @@ def test_can_register_with_google_with_invite_if_registration_disabled(
     Invite.objects.create(organisation=organisation, email=email)
 
     # When
-    response = client.post(url, data={"access_token": "some-token"})
+    response = client.post(
+        url,
+        data={
+            "access_token": "some-token",
+            "sign_up_type": SignUpType.INVITE_EMAIL.value,
+        },
+    )
 
     # Then
     assert response.status_code == status.HTTP_200_OK
@@ -89,7 +96,13 @@ def test_can_register_with_github_with_invite_if_registration_disabled(
     Invite.objects.create(organisation=organisation, email=email)
 
     # When
-    response = client.post(url, data={"access_token": "some-token"})
+    response = client.post(
+        url,
+        data={
+            "access_token": "some-token",
+            "sign_up_type": SignUpType.INVITE_EMAIL.value,
+        },
+    )
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
@@ -2,15 +2,11 @@ import pytest
 from django.test import RequestFactory
 from pytest_django.fixtures import SettingsWrapper
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.serializers import ModelSerializer
 
 from custom_auth.constants import (
     USER_REGISTRATION_WITHOUT_INVITE_ERROR_MESSAGE,
 )
-from custom_auth.serializers import (
-    CustomUserCreateSerializer,
-    InviteLinkValidationMixin,
-)
+from custom_auth.serializers import CustomUserCreateSerializer
 from organisations.invites.models import InviteLink
 from users.models import FFAdminUser, SignUpType
 
@@ -113,12 +109,12 @@ def test_invite_link_validation_mixin_validate_fails_if_invite_link_hash_not_pro
     # Given
     settings.ALLOW_REGISTRATION_WITHOUT_INVITE = False
 
-    class TestSerializer(InviteLinkValidationMixin, ModelSerializer):
-        class Meta:
-            model = FFAdminUser
-            fields = ("sign_up_type",)
-
-    serializer = TestSerializer(data={"sign_up_type": SignUpType.INVITE_LINK.value})
+    serializer = CustomUserCreateSerializer(
+        data={
+            **user_dict,
+            "sign_up_type": SignUpType.INVITE_LINK.value,
+        }
+    )
 
     # When
     with pytest.raises(PermissionDenied) as exc_info:
@@ -135,13 +131,9 @@ def test_invite_link_validation_mixin_validate_fails_if_invite_link_hash_not_val
     # Given
     settings.ALLOW_REGISTRATION_WITHOUT_INVITE = False
 
-    class TestSerializer(InviteLinkValidationMixin, ModelSerializer):
-        class Meta:
-            model = FFAdminUser
-            fields = ("sign_up_type",)
-
-    serializer = TestSerializer(
+    serializer = CustomUserCreateSerializer(
         data={
+            **user_dict,
             "sign_up_type": SignUpType.INVITE_LINK.value,
             "invite_hash": "invalid-hash",
         }


### PR DESCRIPTION
## Changes

This PR adds a new `invite_hash` field to the payload on the register endpoint to ensure that it's not possible to bypass the `ALLOW_REGISTRATION_WITHOUT_INVITE` setting. 

Note: this will need to be added on the frontend. It's likely that the E2E tests will fail until that is done.  

## How did you test this code?

Added new tests and updated an existing test. 
