### PR TITLE
chore: Remove version property from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 # See https://docs.flagsmith.com/deployment/docker for more information on running Flagsmith in Docker
 # This Docker Compose file will run the entire Flagsmith Platform
 
-version: '3'
-
 volumes:
   pgdata:
 


### PR DESCRIPTION
Fixes this warning

```console
% docker compose up
WARN[0000] /Users/rolodato/source/flagsmith/flagsmith/docker-compose.yml: `version` is obsolete
```

See https://docs.docker.com/reference/compose-file/version-and-name/

> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative and you'll receive a warning message that it is obsolete if used.