### PR TITLE
fix: users with VIEW_ENVIRONMENT should be able to retrieve environment

### DIFF
--- a/api/environments/permissions/permissions.py
+++ b/api/environments/permissions/permissions.py
@@ -45,7 +45,7 @@ class EnvironmentPermissions(IsAuthenticated):
     def has_object_permission(self, request, view, obj):
         if view.action == "clone":
             return request.user.has_project_permission(CREATE_ENVIRONMENT, obj.project)
-        elif view.action == "get_document":
+        elif view.action in ("get_document", "retrieve", "trait_keys"):
             return request.user.has_environment_permission(VIEW_ENVIRONMENT, obj)
 
         return request.user.is_environment_admin(obj) or view.action in [

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -76,6 +76,23 @@ def test_retrieve_environment(
     )
 
 
+def test_user_with_view_environment_permission_can_retrieve_environment(
+    staff_client: APIClient,
+    environment: Environment,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    url = reverse("api-v1:environments:environment-detail", args=[environment.api_key])
+
+    with_environment_permissions([VIEW_ENVIRONMENT])
+
+    # When
+    response = staff_client.get(url)
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+
+
 def test_can_clone_environment_with_create_environment_permission(
     test_user,
     test_user_client,
@@ -918,6 +935,27 @@ def test_get_all_trait_keys_for_environment_only_returns_distinct_keys(
 
     # and - only distinct keys are returned
     assert len(res.json().get("keys")) == 2
+
+
+def test_user_with_view_environment_can_get_trait_keys(
+    identity: Identity,
+    staff_client: APIClient,
+    trait: Trait,
+    environment: Environment,
+    with_environment_permissions: WithEnvironmentPermissionsCallable,
+) -> None:
+    # Given
+    url = reverse(
+        "api-v1:environments:environment-trait-keys", args=[environment.api_key]
+    )
+
+    with_environment_permissions([VIEW_ENVIRONMENT])
+
+    # When
+    res = staff_client.get(url)
+
+    # Then
+    assert res.status_code == status.HTTP_200_OK
 
 
 def test_delete_trait_keys_deletes_traits_matching_provided_key_only(


### PR DESCRIPTION
## Changes

Fixes an issue where users with VIEW_ENVIRONMENT permission weren't able to call the GET /environments/:key endpoint. 

Also fixes the same issue for the `trait-keys` endpoint, although it's not used by the Flagsmith UI. 

## How did you test this code?

Added new test cases. 
