### PR TITLE
fix: searching edge identities (dashboard_alias prefix and identifier casing)

### DIFF
--- a/api/edge_api/identities/serializers.py
+++ b/api/edge_api/identities/serializers.py
@@ -289,7 +289,7 @@ class EdgeIdentitySearchField(serializers.CharField):
 
         if search_term.startswith(DASHBOARD_ALIAS_SEARCH_PREFIX):
             kwargs["search_attribute"] = DASHBOARD_ALIAS_ATTRIBUTE
-            search_term = search_term.lstrip(DASHBOARD_ALIAS_SEARCH_PREFIX)
+            search_term = search_term.removeprefix(DASHBOARD_ALIAS_SEARCH_PREFIX)
         else:
             kwargs["search_attribute"] = IDENTIFIER_ATTRIBUTE
 

--- a/api/edge_api/identities/serializers.py
+++ b/api/edge_api/identities/serializers.py
@@ -285,11 +285,14 @@ class GetEdgeIdentityOverridesQuerySerializer(serializers.Serializer):
 class EdgeIdentitySearchField(serializers.CharField):
     def to_internal_value(self, data: str) -> EdgeIdentitySearchData:
         kwargs = {}
-        search_term = data.lower()
+        search_term = data
 
         if search_term.startswith(DASHBOARD_ALIAS_SEARCH_PREFIX):
             kwargs["search_attribute"] = DASHBOARD_ALIAS_ATTRIBUTE
-            search_term = search_term.removeprefix(DASHBOARD_ALIAS_SEARCH_PREFIX)
+            # dashboard aliases are always stored in lower case
+            search_term = search_term.removeprefix(
+                DASHBOARD_ALIAS_SEARCH_PREFIX
+            ).lower()
         else:
             kwargs["search_attribute"] = IDENTIFIER_ATTRIBUTE
 

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -375,6 +375,10 @@ def identity_document(
     mv_feature_name,
     mv_feature,
 ):
+    # use a mixture of cases and symbols to make sure we're testing all cases
+    _identifier = "User1-Test"
+    _dashboard_alias = "Dashboard-Alias"
+
     _environment_feature_state_1_document = {
         "featurestate_uuid": "ad71c644-71df-4e83-9cb5-cd2cd0160200",
         "multivariate_feature_state_values": [],
@@ -431,15 +435,15 @@ def identity_document(
         "feature_segment": None,
     }
     return {
-        "composite_key": f"{environment_api_key}_user_1_test",
-        "dashboard_alias": "dashboard-alias",
+        "composite_key": f"{environment_api_key}_{_identifier}",
+        "dashboard_alias": _dashboard_alias,
         "identity_traits": identity_traits,
         "identity_features": [
             _environment_feature_state_1_document,
             _environment_feature_state_2_document,
             _mv_feature_state_document,
         ],
-        "identifier": "user_1_test",
+        "identifier": _identifier,
         "created_date": "2021-09-21T10:12:42.230257+00:00",
         "environment_api_key": environment_api_key,
         "identity_uuid": "59efa2a7-6a45-46d6-b953-a7073a90eacf",

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -375,9 +375,8 @@ def identity_document(
     mv_feature_name,
     mv_feature,
 ):
-    # use a mixture of cases and symbols to make sure we're testing all cases
-    _identifier = "User1-Test"
-    _dashboard_alias = "Dashboard-Alias"
+    _identifier = "User1-Test"  # use a mixture of cases and symbols to make sure we're testing all cases
+    _dashboard_alias = "dashboard-alias"
 
     _environment_feature_state_1_document = {
         "featurestate_uuid": "ad71c644-71df-4e83-9cb5-cd2cd0160200",

--- a/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
@@ -388,7 +388,7 @@ def test_search_for_identities_by_dashboard_alias_exact(
 ) -> None:
     # Given
     identifier = identity_document["identifier"]
-    dashboard_alias = "hans"
+    dashboard_alias = identity_document["dashboard_alias"]
 
     flagsmith_identities_table.put_item(Item=identity_document)
 

--- a/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
@@ -350,8 +350,10 @@ def test_search_for_identities_by_dashboard_alias_prefix(
     # Given
     identifier = identity_document["identifier"]
 
-    # Using this specific email address to reproduce an issue seen in
-    # production, due to the use of lstrip instead or removeprefix.
+    # This test verifies a previous bug which meant that if any of the
+    # leading characters to the search string were contained in the
+    # `string `"dashboard_alias:"` then they would also be removed
+    # and the search would fail.
     identity_document["dashboard_alias"] = "hans.gruber@example.com"
     search_string = "hans"
 


### PR DESCRIPTION
## Changes

This PR fixes 2 issues: 

 1. Any search term that began with any number of characters contained in the string `"dashboard_alias:"` would fail because of the way in which `lstrip` works. 
 2. When searching by an identifier, the search term was incorrectly lower cased, meaning that the search would return no results if the identifier contained upper case characters (see [here](https://github.com/Flagsmith/flagsmith/pull/4676) for the culprit PR)

tl;dr on (1) - TIL `str.lstrip()` removes all characters from the beginning of the string that match the input string. What we actually wanted here was `str.removeprefix()`. More information available [here](https://docs.python.org/3/library/stdtypes.html#str.lstrip). 

## How did you test this code?

Added a new unit test with a specific example of the issue. 
