### PR TITLE
fix: Allow any auth except LDAP and SAML to change email

### DIFF
--- a/frontend/web/components/pages/AccountSettingsPage.js
+++ b/frontend/web/components/pages/AccountSettingsPage.js
@@ -188,7 +188,9 @@ class TheComponent extends Component {
                     />
                     <div className='col-md-6'>
                       <form className='mb-0' onSubmit={this.save}>
-                        {AccountStore.model.auth_type === 'EMAIL' && (
+                        {!['LDAP', 'SAML'].includes(
+                          AccountStore.model.auth_type,
+                        ) && (
                           <div>
                             <InputGroup
                               className='mt-2'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Allows oauth users to change email, see https://github.com/Flagsmith/flagsmith/issues/4660

## How did you test this code?

Verified email/oauth users can see the change email UI