### PR TITLE
fix: ensure that usage notification logic is independent of other organisations notifications

### DIFF
--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -139,6 +139,7 @@ def handle_api_usage_notification_for_organisation(organisation: Organisation) -
         return
 
     if OrganisationAPIUsageNotification.objects.filter(
+        organisation_id=organisation.id,
         notified_at__gt=period_starts_at,
         percent_usage__gte=matched_threshold,
     ).exists():

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -362,11 +362,28 @@ def test_handle_api_usage_notifications_below_100(
         organisation=organisation,
     ).exists()
 
+    # Create an OrganisationApiUsageNotification object for another organisation
+    # to verify that only the correct organisation's notifications are taken into
+    # account.
+    another_organisation = Organisation.objects.create(name="Another Organisation")
+    OrganisationAPIUsageNotification.objects.create(
+        organisation=another_organisation,
+        percent_usage=100,
+        notified_at=now - timedelta(days=1),
+    )
+
     # When
     handle_api_usage_notifications()
 
     # Then
-    mock_api_usage.assert_called_once_with(organisation.id, now - timedelta(days=14))
+    assert len(mock_api_usage.call_args_list) == 2
+
+    # We only care about the call for the main organisation,
+    # not the call for 'another_organisation'
+    assert mock_api_usage.call_args_list[0].args == (
+        organisation.id,
+        now - timedelta(days=14),
+    )
 
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
@@ -410,7 +427,12 @@ def test_handle_api_usage_notifications_below_100(
         ).count()
         == 1
     )
-    assert OrganisationAPIUsageNotification.objects.first() == api_usage_notification
+    assert (
+        OrganisationAPIUsageNotification.objects.filter(
+            organisation=organisation
+        ).first()
+        == api_usage_notification
+    )
 
 
 @pytest.mark.freeze_time("2023-01-19T09:09:47.325132+00:00")


### PR DESCRIPTION
## Changes

Fixes an issue where usage notifications weren't sent if another organisation had been notified in the same billing period. 

## How did you test this code?

Updated an existing test. Watched the test fail before adding the fix and watching it pass. 
