### PR TITLE
fix: Missing permissions for LaunchDarkly view

### DIFF
--- a/api/integrations/launch_darkly/views.py
+++ b/api/integrations/launch_darkly/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.exceptions import ValidationError
-from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -37,7 +37,6 @@ class LaunchDarklyImportRequestViewSet(
 
     def get_permissions(self) -> list[BasePermission]:
         return [
-            IsAuthenticated(),
             NestedProjectPermissions(
                 action_permission_map={
                     "retrieve": VIEW_PROJECT,

--- a/api/tests/unit/integrations/launch_darkly/test_views.py
+++ b/api/tests/unit/integrations/launch_darkly/test_views.py
@@ -27,6 +27,38 @@ def test_launch_darkly_import_request_view__list__wrong_project__return_expected
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
+def test_launch_darkly_import_request_view__list__return_expected(
+    import_request: LaunchDarklyImportRequest,
+    project: Project,
+    admin_client: APIClient,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    url = reverse("api-v1:projects:imports-launch-darkly-list", args=[project.id])
+
+    # When
+    response = admin_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [
+        {
+            "completed_at": None,
+            "created_at": mocker.ANY,
+            "created_by": "user@example.com",
+            "id": import_request.id,
+            "project": project.id,
+            "status": {
+                "error_messages": [],
+                "requested_environment_count": 2,
+                "requested_flag_count": 9,
+                "result": None,
+            },
+            "updated_at": mocker.ANY,
+        },
+    ]
+
+
 def test_launch_darkly_import_request_view__create__return_expected(
     ld_client_class_mock: MagicMock,
     project: Project,

--- a/api/tests/unit/integrations/launch_darkly/test_views.py
+++ b/api/tests/unit/integrations/launch_darkly/test_views.py
@@ -24,7 +24,7 @@ def test_launch_darkly_import_request_view__list__wrong_project__return_expected
     response = api_client.get(url)
 
     # Then
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_launch_darkly_import_request_view__create__return_expected(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds the `IsAuthenticated` permission to the LD import request view, and moves the permission logic out of the view actions.

## How did you test this code?

Ran existing unit tests and updated a relevant one.