### PR TITLE
fix(ci): Anonymous registry pushes attempted for Tribvy databases

### DIFF
--- a/.github/workflows/platform-docker-trivy-scan.yml
+++ b/.github/workflows/platform-docker-trivy-scan.yml
@@ -39,7 +39,7 @@ env:
     ${{ github.event.inputs.trivy-java-db-repository-source || 'ghcr.io/aquasecurity/trivy-java-db:1' }}
   TRIVY_DB_REPOSITORY: ${{ github.event.inputs.trivy-db-repository || 'ghcr.io/flagsmith/trivy-db:latest' }}
   TRIVY_JAVA_DB_REPOSITORY:
-    ${{ github.event.inputs.trivy-java-db-repository || 'ghcr.io/aquasecurity/trivy-java-db:latest' }}
+    ${{ github.event.inputs.trivy-java-db-repository || 'ghcr.io/flagsmith/trivy-java-db:latest' }}
 
 jobs:
   pull-trivy-db:
@@ -58,6 +58,7 @@ jobs:
         with:
           shell: bash
           command: |
+            echo ${{ secrets.GITHUB_TOKEN }} | oras login -u ${{ github.action }} --password-stdin
             oras pull --no-tty $TRIVY_DB_REPOSITORY_SOURCE
             oras pull --no-tty $TRIVY_JAVA_DB_REPOSITORY_SOURCE
             oras push $TRIVY_DB_REPOSITORY db.tar.gz:$MIME_TYPE+gzip --artifact-type $MIME_TYPE+json


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes the following error encountered in cron runs:

```
Error response from registry: HEAD "https://ghcr.io/v2/flagsmith/trivy-db/manifests/sha256:29ff7ac50f523989ecc8224444cb3be4046e530a685cbd05a2d4c25b5f138335": denied: requested access to the resource is denied
``` 

## How did you test this code?

This is a CI change