### PR TITLE
fix(webhook/changed_by): Return name of the master api key

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -638,6 +638,11 @@ def environment_api_key(environment):
 
 
 @pytest.fixture()
+def master_api_key_name() -> str:
+    return "test-key"
+
+
+@pytest.fixture()
 def admin_master_api_key(organisation: Organisation) -> typing.Tuple[MasterAPIKey, str]:
     master_api_key, key = MasterAPIKey.objects.create_key(
         name="test_key", organisation=organisation, is_admin=True
@@ -646,11 +651,18 @@ def admin_master_api_key(organisation: Organisation) -> typing.Tuple[MasterAPIKe
 
 
 @pytest.fixture()
-def master_api_key(organisation: Organisation) -> typing.Tuple[MasterAPIKey, str]:
+def master_api_key(
+    master_api_key_name: str, organisation: Organisation
+) -> typing.Tuple[MasterAPIKey, str]:
     master_api_key, key = MasterAPIKey.objects.create_key(
-        name="test_key", organisation=organisation, is_admin=False
+        name=master_api_key_name, organisation=organisation, is_admin=False
     )
     return master_api_key, key
+
+
+@pytest.fixture()
+def admin_user_email(admin_user: FFAdminUser) -> str:
+    return admin_user.email
 
 
 @pytest.fixture

--- a/api/features/tasks.py
+++ b/api/features/tasks.py
@@ -28,11 +28,14 @@ def trigger_feature_state_change_webhooks(
         else ""
     )
     changed_by = (
-        str(history_instance.history_user)
+        history_instance.history_user.email
         if history_instance and history_instance.history_user
-        else ""
+        else (
+            history_instance.master_api_key.name
+            if history_instance and history_instance.master_api_key
+            else ""
+        )
     )
-
     new_state = (
         None
         if event_type == WebhookEventType.FLAG_DELETED

--- a/api/webhooks/sample_webhook_data.py
+++ b/api/webhooks/sample_webhook_data.py
@@ -1,6 +1,6 @@
 environment_webhook_data = {
     "data": {
-        "changed_by": "John Doe",
+        "changed_by": "user@domain.com",
         "new_state": {
             "enabled": True,
             "environment": {"id": 1, "name": "Development"},

--- a/docs/docs/system-administration/webhooks.md
+++ b/docs/docs/system-administration/webhooks.md
@@ -51,7 +51,7 @@ Environment:
 ```json
 {
  "data": {
-  "changed_by": "Ben Rometsch",
+  "changed_by": "user@domain.com"(or the name of the Organisation API Key),
   "new_state": {
    "enabled": true,
    "environment": {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Return name of the master api_key if the change was made using it instead of empty string

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

test cases updated
