### PR TITLE
chore: Remove realtime_setting FoF flag

### DIFF
--- a/frontend/web/components/PlanBasedAccess.tsx
+++ b/frontend/web/components/PlanBasedAccess.tsx
@@ -63,9 +63,9 @@ export const featureDescriptions: Record<PaidFeature, any> = {
     title: 'Role-based access control',
   },
   'REALTIME': {
-    description: 'Add real time detection of feature flag changes in your SDK.',
+    description: 'Add real-time detection of feature flag changes in your SDK.',
     docs: 'https://docs.flagsmith.com/advanced-use/real-time-flags',
-    title: 'Realtime Updates',
+    title: 'Real-time flag updates',
   },
   'SAML': {
     description: 'Configure 2FA, SAML, Okta, ADFS and LDAP.',

--- a/frontend/web/components/pages/ProjectSettingsPage.js
+++ b/frontend/web/components/pages/ProjectSettingsPage.js
@@ -541,20 +541,16 @@ const ProjectSettingsPage = class extends Component {
                       data-test='js-sdk-settings'
                       tabLabel='SDK Settings'
                     >
-                      {Utils.isSaas() &&
-                        Utils.getFlagsmithHasFeature('realtime_setting') &&
-                        Utils.isSaas() && (
-                          <FormGroup className='mt-4 col-md-8'>
-                            <Setting
-                              feature='REALTIME'
-                              disabled={isSaving}
-                              onChange={() =>
-                                this.toggleRealtimeUpdates(project, editProject)
-                              }
-                              checked={project.enable_realtime_updates}
-                            />
-                          </FormGroup>
-                        )}
+                      <FormGroup className='mt-4 col-md-8'>
+                        <Setting
+                          feature='REALTIME'
+                          disabled={isSaving}
+                          onChange={() =>
+                            this.toggleRealtimeUpdates(project, editProject)
+                          }
+                          checked={project.enable_realtime_updates}
+                        />
+                      </FormGroup>
                       <div className='mt-4'>
                         <form onSubmit={saveProject}>
                           <FormGroup className='mt-4 col-md-8'>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This change removes the `realtime_setting` Flagsmith-on-Flagsmith flag, in preparation for releasing real-time flag updates outside of SaaS. Also minor wording changes for consistency with the current docs.

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/1a90d110-096b-4612-9e79-392f1f2eb752">


## How did you test this code?

Manually by browsing to Project Settings.