### PR TITLE
fix: update permissions on classes with missing / unclear permissions

### DIFF
--- a/api/integrations/slack/permissions.py
+++ b/api/integrations/slack/permissions.py
@@ -17,7 +17,7 @@ class OauthInitPermission(IsAuthenticated):
 
 class SlackGetChannelPermissions(IsAuthenticated):
     def has_permission(self, request, view):
-        if not super().has_permission(request, view):
+        if not super().has_permission(request, view):  # pragma: no cover
             return False
 
         environment = get_object_or_404(

--- a/api/integrations/slack/permissions.py
+++ b/api/integrations/slack/permissions.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 
 from environments.models import Environment
@@ -12,3 +13,15 @@ class OauthInitPermission(IsAuthenticated):
             api_key=view.kwargs.get("environment_api_key")
         )
         return request.user.is_environment_admin(environment)
+
+
+class SlackGetChannelPermissions(IsAuthenticated):
+    def has_permission(self, request, view):
+        if not super().has_permission(request, view):
+            return False
+
+        environment = get_object_or_404(
+            Environment.objects.select_related("project"),
+            api_key=view.kwargs.get("environment_api_key"),
+        )
+        return request.user.is_project_admin(environment.project)

--- a/api/integrations/slack/views.py
+++ b/api/integrations/slack/views.py
@@ -6,13 +6,12 @@ from django.core.signing import TimestampSigner
 from django.shortcuts import redirect
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from slack_sdk.oauth import AuthorizeUrlGenerator
 
 from environments.models import Environment
-from environments.permissions.permissions import NestedEnvironmentPermissions
 from integrations.common.views import EnvironmentIntegrationCommonViewSet
 from integrations.slack.models import SlackConfiguration, SlackEnvironment
 from integrations.slack.serializers import (
@@ -29,7 +28,7 @@ from .exceptions import (
     InvalidStateError,
     SlackConfigurationDoesNotExist,
 )
-from .permissions import OauthInitPermission
+from .permissions import OauthInitPermission, SlackGetChannelPermissions
 
 signer = TimestampSigner()
 
@@ -37,7 +36,7 @@ signer = TimestampSigner()
 class SlackGetChannelsViewSet(GenericViewSet):
     serializer_class = SlackChannelListSerializer
     pagination_class = None  # set here to ensure documentation is correct
-    permission_classes = [IsAuthenticated, NestedEnvironmentPermissions]
+    permission_classes = [SlackGetChannelPermissions]
 
     def get_api_token(self) -> str:
         environment = Environment.objects.get(

--- a/api/integrations/slack/views.py
+++ b/api/integrations/slack/views.py
@@ -6,12 +6,13 @@ from django.core.signing import TimestampSigner
 from django.shortcuts import redirect
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from slack_sdk.oauth import AuthorizeUrlGenerator
 
 from environments.models import Environment
+from environments.permissions.permissions import NestedEnvironmentPermissions
 from integrations.common.views import EnvironmentIntegrationCommonViewSet
 from integrations.slack.models import SlackConfiguration, SlackEnvironment
 from integrations.slack.serializers import (
@@ -36,6 +37,7 @@ signer = TimestampSigner()
 class SlackGetChannelsViewSet(GenericViewSet):
     serializer_class = SlackChannelListSerializer
     pagination_class = None  # set here to ensure documentation is correct
+    permission_classes = [IsAuthenticated, NestedEnvironmentPermissions]
 
     def get_api_token(self) -> str:
         environment = Environment.objects.get(

--- a/api/sales_dashboard/urls.py
+++ b/api/sales_dashboard/urls.py
@@ -1,4 +1,3 @@
-from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import path
 
 from . import views
@@ -7,7 +6,7 @@ app_name = "sales_dashboard"
 
 
 urlpatterns = [
-    path("", staff_member_required(views.OrganisationList.as_view()), name="index"),
+    path("", views.OrganisationList.as_view(), name="index"),
     path(
         "organisations/<int:organisation_id>",
         views.organisation_info,
@@ -40,7 +39,7 @@ urlpatterns = [
     ),
     path(
         "email-usage/",
-        staff_member_required(views.EmailUsage.as_view()),
+        views.EmailUsage.as_view(),
         name="email-usage",
     ),
     path(

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -21,6 +21,7 @@ from django.shortcuts import get_object_or_404
 from django.template import loader
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.views.generic import ListView
 from django.views.generic.edit import FormView
@@ -54,6 +55,10 @@ DEFAULT_ORGANISATION_SORT_DIRECTION = "DESC"
 email_regex = re.compile(r"^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$")
 
 
+@method_decorator(
+    name="list",
+    decorator=staff_member_required(),
+)
 class OrganisationList(ListView):
     model = Organisation
     paginate_by = OBJECTS_PER_PAGE
@@ -261,6 +266,14 @@ def migrate_identities_to_edge(request, project_id):
     return HttpResponseRedirect(reverse("sales_dashboard:index"))
 
 
+@method_decorator(
+    name="get",
+    decorator=staff_member_required(),
+)
+@method_decorator(
+    name="post",
+    decorator=staff_member_required(),
+)
 class EmailUsage(FormView):
     form_class = EmailUsageForm
     template_name = "sales_dashboard/email-usage.html"

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -56,7 +56,7 @@ email_regex = re.compile(r"^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$")
 
 
 @method_decorator(
-    name="list",
+    name="get",
     decorator=staff_member_required(),
 )
 class OrganisationList(ListView):

--- a/api/tests/integration/slack/test_slack_get_channels.py
+++ b/api/tests/integration/slack/test_slack_get_channels.py
@@ -2,6 +2,25 @@ from dataclasses import asdict
 
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APIClient
+
+from environments.models import Environment
+
+
+def test_get_channels_fails_if_user_has_no_permission(
+    staff_client: APIClient, environment: Environment, environment_api_key: str
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:environments:integrations-slack-channels-list",
+        args=[environment_api_key],
+    )
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_get_channels_returns_400_when_slack_project_config_does_not_exist(

--- a/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
+++ b/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
@@ -145,3 +145,57 @@ def test_list_organisations_filter_plan(
     # Then
     assert response.status_code == 200
     assert list(response.context_data["organisation_list"]) == [organisation]
+
+
+def test_list_organisations_fails_if_not_staff(
+    organisation: Organisation,
+    client: Client,
+) -> None:
+    # Given
+    user = FFAdminUser.objects.create(email="notastaffuser@example.com")
+    client.force_login(user)
+
+    url = reverse("sales_dashboard:index")
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == 302
+    assert response.url == "/admin/login/?next=/sales-dashboard/"
+
+
+def test_get_email_usage_fails_if_not_staff(
+    organisation: Organisation,
+    client: Client,
+) -> None:
+    # Given
+    user = FFAdminUser.objects.create(email="notastaffuser@example.com")
+    client.force_login(user)
+
+    url = reverse("sales_dashboard:email-usage")
+
+    # When
+    response = client.get(url)
+
+    # Then
+    assert response.status_code == 302
+    assert response.url == "/admin/login/?next=/sales-dashboard/email-usage/"
+
+
+def test_post_email_usage_fails_if_not_staff(
+    organisation: Organisation,
+    client: Client,
+) -> None:
+    # Given
+    user = FFAdminUser.objects.create(email="notastaffuser@example.com")
+    client.force_login(user)
+
+    url = reverse("sales_dashboard:email-usage")
+
+    # When
+    response = client.post(url)
+
+    # Then
+    assert response.status_code == 302
+    assert response.url == "/admin/login/?next=/sales-dashboard/email-usage/"


### PR DESCRIPTION
## Changes

1. Adds the required permission class to the SlackGetChannelsViewSet
2. Moves the `staff_member_required` from urls.py to decorate the methods on the class for consistency with other permission definitions

## How did you test this code?

Added new tests for permissions failure use cases. Existing tests cover happy paths. 
