### PR TITLE
fix(github-4555): use api_key name for changed_by

### DIFF
--- a/api/api_keys/user.py
+++ b/api/api_keys/user.py
@@ -23,6 +23,9 @@ class APIKeyUser(UserABC):
     def __init__(self, key: MasterAPIKey):
         self.key = key
 
+    def __str__(self) -> str:
+        return self.key.name
+
     @property
     def is_authenticated(self) -> bool:
         return True

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -21,6 +21,7 @@ from urllib3.connectionpool import HTTPConnectionPool
 from xdist import get_xdist_worker_id
 
 from api_keys.models import MasterAPIKey
+from api_keys.user import APIKeyUser
 from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
 from environments.models import Environment, EnvironmentAPIKey
@@ -659,10 +660,25 @@ def master_api_key_object(
 
 
 @pytest.fixture
+def master_api_key_id(master_api_key_object: MasterAPIKey) -> str:
+    return master_api_key_object.id
+
+
+@pytest.fixture
+def admin_user_id(admin_user: FFAdminUser) -> str:
+    return admin_user.id
+
+
+@pytest.fixture
 def admin_master_api_key_object(
     admin_master_api_key: typing.Tuple[MasterAPIKey, str]
 ) -> MasterAPIKey:
     return admin_master_api_key[0]
+
+
+@pytest.fixture
+def api_key_user(master_api_key_object: MasterAPIKey) -> APIKeyUser:
+    return APIKeyUser(master_api_key_object)
 
 
 @pytest.fixture()

--- a/api/edge_api/identities/serializers.py
+++ b/api/edge_api/identities/serializers.py
@@ -189,7 +189,7 @@ class BaseEdgeIdentityFeatureStateSerializer(serializers.Serializer):
                 "environment_api_key": identity.environment_api_key,
                 "identity_id": identity.id,
                 "identity_identifier": identity.identifier,
-                "changed_by_user_id": request.user.id,
+                "changed_by_user_id": request.user.pk,
                 "new_enabled_state": self.instance.enabled,
                 "new_value": new_value,
                 "previous_enabled_state": getattr(previous_state, "enabled", None),

--- a/api/edge_api/identities/serializers.py
+++ b/api/edge_api/identities/serializers.py
@@ -171,10 +171,7 @@ class BaseEdgeIdentityFeatureStateSerializer(serializers.Serializer):
             self.instance.multivariate_feature_state_values,
         )
 
-        identity.save(
-            user=request.user,
-            master_api_key=getattr(request, "master_api_key", None),
-        )
+        identity.save(user=request.user)
 
         new_value = self.instance.get_value(identity.id)
         previous_value = (
@@ -189,7 +186,7 @@ class BaseEdgeIdentityFeatureStateSerializer(serializers.Serializer):
                 "environment_api_key": identity.environment_api_key,
                 "identity_id": identity.id,
                 "identity_identifier": identity.identifier,
-                "changed_by_user_id": request.user.pk,
+                "changed_by": str(request.user),
                 "new_enabled_state": self.instance.enabled,
                 "new_value": new_value,
                 "previous_enabled_state": getattr(previous_state, "enabled", None),

--- a/api/edge_api/identities/tasks.py
+++ b/api/edge_api/identities/tasks.py
@@ -5,14 +5,12 @@ from django.utils import timezone
 from task_processor.decorators import register_task_handler
 from task_processor.models import TaskPriority
 
-from api_keys.models import MasterAPIKey
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from edge_api.identities.types import IdentityChangeset
 from environments.dynamodb import DynamoEnvironmentV2Wrapper
 from environments.models import Environment, Webhook
 from features.models import Feature, FeatureState
-from users.models import FFAdminUser
 from util.mappers import map_identity_changeset_to_identity_override_changeset
 from webhooks.webhooks import WebhookEventType, call_environment_webhooks
 
@@ -25,7 +23,7 @@ def call_environment_webhook_for_feature_state_change(
     environment_api_key: str,
     identity_id: typing.Union[id, str],
     identity_identifier: str,
-    changed_by_user_id: int | str,
+    changed_by: str,
     timestamp: str,
     new_enabled_state: bool = None,
     new_value: typing.Union[bool, int, str] = None,
@@ -41,11 +39,6 @@ def call_environment_webhook_for_feature_state_change(
         return
 
     feature = Feature.objects.get(id=feature_id)
-    match changed_by_user_id:
-        case str():
-            changed_by = MasterAPIKey.objects.get(id=changed_by_user_id).name
-        case _:
-            changed_by = FFAdminUser.objects.get(id=changed_by_user_id).email
 
     data = {
         "changed_by": changed_by,

--- a/api/edge_api/identities/views.py
+++ b/api/edge_api/identities/views.py
@@ -161,10 +161,7 @@ class EdgeIdentityViewSet(
 
     def perform_destroy(self, instance):
         edge_identity = EdgeIdentity.from_identity_document(instance)
-        edge_identity.delete(
-            user=self.request.user,
-            master_api_key=getattr(self.request, "master_api_key", None),
-        )
+        edge_identity.delete(user=self.request.user)
 
     @swagger_auto_schema(
         responses={200: EdgeIdentityTraitsSerializer(many=True)},
@@ -284,10 +281,7 @@ class EdgeIdentityFeatureStateViewSet(viewsets.ModelViewSet):
 
     def perform_destroy(self, instance):
         self.identity.remove_feature_override(instance)
-        self.identity.save(
-            user=self.request.user,
-            master_api_key=getattr(self.request, "master_api_key", None),
-        )
+        self.identity.save(user=self.request.user)
 
     @swagger_auto_schema(responses={200: IdentityAllFeatureStatesSerializer(many=True)})
     @action(detail=False, methods=["GET"])
@@ -332,10 +326,7 @@ class EdgeIdentityFeatureStateViewSet(viewsets.ModelViewSet):
         )
 
         self.identity.clone_flag_states_from(source_identity)
-        self.identity.save(
-            user=request.user.id,
-            master_api_key=getattr(request, "master_api_key", None),
-        )
+        self.identity.save(user=request.user)
 
         return self.all(request, *args, **kwargs)
 
@@ -391,10 +382,7 @@ class EdgeIdentityWithIdentifierFeatureStateView(APIView):
         feature_state = self.identity.get_feature_state_by_feature_name_or_id(feature)
         if feature_state:
             self.identity.remove_feature_override(feature_state)
-            self.identity.save(
-                user=request.user.id,
-                master_api_key=getattr(request, "master_api_key", None),
-            )
+            self.identity.save(user=request.user)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_featurestates_viewset.py
@@ -1,6 +1,7 @@
 import json
 import typing
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 from core.constants import BOOLEAN, INTEGER, STRING
@@ -351,15 +352,15 @@ def test_edge_identities_create_featurestate_returns_400_if_feature_state_alread
 
 
 def test_edge_identities_create_featurestate(
-    dynamodb_wrapper_v2,
-    admin_client,
-    environment,
-    environment_api_key,
-    identity_document_without_fs,
-    edge_identity_dynamo_wrapper_mock,
-    feature,
-    feature_name,
-    webhook_mock,
+    dynamodb_wrapper_v2: DynamoEnvironmentV2Wrapper,
+    admin_client_new: APIClient,
+    environment: int,
+    environment_api_key: str,
+    identity_document_without_fs: dict,
+    edge_identity_dynamo_wrapper_mock: MagicMock,
+    feature: int,
+    feature_name: str,
+    webhook_mock: MagicMock,
 ):
     # Given
     edge_identity_dynamo_wrapper_mock.get_item_from_uuid_or_404.return_value = (
@@ -381,7 +382,7 @@ def test_edge_identities_create_featurestate(
     }
 
     # When
-    response = admin_client.post(
+    response = admin_client_new.post(
         url, data=json.dumps(data), content_type="application/json"
     )
 

--- a/api/tests/unit/api_keys/test_user.py
+++ b/api/tests/unit/api_keys/test_user.py
@@ -17,6 +17,17 @@ def test_is_authenticated(master_api_key_object):
     assert user.is_authenticated is True
 
 
+def test__str__returns_name(master_api_key_object):
+    # Given
+    user = APIKeyUser(master_api_key_object)
+
+    # When
+    result = str(user)
+
+    # Then
+    assert result == master_api_key_object.name
+
+
 @pytest.mark.parametrize(
     "for_organisation, expected_result",
     [

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
@@ -1,5 +1,8 @@
+import pytest
+from django.test import RequestFactory
 from django.utils import timezone
 from flag_engine.features.models import FeatureModel, FeatureStateModel
+from pytest_lazyfixture import lazy_fixture
 
 from edge_api.identities.models import EdgeIdentity
 from edge_api.identities.serializers import EdgeIdentityFeatureStateSerializer
@@ -51,15 +54,27 @@ def test_edge_identity_feature_state_serializer_save_allows_missing_mvfsvs(
     assert saved_identity_feature_state["feature"]["id"] == feature.id
 
 
+@pytest.mark.parametrize(
+    "user",
+    [
+        lazy_fixture("api_key_user"),
+        lazy_fixture("admin_user"),
+    ],
+)
 def test_edge_identity_feature_state_serializer_save_calls_webhook_for_new_override(
-    mocker, identity, feature, admin_user
+    mocker,
+    identity,
+    feature,
+    user,
+    rf: RequestFactory,
 ):
     # Given
     identity_model = EdgeIdentity.from_identity_document(
         map_identity_to_identity_document(identity)
     )
     view = mocker.MagicMock(identity=identity_model)
-    request = mocker.MagicMock(user=admin_user, master_api_key=None)
+    request = rf.post("/")
+    request.user = user
 
     new_enabled_state = True
     new_value = "foo"
@@ -93,7 +108,7 @@ def test_edge_identity_feature_state_serializer_save_calls_webhook_for_new_overr
             "environment_api_key": identity.environment.api_key,
             "identity_id": identity.id,
             "identity_identifier": identity.identifier,
-            "changed_by_user_id": admin_user.id,
+            "changed_by": str(user),
             "new_enabled_state": new_enabled_state,
             "new_value": new_value,
             "previous_enabled_state": None,
@@ -154,7 +169,7 @@ def test_edge_identity_feature_state_serializer_save_calls_webhook_for_update(
             "environment_api_key": identity.environment.api_key,
             "identity_id": identity.id,
             "identity_identifier": identity.identifier,
-            "changed_by_user_id": admin_user.id,
+            "changed_by": str(admin_user),
             "new_enabled_state": new_enabled_state,
             "new_value": new_value,
             "previous_enabled_state": previous_enabled_state,

--- a/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
+++ b/api/tests/unit/edge_api/identities/test_edge_api_identities_serializers.py
@@ -3,14 +3,18 @@ from django.test import RequestFactory
 from django.utils import timezone
 from flag_engine.features.models import FeatureModel, FeatureStateModel
 from pytest_lazyfixture import lazy_fixture
+from pytest_mock import MockerFixture
 
+from api_keys.user import APIKeyUser
 from edge_api.identities.models import EdgeIdentity
 from edge_api.identities.serializers import EdgeIdentityFeatureStateSerializer
+from environments.identities.models import Identity
 from environments.identities.serializers import (
     IdentityAllFeatureStatesSerializer,
 )
 from features.feature_types import STANDARD
-from features.models import FeatureState
+from features.models import Feature, FeatureState
+from users.models import FFAdminUser
 from util.mappers import map_identity_to_identity_document
 from webhooks.constants import WEBHOOK_DATETIME_FORMAT
 
@@ -62,10 +66,10 @@ def test_edge_identity_feature_state_serializer_save_allows_missing_mvfsvs(
     ],
 )
 def test_edge_identity_feature_state_serializer_save_calls_webhook_for_new_override(
-    mocker,
-    identity,
-    feature,
-    user,
+    mocker: MockerFixture,
+    identity: Identity,
+    feature: Feature,
+    user: FFAdminUser | APIKeyUser,
     rf: RequestFactory,
 ):
     # Given

--- a/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
+++ b/api/tests/unit/edge_api/identities/test_unit_edge_api_identities_tasks.py
@@ -4,7 +4,6 @@ import pytest
 from django.utils import timezone
 from pytest_mock import MockerFixture
 
-from api_keys.models import MasterAPIKey
 from audit.models import AuditLog
 from audit.related_object_type import RelatedObjectType
 from edge_api.identities.tasks import (
@@ -17,9 +16,7 @@ from environments.dynamodb.types import (
     IdentityOverridesV2Changeset,
     IdentityOverrideV2,
 )
-from environments.identities.models import Identity
 from environments.models import Environment, Webhook
-from features.models import Feature
 from webhooks.webhooks import WebhookEventType
 
 
@@ -51,7 +48,7 @@ def test_call_environment_webhook_for_feature_state_change_with_new_state_only(
         environment_api_key=environment.api_key,
         identity_id=identity.id,
         identity_identifier=identity.identifier,
-        changed_by_user_id=admin_user.id,
+        changed_by=str(admin_user),
         timestamp=now_isoformat,
         new_enabled_state=new_enabled_state,
         new_value=new_value,
@@ -104,7 +101,7 @@ def test_call_environment_webhook_for_feature_state_change_with_previous_state_o
         environment_api_key=environment.api_key,
         identity_id=identity.id,
         identity_identifier=identity.identifier,
-        changed_by_user_id=admin_user.id,
+        changed_by=str(admin_user),
         timestamp=now_isoformat,
         previous_enabled_state=previous_enabled_state,
         previous_value=previous_value,
@@ -129,49 +126,6 @@ def test_call_environment_webhook_for_feature_state_change_with_previous_state_o
     assert data["previous_state"] == mock_feature_state_data
     assert data["changed_by"] == admin_user.email
     assert data["timestamp"] == now_isoformat
-
-
-def test_call_environment_webhook_for_feature_state_change_with_master_api_key_id(
-    mocker: MockerFixture,
-    environment: Environment,
-    feature: Feature,
-    identity: Identity,
-    master_api_key_object: MasterAPIKey,
-) -> None:
-    # Given
-    mock_call_environment_webhooks = mocker.patch(
-        "edge_api.identities.tasks.call_environment_webhooks"
-    )
-    Webhook.objects.create(environment=environment, url="https://foo.com/webhook")
-
-    mock_feature_state_data = mocker.MagicMock()
-    mocker.patch.object(
-        Webhook,
-        "generate_webhook_feature_state_data",
-        return_value=mock_feature_state_data,
-    )
-
-    now_isoformat = timezone.now().isoformat()
-    previous_enabled_state = True
-    previous_value = "foo"
-
-    # When
-    call_environment_webhook_for_feature_state_change(
-        feature_id=feature.id,
-        environment_api_key=environment.api_key,
-        identity_id=identity.id,
-        identity_identifier=identity.identifier,
-        changed_by_user_id=master_api_key_object.id,
-        timestamp=now_isoformat,
-        previous_enabled_state=previous_enabled_state,
-        previous_value=previous_value,
-    )
-
-    # Then
-    call_args = mock_call_environment_webhooks.call_args
-
-    data = call_args[0][1]
-    assert data["changed_by"] == master_api_key_object.name
 
 
 @pytest.mark.parametrize(
@@ -216,7 +170,7 @@ def test_call_environment_webhook_for_feature_state_change_with_both_states(
         environment_api_key=environment.api_key,
         identity_id=identity.id,
         identity_identifier=identity.identifier,
-        changed_by_user_id=admin_user.id,
+        changed_by=str(admin_user),
         timestamp=now_isoformat,
         previous_enabled_state=previous_enabled_state,
         previous_value=previous_value,
@@ -277,7 +231,7 @@ def test_call_environment_webhook_for_feature_state_change_does_nothing_if_no_we
         environment_api_key=environment.api_key,
         identity_id=identity.id,
         identity_identifier=identity.identifier,
-        changed_by_user_id=admin_user.id,
+        changed_by=str(admin_user),
         timestamp=now_isoformat,
         new_enabled_state=True,
         new_value="foo",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fix the issue with updating feature states for edge identities using the API key by setting the changed_by webhook field to the name of the key.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Updates unit tests
