### PR TITLE
Introducing Flagsmith Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Join the Discord chat](https://img.shields.io/discord/517647859495993347)](https://discord.gg/hFhxNtXzgm)
 [![Coverage](https://codecov.io/gh/Flagsmith/flagsmith/branch/main/graph/badge.svg?token=IyGii7VSdc)](https://codecov.io/gh/Flagsmith/flagsmith)
 <a href="https://depot.dev?utm_source=Flagsmith"><img src="https://depot.dev/badges/built-with-depot.svg" alt="Built with Depot" height="20"></a>
+[![](https://img.shields.io/badge/Gurubase-Ask%20Flagsmith%20Guru-006BFF)](https://gurubase.io/g/flagsmith)
 
 [Flagsmith](https://flagsmith.com/) is an open source, fully featured, Feature Flag and Remote Config service. Use our
 hosted API, deploy to your own private cloud, or run on-premise.
@@ -78,6 +79,7 @@ REST calls to the API.
 - [Website](https://flagsmith.com/)
 - [Documentation](https://docs.flagsmith.com/)
 - If you have any questions about our projects you can email [support@flagsmith.com](mailto:support@flagsmith.com)
+- You can also [Ask Flagsmith Guru](https://gurubase.io/g/flagsmith), it is a Flagsmith-focused AI to answer your questions.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ REST calls to the API.
 - [Website](https://flagsmith.com/)
 - [Documentation](https://docs.flagsmith.com/)
 - If you have any questions about our projects you can email [support@flagsmith.com](mailto:support@flagsmith.com)
-- You can also [Ask Flagsmith Guru](https://gurubase.io/g/flagsmith), it is a Flagsmith-focused AI to answer your questions.
+- You can also [Ask Flagsmith Guru](https://gurubase.io/g/flagsmith), it is a Flagsmith-focused AI to answer your
+  questions.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Flagsmith Guru](https://gurubase.io/g/flagsmith) to Gurubase. Flagsmith Guru uses the data from this repo and data from the [docs](https://docs.flagsmith.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Flagsmith Guru", which highlights that Flagsmith now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Flagsmith Guru in Gurubase, just let me know that's totally fine.