### PR TITLE
chore(dev): set `DEBUG=True` when enabling DB logging

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -616,7 +616,7 @@ if APPLICATION_INSIGHTS_CONNECTION_STRING:
     LOGGING["loggers"][""]["handlers"].append("azure")
 
 ENABLE_DB_LOGGING = env.bool("DJANGO_ENABLE_DB_LOGGING", default=False)
-if ENABLE_DB_LOGGING:
+if ENABLE_DB_LOGGING:  # pragma: no cover
     if not DEBUG:
         warnings.warn("Setting DEBUG=True to ensure DB logging functions correctly.")
         DEBUG = True

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -617,6 +617,8 @@ if APPLICATION_INSIGHTS_CONNECTION_STRING:
 
 ENABLE_DB_LOGGING = env.bool("DJANGO_ENABLE_DB_LOGGING", default=False)
 if ENABLE_DB_LOGGING:
+    if not DEBUG:  # pragma: no cover
+        raise ImproperlyConfigured("DB logging will not work without DEBUG=True")
     LOGGING["loggers"]["django.db.backends"] = {
         "level": "DEBUG",
         "handlers": ["console"],

--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -617,8 +617,10 @@ if APPLICATION_INSIGHTS_CONNECTION_STRING:
 
 ENABLE_DB_LOGGING = env.bool("DJANGO_ENABLE_DB_LOGGING", default=False)
 if ENABLE_DB_LOGGING:
-    if not DEBUG:  # pragma: no cover
-        raise ImproperlyConfigured("DB logging will not work without DEBUG=True")
+    if not DEBUG:
+        warnings.warn("Setting DEBUG=True to ensure DB logging functions correctly.")
+        DEBUG = True
+
     LOGGING["loggers"]["django.db.backends"] = {
         "level": "DEBUG",
         "handlers": ["console"],


### PR DESCRIPTION
## Changes

Raises an exception on startup if `ENABLE_DB_LOGGING == True and DEBUG != True` since DB logging functionality does not work without the DEBUG environment variable set to true. 

This caught me out for a while so I figured it would be good to ensure it doesn't affect others in the future. 

## How did you test this code?

Ran the application locally with all combinations of `DJANGO_ENABLE_DB_LOGGING` and `DEBUG` environment variables. 
