### PR TITLE
fix: Set organisation api usage to zero

### DIFF
--- a/api/organisations/subscription_info_cache.py
+++ b/api/organisations/subscription_info_cache.py
@@ -85,12 +85,21 @@ def _update_caches_with_influx_data(
 
         org_calls = get_top_organisations(date_start, limit)
 
+        covered_orgs = set()
+
         for org_id, calls in org_calls.items():
             subscription_info_cache = organisation_info_cache_dict.get(org_id)
+            covered_orgs.add(org_id)
+
             if not subscription_info_cache:
                 # I don't think this is a valid case but worth checking / handling
                 continue
             setattr(subscription_info_cache, key, calls)
+
+        for org_id in organisation_info_cache_dict:
+            if org_id not in covered_orgs:
+                subscription_info_cache = organisation_info_cache_dict.get(org_id)
+                setattr(subscription_info_cache, key, 0)
 
 
 def _update_caches_with_chargebee_data(


### PR DESCRIPTION
## Changes

The original code involved in setting `api_calls_24h`, `api_calls_7d`, and `api_calls_30d` for the `OrganisationSubscriptionInformationCache` only updated values that were known to InfluxDB, this led to an issue where once an organisation left Flagsmith the code updating the values for `0` level API responses were instead left their previous value. This PR fixes that by checking for organisations that have no values and sets them to `0`.

## How did you test this code?

Partially manually against production InfluxDB and then added a test for the empty caches case.