### PR TITLE
fix: incorrect statistics in organisation admin list

### DIFF
--- a/api/organisations/admin.py
+++ b/api/organisations/admin.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
-from django.db.models import Count
+from django.db.models import Count, Q
 
 from organisations.models import Organisation, Subscription, UserOrganisation
 from projects.models import Project
@@ -49,12 +49,14 @@ class OrganisationAdmin(admin.ModelAdmin):
     list_filter = ("subscription__plan",)
     search_fields = ("id", "name", "subscription__subscription_id", "users__email")
 
-    def get_queryset(self, request):
+    def get_queryset(self, request):  # pragma: no cover
         return (
             Organisation.objects.select_related("subscription")
             .annotate(
-                num_users=Count("users", distinct=True),
-                num_projects=Count("projects", distinct=True),
+                num_users=Count("users", distinct=True, filter=Q(is_active=True)),
+                num_projects=Count(
+                    "projects", distinct=True, filter=Q(deleted_at__isnull=True)
+                ),
             )
             .all()
         )

--- a/api/organisations/admin.py
+++ b/api/organisations/admin.py
@@ -53,9 +53,13 @@ class OrganisationAdmin(admin.ModelAdmin):
         return (
             Organisation.objects.select_related("subscription")
             .annotate(
-                num_users=Count("users", distinct=True, filter=Q(is_active=True)),
+                num_users=Count(
+                    "users", distinct=True, filter=Q(users__is_active=True)
+                ),
                 num_projects=Count(
-                    "projects", distinct=True, filter=Q(deleted_at__isnull=True)
+                    "projects",
+                    distinct=True,
+                    filter=Q(projects__deleted_at__isnull=True),
                 ),
             )
             .all()


### PR DESCRIPTION
## Changes

Fixes incorrect statistics in organisation admin list view. 

## How did you test this code?

Manually: 

 1. Run the API locally
 2. Create a project in a given organisation
 3. Confirm that the number of projects in the django admin list is correct
 4. Delete the project
 5. Confirm that the number of projects in the django admin list is correct
