### PR TITLE
fix(versioning): use transaction.atomic to prevent corrupt versions being created

### DIFF
--- a/api/features/versioning/serializers.py
+++ b/api/features/versioning/serializers.py
@@ -1,6 +1,7 @@
 import typing
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from rest_framework import serializers
 
 from api_keys.user import APIKeyUser
@@ -140,6 +141,7 @@ class EnvironmentFeatureVersionCreateSerializer(EnvironmentFeatureVersionSeriali
             "publish_immediately",
         )
 
+    @transaction.atomic
     def create(
         self, validated_data: dict[str, typing.Any]
     ) -> EnvironmentFeatureVersion:

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -400,6 +400,14 @@ def test_publish_version_change_set_raises_error_when_segment_override_does_not_
         f"An unresolvable conflict occurred: segment override does not exist for segment '{segment.name}'."
     )
 
+    # and we should still only have a single version for the feature
+    assert (
+        EnvironmentFeatureVersion.objects.filter(
+            environment=environment_v2_versioning, feature=feature
+        ).count()
+        == 1
+    )
+
 
 def test_publish_version_change_set_raises_error_when_serializer_not_valid(
     change_request: ChangeRequest,


### PR DESCRIPTION
## Changes

Prevent versions from being persisted to the database if the request fails. 

## How did you test this code?

Updated an existing test. 
