### PR TITLE
fix: protect get environment document endpoint

### DIFF
--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -45,6 +45,8 @@ class EnvironmentPermissions(IsAuthenticated):
     def has_object_permission(self, request, view, obj):
         if view.action == "clone":
             return request.user.has_project_permission(CREATE_ENVIRONMENT, obj.project)
+        elif view.action == "get_document":
+            return request.user.has_environment_permission(VIEW_ENVIRONMENT, obj)
 
         return request.user.is_environment_admin(obj) or view.action in [
             "user_permissions"

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -225,7 +225,10 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
     @swagger_auto_schema(responses={200: SDKEnvironmentDocumentModel})
     @action(detail=True, methods=["GET"], url_path="document")
     def get_document(self, request, api_key: str):
-        return Response(Environment.get_environment_document(api_key))
+        environment = (
+            self.get_object()
+        )  # use get_object to ensure permissions check is performed
+        return Response(Environment.get_environment_document(environment.api_key))
 
     @swagger_auto_schema(request_body=no_body, responses={202: ""})
     @action(detail=True, methods=["POST"], url_path="enable-v2-versioning")

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -766,11 +766,13 @@ def test_audit_log_entry_created_when_environment_updated(
 def test_get_document(
     environment: Environment,
     project: Project,
-    admin_client_new: APIClient,
+    staff_client: APIClient,
     feature: Feature,
     segment: Segment,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
 ) -> None:
     # Given
+    with_environment_permissions([VIEW_ENVIRONMENT])
 
     # and some sample data to make sure we're testing all of the document
     segment_rule = SegmentRule.objects.create(
@@ -786,11 +788,26 @@ def test_get_document(
     )
 
     # When
-    response = admin_client_new.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_200_OK
     assert response.json()
+
+
+def test_cannot_get_environment_document_without_permission(
+    staff_client: APIClient, environment: Environment
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:environments:environment-get-document", args=[environment.api_key]
+    )
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_get_all_trait_keys_for_environment_only_returns_distinct_keys(


### PR DESCRIPTION
## Changes

Ensures that `get_document` endpoint is correctly protected by permissions. 

## How did you test this code?

Added a new unit test and updated existing one to ensure that the correct permission check is performed. 
