### PR TITLE
fix: Don't include null traits in transient identifier

### DIFF
--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -95,8 +95,9 @@ def get_transient_identifier(sdk_trait_data: list[SDKTraitData]) -> str:
     if sdk_trait_data:
         return hashlib.sha256(
             "".join(
-                f'{trait["trait_key"]}{trait["trait_value"]["value"]}'
+                f'{trait["trait_key"]}{trait_value["value"]}'
                 for trait in sorted(sdk_trait_data, key=itemgetter("trait_key"))
+                if (trait_value := trait["trait_value"])
             ).encode(),
             usedforsecurity=False,
         ).hexdigest()

--- a/api/environments/sdk/services.py
+++ b/api/environments/sdk/services.py
@@ -97,7 +97,7 @@ def get_transient_identifier(sdk_trait_data: list[SDKTraitData]) -> str:
             "".join(
                 f'{trait["trait_key"]}{trait_value["value"]}'
                 for trait in sorted(sdk_trait_data, key=itemgetter("trait_key"))
-                if (trait_value := trait["trait_value"])
+                if (trait_value := trait["trait_value"]) is not None
             ).encode(),
             usedforsecurity=False,
         ).hexdigest()

--- a/api/environments/sdk/types.py
+++ b/api/environments/sdk/types.py
@@ -10,5 +10,5 @@ class SDKTraitValueData(typing.TypedDict):
 
 class SDKTraitData(typing.TypedDict):
     trait_key: str
-    trait_value: SDKTraitValueData
+    trait_value: SDKTraitValueData | None
     transient: NotRequired[bool]

--- a/api/tests/integration/environments/identities/test_integration_identities.py
+++ b/api/tests/integration/environments/identities/test_integration_identities.py
@@ -304,6 +304,7 @@ def test_get_feature_states_for_identity__segment_match_expected(
                         "trait_value": segment_condition_value,
                     },
                     {"trait_key": "a", "trait_value": "value_a"},
+                    {"trait_key": "c", "trait_value": None},
                 ],
             }
         ),


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #4597.

This clarifies typing and discards null traits from the transient identifier generation.

## How did you test this code?

Added a null trait to corresponding integration test.