### PR TITLE
fix: Missing permissions for integration API endpoints

### DIFF
--- a/api/integrations/slack/views.py
+++ b/api/integrations/slack/views.py
@@ -6,6 +6,7 @@ from django.core.signing import TimestampSigner
 from django.shortcuts import redirect
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from slack_sdk.oauth import AuthorizeUrlGenerator
@@ -63,11 +64,21 @@ class SlackEnvironmentViewSet(EnvironmentIntegrationCommonViewSet):
     pagination_class = None  # set here to ensure documentation is correct
     model_class = SlackEnvironment
 
+    def get_permissions(self) -> list[BasePermission]:
+        if (action := self.action) in [
+            "slack_oauth_callback",
+            "get_temporary_signature",
+        ]:
+            return []
+        if action == "slack_oauth_init":
+            return [OauthInitPermission()]
+        return super().get_permissions()
+
     @action(detail=False, methods=["GET"], url_path="signature")
     def get_temporary_signature(self, request, *args, **kwargs):
         return Response({"signature": signer.sign(request.user.id)})
 
-    @action(detail=False, methods=["GET"], url_path="callback", permission_classes=[])
+    @action(detail=False, methods=["GET"], url_path="callback")
     def slack_oauth_callback(self, request, environment_api_key):
         code = request.GET.get("code")
         if not code:
@@ -75,14 +86,13 @@ class SlackEnvironmentViewSet(EnvironmentIntegrationCommonViewSet):
                 "code not found in query params",
                 status.HTTP_400_BAD_REQUEST,
             )
-        env = self.get_environment_from_request()
         validate_state(request.GET.get("state"), request)
         bot_token = SlackWrapper().get_bot_token(
             code, self._get_slack_callback_url(environment_api_key)
         )
 
         SlackConfiguration.objects.update_or_create(
-            project=env.project, defaults={"api_token": bot_token}
+            project=request.environment.project, defaults={"api_token": bot_token}
         )
         return redirect(self._get_front_end_redirect_url())
 
@@ -91,7 +101,6 @@ class SlackEnvironmentViewSet(EnvironmentIntegrationCommonViewSet):
         methods=["GET"],
         url_path="oauth",
         authentication_classes=[OauthInitAuthentication],
-        permission_classes=[OauthInitPermission],
     )
     def slack_oauth_init(self, request, environment_api_key):
         if not settings.SLACK_CLIENT_ID:

--- a/api/projects/permissions.py
+++ b/api/projects/permissions.py
@@ -151,6 +151,9 @@ class NestedProjectPermissions(IsAuthenticated):
                 self.action_permission_map[view.action], project
             )
 
+        if view.action == "create":
+            return request.user.is_project_admin(project)
+
         return view.detail
 
     def has_object_permission(self, request, view, obj):

--- a/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
+++ b/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
@@ -153,3 +153,27 @@ def test_create_datadog_configuration_in_project_with_deleted_configuration(
     response_json = response.json()
     assert response_json["api_key"] == api_key
     assert response_json["base_url"] == base_url
+
+
+def test_datadog_project_view__no_permissions__return_expected(
+    test_user_client: APIClient,
+    project: Project,
+) -> None:
+    # Given
+    data = {
+        "base_url": "http://test.com",
+        "api_key": "abc-123",
+        "use_custom_source": True,
+    }
+    url = reverse("api-v1:projects:integrations-datadog-list", args=[project.id])
+
+    # When
+    response = test_user_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not DataDogConfiguration.objects.filter(project=project).exists()

--- a/api/tests/unit/integrations/dynatrace/test_unit_dynatrace_views.py
+++ b/api/tests/unit/integrations/dynatrace/test_unit_dynatrace_views.py
@@ -144,3 +144,30 @@ def test_should_remove_configuration_when_delete(
     # Then
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not DynatraceConfiguration.objects.filter(environment=environment).exists()
+
+
+def test_dynatrace_environment_view__no_permissions__return_expected(
+    test_user_client: APIClient,
+    environment: Environment,
+) -> None:
+    # Given
+    data = {
+        "base_url": "http://test.com",
+        "api_key": "abc-123",
+        "entity_selector": "type(APPLICATION),entityName(docs)",
+    }
+    url = reverse(
+        "api-v1:environments:integrations-dynatrace-list",
+        args=[environment.api_key],
+    )
+
+    # When
+    response = test_user_client.post(
+        url,
+        data=json.dumps(data),
+        content_type="application/json",
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not DynatraceConfiguration.objects.filter(environment=environment).exists()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes an issue when a previously non-existent environment or project integration can be created for a project a user does not belong to.

The base integration view are refactored to use proper permissions rather than current hacky queryset filtration that did not get applied for the `create` action.

## How did you test this code?

Added unit tests reproducing the problem for an environment and a project-level integration.