### PR TITLE
fix: Edit identity override with prevent flag defaults enabled

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -721,7 +721,7 @@ const CreateFlag = class extends Component {
       </>
     )
 
-    const Value = (error, projectAdmin, createFeature) => {
+    const Value = (error, projectAdmin, createFeature, hideValue) => {
       const { featureError, featureWarning } = this.parseError(error)
       return (
         <>
@@ -809,41 +809,43 @@ const CreateFlag = class extends Component {
               />
             </FormGroup>
           )}
-          <div
-            className={`${identity && !description ? 'mt-4 mx-3' : ''} ${
-              identity ? 'mx-3' : ''
-            }`}
-          >
-            <Feature
-              readOnly={noPermissions}
-              multivariate_options={multivariate_options}
-              environmentVariations={environmentVariations}
-              isEdit={isEdit}
-              error={error?.initial_value?.[0]}
-              canCreateFeature={createFeature}
-              identity={identity}
-              removeVariation={this.removeVariation}
-              updateVariation={this.updateVariation}
-              addVariation={this.addVariation}
-              checked={default_enabled}
-              value={initial_value}
-              identityVariations={this.state.identityVariations}
-              onChangeIdentityVariations={(identityVariations) => {
-                this.setState({ identityVariations, valueChanged: true })
-              }}
-              environmentFlag={this.props.environmentFlag}
-              projectFlag={projectFlag}
-              onValueChange={(e) => {
-                const initial_value = Utils.getTypedValue(
-                  Utils.safeParseEventValue(e),
-                )
-                this.setState({ initial_value, valueChanged: true })
-              }}
-              onCheckedChange={(default_enabled) =>
-                this.setState({ default_enabled })
-              }
-            />
-          </div>
+          {!hideValue && (
+            <div
+              className={`${identity && !description ? 'mt-4 mx-3' : ''} ${
+                identity ? 'mx-3' : ''
+              }`}
+            >
+              <Feature
+                readOnly={noPermissions}
+                multivariate_options={multivariate_options}
+                environmentVariations={environmentVariations}
+                isEdit={isEdit}
+                error={error?.initial_value?.[0]}
+                canCreateFeature={createFeature}
+                identity={identity}
+                removeVariation={this.removeVariation}
+                updateVariation={this.updateVariation}
+                addVariation={this.addVariation}
+                checked={default_enabled}
+                value={initial_value}
+                identityVariations={this.state.identityVariations}
+                onChangeIdentityVariations={(identityVariations) => {
+                  this.setState({ identityVariations, valueChanged: true })
+                }}
+                environmentFlag={this.props.environmentFlag}
+                projectFlag={projectFlag}
+                onValueChange={(e) => {
+                  const initial_value = Utils.getTypedValue(
+                    Utils.safeParseEventValue(e),
+                  )
+                  this.setState({ initial_value, valueChanged: true })
+                }}
+                onCheckedChange={(default_enabled) =>
+                  this.setState({ default_enabled })
+                }
+              />
+            </div>
+          )}
           {!isEdit &&
             !identity &&
             Settings(projectAdmin, createFeature, featureContentType)}
@@ -1897,7 +1899,12 @@ const CreateFlag = class extends Component {
                                     'features',
                                     featureLimitAlert.percentage,
                                   )}
-                                {Value(error, projectAdmin, createFeature)}
+                                {Value(
+                                  error,
+                                  projectAdmin,
+                                  createFeature,
+                                  project.prevent_flag_defaults && !identity,
+                                )}
                                 <ModalHR
                                   className={`my-4 ${identity ? 'mx-3' : ''}`}
                                 />

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -721,7 +721,7 @@ const CreateFlag = class extends Component {
       </>
     )
 
-    const Value = (error, projectAdmin, createFeature, hideValue) => {
+    const Value = (error, projectAdmin, createFeature) => {
       const { featureError, featureWarning } = this.parseError(error)
       return (
         <>
@@ -809,43 +809,41 @@ const CreateFlag = class extends Component {
               />
             </FormGroup>
           )}
-          {!hideValue && (
-            <div
-              className={`${identity && !description ? 'mt-4 mx-3' : ''} ${
-                identity ? 'mx-3' : ''
-              }`}
-            >
-              <Feature
-                readOnly={noPermissions}
-                multivariate_options={multivariate_options}
-                environmentVariations={environmentVariations}
-                isEdit={isEdit}
-                error={error?.initial_value?.[0]}
-                canCreateFeature={createFeature}
-                identity={identity}
-                removeVariation={this.removeVariation}
-                updateVariation={this.updateVariation}
-                addVariation={this.addVariation}
-                checked={default_enabled}
-                value={initial_value}
-                identityVariations={this.state.identityVariations}
-                onChangeIdentityVariations={(identityVariations) => {
-                  this.setState({ identityVariations, valueChanged: true })
-                }}
-                environmentFlag={this.props.environmentFlag}
-                projectFlag={projectFlag}
-                onValueChange={(e) => {
-                  const initial_value = Utils.getTypedValue(
-                    Utils.safeParseEventValue(e),
-                  )
-                  this.setState({ initial_value, valueChanged: true })
-                }}
-                onCheckedChange={(default_enabled) =>
-                  this.setState({ default_enabled })
-                }
-              />
-            </div>
-          )}
+          <div
+            className={`${identity && !description ? 'mt-4 mx-3' : ''} ${
+              identity ? 'mx-3' : ''
+            }`}
+          >
+            <Feature
+              readOnly={noPermissions}
+              multivariate_options={multivariate_options}
+              environmentVariations={environmentVariations}
+              isEdit={isEdit}
+              error={error?.initial_value?.[0]}
+              canCreateFeature={createFeature}
+              identity={identity}
+              removeVariation={this.removeVariation}
+              updateVariation={this.updateVariation}
+              addVariation={this.addVariation}
+              checked={default_enabled}
+              value={initial_value}
+              identityVariations={this.state.identityVariations}
+              onChangeIdentityVariations={(identityVariations) => {
+                this.setState({ identityVariations, valueChanged: true })
+              }}
+              environmentFlag={this.props.environmentFlag}
+              projectFlag={projectFlag}
+              onValueChange={(e) => {
+                const initial_value = Utils.getTypedValue(
+                  Utils.safeParseEventValue(e),
+                )
+                this.setState({ initial_value, valueChanged: true })
+              }}
+              onCheckedChange={(default_enabled) =>
+                this.setState({ default_enabled })
+              }
+            />
+          </div>
           {!isEdit &&
             !identity &&
             Settings(projectAdmin, createFeature, featureContentType)}
@@ -1899,12 +1897,7 @@ const CreateFlag = class extends Component {
                                     'features',
                                     featureLimitAlert.percentage,
                                   )}
-                                {Value(
-                                  error,
-                                  projectAdmin,
-                                  createFeature,
-                                  project.prevent_flag_defaults,
-                                )}
+                                {Value(error, projectAdmin, createFeature)}
                                 <ModalHR
                                   className={`my-4 ${identity ? 'mx-3' : ''}`}
                                 />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

It adds the identity verification in `hideValue` param on the `Value` component in order to render the input fields, where wasn't possible to edit under identity override

Closes: #4771

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

- Go to project settings
- Enable the prevent flag defaults
- Create a feature 
- Go to identities
- Clicking on the feature you created you should be able to edit it

**Note to the reviewer**: I was looking into it and indeed removing the parameter mentioned to the `Value` component seems to solve the issue. But I'm afraid I'm missing something because the verification using `prevent_flag_defaults` was added 2 years ago here #1453