### PR TITLE
docs: Update local evaluation documentation

### DIFF
--- a/docs/docs/clients/index.md
+++ b/docs/docs/clients/index.md
@@ -55,8 +55,8 @@ treated as secret.
 
 The Server-side SDKs can operate in 2 different modes:
 
-1. `Remote Evaluation`
-2. `Local Evaluation`
+1. Remote Evaluation
+2. Local Evaluation
 
 It's important to understand which mode is right for your use case, and what the pros and cons of each one are. This is
 detailed below.
@@ -70,7 +70,7 @@ the particular request.
 
 ![Remote Evaluation Diagram](/img/sdk-remote-evaluation.svg)
 
-`Remote Evaluation` is the default mode; initialise the SDK and you will be running in `Remote Evaluation` mode.
+Remote Evaluation is the default mode; initialise the SDK and you will be running in Remote Evaluation mode.
 
 This is the same way that the [Client-side SDKs](#client-side-sdks) work.
 
@@ -81,12 +81,12 @@ the Flag Engine, and the engine runs within your server environment within the F
 
 ![Local Evaluation Diagram](/img/sdk-local-evaluation.svg)
 
-You have to configure the SDK to run in `Local Evaluation` mode. See the
+You have to configure the SDK to run in Local Evaluation mode. See the
 [SDK configuration options](server-side.md#configuring-the-sdk) for details on how to do that in your particular
 language.
 
-When the SDK is initialised in `Local Evaluation` mode, it grabs the entire set of details about the Environment from
-the Flagsmith API. For a given Environment, this includes:
+When the SDK is initialised in Local Evaluation mode, it grabs the entire set of details about the Environment from the
+Flagsmith API. For a given Environment, this includes:
 
 - Flags and flag values
 - Segments, segment rules, and segment overrides
@@ -97,8 +97,18 @@ within your server infrastructure.
 
 :::info
 
-Identity overrides in local evaluation mode do not include persisted traits. You will need to provide a full set of
-traits when requesting identity flags. See [Pros, Cons and Caveats](#for-local-evaluation).
+- Identity overrides in local evaluation mode do not include persisted traits. You will need to provide a full set of
+  traits when requesting identity flags. See [Pros, Cons and Caveats](#for-local-evaluation).
+- If your project was created before January 2024, make sure to toggle **Environment Settings > SDK Settings > Use
+  identity overrides in local evaluation**.
+
+:::
+
+:::tip
+
+The SDK has to request all of the data about an Environment in order to run. Because some of this data could be
+sensitive (for example, your Segment Rules), the SDK requires a specific
+[Server-side Environment Key](#server-side-sdk).
 
 :::
 
@@ -106,36 +116,18 @@ The benefits to doing this are mainly one of latency and performance. Your serve
 Flagsmith API each time a user requests their flags - the flags can be computed locally. Hence it does not need to block
 and wait for a response back from the Flagsmith API.
 
-:::tip
-
-The SDK has to request all of the data about an Environment in order to run. Because some of this data could be
-sensitive (for example, your Segment Rules), the SDK requires a specific
-[`Server-side Environment Key`](#server-side-sdk).
-
-:::
-
-In order to keep their Environment data up-to-date, SDKs running in `Local Evaluation` mode will poll the Flagsmith API
+In order to keep their Environment data up-to-date, SDKs running in Local Evaluation mode will poll the Flagsmith API
 regularly and update their local Environment data with any changes from the Flagsmith API. By default the SDK will poll
-the Flagsmith every `60` seconds; this rate is configurable within each SDK.
+the Flagsmith every 60 seconds; this rate is configurable within each SDK.
 
-It's important to understand the [pros and cons](#pros-cons-and-caveats) for running `Local Evaluation`.
+It's important to understand the [pros and cons](#pros-cons-and-caveats) for running Local Evaluation.
 
-:::info
-
-Identities and their Traits are **not** read from or written to the Flagsmith API, and so are not persisted in the
-datastore. This means that you have to provide the full complement of Traits when requesting the Flags for a particular
-Identity. Our SDKs all provide relevant methods to achieve this.
-
-[Read up on the other pros, cons and caveats.](#pros-cons-and-caveats)
-
-:::
-
-All our Client-side SDKs run in `Remote Evaluation` mode only; they cannot run in `Local Evaluation mode`. The reason
-for this is down to data sensitivity. Because some of this data could be sensitive (for example, your Segment Rules), we
-only allow Client-side SDKs to run in `Remote Evaluation` mode.
+All our Client-side SDKs run in Remote Evaluation mode only; they cannot run in Local Evaluation mode. The reason for
+this is down to data sensitivity. Because some of this data could be sensitive (for example, your Segment Rules), we
+only allow Client-side SDKs to run in Remote Evaluation mode.
 
 Because Clients are almost always operating remotely from your server infrastructure, there is little benefit to them
-running in `Local Evaluation` mode.
+running in Local Evaluation mode.
 
 ## Networking Model
 

--- a/docs/docs/clients/index.md
+++ b/docs/docs/clients/index.md
@@ -97,10 +97,13 @@ within your server infrastructure.
 
 :::info
 
-- Identity overrides in local evaluation mode do not include persisted traits. You will need to provide a full set of
-  traits when requesting identity flags. See [Pros, Cons and Caveats](#for-local-evaluation).
-- If your project was created before January 2024, make sure to toggle **Environment Settings > SDK Settings > Use
-  identity overrides in local evaluation**.
+When using identity overrides in local evaluation:
+
+- Keep overrides count under 1500-2000, depending on flag value size.
+- Make sure your environment settings enable it.
+- Provide a full set of traits when requesting identity flags.
+
+See [Pros, Cons and Caveats](#for-local-evaluation).
 
 :::
 
@@ -346,11 +349,29 @@ serverless platforms.
 The benefit of running in Local Evaluation mode is that you can process flag evaluations much more efficiently as they
 are all computed locally.
 
+- Make sure **Environment Settings > SDK Settings > Use identity overrides in local evaluation** is toggled on. To keep
+  evaluation consistent, it's off by default for projects created before January 2024.
 - Identities and their Traits are **not** read from or written to the Flagsmith API, and so are not persisted in the
   datastore. This means that you have to provide the full complement of Traits when requesting the Flags for a
   particular Identity. Our SDKs all provide relevant methods to achieve this.
 - [Analytics-based Integrations](/integrations#analytics-platforms) do not run.
   [Flag Analytics](/advanced-use/flag-analytics) do still work, if enabled within the
   [SDK setup](/clients/server-side#configuring-the-sdk).
-- In circumstances where you need to target a specific identity, you can do this by creating a segment to target that
-  specific user and subsequently adding a segment override for that segment.
+- Currently, Flagsmith SDKs support up to 1500-2000 identity overrides, depending on flag value sizes, when used with
+  Edge API. If you store more than 1MB of override data, you will need to query the Edge API endpoint directly and use
+  pagination:
+
+```bash
+curl https://edge.api.flagsmith.com/api/v1/environment-document \
+  -H 'x-environment-key: <Your Server-Side Env Key>' \
+  --verbose
+```
+
+The `link` response header will contain the url to next page:
+
+```
+content-type: application/json
+...
+link: </api/v1/environment-document/?page_id=identity_override%3A60074%lastreadid>; rel="next"
+...
+```

--- a/docs/docs/clients/index.md
+++ b/docs/docs/clients/index.md
@@ -85,10 +85,22 @@ You have to configure the SDK to run in `Local Evaluation` mode. See the
 [SDK configuration options](server-side.md#configuring-the-sdk) for details on how to do that in your particular
 language.
 
-When the SDK is initialised in `Local Evaluation` mode, it will grab the entire set of details about the Environment
-from the Flagsmith API. This will include all the Flags, Flag values, Segment rules, Segment overrides etc for that
-Environment. This full complement of data about the Environment enables the Flagsmith SDK to run the Flag Engine
-_locally_ and _natively_ within your server infrastructure.
+When the SDK is initialised in `Local Evaluation` mode, it grabs the entire set of details about the Environment from
+the Flagsmith API. For a given Environment, this includes:
+
+- Flags and flag values
+- Segments, segment rules, and segment overrides
+- Identity overrides
+
+This full complement of Environment data enables the Flagsmith SDK to run the Flag Engine _locally_ and _natively_
+within your server infrastructure.
+
+:::info
+
+Identity overrides in local evaluation mode do not include persisted traits. You will need to provide a full set of
+traits when requesting identity flags. See [Pros, Cons and Caveats](#for-local-evaluation).
+
+:::
 
 The benefits to doing this are mainly one of latency and performance. Your server-side code does not need to hit the
 Flagsmith API each time a user requests their flags - the flags can be computed locally. Hence it does not need to block
@@ -320,13 +332,13 @@ common pattern for networking implementation is:
 
 ## Pros, Cons and Caveats
 
-### Remote Evaluation
+### For Remote Evaluation
 
 - Identities are persisted within the Flagsmith Datastore.
 - Identity overrides specified within the Dashboard.
 - All Integrations work as designed.
 
-### Local Evaluation
+### For Local Evaluation
 
 :::tip
 
@@ -345,10 +357,6 @@ are all computed locally.
 - Identities and their Traits are **not** read from or written to the Flagsmith API, and so are not persisted in the
   datastore. This means that you have to provide the full complement of Traits when requesting the Flags for a
   particular Identity. Our SDKs all provide relevant methods to achieve this.
-- [Identity overrides](../basic-features/managing-identities#identity-overrides) work with self-hosted Flagsmith
-  instances. We're rolling them out gradually for the SaaS version. If you are a SaaS customer,
-  <a class="open-chat" data-crisp-chat-message="Hi! I'm interested to try out identity overrides in Local Evaluation mode with Flagsmith SaaS!" href="#local-evaluation-1">contact
-  us</a> to try them out!
 - [Analytics-based Integrations](/integrations#analytics-platforms) do not run.
   [Flag Analytics](/advanced-use/flag-analytics) do still work, if enabled within the
   [SDK setup](/clients/server-side#configuring-the-sdk).

--- a/docs/docs/clients/server-side.md
+++ b/docs/docs/clients/server-side.md
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 :::tip
 
-Server Side SDKs can run in 2 different modes: `Local Evaluation` and `Remote Evaluation`. We recommend
+Server Side SDKs can run in 2 different modes: Local Evaluation and Remote Evaluation. We recommend
 [reading up about the differences](/clients#server-side-sdks) first before integrating the SDKS into your applications.
 
 :::


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This makes the local evaluation documentation represent current state after all the remaining projects in production are migrated to V2.

I've added a more accurate description of what currently constitutes an environment document, and emphasised the caveat of having to provide a full set of traits even when an identity override is present.  

## How did you test this code?

Ran Docusaurus locally.