### PR TITLE
fix(edge-v2): Migrate only Edge API-enabled projects

### DIFF
--- a/api/edge_api/management/commands/migrate_to_edge_v2.py
+++ b/api/edge_api/management/commands/migrate_to_edge_v2.py
@@ -15,7 +15,8 @@ class Command(BaseCommand):
             edge_v2_migration_status__in=(
                 EdgeV2MigrationStatus.NOT_STARTED,
                 EdgeV2MigrationStatus.INCOMPLETE,
-            )
+            ),
+            enable_dynamo_db=True,
         ).values_list("id", flat=True):
             try:
                 migrate_project_environments_to_v2(project_id)

--- a/api/tests/unit/edge_api/test_unit_edge_api_commands.py
+++ b/api/tests/unit/edge_api/test_unit_edge_api_commands.py
@@ -15,11 +15,13 @@ def test_migrate_to_edge_v2__new_projects__dont_migrate(
                 name="edge_v2_not_started",
                 organisation=project.organisation,
                 edge_v2_migration_status=EdgeV2MigrationStatus.NOT_STARTED,
+                enable_dynamo_db=True,
             ),
             Project(
                 name="edge_v2_incomplete",
                 organisation=project.organisation,
                 edge_v2_migration_status=EdgeV2MigrationStatus.INCOMPLETE,
+                enable_dynamo_db=True,
             ),
         ],
     )
@@ -39,3 +41,38 @@ def test_migrate_to_edge_v2__new_projects__dont_migrate(
     )
     # the migrated `project` was not redundantly migrated
     migrate_project_environments_to_v2_mock.call_count == len(unmigrated_projects)
+
+
+def test_migrate_to_edge_v2__core_projects__dont_migrate(
+    mocker: MockerFixture, project: Project
+) -> None:
+    # Given
+    # unmigrated Core projects are present
+    Project.objects.bulk_create(
+        [
+            Project(
+                name="core__edge_v2_not_started",
+                organisation=project.organisation,
+                edge_v2_migration_status=EdgeV2MigrationStatus.NOT_STARTED,
+                enable_dynamo_db=False,
+            ),
+            Project(
+                name="core__edge_v2_incomplete",
+                organisation=project.organisation,
+                edge_v2_migration_status=EdgeV2MigrationStatus.INCOMPLETE,
+                enable_dynamo_db=False,
+            ),
+        ],
+    )
+
+    migrate_project_environments_to_v2_mock = mocker.patch(
+        "edge_api.management.commands.migrate_to_edge_v2.migrate_project_environments_to_v2",
+        autospec=True,
+    )
+
+    # When
+    call_command("migrate_to_edge_v2")
+
+    # Then
+    # unmigrated Core projects were not migrated
+    migrate_project_environments_to_v2_mock.assert_not_called()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This removes Core projects from the Edge V2 migrations.

## How did you test this code?

Added a unit test.
