### PR TITLE
fix: Handle environment admin not being able to check VIEW_PROJECT permissions

### DIFF
--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -62,6 +62,7 @@ import classNames from 'classnames'
 import OrganisationProvider from 'common/providers/OrganisationProvider'
 import { useHasPermission } from 'common/providers/Permission'
 import PlanBasedAccess from './PlanBasedAccess'
+import WarningMessage from './WarningMessage'
 
 const Project = require('common/project')
 
@@ -255,6 +256,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
       createRolePermissionGroup,
       { data: groupsData, isSuccess: groupAdded },
     ] = useCreateRolePermissionGroupMutation()
+    const [parentWarning, setParentWarning] = useState(false)
 
     const [deleteRolePermissionGroup] = useDeleteRolePermissionGroupMutation()
 
@@ -393,6 +395,10 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
             } else {
               setParentError(false)
             }
+          })
+          .catch(() => {
+            setParentWarning(true)
+            return []
           })
       }
       if (!role) {
@@ -758,6 +764,11 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
               .
             </p>
 
+            {!!parentWarning && (
+              <WarningMessage
+                warningMessage={`As a ${level} admin, you do not have permissions to see if this user has view ${parentLevel} permissions. If you need to troubleshoot, contact a ${parentLevel} administrator.`}
+              />
+            )}
             {parentError && !role && (
               <div className='mt-4'>
                 <InfoMessage>

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -765,9 +765,11 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
             </p>
 
             {!!parentWarning && (
-              <WarningMessage
-                warningMessage={`As a ${level} admin, you do not have permissions to see if this user has view ${parentLevel} permissions. If you need to troubleshoot, contact a ${parentLevel} administrator.`}
-              />
+              <InfoMessage>
+                You do not have permission to verify whether this user has view
+                access for this {parentLevel}. If you need assistance, please
+                contact a {parentLevel} administrator.
+              </InfoMessage>
             )}
             {parentError && !role && (
               <div className='mt-4'>


### PR DESCRIPTION
…ions

Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Environment admins were not able to correctly view and manage environment permissions. This was due to it checking for VIEW_PROJECT permissions to detect any issues. This will now show an info banner for this usecase.

![image](https://github.com/user-attachments/assets/92d26dfc-2704-481a-ac68-1023e7034e45)


## How did you test this code?

View permissions as an environment admin.