### PR TITLE
fix: usage and analytics data duplicates the current day

### DIFF
--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -186,7 +186,7 @@ def get_event_list_for_organisation(
     results = InfluxDBWrapper.influx_query_manager(
         filters=f'|> filter(fn:(r) => r._measurement == "api_call") \
                   |> filter(fn: (r) => r["organisation_id"] == "{organisation_id}")',
-        extra="|> aggregateWindow(every: 24h, fn: sum)",
+        extra='|> aggregateWindow(every: 24h, fn: sum, timeSrc: "_start")',
         date_start=date_start,
         date_stop=date_stop,
     )
@@ -241,7 +241,7 @@ def get_multiple_event_list_for_organisation(
         date_start=date_start,
         date_stop=date_stop,
         filters=build_filter_string(filters),
-        extra="|> aggregateWindow(every: 24h, fn: sum)",
+        extra='|> aggregateWindow(every: 24h, fn: sum, timeSrc: "_start")',
     )
     if not results:
         return results
@@ -319,7 +319,7 @@ def get_multiple_event_list_for_feature(
                   |> filter(fn: (r) => r["_field"] == "request_count") \
                   |> filter(fn: (r) => r["environment_id"] == "{environment_id}") \
                   |> filter(fn: (r) => r["feature_id"] == "{feature_name}")',
-        extra=f'|> aggregateWindow(every: {aggregate_every}, fn: sum, createEmpty: false) \
+        extra=f'|> aggregateWindow(every: {aggregate_every}, fn: sum, createEmpty: false, timeSrc: "_start") \
                    |> yield(name: "sum")',
     )
     if not results:

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -146,7 +146,7 @@ class OrganisationViewSet(viewsets.ModelViewSet):
 
     @swagger_auto_schema(
         deprecated=True,
-        operation_description="Please use ​​/api​/v1​/organisations​/{organisation_pk}​/usage-data​/total-count​/",
+        operation_description="Please use /api/v1/organisations/{organisation_pk}/usage-data/total-count/",
     )
     @action(
         detail=True,
@@ -221,7 +221,7 @@ class OrganisationViewSet(viewsets.ModelViewSet):
 
     @swagger_auto_schema(
         deprecated=True,
-        operation_description="Please use ​​/api​/v1​/organisations​/{organisation_pk}​/usage-data​/",
+        operation_description="Please use /api/v1/organisations/{organisation_pk}/usage-data/",
         query_serializer=InfluxDataQuerySerializer(),
     )
     @action(detail=True, methods=["GET"], url_path="influx-data")

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
@@ -131,7 +131,7 @@ def test_influx_db_query_when_get_events_list_then_query_api_called(monkeypatch)
         f'|> filter(fn: (r) => r["organisation_id"] == "{org_id}") '
         f'|> drop(columns: ["organisation", "organisation_id", "type", "project", '
         f'"project_id", "environment", "environment_id", "host"])'
-        f"|> aggregateWindow(every: 24h, fn: sum)"
+        f'|> aggregateWindow(every: 24h, fn: sum, timeSrc: "_start")'
     )
     mock_influxdb_client = mock.MagicMock()
     monkeypatch.setattr(
@@ -198,7 +198,7 @@ def test_influx_db_query_when_get_multiple_events_for_organisation_then_query_ap
             f"{build_filter_string(expected_filters)}"
             '|> drop(columns: ["organisation", "organisation_id", "type", "project", '
             '"project_id", "environment", "environment_id", "host"]) '
-            "|> aggregateWindow(every: 24h, fn: sum)"
+            '|> aggregateWindow(every: 24h, fn: sum, timeSrc: "_start")'
         )
         .replace(" ", "")
         .replace("\n", "")
@@ -237,7 +237,7 @@ def test_influx_db_query_when_get_multiple_events_for_feature_then_query_api_cal
         f'|> filter(fn: (r) => r["feature_id"] == "{feature_name}") '
         '|> drop(columns: ["organisation", "organisation_id", "type", "project", '
         '"project_id", "environment", "environment_id", "host"])'
-        "|> aggregateWindow(every: 24h, fn: sum, createEmpty: false)                    "
+        '|> aggregateWindow(every: 24h, fn: sum, createEmpty: false, timeSrc: "_start")                    '
         '|> yield(name: "sum")'
     )
 


### PR DESCRIPTION
## Changes

This code fixes an issue where the current day was duplicated in the usage / analytics graphs and all other days seemed to be off by one. 

The reason for this was that the influx query was using the end of the aggregation window to use as the key for the data. This PR updates all uses of `aggregateWindow` in the code to use the start of the window as the key. 

Note that this will mean that we get e.g. 91 results when asking for the last 90 days because it's essentially requesting the exact last (90 x 24h), so it will include today and the same chunk of the first day in the period. Without overcomplicating the query in Influx this would be difficult to solve and I think is perfectly acceptable for now. 

Reference: https://docs.influxdata.com/flux/v0/stdlib/universe/aggregatewindow/#timesrc

## How did you test this code?

I have updated the (mocked) tests, but obviously this isn't very useful. 

@zachaysan and I ran the code against influx directly from my laptop and verified that the data was correct. 
