### PR TITLE
fix: multivariate toggle

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -141,6 +141,21 @@ class TheComponent extends Component {
     const changeRequestsEnabled = Utils.changeRequestsEnabled(
       environment && environment.minimum_change_request_approvals,
     )
+    const onChange = ()=> {
+        if(disableControls) {
+          return;
+        }
+        if (
+          projectFlag?.multivariate_options?.length ||
+          Utils.changeRequestsEnabled(
+            environment.minimum_change_request_approvals,
+          )
+        ) {
+          this.editFeature(projectFlag, environmentFlags[id])
+          return
+        }
+        this.confirmToggle()
+    }
     const isCompact = getViewMode() === 'compact'
     if (this.props.condensed) {
       return (
@@ -171,14 +186,7 @@ class TheComponent extends Component {
                     : '-off'
                 }`}
                 checked={environmentFlags[id] && environmentFlags[id].enabled}
-                onChange={() => {
-                  if (disableControls) return
-                  if (changeRequestsEnabled) {
-                    this.editFeature(projectFlag, environmentFlags[id])
-                    return
-                  }
-                  this.confirmToggle()
-                }}
+                onChange={onChange}
               />
             </Row>
           </div>
@@ -357,17 +365,7 @@ class TheComponent extends Component {
                 : '-off'
             }`}
             checked={environmentFlags[id] && environmentFlags[id].enabled}
-            onChange={() => {
-              if (
-                Utils.changeRequestsEnabled(
-                  environment.minimum_change_request_approvals,
-                )
-              ) {
-                this.editFeature(projectFlag, environmentFlags[id])
-                return
-              }
-              this.confirmToggle()
-            }}
+            onChange={onChange}
           />
         </div>
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Currently, clicking the switch to toggle a multivariate feature flag does not work due to not having feature state variation options. Rather than add another code path for such a slim usecase, attempting to switch on an MV flag directly will just open the feature flag modal (same as change requests).

## How did you test this code?

- Attempt to switch on an MV flag
