### PR TITLE
fix: ensure MANAGE_TAGS permission allows create tag

### DIFF
--- a/api/projects/tags/permissions.py
+++ b/api/projects/tags/permissions.py
@@ -11,14 +11,10 @@ class TagPermissions(BasePermission):
             return False
         project = Project.objects.get(pk=project_pk)
 
-        if request.user.is_project_admin(project):
-            return True
-
-        if view.action in ["list", "get_by_uuid"]:
-            return request.user.has_project_permission(VIEW_PROJECT, project)
-
-        # move on to object specific permissions
-        return view.detail
+        permission = (
+            VIEW_PROJECT if view.action in ("list", "get_by_uuid") else MANAGE_TAGS
+        )
+        return request.user.has_project_permission(permission, project) or view.detail
 
     def has_object_permission(self, request, view, obj):
         project = obj.project

--- a/api/tests/unit/projects/tags/test_unit_projects_tags_permissions.py
+++ b/api/tests/unit/projects/tags/test_unit_projects_tags_permissions.py
@@ -144,6 +144,48 @@ def test_project_user_has_detail_permission(
     assert result is True
 
 
+def test_project_user_with_manage_tags_has_permission_to_create(
+    staff_user: FFAdminUser,
+    project: Project,
+    with_project_permissions: WithProjectPermissionsCallable,
+) -> None:
+    # Given
+    with_project_permissions([VIEW_PROJECT, MANAGE_TAGS])
+    mock_request = mock.MagicMock(user=staff_user)
+    mock_view = mock.MagicMock(
+        action="create",
+        kwargs={"project_pk": project.id},
+    )
+    permissions = TagPermissions()
+
+    # When
+    result = permissions.has_permission(mock_request, mock_view)
+
+    # Then
+    assert result is True
+
+
+def test_project_user_with_view_project_does_not_have_permission_to_create(
+    staff_user: FFAdminUser,
+    project: Project,
+    with_project_permissions: WithProjectPermissionsCallable,
+) -> None:
+    # Given
+    with_project_permissions([VIEW_PROJECT])
+    mock_request = mock.MagicMock(user=staff_user)
+    mock_view = mock.MagicMock(
+        action="create",
+        kwargs={"project_pk": project.id},
+    )
+    permissions = TagPermissions()
+
+    # When
+    result = permissions.has_permission(mock_request, mock_view)
+
+    # Then
+    assert result is False
+
+
 def test_project_user_with_manage_tags_has_detail_permission(
     staff_user: FFAdminUser,
     project: Project,

--- a/api/tests/unit/projects/tags/test_unit_projects_tags_permissions.py
+++ b/api/tests/unit/projects/tags/test_unit_projects_tags_permissions.py
@@ -155,6 +155,7 @@ def test_project_user_with_manage_tags_has_permission_to_create(
     mock_view = mock.MagicMock(
         action="create",
         kwargs={"project_pk": project.id},
+        detail=False,
     )
     permissions = TagPermissions()
 
@@ -176,6 +177,7 @@ def test_project_user_with_view_project_does_not_have_permission_to_create(
     mock_view = mock.MagicMock(
         action="create",
         kwargs={"project_pk": project.id},
+        detail=False,
     )
     permissions = TagPermissions()
 


### PR DESCRIPTION
## Changes

Fixes an issue found in testing #4615 where it was not possible to create a tag when a user had the MANAGE_TAGS permission. 

## How did you test this code?

Added new tests to confirm both negative and positive cases. 
