### PR TITLE
fix: `AttributeError` when using `LOGGING_CONFIGURATION_FILE` environment variable

### DIFF
--- a/api/tests/unit/util/test_logging.py
+++ b/api/tests/unit/util/test_logging.py
@@ -1,8 +1,11 @@
 import json
 import logging
+import logging.config
 import os
 
 import pytest
+from gunicorn.config import Config
+from pytest_django.fixtures import SettingsWrapper
 
 from util.logging import JsonFormatter
 
@@ -59,3 +62,16 @@ def test_json_formatter__outputs_expected(
             "exc_info": expected_tb_string,
         },
     ]
+
+
+def test_gunicorn_json_capable_logger__non_existent_setting__not_raises(
+    settings: SettingsWrapper,
+) -> None:
+    # Given
+    del settings.LOG_FORMAT
+    config = Config()
+
+    # When & Then
+    from util.logging import GunicornJsonCapableLogger
+
+    GunicornJsonCapableLogger(config)

--- a/api/tests/unit/util/test_logging.py
+++ b/api/tests/unit/util/test_logging.py
@@ -28,7 +28,7 @@ def test_json_formatter__outputs_expected(
     expected_tb_string = (
         "Traceback (most recent call last):\n"
         f'  File "{expected_module_path}",'
-        " line 34, in _log_traceback\n"
+        " line 37, in _log_traceback\n"
         "    raise Exception()\nException"
     )
 

--- a/api/util/logging.py
+++ b/api/util/logging.py
@@ -57,7 +57,7 @@ class GunicornAccessLogJsonFormatter(JsonFormatter):
 class GunicornJsonCapableLogger(GunicornLogger):
     def setup(self, cfg: Config) -> None:
         super().setup(cfg)
-        if settings.LOG_FORMAT == "json":
+        if getattr(settings, "LOG_FORMAT", None) == "json":
             self._set_handler(
                 self.error_log,
                 cfg.errorlog,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #4692.

## How did you test this code?

Ran Flagsmith with `LOGGING_CONFIGURATION_FILE` as per the issue description.
