### PR TITLE
fix: allow unknown attrs from cb json meta

### DIFF
--- a/api/organisations/subscriptions/metadata.py
+++ b/api/organisations/subscriptions/metadata.py
@@ -10,6 +10,7 @@ class BaseSubscriptionMetadata:
         api_calls: int = 0,
         projects: typing.Optional[int] = None,
         chargebee_email=None,
+        **kwargs,  # allows for extra unknown attrs from CB json metadata
     ):
         self.seats = seats
         self.api_calls = api_calls

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_cache.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_cache.py
@@ -57,6 +57,7 @@ def test_chargebee_cache(mocker, db):
         "seats": 10,
         "api_calls": 100,
         "projects": 10,
+        "some_unknown_key": 1,
     }
     plan_id = "plan_id"
     plan_items = [
@@ -69,6 +70,7 @@ def test_chargebee_cache(mocker, db):
         "seats": 1,
         "api_calls": 10,
         "projects": 1,
+        "some_unknown_key": 1,
     }
     addon_id = "addon_id"
     addon_items = [

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_cache.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_cache.py
@@ -57,7 +57,7 @@ def test_chargebee_cache(mocker, db):
         "seats": 10,
         "api_calls": 100,
         "projects": 10,
-        "some_unknown_key": 1,
+        "some_unknown_key": 1,  # should be ignored
     }
     plan_id = "plan_id"
     plan_items = [
@@ -70,7 +70,7 @@ def test_chargebee_cache(mocker, db):
         "seats": 1,
         "api_calls": 10,
         "projects": 1,
-        "some_unknown_key": 1,
+        "some_unknown_key": 1,  # should be ignored
     }
     addon_id = "addon_id"
     addon_items = [
@@ -92,8 +92,10 @@ def test_chargebee_cache(mocker, db):
     assert cache.plans[plan_id].seats == plan_metadata["seats"]
     assert cache.plans[plan_id].api_calls == plan_metadata["api_calls"]
     assert cache.plans[plan_id].projects == plan_metadata["projects"]
+    assert not hasattr(cache.plans[plan_id], "some_unknown_key")
 
     assert len(cache.addons) == 1
     assert cache.addons[addon_id].seats == addon_metadata["seats"]
     assert cache.addons[addon_id].api_calls == addon_metadata["api_calls"]
     assert cache.addons[addon_id].projects == addon_metadata["projects"]
+    assert not hasattr(cache.addons[addon_id], "some_unknown_key")


### PR DESCRIPTION
## Changes

This PR fixes an issue where adding elements to the metadata in a chargebee plan / add on causes an unhandled exception. 

I'd like to move the SubscriptionMetadata classes to e.g. pydantic, but this is a quick solution to avoid too many conflicts with my other PR - #4433. 

Resolves [this](https://flagsmith.sentry.io/issues/5720158471) sentry issue.

## How did you test this code?

Updated an existing test to include an unknown key for both a plan and an addon. 
