### PR TITLE
fix: Handle cancellation date for api usage

### DIFF
--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -97,9 +97,12 @@ def _send_api_usage_notification(
 def handle_api_usage_notification_for_organisation(organisation: Organisation) -> None:
     now = timezone.now()
 
-    if organisation.subscription.is_free_plan:
+    if (
+        organisation.subscription.is_free_plan
+        or organisation.subscription.cancellation_date is not None
+    ):
         allowed_api_calls = organisation.subscription.max_api_calls
-        # Default to a rolling month for free accounts
+        # Default to a rolling month for free accounts or canceled subscriptions.
         days = 30
         period_starts_at = now - timedelta(days)
     elif not organisation.has_subscription_information_cache():

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -191,7 +191,8 @@ def charge_for_api_call_count_overages():
             - month_window_end,
         )
         .exclude(
-            subscription__plan=FREE_PLAN_ID,
+            Q(subscription__plan=FREE_PLAN_ID)
+            | Q(subscription__cancellation_date__isnull=False),
         )
         .select_related(
             "subscription_information_cache",


### PR DESCRIPTION
## Changes

Two small updates to the API usage alerting code that checks for subscription being cancelled and treating them as free accounts.

## How did you test this code?

Two new tests.
