### PR TITLE
docs: Add missing trailing slash to Edge Proxy example API call

### DIFF
--- a/docs/docs/deployment/hosting/locally-edge-proxy.md
+++ b/docs/docs/deployment/hosting/locally-edge-proxy.md
@@ -294,7 +294,7 @@ domain name and you're good to go. For example, lets say you had your proxy runn
 above:
 
 ```bash
-curl "http://localhost:8000/api/v1/flags" -H "x-environment-key: 95DybY5oJoRNhxPZYLrxk4" | jq
+curl "http://localhost:8000/api/v1/flags/" -H "x-environment-key: 95DybY5oJoRNhxPZYLrxk4" | jq
 
 [
     {


### PR DESCRIPTION
This endpoint requires a trailing slash https://github.com/Flagsmith/edge-proxy/blob/9771a6e8180df5323bbed6236fd295a697d305b7/src/edge_proxy/server.py#L53