### PR TITLE
docs: Update Django docs links to 4.2

### DIFF
--- a/docs/docs/deployment/hosting/kubernetes.md
+++ b/docs/docs/deployment/hosting/kubernetes.md
@@ -198,7 +198,7 @@ should be provided as:
 
 :::caution
 
-It's important to define a [`secretKey`](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-SECRET_KEY)
+It's important to define a [`secretKey`](https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-SECRET_KEY)
 value in your helm chart when running in Kubernetes. Use a password manager to generate a random hash and set this so
 that all the API nodes are running with an identical `DJANGO_SECRET_KEY`.
 

--- a/docs/docs/deployment/hosting/locally-api.md
+++ b/docs/docs/deployment/hosting/locally-api.md
@@ -187,23 +187,23 @@ the below variables will be ignored.
 - `ENABLE_ADMIN_ACCESS_USER_PASS`: Boolean. Set this flag to enable login to admin panel using username and password.
 - `USE_X_FORWARDED_HOST`: Boolean. Default `False`. Specifies whether to use the X-Forwarded-Host header in preference
   to the Host header. This should only be enabled if a proxy which sets this header is in use.
-  [More Info](https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-USE_X_FORWARDED_HOST).
+  [More Info](https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-USE_X_FORWARDED_HOST).
 - `SECURE_PROXY_SSL_HEADER_NAME`: String. The name of the header looked for by Django's
-  [`SECURE_PROXY_SSL_HEADER`](https://docs.djangoproject.com/en/4.0/ref/settings/#secure-proxy-ssl-header). Defaults to
+  [`SECURE_PROXY_SSL_HEADER`](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-proxy-ssl-header). Defaults to
   `HTTP_X_FORWARDED_PROTO`.
 - `SECURE_PROXY_SSL_HEADER_VALUE`: String. The value of the header looked for by Django's
-  [`SECURE_PROXY_SSL_HEADER`](https://docs.djangoproject.com/en/4.0/ref/settings/#secure-proxy-ssl-header). Defaults to
+  [`SECURE_PROXY_SSL_HEADER`](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-proxy-ssl-header). Defaults to
   `https`.
 - `DJANGO_SECURE_REDIRECT_EXEMPT`: List. Passthrough of Django's
-  [`SECURE_REDIRECT_EXEMPT`](https://docs.djangoproject.com/en/4.0/ref/settings/#secure-redirect-exempt). Defaults to an
+  [`SECURE_REDIRECT_EXEMPT`](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-redirect-exempt). Defaults to an
   empty list `[]`.
 - `DJANGO_SECURE_REFERRER_POLICY`: String. Passthrough of Django's
-  [`SECURE_REFERRER_POLICY`](https://docs.djangoproject.com/en/4.0/ref/settings/#secure-referrer-policy). Defaults to
+  [`SECURE_REFERRER_POLICY`](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-referrer-policy). Defaults to
   `same-origin`.
 - `DJANGO_SECURE_SSL_HOST`: String. Passthrough of Django's
-  [`SECURE_SSL_HOST`](https://docs.djangoproject.com/en/4.0/ref/settings/#secure-ssl-host). Defaults to `None`.
+  [`SECURE_SSL_HOST`](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-ssl-host). Defaults to `None`.
 - `DJANGO_SECURE_SSL_REDIRECT`: Boolean. Passthrough of Django's
-  [`SECURE_SSL_REDIRECT`](https://docs.djangoproject.com/en/4.0/ref/settings/#secure-ssl-redirect). Defaults to `False`.
+  [`SECURE_SSL_REDIRECT`](https://docs.djangoproject.com/en/4.2/ref/settings/#secure-ssl-redirect). Defaults to `False`.
 - [`APPLICATION_INSIGHTS_CONNECTION_STRING`](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview).
   String. Connection string to set up Flagsmith to send telemetry to Azure Application Insights.
 - [`OPENCENSUS_SAMPLING_RATE`](https://opencensus.io/tracing/sampling/probabilistic/): Float. The tracer sample rate.
@@ -392,8 +392,8 @@ variables:
 | Environment Variable                                               | Description                                                                                                                    | Example value                                          | Default                                       |
 | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ | --------------------------------------------- |
 | <code>GET\_[FLAGS&#124;IDENTITIES]\_ENDPOINT_CACHE_SECONDS</code>  | Number of seconds to cache the response to `GET /api/v1/flags`                                                                 | `60`                                                   | `0`                                           |
-| <code>GET\_[FLAGS&#124;IDENTITIES]\_ENDPOINT_CACHE_BACKEND</code>  | Python path to the django cache backend chosen. See documentation [here](https://docs.djangoproject.com/en/3.2/topics/cache/). | `django.core.cache.backends.memcached.PyMemcacheCache` | `django.core.cache.backends.dummy.DummyCache` |
-| <code>GET\_[FLAGS&#124;IDENTITIES]\_ENDPOINT_CACHE_LOCATION</code> | The location for the cache. See documentation [here](https://docs.djangoproject.com/en/3.2/topics/cache/).                     | `127.0.0.1:11211`                                      | `get_flags_endpoint_cache`                    |
+| <code>GET\_[FLAGS&#124;IDENTITIES]\_ENDPOINT_CACHE_BACKEND</code>  | Python path to the django cache backend chosen. See documentation [here](https://docs.djangoproject.com/en/4.2/topics/cache/). | `django.core.cache.backends.memcached.PyMemcacheCache` | `django.core.cache.backends.dummy.DummyCache` |
+| <code>GET\_[FLAGS&#124;IDENTITIES]\_ENDPOINT_CACHE_LOCATION</code> | The location for the cache. See documentation [here](https://docs.djangoproject.com/en/4.2/topics/cache/).                     | `127.0.0.1:11211`                                      | `get_flags_endpoint_cache`                    |
 
 An example configuration to cache both flags and identities requests for 30 seconds in a memcached instance hosted at
 `memcached-container`:
@@ -416,8 +416,8 @@ cache will be cleared automatically by certain actions in the platform when the 
 | Environment Variable         | Description                                                                                                                    | Example value                                          | Default                                       |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ | --------------------------------------------- |
 | `ENVIRONMENT_CACHE_SECONDS`  | Number of seconds to cache the environment for                                                                                 | `60`                                                   | `86400` ( = 24h)                              |
-| `ENVIRONMENT_CACHE_BACKEND`  | Python path to the django cache backend chosen. See documentation [here](https://docs.djangoproject.com/en/3.2/topics/cache/). | `django.core.cache.backends.memcached.PyMemcacheCache` | `django.core.cache.backends.dummy.DummyCache` |
-| `ENVIRONMENT_CACHE_LOCATION` | The location for the cache. See documentation [here](https://docs.djangoproject.com/en/3.2/topics/cache/).                     | `127.0.0.1:11211`                                      | `environment-objects`                         |
+| `ENVIRONMENT_CACHE_BACKEND`  | Python path to the django cache backend chosen. See documentation [here](https://docs.djangoproject.com/en/4.2/topics/cache/). | `django.core.cache.backends.memcached.PyMemcacheCache` | `django.core.cache.backends.dummy.DummyCache` |
+| `ENVIRONMENT_CACHE_LOCATION` | The location for the cache. See documentation [here](https://docs.djangoproject.com/en/4.2/topics/cache/).                     | `127.0.0.1:11211`                                      | `environment-objects`                         |
 
 ## Unified Front End and Back End Build
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Update all links to Django documentation to point to the current Django version (4.2).

Older Django versions don't have features that customers might want to use with Flagsmith, such as support for Redis as a cache backend.

I considered dynamically fetching the current Django version we're using but there's no guarantee that these documentation links will continue to be valid in newer Django versions. [Security support for Django 4.2](https://endoflife.date/django) ends in April 2026 so this likely isn't worth automating for now.

## How did you test this code?

Manually by opening all the new links.