### PR TITLE
chore: Only show stale flag warning when feature_versioning enabled

### DIFF
--- a/frontend/web/components/StaleFlagWarning.tsx
+++ b/frontend/web/components/StaleFlagWarning.tsx
@@ -8,12 +8,14 @@ import { IonIcon } from '@ionic/react'
 import { close, warning } from 'ionicons/icons'
 import Tooltip from './Tooltip'
 import ProjectStore from 'common/stores/project-store'
+import flagsmith from 'flagsmith/isomorphic'
 
 type StaleFlagWarningType = {
   projectFlag: ProjectFlag
 }
 
 const StaleFlagWarning: FC<StaleFlagWarningType> = ({ projectFlag }) => {
+  if (!flagsmith.hasFeature('feature_versioning')) return null
   const protectedTags = getProtectedTags(projectFlag, `${projectFlag.project}`)
   if (protectedTags?.length) {
     return null


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Hide the "Created X days ago" warning if `feature_versioning` is disabled. `stale_flags_limit_days` also depends on `feature_versioning` for being configurable, so until versioning is released showing this warning only adds confusion, or requires customers to manually modify their projects using the API.

## How did you test this code?

Manually by looking at any stale feature in the features list.
