### PR TITLE
fix: Disable is_admin switcher in Organization API Keys

### DIFF
--- a/frontend/web/components/AdminAPIKeys.js
+++ b/frontend/web/components/AdminAPIKeys.js
@@ -178,9 +178,6 @@ export class CreateAPIKey extends PureComponent {
     const { expiry_date, is_admin, roles, showRoles } = this.state
     const buttonText = this.props.isEdit ? 'Update' : 'Create'
     const buttonSavingText = this.props.isEdit ? 'Updating' : 'Creating'
-    const isFreePlan =
-      AccountStore.getOrganisation().subscription.plan === 'free'
-
     return (
       <>
         <div className='modal-body flex flex-column flex-fill px-4'>
@@ -216,7 +213,7 @@ export class CreateAPIKey extends PureComponent {
                       })
                     }}
                     checked={is_admin}
-                    disabled={isFreePlan && is_admin}
+                    disabled={!Utils.getPlansPermission('RBAC') && is_admin}
                   />
                 </Row>
                 {!is_admin && (

--- a/frontend/web/components/AdminAPIKeys.js
+++ b/frontend/web/components/AdminAPIKeys.js
@@ -178,6 +178,9 @@ export class CreateAPIKey extends PureComponent {
     const { expiry_date, is_admin, roles, showRoles } = this.state
     const buttonText = this.props.isEdit ? 'Update' : 'Create'
     const buttonSavingText = this.props.isEdit ? 'Updating' : 'Creating'
+    const isFreePlan =
+      AccountStore.getOrganisation().subscription.plan === 'free'
+
     return (
       <>
         <div className='modal-body flex flex-column flex-fill px-4'>
@@ -213,6 +216,7 @@ export class CreateAPIKey extends PureComponent {
                       })
                     }}
                     checked={is_admin}
+                    disabled={isFreePlan && is_admin}
                   />
                 </Row>
                 {!is_admin && (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

It proposes to disabled the "is admin" switcher in order to not display roles toggle for free plans

Closes #3644

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- Go to organization API Keys
- Create or edit an api key
- Is admin should be disabled for free plans
