### PR TITLE
fix: Make influx cache task recurring

### DIFF
--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -82,6 +82,10 @@ def send_org_subscription_cancelled_alert(
 @register_recurring_task(
     run_every=timedelta(hours=6),
 )
+def update_organisation_subscription_information_influx_cache_recurring():
+    subscription_info_cache.update_caches((SubscriptionCacheEntity.INFLUX,))
+
+
 @register_task_handler()
 def update_organisation_subscription_information_influx_cache():
     subscription_info_cache.update_caches((SubscriptionCacheEntity.INFLUX,))

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -79,11 +79,13 @@ def send_org_subscription_cancelled_alert(
     )
 
 
+# We're redefining the task function here to register a recurring task
+# since the decorators don't stack correctly. (TODO)
 @register_recurring_task(
     run_every=timedelta(hours=6),
 )
 def update_organisation_subscription_information_influx_cache_recurring():
-    subscription_info_cache.update_caches((SubscriptionCacheEntity.INFLUX,))
+    update_organisation_subscription_information_influx_cache()
 
 
 @register_task_handler()

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -79,13 +79,15 @@ def send_org_subscription_cancelled_alert(
     )
 
 
-# We're redefining the task function here to register a recurring task
-# since the decorators don't stack correctly. (TODO)
 @register_recurring_task(
     run_every=timedelta(hours=6),
 )
 def update_organisation_subscription_information_influx_cache_recurring():
-    update_organisation_subscription_information_influx_cache()
+    """
+    We're redefining the task function here to register a recurring task
+    since the decorators don't stack correctly. (TODO)
+    """
+    update_organisation_subscription_information_influx_cache()  # pragma: no cover
 
 
 @register_task_handler()


### PR DESCRIPTION
## Changes

Stacking the task decorators doesn't work. I looked into the task processor implementation and I think it's because the wrapped function can't be called. So instead I just redefined the function with an extended name.

## How did you test this code?

I did not test the code since the change is simple.
