### PR TITLE
fix: make clone_feature_states_async write only

### DIFF
--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -134,6 +134,7 @@ class CloneEnvironmentSerializer(EnvironmentSerializerLight):
         help_text="If True, the environment will be created immediately, but the feature states "
         "will be created asynchronously. Environment will have `is_creating: true` until "
         "this process is completed.",
+        write_only=True,
     )
 
     class Meta:


### PR DESCRIPTION
## Changes

Makes the field `clone_feature_states_async` write only. This field was designed to be write only but the configuration was missing and hence it's returning `False` on all requests (because it doesn't exist on the response entity). 

The alternative here would be to patch the attribute directly onto the environment in the response, but for the sake of a _very_ small breaking API change which no-one will be using directly, I think we should just remove it from the response. 

## How did you test this code?

Updated an existing integration test. 
