### PR TITLE
docs: break build on bad sdk version

### DIFF
--- a/docs/docs/clients/client-side/android.md
+++ b/docs/docs/clients/client-side/android.md
@@ -26,7 +26,7 @@ repositories {
 
 In your project path `app/build.gradle` add a new dependency:
 
-<CodeBlock>{`implementation("com.flagsmith:flagsmith-kotlin-android-client:v`}<AndroidVersion />"{`)`}</CodeBlock>
+<CodeBlock>{`implementation("com.flagsmith:flagsmith-kotlin-android-client:`}<AndroidVersion />"{`)`}</CodeBlock>
 
 ## Basic Usage
 

--- a/docs/plugins/flagsmith-versions/index.js
+++ b/docs/plugins/flagsmith-versions/index.js
@@ -26,11 +26,10 @@ const fetchJavaVersions = async () =>
         artifactId: 'flagsmith-java-client',
     });
 
-const fetchAndroidVersions = async () =>
-    fetchMavenVersions({
-        groupId: 'com.flagsmith',
-        artifactId: 'flagsmith-kotlin-android-client',
-    });
+const fetchAndroidVersions = async () => {
+    const data = await fetchJSON('https://api.github.com/repos/flagsmith/flagsmith-kotlin-android-client/releases');
+    return data.map((release) => release.tag_name);
+};
 
 const fetchIOSVersions = async () => {
     // retrieved from https://cocoapods.org/pods/FlagsmithClient

--- a/docs/plugins/flagsmith-versions/index.js
+++ b/docs/plugins/flagsmith-versions/index.js
@@ -28,7 +28,7 @@ const fetchJavaVersions = async () =>
 
 const fetchAndroidVersions = async () => {
     const data = await fetchJSON('https://api.github.com/repos/flagsmith/flagsmith-kotlin-android-client/releases');
-    return data.map((release) => release.tag_name);
+    return data.map((release) => (release.tag_name.startsWith('v') ? release.tag_name.slice(1) : release.tag_name));
 };
 
 const fetchIOSVersions = async () => {

--- a/docs/src/components/SdkVersions.js
+++ b/docs/src/components/SdkVersions.js
@@ -4,7 +4,9 @@ import { maxSatisfying } from 'semver';
 
 const Version = ({ sdk, spec = '*', options = {} }) => {
     const {
-        siteConfig: { CI },
+        siteConfig: {
+            customFields: { CI },
+        },
     } = useDocusaurusContext();
     const versions = usePluginData('flagsmith-versions')[sdk];
     if (!versions) throw new Error('unknown sdk: ' + sdk);


### PR DESCRIPTION
https://docs.flagsmith.com/clients/android is incorrectly showing a fallback version of `x.y.z` since we're not properly checking for CI during the docs build.

Also changes the source for Android SDK versions to be GitHub releases (i.e. JitPack) until we can sort out publishing to Maven Central.

Tested locally:

```console
$ CI=1 npm run build
[...]
[ERROR] Error: Unable to build website for locale en.
    at tryToBuildLocale (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:54:19)
    at async /Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:65:9
    at async mapAsyncSequential (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/utils/lib/jsUtils.js:20:24)
    at async Command.build (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:63:5) {
  [cause]: Error: Docusaurus static site generation failed for 1 paths:
  - "/clients/android"
      at generateStaticFiles (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/ssg.js:85:15)
      at async executeSSG (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:175:23)
      ... 4 lines matching cause stack trace ...
      at async Command.build (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:63:5) {
    [cause]: AggregateError
        at generateStaticFiles (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/ssg.js:86:20)
        at async executeSSG (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:175:23)
        at async buildLocale (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:135:31)
        at async tryToBuildLocale (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:47:13)
        at async /Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:65:9
        at async mapAsyncSequential (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/utils/lib/jsUtils.js:20:24)
        at async Command.build (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/commands/build.js:63:5) {
      [errors]: [
        Error: Can't render static file for pathname "/clients/android"
            at generateStaticFile (/Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/@docusaurus/core/lib/ssg.js:119:15)
            at runNextTicks (node:internal/process/task_queues:60:5)
            at process.processImmediate (node:internal/timers:447:9)
            at async /Users/rolodato/source/flagsmith/flagsmith/docs/node_modules/p-map/index.js:57:22 {
          [cause]: Error: no version found for android that matches ~1. available versions: []
              at Version (server.bundle.js:55365:577)
              at AndroidVersion (server.bundle.js:55365:741)
              at Uc (server.bundle.js:91194:44)
              at Xc (server.bundle.js:91196:253)
              at Z (server.bundle.js:91202:89)
              at Yc (server.bundle.js:91205:98)
              at $c (server.bundle.js:91204:140)
              at Z (server.bundle.js:91202:345)
              at Yc (server.bundle.js:91205:98)
              at Xc (server.bundle.js:91197:145)
        }
      ]
    }
  }
}
```

This now works: https://docs-git-docs-break-build-on-bad-sdk-version-flagsmith.vercel.app/clients/android