### PR TITLE
fix: subscription info cache race condition

### DIFF
--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -458,6 +458,10 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
         self.organisation.api_usage_notifications.all().delete()
 
     def reset_to_defaults(self):
+        """
+        Resets all limits and CB related data to the defaults, leaving the
+        usage data intact.
+        """
         self.current_billing_term_starts_at = None
         self.current_billing_term_ends_at = None
 

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -303,18 +303,14 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):
         if not getattr(self.organisation, "subscription_information_cache", None):
             return
 
-        # There is a weird bug where the cache is present, but the id is unset.
-        # See here for more: https://flagsmith.sentry.io/issues/4945988284/
-        if not self.organisation.subscription_information_cache.id:
-            return
-
-        self.organisation.subscription_information_cache.delete()
+        self.organisation.subscription_information_cache.reset_to_defaults()
+        self.organisation.subscription_information_cache.save()
 
     def prepare_for_cancel(
         self, cancellation_date=timezone.now(), update_chargebee=True
     ) -> None:
         """
-        This method get's a subscription ready for cancelation.
+        This method gets a subscription ready for cancellation.
 
         If cancellation_date is in the future some aspects are
         reserved for a task after the date has passed.
@@ -451,7 +447,7 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
     api_calls_7d = models.IntegerField(default=0)
     api_calls_30d = models.IntegerField(default=0)
 
-    allowed_seats = models.IntegerField(default=1)
+    allowed_seats = models.IntegerField(default=MAX_SEATS_IN_FREE_PLAN)
     allowed_30d_api_calls = models.IntegerField(default=MAX_API_CALLS_IN_FREE_PLAN)
     allowed_projects = models.IntegerField(default=1, blank=True, null=True)
 
@@ -460,6 +456,16 @@ class OrganisationSubscriptionInformationCache(LifecycleModelMixin, models.Model
     @hook(AFTER_SAVE, when="allowed_30d_api_calls", has_changed=True)
     def erase_api_notifications(self):
         self.organisation.api_usage_notifications.all().delete()
+
+    def reset_to_defaults(self):
+        self.current_billing_term_starts_at = None
+        self.current_billing_term_ends_at = None
+
+        self.allowed_seats = MAX_SEATS_IN_FREE_PLAN
+        self.allowed_30d_api_calls = MAX_API_CALLS_IN_FREE_PLAN
+        self.allowed_projects = 1
+
+        self.chargebee_email = None
 
 
 class OrganisationAPIUsageNotification(models.Model):


### PR DESCRIPTION
## Changes

Fixes race condition(s) related to the cancellation of a subscription. Related sentry issue [here](https://flagsmith.sentry.io/issues/5517108730). 

As far as I can tell from doing some manual testing locally by running the API and pointing it to the staging database, there were likely 2 issues in the code here: 

 1. There was a `BEFORE_DELETE` hook on the organisation model which cancelled the subscription if it was paid. This involved deleting the related `OrganisationSubscriptionInformationCache` object, but the execution path then continued to delete the organisation, and subsequently try and cascade delete the OSIC object. This would fail (seemingly only some of the time). 
 2. When a subscription is cancelled in chargebee, that also triggers a webhook which will execute the same code and try to delete the OSIC object which possibly won't exist depending on when the webhook is triggered / received. 

## How did you test this code?

I have updated a unit test to test the new behaviour, however, (perhaps more importantly) I have also tested this locally to confirm I can delete an organisation that I was previously unable to delete due to the related sentry issue. 
