### PR TITLE
fix: Update email wording for paid customers with API usage notifications

### DIFF
--- a/api/organisations/templates/organisations/api_usage_notification.html
+++ b/api/organisations/templates/organisations/api_usage_notification.html
@@ -14,9 +14,8 @@
                  current subscription period.
 
                  {% if organisation.is_paid %}
-                 If this is expected, no action is required. If you are expecting to go over, you can upgrade your
-                 organisation’s account limits by reaching out to support@flagsmith.com. We will automatically charge
-                 for overages after our first grace period of 30 days.
+                 If this is expected, no action is required. If you are expecting to go over, you can upgrade your organisation’s account
+                 limits by reaching out to support@flagsmith.com. We will automatically charge for overages at the end of the pay period. For more information check the <a href="https://www.flagsmith.com/terms-of-service">Terms of Service</a>.
                  {% else %}
                  Please note that once 100% use has been breached, the serving of feature flags and admin access may
                  be disabled{% if grace_period %} after a 7-day grace period{% endif %}. Please reach out to

--- a/api/organisations/templates/organisations/api_usage_notification.txt
+++ b/api/organisations/templates/organisations/api_usage_notification.txt
@@ -5,8 +5,7 @@ reached {{ matched_threshold }}% of your API usage within the current subscripti
 
 {% if organisation.is_paid %}
 If this is expected, no action is required. If you are expecting to go over, you can upgrade your organisation’s account
-limits by reaching out to support@flagsmith.com. We will automatically charge for overages after our first grace period
-of 30 days.
+limits by reaching out to support@flagsmith.com. We will automatically charge for overages at the end of the pay period. For more information check the Terms of Service at https://www.flagsmith.com/terms-of-service.
 {% else %}
 Please note that once 100% use has been breached, the serving of feature flags and admin access may be disabled{% if grace_period %}
 after a 7-day grace period{% endif %}. Please reach out to support@flagsmith.com in order to upgrade your account.

--- a/api/organisations/templates/organisations/api_usage_notification_limit.html
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.html
@@ -14,9 +14,8 @@
                  current subscription period.
 
                  {% if organisation.is_paid %}
-                 We will charge for overages after our first grace period of 30 days. Please see the pricing page for
-                 more information. You can reach out to support@flagsmith.com if you’d like to take advantage of better
-                 contracted rates.
+                 We will charge for overages at the end of the pay period. Please see the pricing page for more information or check the <a href="https://www.flagsmith.com/terms-of-service">Terms of Service</a>.
+                 You can reach out to support@flagsmith.com if you’d like to take advantage of better contracted rates.
                  {% else %}
                  Please note that the serving of feature flags and admin access will be disabled{% if grace_period %} after a 7 day grace
                  period{% endif %} until the next subscription period. If you’d like to continue service you can upgrade your

--- a/api/organisations/templates/organisations/api_usage_notification_limit.txt
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.txt
@@ -4,7 +4,7 @@ This is a system generated notification related to your Flagsmith API Usage. You
 has reached {{ matched_threshold }}% of your API usage within the current subscription period.
 
 {% if organisation.is_paid %}
-We will charge for overages after our first grace period of 30 days. Please see the pricing page for more information.
+We will charge for overages at the end of the pay period. Please see the pricing page for more information or check the Terms of Service at https://www.flagsmith.com/terms-of-service.
 You can reach out to support@flagsmith.com if you’d like to take advantage of better contracted rates.
 {% else %}
 Please note that the serving of feature flags and admin access will be disabled{% if grace_period %} after a 7 day


### PR DESCRIPTION
## Changes

Update the API usage notification emails to remove mentions of grace period for paid accounts and to point people towards the ToS.

## How did you test this code?

Ran the existing tests which all passed.