### PR TITLE
fix: Add logic to handle grace period breached for paid accounts

### DIFF
--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -206,7 +206,10 @@ def charge_for_api_call_count_overages():
         api_usage = get_current_api_usage(organisation.id)
 
         # Grace period for organisations < 200% of usage.
-        if api_usage / subscription_cache.allowed_30d_api_calls < 2.0:
+        if (
+            not hasattr(organisation, "breached_grace_period")
+            and api_usage / subscription_cache.allowed_30d_api_calls < 2.0
+        ):
             logger.info("API Usage below normal usage or grace period.")
             continue
 

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -211,6 +211,12 @@ def charge_for_api_call_count_overages():
             and api_usage / subscription_cache.allowed_30d_api_calls < 2.0
         ):
             logger.info("API Usage below normal usage or grace period.")
+
+            # Set organisation grace period breach for following months.
+            if api_usage / subscription_cache.allowed_30d_api_calls > 1.0:
+                OrganisationBreachedGracePeriod.objects.get_or_create(
+                    organisation=organisation
+                )
             continue
 
         api_billings = OrganisationAPIBilling.objects.filter(


### PR DESCRIPTION
## Changes

Fixes https://github.com/Flagsmith/flagsmith/issues/4513

Handle grace periods for paid accounts will now include the grace period check to see if they've done so in a previous month.

## How did you test this code?

Added a check on one existing test and created a new test to handle when grace period has been breached.