### PR TITLE
fix: Prevent newlines in environment variables from causing frontend syntax errors

### DIFF
--- a/frontend/api/index.js
+++ b/frontend/api/index.js
@@ -40,7 +40,7 @@ app.get('/config/project-overrides', (req, res) => {
             `
     }
 
-    return `    ${name}: '${value}',
+    return `    ${name}: '${value.trim()}',
         `
   }
   const envToBool = (name, defaultVal) => {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

If a frontend environment variable such as `FLAGSMITH_ON_FLAGSMITH_API_KEY` includes a trailing newline, the response from `/config/project-overrides` will be invalid JavaScript. For example, running the frontend like this causes a syntax error on the login page:

```
rolodato@rolosmith frontend % FLAGSMITH_ON_FLAGSMITH_API_KEY='ENktaJnfLVbLifybz34JmX
' npm run dev
```

results in this response, which is invalid and causes a frontend syntax error:

```
window.projectOverrides = {
            preventSignup: false,
                    preventEmailPassword: false,
                    preventForgotPassword: false,
                    superUserCreateOnly: false,
                    flagsmith: 'ENktaJnfLVbLifybz34JmX
',
            maintenance: false,
                    disableAnalytics: false,
                    flagsmithAnalytics: true,
                flagsmithRealtime: false,
                    hideInviteLinks: false,
                    linkedinPartnerTracking: false,
                    useSecureCookies: true,
            
    };
```

A customer ran into this when using a manually base64-encoded Kubernetes secret without realising it had a trailing newline, which broke their frontend.

`String.prototype.trim` removes all surrounding whitespace, not just newlines, but I'm 99% certain we will never have environment variables that depend on trailing or leading whitespace.

This can still break if environment variables contain `'`, `/*` or other strings that interfere with JS. We should use a smarter mechanism to inject configuration that cannot cause a syntax error in the frontend, such as injecting a JSON payload and trying to decode that from JS, instead of injecting JS directly.

## How did you test this code?

Manually by running the FE locally, and confirming this works as expected with this change:

```
FLAGSMITH_ON_FLAGSMITH_API_KEY='ENktaJnfLVbLifybz34JmX
' npm run dev
```