### PR TITLE
chore: expose timezone setting

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -174,6 +174,7 @@ DJANGO_DB_CONN_MAX_AGE = None if db_conn_max_age == -1 else db_conn_max_age
 DATABASE_ROUTERS = ["app.routers.PrimaryReplicaRouter"]
 NUM_DB_REPLICAS = 0
 NUM_CROSS_REGION_DB_REPLICAS = 0
+
 # Allows collectstatic to run without a database, mainly for Docker builds to collectstatic at build time
 if "DATABASE_URL" in os.environ:
     DATABASES = {
@@ -404,7 +405,7 @@ LANGUAGE_CODE = "en-us"
 
 if (custom_time_zone := env("TIME_ZONE", default=None)) is not None:
     TIME_ZONE = custom_time_zone
-    DATABASES["TIME_ZONE"] = custom_time_zone
+    DATABASES["default"]["TIME_ZONE"] = custom_time_zone
 else:
     TIME_ZONE = "UTC"
 

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -402,7 +402,11 @@ DJANGO_ADMIN_SSO_OAUTH_CLIENT_SECRET = env.str("OAUTH_CLIENT_SECRET", default=""
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = env("TIME_ZONE", default="UTC")
+if (custom_time_zone := env("TIME_ZONE", default=None)) is not None:
+    TIME_ZONE = custom_time_zone
+    DATABASES["TIME_ZONE"] = custom_time_zone
+else:
+    TIME_ZONE = "UTC"
 
 USE_I18N = True
 

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -402,7 +402,7 @@ DJANGO_ADMIN_SSO_OAUTH_CLIENT_SECRET = env.str("OAUTH_CLIENT_SECRET", default=""
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = env("TIME_ZONE", default="UTC")
 
 USE_I18N = True
 


### PR DESCRIPTION
## Changes

Due to configuration from a specific customer, it might be necessary to expose the timezone setting to work around a misconfiguration of their postgres database(s). 

NOTE: this is a change that will need to be tested by the customer so shouldn't yet be merged. 

## How did you test this code?

Ran the application in docker compose against a database with it's timezone set to something other than UTC, configured the Flagsmith application's TIME_ZONE setting to match the database and verified that times were shown correctly in the dashboard. 
