### PR TITLE
fix: Clear project org search on close

### DIFF
--- a/frontend/web/components/BreadcrumbSeparator.tsx
+++ b/frontend/web/components/BreadcrumbSeparator.tsx
@@ -179,6 +179,17 @@ const BreadcrumbSeparator: FC<BreadcrumbSeparatorType> = ({
     //eslint-disable-next-line
   }, [])
 
+  useEffect(() => {
+    if(!open) {
+      if(projectSearch) {
+        setProjectSearch('')
+      }
+      if(organisationSearch) {
+        setOrganisationSearch('')
+      }
+    }
+  }, [open]);
+
   const { data: projects } = useGetProjectsQuery(
     {
       organisationId: `${hoveredOrganisation?.id}`,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Clears organisation search and project search on close

## How did you test this code?

search + select project, reopen menu and hover organisations.