### PR TITLE
fix: 404 when last organisation doesn't exist

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -219,7 +219,7 @@ const App = class extends Component {
               id: lastEnv.orgId,
             })
             if (!lastOrg) {
-              this.context.router.history.replace('/select-organistion')
+              this.context.router.history.replace('/organisations')
               return
             }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fix 404 when the last organisation doesn't exist - not exactly sure how this happens but probably involves removing a user from an org.

## How did you test this code?

Not tested - I've landed on this route several times in production and it's the only place where it is referenced in code.