### PR TITLE
feat: Support `PREVENT_EMAIL_PASSWORD` in backend

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -790,6 +790,9 @@ TRENCH_AUTH = {
 USER_CREATE_PERMISSIONS = env.list(
     "USER_CREATE_PERMISSIONS", default=["custom_auth.permissions.IsSignupAllowed"]
 )
+USER_LOGIN_PERMISSIONS = env.list(
+    "USER_LOGIN_PERMISSIONS", default=["custom_auth.permissions.IsPasswordLoginAllowed"]
+)
 
 DJOSER = {
     "PASSWORD_RESET_CONFIRM_URL": "password-reset/confirm/{uid}/{token}",
@@ -817,6 +820,7 @@ DJOSER = {
         "user": ["custom_auth.permissions.CurrentUser"],
         "user_list": ["custom_auth.permissions.CurrentUser"],
         "user_create": USER_CREATE_PERMISSIONS,
+        "token_create": USER_LOGIN_PERMISSIONS,
     },
 }
 SIMPLE_JWT = {
@@ -895,7 +899,6 @@ PROJECT_METADATA_TABLE_NAME_DYNAMO = env.str("PROJECT_METADATA_TABLE_NAME_DYNAMO
 API_URL = env("API_URL", default="/api/v1/")
 ASSET_URL = env("ASSET_URL", default="/")
 MAINTENANCE_MODE = env.bool("MAINTENANCE_MODE", default=False)
-PREVENT_EMAIL_PASSWORD = env.bool("PREVENT_EMAIL_PASSWORD", default=False)
 DISABLE_ANALYTICS_FEATURES = env.bool(
     "DISABLE_INFLUXDB_FEATURES", default=False
 ) or env.bool("DISABLE_ANALYTICS_FEATURES", default=False)
@@ -1032,6 +1035,7 @@ BUCKETED_ANALYTICS_DATA_RETENTION_DAYS = env.int(
 
 DISABLE_INVITE_LINKS = env.bool("DISABLE_INVITE_LINKS", False)
 PREVENT_SIGNUP = env.bool("PREVENT_SIGNUP", default=False)
+PREVENT_EMAIL_PASSWORD = env.bool("PREVENT_EMAIL_PASSWORD", default=False)
 COOKIE_AUTH_ENABLED = env.bool("COOKIE_AUTH_ENABLED", default=False)
 USE_SECURE_COOKIES = env.bool("USE_SECURE_COOKIES", default=True)
 COOKIE_SAME_SITE = env.str("COOKIE_SAME_SITE", default="none")

--- a/api/custom_auth/permissions.py
+++ b/api/custom_auth/permissions.py
@@ -19,3 +19,8 @@ class CurrentUser(IsAuthenticated):
 class IsSignupAllowed(AllowAny):
     def has_permission(self, request: Request, view: View) -> bool:
         return not settings.PREVENT_SIGNUP
+
+
+class IsPasswordLoginAllowed(AllowAny):
+    def has_permission(self, request: Request, view: View) -> bool:
+        return not settings.PREVENT_EMAIL_PASSWORD


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds a permission class to ensure that the `/api/v1/auth/login` endpoint can not be used when `PREVENT_EMAIL_PASSWORD` setting is enabled.

## How did you test this code?

Enabled the setting locally and tried to access the `/api/v1/auth/login` endpoint.