### PR TITLE
docs: Don't use TOC headings for headings within tabs

### DIFF
--- a/docs/docs/clients/server-side.md
+++ b/docs/docs/clients/server-side.md
@@ -1272,7 +1272,7 @@ _flagsmithClient = new FlagsmithClient(
 )
 ```
 
-### Singleton Initialization
+<h3>Singleton Initialization</h3>
 
 Singleton ensures a single instance of FlagsmithClient throughout the application, optimizing resources and maintaining
 consistency in configuration.

--- a/docs/docs/clients/server-side.md
+++ b/docs/docs/clients/server-side.md
@@ -1272,7 +1272,7 @@ _flagsmithClient = new FlagsmithClient(
 )
 ```
 
-<h3>Singleton Initialization</h3>
+<h3>Singleton Initialisation</h3>
 
 Singleton ensures a single instance of FlagsmithClient throughout the application, optimizing resources and maintaining
 consistency in configuration.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The "Singleton Initialisation" table of contents heading does not work if you're not already viewing the .NET SDK. This change removes this heading from the TOC, see https://docusaurus.io/docs/markdown-features/toc#customizing-table-of-contents-generation

> Markdown headings within hideable areas will still show up in the TOC. For example, headings within [Tabs](https://docusaurus.io/docs/markdown-features/tabs) and [details](https://docusaurus.io/docs/markdown-features#details) will not be excluded.
> 
> Non-Markdown headings will not show up in the TOC. This can be used to your advantage to tackle the aforementioned issue.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manually