### PR TITLE
fix: hide view features from associated segment overrides

### DIFF
--- a/frontend/web/components/SegmentOverrideActions.tsx
+++ b/frontend/web/components/SegmentOverrideActions.tsx
@@ -13,12 +13,13 @@ interface SegmentOverrideActionProps {
   canRemove: boolean
   onRemove: () => void
   onEdit: () => void
+  hideViewSegment?: void
   onCopyValue: () => void
   canEdit: boolean
   canCopyValue: boolean
 }
 
-type ActionType = 'edit' | 'remove'
+type ActionType = 'edit' | 'remove' | 'copy'
 
 function calculateListPosition(
   btnEl: HTMLElement,
@@ -33,6 +34,7 @@ export const SegmentOverrideAction: FC<SegmentOverrideActionProps> = ({
   canCopyValue,
   canEdit,
   canRemove,
+  hideViewSegment,
   onCopyValue,
   onEdit,
   onRemove,
@@ -80,7 +82,7 @@ export const SegmentOverrideAction: FC<SegmentOverrideActionProps> = ({
     )
   }
 
-  if (!!canEdit && !canRemove) {
+  if (!!canEdit && !canRemove && !hideViewSegment) {
     return (
       <Button onClick={() => handleActionClick('edit')} size='small'>
         View Segment
@@ -111,7 +113,7 @@ export const SegmentOverrideAction: FC<SegmentOverrideActionProps> = ({
           ref={listRef}
           className='feature-action__list'
         >
-          {!!canEdit && (
+          {!!canEdit && !hideViewSegment && (
             <div
               className='feature-action__item'
               onClick={(e) => {

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -47,6 +47,7 @@ const SegmentOverrideInner = class Override extends React.Component {
       confirmRemove,
       controlValue,
       disabled,
+      hideViewSegment,
       index,
       multivariateOptions,
       name,
@@ -185,6 +186,7 @@ const SegmentOverrideInner = class Override extends React.Component {
                       Constants.projectPermissions('Manage Segments'),
                       <>
                         <SegmentOverrideActions
+                          hideViewSegment={hideViewSegment}
                           onCopyValue={() => {
                             this.setState({ changed: true })
                             setValue(
@@ -346,6 +348,7 @@ const SegmentOverrideListInner = ({
   controlValue,
   disabled,
   environmentId,
+  hideViewSegment,
   id,
   items,
   multivariateOptions,
@@ -370,6 +373,7 @@ const SegmentOverrideListInner = ({
             id={id}
             name={name}
             segment={value.segment}
+            hideViewSegment={hideViewSegment}
             onSortEnd={onSortEnd}
             disabled={disabled}
             showEditSegment={showEditSegment}
@@ -705,6 +709,7 @@ class TheComponent extends Component {
                       setSegmentEditId={this.setSegmentEditId}
                       onSortEnd={this.onSortEnd}
                       projectFlag={this.props.projectFlag}
+                      hideViewSegment={this.props.hideViewSegment}
                     />
                     <div className='text-left mt-4'>
                       <JSONReference

--- a/frontend/web/components/modals/AssociatedSegmentOverrides.js
+++ b/frontend/web/components/modals/AssociatedSegmentOverrides.js
@@ -266,6 +266,7 @@ export default class SegmentOverridesInner extends Component {
         <UncontrolledSegmentOverrides
           feature={projectFlag.id}
           readOnly
+          hideViewSegment
           projectId={projectId}
           multivariateOptions={_.cloneDeep(projectFlag.multivariate_options)}
           environmentId={environmentId}
@@ -364,6 +365,7 @@ export default class SegmentOverridesInner extends Component {
                 name=' '
                 disableCreate
                 projectId={projectId}
+                hideViewSegment
                 onRemove={this.props.onRemove}
                 multivariateOptions={_.cloneDeep(
                   projectFlag.multivariate_options,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes https://github.com/Flagsmith/flagsmith/issues/4740, view segment button is hidden from associated segment overrides.

![image](https://github.com/user-attachments/assets/ffec72ec-e939-4377-bd53-1c3c57cabca1)

## How did you test this code?

Viewed segment from segment overrides, but couldn't from segment modal
![image](https://github.com/user-attachments/assets/e840e6f5-3958-4362-8872-a14edb03b2e2)
