### PR TITLE
fix: audit log creation failure when a segment override is deleted

### DIFF
--- a/api/audit/tasks.py
+++ b/api/audit/tasks.py
@@ -89,7 +89,9 @@ def create_audit_log_from_historical_record(
     if not (history_user or override_author or history_instance.master_api_key):
         return
 
-    environment, project = instance.get_environment_and_project()
+    environment = project = None
+    if instance.__class__.objects.filter(pk=instance.pk).exists():
+        environment, project = instance.get_environment_and_project()
 
     related_object_id = instance.get_audit_log_related_object_id(history_instance)
     related_object_type = instance.get_audit_log_related_object_type(history_instance)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

closes https://github.com/Flagsmith/flagsmith/issues/4828

## Changes

`instance` is already deleted in the audit tasks while it is processed

this PR introduces a check to see if the instance exists before getting the environment from a non-existent object

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

As described in the [issue](https://github.com/Flagsmith/flagsmith/issues/4828)
