### PR TITLE
fix(ldap-login): create custom serializer to fix login field

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -808,6 +808,7 @@ DJOSER = {
     "SEND_CONFIRMATION_EMAIL": False,
     "SERIALIZERS": {
         "token": "custom_auth.serializers.CustomTokenSerializer",
+        "token_create": "custom_auth.serializers.CustomTokenCreateSerializer",
         "user_create": "custom_auth.serializers.CustomUserCreateSerializer",
         "user_delete": "custom_auth.serializers.CustomUserDelete",
         "current_user": "users.serializers.CustomCurrentUserSerializer",
@@ -1125,13 +1126,14 @@ GITHUB_APP_URL = env.int(
     "GITHUB_APP_URL",
     default=None,
 )
+LOGIN_FIELD = "email"
 
 # LDAP setting
 LDAP_INSTALLED = importlib.util.find_spec("flagsmith_ldap")
 # The URL of the LDAP server.
 LDAP_AUTH_URL = env.str("LDAP_AUTH_URL", None)
 
-if LDAP_INSTALLED and LDAP_AUTH_URL:
+if LDAP_INSTALLED and LDAP_AUTH_URL:  # pragma: no cover
     AUTHENTICATION_BACKENDS.insert(0, "django_python3_ldap.auth.LDAPBackend")
     INSTALLED_APPS.append("flagsmith_ldap")
 
@@ -1204,6 +1206,7 @@ if LDAP_INSTALLED and LDAP_AUTH_URL:
     # The LDAP user username and password used by `sync_ldap_users_and_groups` command
     LDAP_SYNC_USER_USERNAME = env.str("LDAP_SYNC_USER_USERNAME", None)
     LDAP_SYNC_USER_PASSWORD = env.str("LDAP_SYNC_USER_PASSWORD", None)
+    LOGIN_FIELD = "username"
 
 SEGMENT_CONDITION_VALUE_LIMIT = env.int("SEGMENT_CONDITION_VALUE_LIMIT", default=1000)
 if not 0 <= SEGMENT_CONDITION_VALUE_LIMIT < 2000000:

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1126,7 +1126,6 @@ GITHUB_APP_URL = env.int(
     "GITHUB_APP_URL",
     default=None,
 )
-LOGIN_FIELD = "email"
 
 # LDAP setting
 LDAP_INSTALLED = importlib.util.find_spec("flagsmith_ldap")
@@ -1206,7 +1205,7 @@ if LDAP_INSTALLED and LDAP_AUTH_URL:  # pragma: no cover
     # The LDAP user username and password used by `sync_ldap_users_and_groups` command
     LDAP_SYNC_USER_USERNAME = env.str("LDAP_SYNC_USER_USERNAME", None)
     LDAP_SYNC_USER_PASSWORD = env.str("LDAP_SYNC_USER_PASSWORD", None)
-    LOGIN_FIELD = "username"
+    DJOSER["LOGIN_FIELD"] = "username"
 
 SEGMENT_CONDITION_VALUE_LIMIT = env.int("SEGMENT_CONDITION_VALUE_LIMIT", default=1000)
 if not 0 <= SEGMENT_CONDITION_VALUE_LIMIT < 2000000:

--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.auth import authenticate
+from djoser.conf import settings as djoser_settings
 from djoser.serializers import TokenCreateSerializer, UserCreateSerializer
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
@@ -19,20 +19,30 @@ from .constants import (
 
 
 class CustomTokenCreateSerializer(TokenCreateSerializer):
+    """
+    NOTE: Some authentication backends (e.g., LDAP) support only
+    username and password authentication. However, the front-end
+    currently sends the email as the login key. To accommodate
+    this, we override the serializer to rename the email field
+    to the username(or any other field configurable using djoser settings) field.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if djoser_settings.LOGIN_FIELD != FFAdminUser.USERNAME_FIELD:
+            # Because djoser have created a field named username(djoser_settings.LOGIN_FIELD) in the serializer
+            # We have to remove this and add the email(FFAdminUser.USERNAME_FIELD) field back
+            self.fields.pop(djoser_settings.LOGIN_FIELD)
+            self.fields[FFAdminUser.USERNAME_FIELD] = serializers.CharField(
+                required=False
+            )
+
     def validate(self, attrs):
-        password = attrs.get("password")
-        # NOTE: Some authentication backends (e.g., LDAP) support only
-        # username and password authentication. However, the front-end
-        # currently sends the email as the login key. To accommodate
-        # this, we map the provided email to the corresponding login
-        # field (which is configurable in settings).
-        params = {settings.LOGIN_FIELD: attrs.get(FFAdminUser.USERNAME_FIELD)}
-        self.user = authenticate(
-            request=self.context.get("request"), **params, password=password
-        )
-        if self.user and self.user.is_active:
-            return attrs
-        self.fail("invalid_credentials")
+        if djoser_settings.LOGIN_FIELD != FFAdminUser.USERNAME_FIELD:
+            attrs[djoser_settings.LOGIN_FIELD] = attrs.pop(FFAdminUser.USERNAME_FIELD)
+
+        return super().validate(attrs)
 
 
 class CustomTokenSerializer(serializers.ModelSerializer):

--- a/api/custom_auth/serializers.py
+++ b/api/custom_auth/serializers.py
@@ -23,8 +23,8 @@ class CustomTokenCreateSerializer(TokenCreateSerializer):
     NOTE: Some authentication backends (e.g., LDAP) support only
     username and password authentication. However, the front-end
     currently sends the email as the login key. To accommodate
-    this, we override the serializer to rename the email field
-    to the username(or any other field configurable using djoser settings) field.
+    this, we override the serializer to rename the username field
+    to the email (or any other field configurable using djoser settings) field.
 
     """
 

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_serializer.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 from django.test import RequestFactory
 from pytest_django.fixtures import SettingsWrapper
@@ -155,9 +157,11 @@ def test_CustomTokenCreateSerializer_validate_uses_login_field_to_authenticate(
     settings: SettingsWrapper, mocker: MockerFixture
 ) -> None:
     # Given
-    settings.LOGIN_FIELD = "username"
+    djoser_settings = deepcopy(settings.DJOSER)
+    djoser_settings["LOGIN_FIELD"] = "username"
+    settings.DJOSER = djoser_settings
 
-    mocked_authenticate = mocker.patch("custom_auth.serializers.authenticate")
+    mocked_authenticate = mocker.patch("djoser.serializers.authenticate")
     serializer = CustomTokenCreateSerializer(
         data={"email": "some_username", "password": "some_password"}
     )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Add a custom login serializer to make login field configurable because LDAP supports login using username/password instead of email/password 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Adds a unit test 
