### PR TITLE
docs: Remove references to unversioned CDN links

### DIFF
--- a/frontend/common/code-help/install/install-js.js
+++ b/frontend/common/code-help/install/install-js.js
@@ -1,11 +1,6 @@
-import Utils from 'common/utils/utils'
-
-module.exports = ({ NPM_CLIENT, URL_CLIENT }) => `// npm
+module.exports = ({ NPM_CLIENT }) => `// npm
 npm i ${NPM_CLIENT} --save
 
 // yarn
 yarn add ${NPM_CLIENT}
-
-// Or script tag
-${Utils.escapeHtml(`<script src="${URL_CLIENT}"></script>`)}
 `

--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -14,7 +14,6 @@ const keywords = {
   NPM_NODE_CLIENT: 'flagsmith-nodejs',
   SEGMENT_NAME: 'superUsers',
   TRAIT_NAME: 'age',
-  URL_CLIENT: 'https://cdn.jsdelivr.net/npm/flagsmith/index.js',
   USER_FEATURE_FUNCTION: 'myEvenCoolerFeature',
   USER_FEATURE_NAME: 'my_even_cooler_feature',
   USER_ID: 'user_123456',


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This change removes unversioned CDN links as a suggested installation method to get started using the client-side JS SDK.

After https://github.com/Flagsmith/flagsmith/pull/4767 was released, we now have proper versioned CDN links in our docs if customers really need it.

## How did you test this code?

Running frontend locally:

<img width="964" alt="image" src="https://github.com/user-attachments/assets/eaf6ac07-9aa2-400c-9119-38441df00212">
