### PR TITLE
fix(views/features): use get_environment_flags_list

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -172,11 +172,11 @@ class FeatureViewSet(viewsets.ModelViewSet):
                 identity__isnull=True,
                 feature_segment__isnull=True,
             )
-            feature_states = FeatureState.objects.get_live_feature_states(
-                self.environment,
+            feature_states = get_environment_flags_list(
+                environment=self.environment,
                 additional_filters=q,
-            ).select_related("feature_state_value", "feature")
-
+                additional_select_related_args=["feature_state_value", "feature"],
+            )
             self._feature_states = {fs.feature_id: fs for fs in feature_states}
 
         return queryset


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Replace `get_live_feature_states` with `get_environment_flags_list`

Why: `get_live_feature_states` doesn't take `live_from` into account when returning feature states, which can result in feature states with less recent live_from values being returned.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Covered by updated unit test
