### PR TITLE
docs: remove CDN option from docs

### DIFF
--- a/docs/docs/clients/client-side/javascript.md
+++ b/docs/docs/clients/client-side/javascript.md
@@ -41,12 +41,6 @@ AsyncStorage to be provided (e.g. @react-native-community/async-storage) in orde
 npm i react-native-flagsmith --save
 ```
 
-### Via JavaScript CDN
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/flagsmith/index.js"></script>
-```
-
 ## Basic Usage
 
 The SDK is initialised against a single environment within a project on [https://flagsmith.com](https://flagsmith.com),

--- a/docs/docs/clients/client-side/react.md
+++ b/docs/docs/clients/client-side/react.md
@@ -42,12 +42,6 @@ AsyncStorage to be provided (e.g. @react-native-community/async-storage) in orde
 npm i react-native-flagsmith --save
 ```
 
-### Via JavaScript CDN
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/flagsmith/index.js"></script>
-```
-
 ## Basic Usage
 
 The SDK is initialised against a single environment. You can find your Client-side Environment Key in the Environment

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -69,16 +69,8 @@ The page looks like this:
 For the purposes of this quickstart tutorial, we will import the SDK inline into our web page:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/flagsmith/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flagsmith@7.0.0/index.js"></script>
 ```
-
-:::warning
-
-Please be aware that using the CDN in this way will always give you the latest version of the Flagsmith SDK. We do not
-recommend using this in production, and always recommend pinning to a specific version. See the docs for installing the
-client using a package manager [here](clients/client-side/javascript.md).
-
-:::
 
 ## 3. Connect to the Flagsmith API
 
@@ -135,7 +127,7 @@ Our entire webpage now reads like this:
  <head>
   <meta charset="utf-8" />
   <title>Flagsmith Quickstart Guide</title>
-  <script src="https://cdn.jsdelivr.net/npm/flagsmith/index.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flagsmith@7.0.0/index.js"></script>
   <script>
    flagsmith.init({
     environmentID: 'ZfmJTbLQZrhZVHkVhXbsNi',

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -66,11 +66,19 @@ The page looks like this:
 
 <div style={{textAlign: 'center'}}><img width="75%" src="/img/quickstart/demo_create_8.png"/></div>
 
-As per our [Javascript Docs](clients/client-side/javascript.md), we will import the SDK inline into our web page:
+For the purposes of this quickstart tutorial, we will import the SDK inline into our web page:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/flagsmith/index.js"></script>
 ```
+
+:::warning
+
+Please be aware that using the CDN in this way will always give you the latest version of the Flagsmith SDK. We do not
+recommend using this in production, and always recommend pinning to a specific version. See the docs for installing the
+client using a package manager [here](clients/client-side/javascript.md).
+
+:::
 
 ## 3. Connect to the Flagsmith API
 


### PR DESCRIPTION
## Changes

Remove CDN option from JS SDK installation docs. 

## How did you test this code?

Ran docusaurus locally and verified the changes.
