### PR TITLE
feat: Hide change email when auth_type !== 'EMAIL'

### DIFF
--- a/docs/docs/deployment/hosting/locally-frontend.md
+++ b/docs/docs/deployment/hosting/locally-frontend.md
@@ -87,6 +87,7 @@ Current variables used between 'frontend/environment.js' and 'frontend/common/pr
   signups.
 - `PREVENT_FORGOT_PASSWORD`: Determines whether to prevent forgot password functionality, useful for LDAP/SAML. Set it
   to any value to prevent forgot password functionality.
+- `PREVENT_EMAIL_PASSWORD`: Disables email address signup, login and change email functionality.
 - `ENABLE_MAINTENANCE_MODE`: Puts the site into maintenance mode. Set it to any value to enable maintenance.
 - `AMPLITUDE_API_KEY`: The Amplitude key to use for behaviour tracking.
 - `MIXPANEL_API_KEY`: Mixpanel analytics key to use for behaviour tracking.

--- a/frontend/web/components/pages/AccountSettingsPage.js
+++ b/frontend/web/components/pages/AccountSettingsPage.js
@@ -188,48 +188,50 @@ class TheComponent extends Component {
                     />
                     <div className='col-md-6'>
                       <form className='mb-0' onSubmit={this.save}>
-                        <div>
-                          <InputGroup
-                            className='mt-2'
-                            title='Email Address'
-                            data-test='firstName'
-                            inputProps={{
-                              className: 'full-width',
-                              name: 'groupName',
-                              readOnly: true,
-                            }}
-                            value={email}
-                            onChange={(e) =>
-                              this.setState({
-                                first_name: Utils.safeParseEventValue(e),
-                              })
-                            }
-                            type='text'
-                            name='Email Address'
-                          />
-                          <div className='text-right mt-5'>
-                            <Button
-                              onClick={() =>
-                                openModal(
-                                  'Change Email Address',
-                                  <ChangeEmailAddress
-                                    onComplete={() => {
-                                      closeModal()
-                                      AppActions.logout()
-                                    }}
-                                  />,
-                                  'p-0',
-                                )
-                              }
-                              id='change-email-button'
-                              data-test='change-email-button'
-                              type='button'
-                              class='input-group-addon'
-                            >
-                              Change Email Address
-                            </Button>
-                          </div>
-                        </div>
+                        {!Project.preventEmailPassword && (
+                            <div>
+                              <InputGroup
+                                  className='mt-2'
+                                  title='Email Address'
+                                  data-test='firstName'
+                                  inputProps={{
+                                    className: 'full-width',
+                                    name: 'groupName',
+                                    readOnly: true,
+                                  }}
+                                  value={email}
+                                  onChange={(e) =>
+                                      this.setState({
+                                        first_name: Utils.safeParseEventValue(e),
+                                      })
+                                  }
+                                  type='text'
+                                  name='Email Address'
+                              />
+                              <div className='text-right mt-5'>
+                                <Button
+                                    onClick={() =>
+                                        openModal(
+                                            'Change Email Address',
+                                            <ChangeEmailAddress
+                                                onComplete={() => {
+                                                  closeModal()
+                                                  AppActions.logout()
+                                                }}
+                                            />,
+                                            'p-0',
+                                        )
+                                    }
+                                    id='change-email-button'
+                                    data-test='change-email-button'
+                                    type='button'
+                                    class='input-group-addon'
+                                >
+                                  Change Email Address
+                                </Button>
+                              </div>
+                            </div>
+                        )}
                         <InputGroup
                           className='mt-2 mb-4'
                           title='First Name'

--- a/frontend/web/components/pages/AccountSettingsPage.js
+++ b/frontend/web/components/pages/AccountSettingsPage.js
@@ -188,7 +188,7 @@ class TheComponent extends Component {
                     />
                     <div className='col-md-6'>
                       <form className='mb-0' onSubmit={this.save}>
-                        {!AccountStore.model.auth_type === 'EMAIL' && (
+                        {AccountStore.model.auth_type === 'EMAIL' && (
                             <div>
                               <InputGroup
                                   className='mt-2'

--- a/frontend/web/components/pages/AccountSettingsPage.js
+++ b/frontend/web/components/pages/AccountSettingsPage.js
@@ -188,7 +188,7 @@ class TheComponent extends Component {
                     />
                     <div className='col-md-6'>
                       <form className='mb-0' onSubmit={this.save}>
-                        {!Project.preventEmailPassword && (
+                        {!AccountStore.model.auth_type === 'EMAIL' && (
                             <div>
                               <InputGroup
                                   className='mt-2'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Documents PREVENT_EMAIL_PASSWORD
- Hide the change email functionality when AccountStore.model.auth_type !== 'EMAIL'


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
