### PR TITLE
fix: Revert "feat: Update amplitude / add session replay"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,9 +9,6 @@
       "version": "2.68.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@amplitude/analytics-browser": "^2.11.3",
-        "@amplitude/plugin-session-replay-browser": "^1.6.24",
-        "@amplitude/session-replay-browser": "^1.13.8",
         "@babel/core": "7.20.7",
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-transform-modules-commonjs": "^7.12.1",
@@ -29,6 +26,7 @@
         "@reduxjs/toolkit": "1.9.1",
         "@sentry/browser": "^7.28.0",
         "@slack/web-api": "^6.9.1",
+        "amplitude-js": "^7.3.3",
         "animejs": "3.0.1",
         "array-find-index": "^1.0.2",
         "babel-loader": "8.3.0",
@@ -164,184 +162,42 @@
       "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
-    "node_modules/@amplitude/analytics-browser": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.11.3.tgz",
-      "integrity": "sha512-7b+LlbIADnM+bS9IYTaUTSiNAfTyWq1JmC/+HyUjcE/TT0A5YsvytQFLx/ejx2ayKBfbah2/xW9JStJGPwZInA==",
+    "node_modules/@amplitude/eslint-config-typescript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/eslint-config-typescript/-/eslint-config-typescript-1.1.0.tgz",
+      "integrity": "sha512-N8sKkwtFakPD2/cSOrBnM5Wudjp4qeDD69U1cG7dZ6DDczxBhUEqnJDJ0wiYmKMPXqr+bmFOsDdbCcOmb/CLYA=="
+    },
+    "node_modules/@amplitude/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-aJebJlI1hfRrzsbcRzW1heTDEClhElwEJ4ODyYZbBacKzH29q3OKZCkgNfaEYdxfgLpoDSh/ffHYpl7fWm3SQA==",
       "dependencies": {
-        "@amplitude/analytics-client-common": "^2.3.2",
-        "@amplitude/analytics-core": "^2.5.1",
-        "@amplitude/analytics-remote-config": "^0.4.0",
-        "@amplitude/analytics-types": "^2.8.1",
-        "@amplitude/plugin-autocapture-browser": "^1.0.1",
-        "@amplitude/plugin-page-view-tracking-browser": "^2.2.22",
-        "tslib": "^2.4.1"
+        "@amplitude/eslint-config-typescript": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/@amplitude/analytics-browser/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-    },
-    "node_modules/@amplitude/analytics-client-common": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.2.tgz",
-      "integrity": "sha512-Xql7l2voFpK8bGuEovjUmuQENU8ijM8GZoQERCk60AwxJwD0aSYh4cIQlcpvIUgRqcdlxkZFYuK1B1KhdGD34w==",
-      "dependencies": {
-        "@amplitude/analytics-connector": "^1.4.8",
-        "@amplitude/analytics-core": "^2.5.1",
-        "@amplitude/analytics-types": "^2.8.1",
-        "tslib": "^2.4.1"
+    "node_modules/@amplitude/ua-parser-js": {
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA==",
+      "engines": {
+        "node": "*"
       }
     },
-    "node_modules/@amplitude/analytics-client-common/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-    },
-    "node_modules/@amplitude/analytics-connector": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
-      "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
-    },
-    "node_modules/@amplitude/analytics-core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.5.1.tgz",
-      "integrity": "sha512-okrbTIOzN0Xa9yV+hFpBvhmLvzWKh2RYJ8X2YwIyffTHCybwunEpw4Xnce39oMi4xDCqQxwtgah36k60+67jrw==",
+    "node_modules/@amplitude/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-TbKgBZNSRFu5RfYTKpprn/DFlZqr8jnmjXASZyQ/m8XDdbD2VoRqHDmKUwFiruX9OhAb2m9BhjLuaiwRYHCcqQ==",
       "dependencies": {
-        "@amplitude/analytics-types": "^2.8.1",
-        "tslib": "^2.4.1"
+        "@amplitude/eslint-config-typescript": "^1.1.0",
+        "@amplitude/types": "^1.1.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
-    },
-    "node_modules/@amplitude/analytics-core/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-    },
-    "node_modules/@amplitude/analytics-remote-config": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.0.tgz",
-      "integrity": "sha512-ilp9Dz8Z92V9Wilmz8XIbvEbtuVaN65+jM06JP8I7wL8eNOHVIi4HcI151BzIyekjbprbS1w18Ps3dj2sHlFXA==",
-      "dependencies": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-core": ">=1 <3",
-        "@amplitude/analytics-types": ">=1 <3",
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@amplitude/analytics-remote-config/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-    },
-    "node_modules/@amplitude/analytics-types": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.8.1.tgz",
-      "integrity": "sha512-q+JRrw92VZmCuFzuaL7gBsRidNtqsjLRqNfLNH5RtbKdG6hmx/UEVIGDm/NeLlH4pQokCTHUWeiS+cbmOkgOwQ=="
-    },
-    "node_modules/@amplitude/plugin-autocapture-browser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.0.1.tgz",
-      "integrity": "sha512-uc+OyTrNyz5C9/T49jattgNCfU7PRcs4jKzgAM+p1rjtaSPDIdQBm09icrFPOsai5hMKFKPYSWUq0HpoK0uaHA==",
-      "dependencies": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-types": ">=1 <3",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@amplitude/plugin-autocapture-browser/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-    },
-    "node_modules/@amplitude/plugin-page-view-tracking-browser": {
-      "version": "2.2.22",
-      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.2.22.tgz",
-      "integrity": "sha512-tC/MciHGbvDSU192EuYKU+JAOiGcGFOWYCKTOzBZIi9u9dNo5t+guFTGuR0gnRboSMxRw/H/3a4yJYJ6fsG3Og==",
-      "dependencies": {
-        "@amplitude/analytics-client-common": "^2.3.2",
-        "@amplitude/analytics-types": "^2.8.1",
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@amplitude/plugin-page-view-tracking-browser/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-    },
-    "node_modules/@amplitude/plugin-session-replay-browser": {
-      "version": "1.6.24",
-      "resolved": "https://registry.npmjs.org/@amplitude/plugin-session-replay-browser/-/plugin-session-replay-browser-1.6.24.tgz",
-      "integrity": "sha512-TuCPD84/1Dpn/HeUdzZgkq5OwI4bdRKJ6+TdatERX3J6KkI+4YQUfHV3/VZUmWIve18vwcwHTGIUL+v0v62cUA==",
-      "dependencies": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-core": ">=1 <3",
-        "@amplitude/analytics-types": ">=1 <3",
-        "@amplitude/session-replay-browser": "^1.13.8",
-        "idb-keyval": "^6.2.1",
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@amplitude/plugin-session-replay-browser/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-    },
-    "node_modules/@amplitude/rrdom": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrdom/-/rrdom-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-OZOqHvpYARmc8vJQG1OfAT+3R0/eZJ7SU7UGTmuZR5nM+NRvNqEBahdxOwueQOG+Dofi9gX4YiX4ekwMXJ+R/A==",
-      "dependencies": {
-        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.20"
-      }
-    },
-    "node_modules/@amplitude/rrweb": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-r2a/ZUTSXwptAsc22pFBvbcb5ixt2Y2l5/HFeyDV7K/bT2uxXoytERZlPIuHuhaK112pnWdAGPRWIqf+IFQGkQ==",
-      "dependencies": {
-        "@amplitude/rrdom": "^2.0.0-alpha.20",
-        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.20",
-        "@amplitude/rrweb-types": "^2.0.0-alpha.20",
-        "@types/css-font-loading-module": "0.0.7",
-        "@xstate/fsm": "^1.4.0",
-        "base64-arraybuffer": "^1.0.1",
-        "fflate": "^0.4.4",
-        "mitt": "^3.0.0"
-      }
-    },
-    "node_modules/@amplitude/rrweb-snapshot": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-cSrAMyFTFnhkyt7m9SVciDRUgpg7OjJAxejDEyAYCDQo8b8cj6WXWS21kPSprILKL27Y/cvaDHTYuU74uTuIiA=="
-    },
-    "node_modules/@amplitude/rrweb-types": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-types/-/rrweb-types-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-TYR14QUDJ6OvDmWkik5atfBmmGRmPZCz1fyNK+hy7gVtfJ24R4oDmpL2ntwTlflYwSzcTACeGvDw0CQnekDkPw==",
-      "dependencies": {
-        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.20"
-      }
-    },
-    "node_modules/@amplitude/session-replay-browser": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/@amplitude/session-replay-browser/-/session-replay-browser-1.13.8.tgz",
-      "integrity": "sha512-8tYsTZQCtMqGcTykeY2SVLtivViTMANpZnan8ZsdhoMPtbZXnwTxC0vqghaYc63ji0x78+VLqIN95WaMOaCyIQ==",
-      "dependencies": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-core": ">=1 <3",
-        "@amplitude/analytics-remote-config": "^0.4.0",
-        "@amplitude/analytics-types": ">=1 <3",
-        "@amplitude/rrweb": "2.0.0-alpha.20",
-        "idb": "^8.0.0",
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@amplitude/session-replay-browser/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -4283,11 +4139,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
-    },
     "node_modules/@types/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
@@ -5043,11 +4894,6 @@
         }
       }
     },
-    "node_modules/@xstate/fsm": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
-      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw=="
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5249,6 +5095,17 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/amplitude-js": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-7.3.3.tgz",
+      "integrity": "sha512-krSXUXeHqbQk15ozx0kC3h0K3i7wQ1ycSG08OfZBga2Vfbi3Y30CP6UXLdtJX4AiBB8EkjMePdMgU6kyuIpi/A==",
+      "dependencies": {
+        "@amplitude/ua-parser-js": "0.7.24",
+        "@amplitude/utils": "^1.0.5",
+        "blueimp-md5": "^2.10.0",
+        "query-string": "5"
+      }
     },
     "node_modules/animejs": {
       "version": "3.0.1",
@@ -5885,14 +5742,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5928,6 +5777,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/blueimp-md5": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -7442,6 +7296,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/decompress-response": {
@@ -8982,11 +8844,6 @@
       "resolved": "https://registry.npmjs.org/fetchify/-/fetchify-0.0.2.tgz",
       "integrity": "sha1-v5JIOvSV0B5seHZ4E7lpUPW7Kms="
     },
-    "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -10491,16 +10348,6 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
-    },
-    "node_modules/idb": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
-      "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
-    },
-    "node_modules/idb-keyval": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -13112,11 +12959,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
-    },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -15009,6 +14851,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -16402,9 +16257,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -17054,6 +16909,14 @@
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dependencies": {
         "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/string_decoder": {
@@ -20114,199 +19977,32 @@
       "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
-    "@amplitude/analytics-browser": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.11.3.tgz",
-      "integrity": "sha512-7b+LlbIADnM+bS9IYTaUTSiNAfTyWq1JmC/+HyUjcE/TT0A5YsvytQFLx/ejx2ayKBfbah2/xW9JStJGPwZInA==",
+    "@amplitude/eslint-config-typescript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/eslint-config-typescript/-/eslint-config-typescript-1.1.0.tgz",
+      "integrity": "sha512-N8sKkwtFakPD2/cSOrBnM5Wudjp4qeDD69U1cG7dZ6DDczxBhUEqnJDJ0wiYmKMPXqr+bmFOsDdbCcOmb/CLYA=="
+    },
+    "@amplitude/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-aJebJlI1hfRrzsbcRzW1heTDEClhElwEJ4ODyYZbBacKzH29q3OKZCkgNfaEYdxfgLpoDSh/ffHYpl7fWm3SQA==",
       "requires": {
-        "@amplitude/analytics-client-common": "^2.3.2",
-        "@amplitude/analytics-core": "^2.5.1",
-        "@amplitude/analytics-remote-config": "^0.4.0",
-        "@amplitude/analytics-types": "^2.8.1",
-        "@amplitude/plugin-autocapture-browser": "^1.0.1",
-        "@amplitude/plugin-page-view-tracking-browser": "^2.2.22",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
+        "@amplitude/eslint-config-typescript": "^1.1.0"
       }
     },
-    "@amplitude/analytics-client-common": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.2.tgz",
-      "integrity": "sha512-Xql7l2voFpK8bGuEovjUmuQENU8ijM8GZoQERCk60AwxJwD0aSYh4cIQlcpvIUgRqcdlxkZFYuK1B1KhdGD34w==",
+    "@amplitude/ua-parser-js": {
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA=="
+    },
+    "@amplitude/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-TbKgBZNSRFu5RfYTKpprn/DFlZqr8jnmjXASZyQ/m8XDdbD2VoRqHDmKUwFiruX9OhAb2m9BhjLuaiwRYHCcqQ==",
       "requires": {
-        "@amplitude/analytics-connector": "^1.4.8",
-        "@amplitude/analytics-core": "^2.5.1",
-        "@amplitude/analytics-types": "^2.8.1",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
-      }
-    },
-    "@amplitude/analytics-connector": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
-      "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
-    },
-    "@amplitude/analytics-core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.5.1.tgz",
-      "integrity": "sha512-okrbTIOzN0Xa9yV+hFpBvhmLvzWKh2RYJ8X2YwIyffTHCybwunEpw4Xnce39oMi4xDCqQxwtgah36k60+67jrw==",
-      "requires": {
-        "@amplitude/analytics-types": "^2.8.1",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
-      }
-    },
-    "@amplitude/analytics-remote-config": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.0.tgz",
-      "integrity": "sha512-ilp9Dz8Z92V9Wilmz8XIbvEbtuVaN65+jM06JP8I7wL8eNOHVIi4HcI151BzIyekjbprbS1w18Ps3dj2sHlFXA==",
-      "requires": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-core": ">=1 <3",
-        "@amplitude/analytics-types": ">=1 <3",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
-      }
-    },
-    "@amplitude/analytics-types": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.8.1.tgz",
-      "integrity": "sha512-q+JRrw92VZmCuFzuaL7gBsRidNtqsjLRqNfLNH5RtbKdG6hmx/UEVIGDm/NeLlH4pQokCTHUWeiS+cbmOkgOwQ=="
-    },
-    "@amplitude/plugin-autocapture-browser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.0.1.tgz",
-      "integrity": "sha512-uc+OyTrNyz5C9/T49jattgNCfU7PRcs4jKzgAM+p1rjtaSPDIdQBm09icrFPOsai5hMKFKPYSWUq0HpoK0uaHA==",
-      "requires": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-types": ">=1 <3",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
-      }
-    },
-    "@amplitude/plugin-page-view-tracking-browser": {
-      "version": "2.2.22",
-      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.2.22.tgz",
-      "integrity": "sha512-tC/MciHGbvDSU192EuYKU+JAOiGcGFOWYCKTOzBZIi9u9dNo5t+guFTGuR0gnRboSMxRw/H/3a4yJYJ6fsG3Og==",
-      "requires": {
-        "@amplitude/analytics-client-common": "^2.3.2",
-        "@amplitude/analytics-types": "^2.8.1",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
-      }
-    },
-    "@amplitude/plugin-session-replay-browser": {
-      "version": "1.6.24",
-      "resolved": "https://registry.npmjs.org/@amplitude/plugin-session-replay-browser/-/plugin-session-replay-browser-1.6.24.tgz",
-      "integrity": "sha512-TuCPD84/1Dpn/HeUdzZgkq5OwI4bdRKJ6+TdatERX3J6KkI+4YQUfHV3/VZUmWIve18vwcwHTGIUL+v0v62cUA==",
-      "requires": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-core": ">=1 <3",
-        "@amplitude/analytics-types": ">=1 <3",
-        "@amplitude/session-replay-browser": "^1.13.8",
-        "idb-keyval": "^6.2.1",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
-      }
-    },
-    "@amplitude/rrdom": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrdom/-/rrdom-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-OZOqHvpYARmc8vJQG1OfAT+3R0/eZJ7SU7UGTmuZR5nM+NRvNqEBahdxOwueQOG+Dofi9gX4YiX4ekwMXJ+R/A==",
-      "requires": {
-        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.20"
-      }
-    },
-    "@amplitude/rrweb": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-r2a/ZUTSXwptAsc22pFBvbcb5ixt2Y2l5/HFeyDV7K/bT2uxXoytERZlPIuHuhaK112pnWdAGPRWIqf+IFQGkQ==",
-      "requires": {
-        "@amplitude/rrdom": "^2.0.0-alpha.20",
-        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.20",
-        "@amplitude/rrweb-types": "^2.0.0-alpha.20",
-        "@types/css-font-loading-module": "0.0.7",
-        "@xstate/fsm": "^1.4.0",
-        "base64-arraybuffer": "^1.0.1",
-        "fflate": "^0.4.4",
-        "mitt": "^3.0.0"
-      }
-    },
-    "@amplitude/rrweb-snapshot": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-cSrAMyFTFnhkyt7m9SVciDRUgpg7OjJAxejDEyAYCDQo8b8cj6WXWS21kPSprILKL27Y/cvaDHTYuU74uTuIiA=="
-    },
-    "@amplitude/rrweb-types": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-types/-/rrweb-types-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-TYR14QUDJ6OvDmWkik5atfBmmGRmPZCz1fyNK+hy7gVtfJ24R4oDmpL2ntwTlflYwSzcTACeGvDw0CQnekDkPw==",
-      "requires": {
-        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.20"
-      }
-    },
-    "@amplitude/session-replay-browser": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/@amplitude/session-replay-browser/-/session-replay-browser-1.13.8.tgz",
-      "integrity": "sha512-8tYsTZQCtMqGcTykeY2SVLtivViTMANpZnan8ZsdhoMPtbZXnwTxC0vqghaYc63ji0x78+VLqIN95WaMOaCyIQ==",
-      "requires": {
-        "@amplitude/analytics-client-common": ">=1 <3",
-        "@amplitude/analytics-core": ">=1 <3",
-        "@amplitude/analytics-remote-config": "^0.4.0",
-        "@amplitude/analytics-types": ">=1 <3",
-        "@amplitude/rrweb": "2.0.0-alpha.20",
-        "idb": "^8.0.0",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-        }
+        "@amplitude/eslint-config-typescript": "^1.1.0",
+        "@amplitude/types": "^1.1.0",
+        "tslib": "^1.9.3"
       }
     },
     "@ampproject/remapping": {
@@ -23146,11 +22842,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/css-font-loading-module": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
-    },
     "@types/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
@@ -23789,11 +23480,6 @@
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
       "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q=="
     },
-    "@xstate/fsm": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
-      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw=="
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -23944,6 +23630,17 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+    },
+    "amplitude-js": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-7.3.3.tgz",
+      "integrity": "sha512-krSXUXeHqbQk15ozx0kC3h0K3i7wQ1ycSG08OfZBga2Vfbi3Y30CP6UXLdtJX4AiBB8EkjMePdMgU6kyuIpi/A==",
+      "requires": {
+        "@amplitude/ua-parser-js": "0.7.24",
+        "@amplitude/utils": "^1.0.5",
+        "blueimp-md5": "^2.10.0",
+        "query-string": "5"
+      }
     },
     "animejs": {
       "version": "3.0.1",
@@ -24426,11 +24123,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -24446,6 +24138,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "blueimp-md5": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
     },
     "body-parser": {
       "version": "1.20.1",
@@ -25526,6 +25223,11 @@
       "requires": {
         "character-entities": "^2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -26711,11 +26413,6 @@
       "resolved": "https://registry.npmjs.org/fetchify/-/fetchify-0.0.2.tgz",
       "integrity": "sha1-v5JIOvSV0B5seHZ4E7lpUPW7Kms="
     },
-    "fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -27822,16 +27519,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
-    },
-    "idb": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
-      "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
-    },
-    "idb-keyval": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -29637,11 +29324,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
-    },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -31025,6 +30707,16 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -32090,9 +31782,9 @@
       }
     },
     "rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -32576,6 +32268,11 @@
       "requires": {
         "readable-stream": "^2.0.1"
       }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,8 +28,6 @@
     "npm": "9.x"
   },
   "dependencies": {
-    "@amplitude/analytics-browser": "^2.11.3",
-    "@amplitude/plugin-session-replay-browser": "^1.6.24",
     "@babel/core": "7.20.7",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
@@ -47,6 +45,7 @@
     "@reduxjs/toolkit": "1.9.1",
     "@sentry/browser": "^7.28.0",
     "@slack/web-api": "^6.9.1",
+    "amplitude-js": "^7.3.3",
     "animejs": "3.0.1",
     "array-find-index": "^1.0.2",
     "babel-loader": "8.3.0",

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -1,8 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { matchPath } from 'react-router'
 import { Link, withRouter } from 'react-router-dom'
-import * as amplitude from '@amplitude/analytics-browser'
-import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser'
+import amplitude from 'amplitude-js'
 import NavLink from 'react-router-dom/NavLink'
 import TwoFactorPrompt from './SimpleTwoFactor/prompt'
 import Maintenance from './Maintenance'
@@ -93,17 +92,6 @@ const App = class extends Component {
   }
 
   componentDidMount = () => {
-    if (Project.amplitude) {
-      amplitude.init(Project.amplitude, {
-        defaultTracking: true,
-        serverZone: 'EU',
-      })
-      const sessionReplayTracking = sessionReplayPlugin({
-        sampleRate: 0.5,
-        serverZone: 'EU',
-      })
-      amplitude.add(sessionReplayTracking)
-    }
     getBuildVersion()
     this.state.projectId = this.getProjectId(this.props)
     if (this.state.projectId) {
@@ -306,6 +294,9 @@ const App = class extends Component {
       pathname === '/signup' ||
       pathname === '/github-setup' ||
       pathname.includes('/invite')
+    if (Project.amplitude) {
+      amplitude.getInstance().init(Project.amplitude)
+    }
     if (
       AccountStore.getOrganisation() &&
       AccountStore.getOrganisation().block_access_to_admin &&

--- a/frontend/web/project/api.js
+++ b/frontend/web/project/api.js
@@ -1,4 +1,4 @@
-import * as amplitude from '@amplitude/analytics-browser'
+import amplitude from 'amplitude-js'
 import data from 'common/data/base/_data'
 const enableDynatrace = !!window.enableDynatrace && typeof dtrum !== 'undefined'
 import freeEmailDomains from 'free-email-domains'
@@ -93,9 +93,9 @@ global.API = {
       })
     }
     if (Project.amplitude) {
-      amplitude.setUserId(id)
+      amplitude.getInstance().setUserId(id)
       const identify = new amplitude.Identify().set('email', id)
-      amplitude.identify(identify)
+      amplitude.getInstance().identify(identify)
     }
     API.flagsmithIdentify()
   },
@@ -223,12 +223,12 @@ global.API = {
       }
 
       if (Project.amplitude) {
-        amplitude.setUserId(id)
+        amplitude.getInstance().setUserId(id)
         const identify = new amplitude.Identify()
           .set('email', id)
           .set('name', { 'first': user.first_name, 'last': user.last_name })
 
-        amplitude.identify(identify)
+        amplitude.getInstance().identify(identify)
       }
       API.flagsmithIdentify()
     } catch (e) {
@@ -334,14 +334,6 @@ global.API = {
       heap.track(data.event, {
         category: data.category,
       })
-    }
-    if (Project.amplitude) {
-      const eventData = {
-        category: data.category,
-        ...(data.extra || {}),
-      }
-
-      amplitude.track(data.event, eventData)
     }
     if (Project.mixpanel) {
       if (!data) {


### PR DESCRIPTION
Reverts Flagsmith/flagsmith#4626

The original PR causes the following error in production:

```
Error: Failed to lookup view "index" in views directory "web/"
    at Function.render (/var/task/node_modules/express/lib/application.js:597:17)
    at ServerResponse.render (/var/task/node_modules/express/lib/response.js:1048:7)
    at /var/task/api/index.js:451:14
    at Layer.handle [as handle_request] (/var/task/node_modules/express/lib/router/layer.js:95:5)
    at next (/var/task/node_modules/express/lib/router/route.js:149:13)
    at Route.dispatch (/var/task/node_modules/express/lib/router/route.js:119:3)
    at Layer.handle [as handle_request] (/var/task/node_modules/express/lib/router/layer.js:95:5)
    at /var/task/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/var/task/node_modules/express/lib/router/index.js:346:12)
    at next (/var/task/node_modules/express/lib/router/index.js:280:10)
```