### PR TITLE
fix: Identity overrides are not deleted when deleting Edge identities

### DIFF
--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -160,7 +160,11 @@ class EdgeIdentityViewSet(
         )
 
     def perform_destroy(self, instance):
-        EdgeIdentity.dynamo_wrapper.delete_item(instance["composite_key"])
+        edge_identity = EdgeIdentity.from_identity_document(instance)
+        edge_identity.delete(
+            user=self.request.user,
+            master_api_key=getattr(self.request, "master_api_key", None),
+        )
 
     @swagger_auto_schema(
         responses={200: EdgeIdentityTraitsSerializer(many=True)},
@@ -281,7 +285,7 @@ class EdgeIdentityFeatureStateViewSet(viewsets.ModelViewSet):
     def perform_destroy(self, instance):
         self.identity.remove_feature_override(instance)
         self.identity.save(
-            user=self.request.user.id,
+            user=self.request.user,
             master_api_key=getattr(self.request, "master_api_key", None),
         )
 

--- a/api/tests/integration/edge_api/identities/conftest.py
+++ b/api/tests/integration/edge_api/identities/conftest.py
@@ -1,4 +1,13 @@
+from typing import Any
+
 import pytest
+from boto3.dynamodb.conditions import Key
+from flag_engine.identities.models import IdentityModel
+
+from edge_api.identities.models import EdgeIdentity
+from environments.dynamodb.wrappers.environment_wrapper import (
+    DynamoEnvironmentV2Wrapper,
+)
 
 
 @pytest.fixture()
@@ -6,3 +15,26 @@ def webhook_mock(mocker):
     return mocker.patch(
         "edge_api.identities.serializers.call_environment_webhook_for_feature_state_change"
     )
+
+
+@pytest.fixture()
+def identity_overrides_v2(
+    dynamo_enabled_environment: int,
+    identity_document_without_fs: dict[str, Any],
+    identity_document: dict[str, Any],
+    dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
+) -> list[str]:
+    edge_identity = EdgeIdentity.from_identity_document(identity_document_without_fs)
+    for feature_override in IdentityModel.model_validate(
+        identity_document
+    ).identity_features:
+        edge_identity.add_feature_override(feature_override)
+    edge_identity.save()
+    return [
+        item["document_key"]
+        for item in dynamodb_wrapper_v2.query_get_all_items(
+            KeyConditionExpression=Key("environment_id").eq(
+                str(dynamo_enabled_environment)
+            ),
+        )
+    ]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes #4457.
Closes #3370.

This adds an Edge V2 table update trigger on Edge identity deletion. As a side effect, we'll have identity override deletion audit logs whenever an Edge identity is deleted, which is better UX than we have now, I believe.

## How did you test this code?

Improved upon an existing integration test by using table mocks instead of a wrapper mock used previously.