### PR TITLE
fix: Rename match variable in external feature resources

### DIFF
--- a/api/features/feature_external_resources/views.py
+++ b/api/features/feature_external_resources/views.py
@@ -82,9 +82,9 @@ class FeatureExternalResourceViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        match = re.search(pattern, url)
-        if match:
-            owner, repo, issue = match.groups()
+        url_match = re.search(pattern, url)
+        if url_match:
+            owner, repo, issue = url_match.groups()
             if GithubRepository.objects.get(
                 github_configuration=github_configuration,
                 repository_owner=owner,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Rename `match` variable to `url_match`
## How did you test this code?

Already exists unit tests