### PR TITLE
fix: Fix stored XSS when rendering tooltips

### DIFF
--- a/frontend/web/components/Tooltip.tsx
+++ b/frontend/web/components/Tooltip.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactElement, ReactNode, useRef } from 'react'
 import ReactTooltip, { TooltipProps as _TooltipProps } from 'react-tooltip'
 import Utils from 'common/utils/utils'
 import classNames from 'classnames'
+import { sanitize } from 'dompurify'
 
 export type TooltipProps = {
   title: ReactNode
@@ -44,7 +45,7 @@ const Tooltip: FC<TooltipProps> = ({
           ) : (
             <div
               style={{ wordBreak: 'break-word' }}
-              dangerouslySetInnerHTML={{ __html: children }}
+              dangerouslySetInnerHTML={{ __html: sanitize(children) }}
             />
           )}
         </ReactTooltip>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes a stored XSS when rendering tooltips. This can be triggered with the following actions:

* Enabling "Compact view" in the Features list and hovering over a feature with an XSS payload in its description
* Comparing two environments or identities in a project that has a feature with an XSS payload in its description
* Visiting the identity details page for any identity in a project containing a feature with an XSS payload in its description

Example description payload:

```
<img src=x onerror=alert('hello')>
```

## How did you test this code?

Locally by performing the above actions and comparing them to the current release version of the frontend.