### PR TITLE
fix: Non-admin users can create invites

### DIFF
--- a/api/organisations/permissions/permissions.py
+++ b/api/organisations/permissions/permissions.py
@@ -95,7 +95,7 @@ class OrganisationPermission(BasePermission):
         if organisation_id and not organisation_id.isnumeric():
             raise ValidationError("Invalid organisation ID")
 
-        if view.action == "remove_users":
+        if view.action in {"remove_users", "invite"}:
             return request.user.is_organisation_admin(int(organisation_id))
 
         if organisation_id:

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -143,7 +143,7 @@ def test_should_update_organisation_data(
 
 def test_should_invite_users_to_organisation(
     settings: SettingsWrapper,
-    staff_client: APIClient,
+    admin_client: APIClient,
     organisation: Organisation,
 ) -> None:
     # Given
@@ -153,7 +153,7 @@ def test_should_invite_users_to_organisation(
     data = {"emails": ["test@example.com"]}
 
     # When
-    response = staff_client.post(
+    response = admin_client.post(
         url, data=json.dumps(data), content_type="application/json"
     )
 

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -188,6 +188,28 @@ def test_should_fail_if_invite_exists_already(
     assert Invite.objects.filter(email=email, organisation=organisation).count() == 1
 
 
+def test_organisation_invite__non_admin__return_expected(
+    settings: SettingsWrapper,
+    staff_client: APIClient,
+    organisation: Organisation,
+) -> None:
+    # Given
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["invite"] = None
+
+    email = "test_2@example.com"
+    data = {"invites": [{"email": email, "role": "ADMIN"}]}
+    url = reverse("api-v1:organisations:organisation-invite", args=[organisation.pk])
+
+    # When
+    response = staff_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not Invite.objects.filter(email=email, organisation=organisation).exists()
+
+
 def test_should_return_all_invites_and_can_resend(
     settings: SettingsWrapper,
     admin_client: APIClient,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This prevents non-admin users from creating invites using the `organisations/{org-id}/invite` endpoint.

## How did you test this code?

Added a unit test for the scenario.