### PR TITLE
fix: Webhook integration not rebuilding environment

### DIFF
--- a/api/integrations/webhook/models.py
+++ b/api/integrations/webhook/models.py
@@ -11,7 +11,7 @@ from webhooks.models import AbstractBaseSoftDeleteExportableWebhookModel
 
 
 class WebhookConfiguration(
-    AbstractBaseSoftDeleteExportableWebhookModel, LifecycleModelMixin
+    LifecycleModelMixin, AbstractBaseSoftDeleteExportableWebhookModel
 ):
     environment = models.OneToOneField(
         Environment, related_name="webhook_config", on_delete=models.CASCADE

--- a/api/tests/unit/integrations/webhook/test_unit_webhook_models.py
+++ b/api/tests/unit/integrations/webhook/test_unit_webhook_models.py
@@ -1,0 +1,19 @@
+from pytest_mock import MockerFixture
+
+from environments.models import Environment
+from integrations.webhook.models import WebhookConfiguration
+
+
+def test_webhook_model__save__call_expected(
+    environment: Environment, mocker: MockerFixture
+) -> None:
+    # Given
+    environment_mock = mocker.patch("integrations.webhook.models.Environment")
+
+    # When
+    WebhookConfiguration.objects.create(environment=environment)
+
+    # Then
+    environment_mock.write_environments_to_dynamodb.assert_called_with(
+        environment_id=environment.id
+    )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes a problem when adding, updating or removing a webhook integration does not trigger an environment document rebuild.

## How did you test this code?

Added a unit test specifically for the case. I did make sure the test was failing without the added changes.