### PR TITLE
fix: add trailing slash to endpoint to retrieve features after feature create

### DIFF
--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -115,7 +115,7 @@ const controller = {
       })
       .then(() =>
         Promise.all([
-          data.get(`${Project.api}projects/${projectId}/features?environment=${ProjectStore.getEnvironmentIdFromKey(environmentId)}`),
+          data.get(`${Project.api}projects/${projectId}/features/?environment=${ProjectStore.getEnvironmentIdFromKey(environmentId)}`),
         ]).then(([features]) => {
           const environmentFeatures = features.results.map((v) => ({
             ...v.environment_feature_state,


### PR DESCRIPTION
## Changes

Adds trailing slash to features endpoint following create feature. 

## How did you test this code?

N/a - trivial change. 
