### PR TITLE
fix(sales-dashboard): prevent 500 error when user doesn't exist on sales dashboard search

### DIFF
--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -137,8 +137,11 @@ class OrganisationList(ListView):
             query = Q()
 
             if domain_regex.match(search_term):
+                matching_users = FFAdminUser.objects.filter(
+                    email__iendswith=search_term
+                )
                 org_ids = UserOrganisation.objects.filter(
-                    user__email__iendswith=search_term
+                    user__in=matching_users
                 ).values_list("organisation_id", flat=True)
                 query = query & Q(id__in=org_ids)
 

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -54,6 +54,7 @@ DEFAULT_ORGANISATION_SORT = "subscription_information_cache__api_calls_30d"
 DEFAULT_ORGANISATION_SORT_DIRECTION = "DESC"
 
 email_regex = re.compile(r"^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$")
+domain_regex = re.compile(r"^[a-z0-9.-]+\.[a-z]{2,}$")
 
 
 @method_decorator(
@@ -127,24 +128,25 @@ class OrganisationList(ListView):
         return data
 
     def _build_search_query(self, search_term: str) -> Q:
-        if email_regex.match(search_term.lower()):
-            # Assume that the search is for the email of a given user
-            user = FFAdminUser.objects.filter(email__iexact=search_term).first()
+        search_term = search_term.lower()
+        if email_regex.match(search_term) and (
+            user := FFAdminUser.objects.filter(email__iexact=search_term).first()
+        ):
+            return Q(id__in=user.organisations.values_list("id", flat=True))
+        else:
+            query = Q()
 
-            if user:
-                org_ids = user.organisations.values_list("id", flat=True)
-            else:
-                domain = search_term.split("@")[-1]
-                matching_users = FFAdminUser.objects.filter(email__iendswith=domain)
+            if domain_regex.match(search_term):
                 org_ids = UserOrganisation.objects.filter(
-                    user__in=matching_users
+                    user__email__iendswith=search_term
                 ).values_list("organisation_id", flat=True)
+                query = query & Q(id__in=org_ids)
 
-            return Q(id__in=org_ids)
-
-        return Q(name__icontains=search_term) | Q(
-            subscription__subscription_id=search_term
-        )
+            return (
+                query
+                | Q(name__icontains=search_term)
+                | Q(subscription__subscription_id__iexact=search_term)
+            )
 
 
 @staff_member_required

--- a/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
+++ b/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
@@ -128,6 +128,26 @@ def test_list_organisations_search_by_user_email(
     assert list(response.context_data["organisation_list"]) == [organisation]
 
 
+def test_list_organisations_search_by_user_email_for_non_existent_user(
+    organisation: Organisation,
+    superuser_client: Client,
+) -> None:
+    # Given
+    domain = "bar.com"
+    user = FFAdminUser.objects.create(email=f"foo@{domain}")
+    user.add_organisation(organisation)
+    search_term = f"baz@{domain}"
+
+    url = "%s?search=%s" % (reverse("sales_dashboard:index"), search_term)
+
+    # When
+    response = superuser_client.get(url)
+
+    # Then
+    assert response.status_code == 200
+    assert list(response.context_data["organisation_list"]) == [organisation]
+
+
 def test_list_organisations_filter_plan(
     organisation: Organisation,
     chargebee_subscription: Subscription,

--- a/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
+++ b/api/tests/unit/sales_dashboard/test_unit_sales_dashboard_views.py
@@ -145,6 +145,25 @@ def test_list_organisations_search_by_user_email_for_non_existent_user(
 
     # Then
     assert response.status_code == 200
+    assert list(response.context_data["organisation_list"]) == []
+
+
+def test_list_organisations_search_by_domain(
+    organisation: Organisation,
+    superuser_client: Client,
+) -> None:
+    # Given
+    domain = "bar.com"
+    user = FFAdminUser.objects.create(email=f"foo@{domain}")
+    user.add_organisation(organisation)
+
+    url = "%s?search=%s" % (reverse("sales_dashboard:index"), domain)
+
+    # When
+    response = superuser_client.get(url)
+
+    # Then
+    assert response.status_code == 200
     assert list(response.context_data["organisation_list"]) == [organisation]
 
 


### PR DESCRIPTION
## Changes

Prevents a 500 error when searching the sales dashboard for a user email address that doesn't exist.

Also adds functionality to search by a domain, which will now search across all users with that domain and return any organisations that belong to users with that domain. 

Note that the reason this can't be simplified to e.g. `users__email__endswith` is because of this PR: #4377. 

## How did you test this code?

Added a new unit test. 
