### PR TITLE
fix: Fix "assigned groups" showing empty when trying to assign groups to a role

### DIFF
--- a/frontend/common/services/useMyGroup.ts
+++ b/frontend/common/services/useMyGroup.ts
@@ -9,7 +9,7 @@ export const myGroupService = service
       getMyGroups: builder.query<Res['myGroups'], Req['getMyGroups']>({
         providesTags: [{ id: 'LIST', type: 'MyGroup' }],
         query: (q) => ({
-          url: `/organisations/${q.orgId}/groups/my-groups`,
+          url: `/organisations/${q.orgId}/groups/my-groups/`,
         }),
       }),
       // END OF ENDPOINTS


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

When the API and FE are running on the same domain, the FE tries to hit `/my-groups` which is not a valid API endpoint. This causes the "Assigned groups" dropdown to show as empty:

![image](https://github.com/user-attachments/assets/815e57ab-1c3f-4f40-987e-ceb11e9673af)

This change adds the missing trailing slash, which makes this work:

![image](https://github.com/user-attachments/assets/854f6799-cf76-44f9-a8eb-c31b4d84bc1f)


## How did you test this code?

Manually by running the FE locally against the API on the same domain.
