### PR TITLE
fix: Remove warning about non-unique health namespace

### DIFF
--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     re_path(r"^health", include("health_check.urls", namespace="health")),
     # Aptible health checks must be on /healthcheck and cannot redirect
     # see https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/health-checks
-    path("healthcheck", include("health_check.urls", namespace="health")),
+    path("healthcheck", include("health_check.urls", namespace="aptible")),
     re_path(r"^version", views.version_info, name="version-info"),
     re_path(
         r"^sales-dashboard/",


### PR DESCRIPTION

Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes a warning about non-unique namespaces, can be seen when API starts up:

```
WARNINGS:
?: (urls.W005) URL namespace 'health' isn't unique. You may not be able to reverse all URLs in this namespace
```

Forgot to add this before merging https://github.com/Flagsmith/flagsmith/pull/4340

## How did you test this code?

`python manage.py runserver`, warning is no longer there
