### PR TITLE
chore: Rename "manage invoices" to "manage subscription"

### DIFF
--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -452,7 +452,7 @@ const OrganisationSettingsPage = class extends Component {
                                       target='_blank'
                                       className='btn'
                                     >
-                                      Manage Invoices
+                                      Manage subscription
                                     </Button>
                                   )}
                                 </div>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I've had to explain too many times that this is the place to go to change your billing email, credit card, etc etc. "Manage subscription" is more accurate than "Manage invoices", since invoices can only be viewed/downloaded but not modified or "managed".

Also sets this to lowercase since "invoice" is not a proper noun

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/717a350b-2766-4fa1-868f-e8767cfad3e2">



## How did you test this code?

Manually by setting a subscription ID