### PR TITLE
docs: update helm chart frontend ingress examples

### DIFF
--- a/docs/docs/deployment/hosting/kubernetes.md
+++ b/docs/docs/deployment/hosting/kubernetes.md
@@ -65,9 +65,7 @@ ingress:
  frontend:
   enabled: true
   hosts:
-   - host: flagsmith.[MYDOMAIN]
-     paths:
-      - /
+   - flagsmith.[MYDOMAIN]
 ```
 
 Then, once any out-of-cluster DNS or CDN changes have been applied, access `https://flagsmith.[MYDOMAIN]` in a browser.
@@ -85,9 +83,8 @@ ingress:
  frontend:
   enabled: true
   hosts:
-   - host: flagsmith.[MYDOMAIN]
-     paths:
-      - /
+   - flagsmith.[MYDOMAIN]
+
  api:
   enabled: true
   hosts:
@@ -116,9 +113,7 @@ ingress:
  frontend:
   enabled: true
   hosts:
-   - host: flagsmith.local
-     paths:
-      - /
+   - flagsmith.local
 ```
 
 and apply. This will create two ingress resources.
@@ -457,8 +452,7 @@ The following table lists the configurable parameters of the chart and their def
 | `ingress.frontend.enabled`                         |                                                                           | `false`                        |
 | `ingress.frontend.ingressClassName`                |                                                                           |                                |
 | `ingress.frontend.annotations`                     |                                                                           | `{}`                           |
-| `ingress.frontend.hosts[].host`                    |                                                                           | `chart-example.local`          |
-| `ingress.frontend.hosts[].paths`                   |                                                                           | `[]`                           |
+| `ingress.frontend.hosts`                           | List of hostnames for frontend ingress                                    | `[chart-example.local]`        |
 | `ingress.frontend.tls`                             |                                                                           | `[]`                           |
 | `ingress.api.enabled`                              |                                                                           | `false`                        |
 | `ingress.api.ingressClassName`                     |                                                                           |                                |


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

I have updated the documentation to reflect that ingress.frontend.hosts should be a list

It looks like the helm charts were updated at some point in the past, but the documentation wasn't. The documentation represents ingress.frontend.hosts as a map

````yaml
ingress:
 frontend:
  enabled: true
  hosts:
   - host: flagsmith.[MYDOMAIN]
     paths:
      - /
````

Whereas the [template](https://github.com/Flagsmith/flagsmith-charts/blob/main/charts/flagsmith/templates/ingress-frontend.yaml#L40) and [default values](https://github.com/Flagsmith/flagsmith-charts/blob/main/charts/flagsmith/values.yaml#L320) inform us that ingress.frontend.hosts should be a string list.


## How did you test this code?

Used helm template to verify.

Rendered template following documentation:

````yaml
---
# Source: flagsmith/templates/ingress-frontend.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-flagsmith-frontend
  labels:
    helm.sh/chart: flagsmith-0.59.0
    app.kubernetes.io/name: flagsmith
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.142.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: frontend
spec:
  rules:
    - host: "map[host:flagsmithpoc.my-domain.com paths:[/]]"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: release-name-flagsmith-frontend
                port:
                  number: 8080
````

Rendered template using correct data type:

````yaml
# Source: flagsmith/templates/ingress-frontend.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-flagsmith-frontend
  labels:
    helm.sh/chart: flagsmith-0.59.0
    app.kubernetes.io/name: flagsmith
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.142.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: frontend
spec:
  rules:
    - host: "flagsmithpoc.my-domain.com"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: release-name-flagsmith-frontend
                port:
                  number: 8080
````