### PR TITLE
fix: Frontend error when creating SAML configuration if API URL is relative

### DIFF
--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -55,7 +55,10 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
     { skip: !samlName },
   )
 
-  const acsUrl = new URL(`/auth/saml/${name}/response/`, Project.api).href
+  const acsUrl = new URL(
+    `./auth/saml/${name}/response/`,
+    new Request(Project.api).url, // Project.api can be relative, e.g. /api/v1/
+  ).href
   const copyAcsUrl = async () => {
     await navigator.clipboard.writeText(acsUrl)
     toast('Copied to clipboard')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

If `Project.api` points to a relative URL such as `/api/v1`, clicking on "Create SAML Configuration" or opening an existing SAML configuration results in an error:

```
Uncaught TypeError: URL constructor: /api/v1/ is not a valid URL.
    CreateSAML CreateSAML.tsx:58
```

This does not happen with the default `npm run dev` because we're setting an absolute URL of `http://localhost:8000/api/v1/`. To reproduce this bug locally, have the FE proxy requests to the BE by running like this:

```
FLAGSMITH_PROXY_API_URL=http://127.0.0.1:8000 npm run dev
```

## How did you test this code?

Manually - using `flagsmith/flagsmith-private-cloud` as the API, try to create a SAML configuration or edit an existing one.