### PR TITLE
fix: Escape json references

### DIFF
--- a/frontend/web/components/JSONReference.tsx
+++ b/frontend/web/components/JSONReference.tsx
@@ -153,7 +153,7 @@ const JSONReference: FC<JSONReferenceType> = ({
               </Button>
             </Row>
             <div className='hljs-container'>
-              <Highlight forceExpanded preventEscape className={'json p-0'}>
+              <Highlight forceExpanded className={'json p-0'}>
                 {condensed ? idsOnly : value}
               </Highlight>
             </div>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

JSON references JSON was not html escaped, this meant that setting a remote config value of `<div>test</div>` would render as markup when previewing JSON.

## How did you test this code?

![image](https://github.com/user-attachments/assets/ea120455-5407-4220-8578-7ce152d51daf)
