### PR TITLE
chore: update dashboard_alias index name

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1024,7 +1024,7 @@ def flagsmith_identities_table(
                 "Projection": {"ProjectionType": "ALL"},
             },
             {
-                "IndexName": "environment_api_key-dashboard_alias-index",
+                "IndexName": "environment_api_key-dashboard_alias-index-v2",
                 "KeySchema": [
                     {"AttributeName": "environment_api_key", "KeyType": "HASH"},
                     {"AttributeName": "dashboard_alias", "KeyType": "RANGE"},

--- a/api/edge_api/identities/search.py
+++ b/api/edge_api/identities/search.py
@@ -6,7 +6,7 @@ DASHBOARD_ALIAS_ATTRIBUTE = "dashboard_alias"
 DASHBOARD_ALIAS_SEARCH_PREFIX = f"{DASHBOARD_ALIAS_ATTRIBUTE}:"
 
 IDENTIFIER_INDEX_NAME = "environment_api_key-identifier-index"
-DASHBOARD_ALIAS_INDEX_NAME = "environment_api_key-identifier-index-v2"
+DASHBOARD_ALIAS_INDEX_NAME = "environment_api_key-dashboard_alias-index-v2"
 
 
 class EdgeIdentitySearchType(enum.Enum):

--- a/api/edge_api/identities/search.py
+++ b/api/edge_api/identities/search.py
@@ -5,6 +5,9 @@ IDENTIFIER_ATTRIBUTE = "identifier"
 DASHBOARD_ALIAS_ATTRIBUTE = "dashboard_alias"
 DASHBOARD_ALIAS_SEARCH_PREFIX = f"{DASHBOARD_ALIAS_ATTRIBUTE}:"
 
+IDENTIFIER_INDEX_NAME = "environment_api_key-identifier-index"
+DASHBOARD_ALIAS_INDEX_NAME = "environment_api_key-identifier-index-v2"
+
 
 class EdgeIdentitySearchType(enum.Enum):
     EQUAL = "EQUAL"
@@ -25,4 +28,6 @@ class EdgeIdentitySearchData:
 
     @property
     def dynamo_index_name(self):
-        return f"environment_api_key-{self.search_attribute}-index"
+        if self.search_attribute == DASHBOARD_ALIAS_ATTRIBUTE:
+            return DASHBOARD_ALIAS_INDEX_NAME
+        return IDENTIFIER_INDEX_NAME


### PR DESCRIPTION
## Changes

Because the original index didn't project the `identity_uuid` attribute I had to create a new index in dynamodb.

## How did you test this code?

Existing unit test coverage. 
