### PR TITLE
feat(permissions): update endpoints to expose tag-supported perms

### DIFF
--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -11,6 +11,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from environments.permissions.constants import TAG_SUPPORTED_PERMISSIONS
 from environments.permissions.permissions import (
     EnvironmentAdminPermission,
     EnvironmentPermissions,
@@ -189,12 +190,14 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-    @swagger_auto_schema(responses={200: PermissionModelSerializer})
+    @swagger_auto_schema(responses={200: PermissionModelSerializer(many=True)})
     @action(detail=False, methods=["GET"])
     def permissions(self, *args, **kwargs):
         return Response(
             PermissionModelSerializer(
-                instance=EnvironmentPermissionModel.objects.all(), many=True
+                instance=EnvironmentPermissionModel.objects.all(),
+                many=True,
+                context={"tag_supported_permissions": TAG_SUPPORTED_PERMISSIONS},
             ).data
         )
 

--- a/api/permissions/serializers.py
+++ b/api/permissions/serializers.py
@@ -4,9 +4,14 @@ from permissions.models import PermissionModel
 
 
 class PermissionModelSerializer(serializers.ModelSerializer):
+    supports_tag = serializers.SerializerMethodField()
+
     class Meta:
         model = PermissionModel
-        fields = ("key", "description")
+        fields = ("key", "description", "supports_tag")
+
+    def get_supports_tag(self, obj: PermissionModel) -> bool:
+        return obj.key in self.context.get("tag_supported_permissions", [])
 
 
 class CreateUpdateUserPermissionSerializerABC(serializers.ModelSerializer):

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -34,6 +34,7 @@ from projects.models import (
     UserProjectPermission,
 )
 from projects.permissions import (
+    TAG_SUPPORTED_PERMISSIONS,
     VIEW_PROJECT,
     IsProjectAdmin,
     ProjectPermissions,
@@ -126,13 +127,15 @@ class ProjectViewSet(viewsets.ModelViewSet):
         return Response(EnvironmentSerializerLight(environments, many=True).data)
 
     @swagger_auto_schema(
-        responses={200: PermissionModelSerializer}, request_body=no_body
+        responses={200: PermissionModelSerializer(many=True)}, request_body=no_body
     )
     @action(detail=False, methods=["GET"])
     def permissions(self, *args, **kwargs):
         return Response(
             PermissionModelSerializer(
-                instance=ProjectPermissionModel.objects.all(), many=True
+                instance=ProjectPermissionModel.objects.all(),
+                many=True,
+                context={"tag_supported_permissions": TAG_SUPPORTED_PERMISSIONS},
             ).data
         )
 

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -952,18 +952,14 @@ def test_delete_trait_keys_deletes_traits_matching_provided_key_only(
     assert Trait.objects.filter(identity=identity, trait_key=trait_to_persist).exists()
 
 
-@pytest.mark.parametrize(
-    "client",
-    [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
-)
 def test_user_can_list_environment_permission(
-    client: APIClient, environment: Environment
+    admin_client_new: APIClient, environment: Environment
 ) -> None:
     # Given
     url = reverse("api-v1:environments:environment-permissions")
 
     # When
-    response = client.get(url)
+    response = admin_client_new.get(url)
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/projects/test_unit_projects_views.py
+++ b/api/tests/unit/projects/test_unit_projects_views.py
@@ -29,6 +29,7 @@ from projects.models import (
 from projects.permissions import (
     CREATE_ENVIRONMENT,
     CREATE_FEATURE,
+    TAG_SUPPORTED_PERMISSIONS,
     VIEW_PROJECT,
 )
 from segments.models import Segment
@@ -142,7 +143,7 @@ def test_can_update_project(
     "client",
     [(lazy_fixture("admin_master_api_key_client")), (lazy_fixture("admin_client"))],
 )
-def test_can_list_project_permission(client, project):
+def test_can_list_project_permission(client: APIClient, project: Project) -> None:
     # Given
     url = reverse("api-v1:projects:project-permissions")
 
@@ -154,6 +155,13 @@ def test_can_list_project_permission(client, project):
     assert (
         len(response.json()) == 7
     )  # hard code how many permissions we expect there to be
+
+    returned_supported_permissions = [
+        permission["key"]
+        for permission in response.json()
+        if permission["supports_tag"] is True
+    ]
+    assert set(returned_supported_permissions) == set(TAG_SUPPORTED_PERMISSIONS)
 
 
 def test_my_permissions_for_a_project_return_400_with_master_api_key(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Add `supports_tag` boolean to the data returned by the `{project/environment}/permissions` endpoints to make the UI aware of permissions that support tags. See: https://github.com/Flagsmith/flagsmith/issues/1535#issuecomment-2250458494


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Covered by updated unit tests
