### PR TITLE
fix: prevent lock when adding FFAdmin.uuid column

### DIFF
--- a/api/users/migrations/0037_add_uuid_field_to_user_model.py
+++ b/api/users/migrations/0037_add_uuid_field_to_user_model.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='ffadminuser',
             name='uuid',
-            field=models.UUIDField(default=uuid.uuid4),
+            field=models.UUIDField(default=None, null=True),
         ),
         migrations.RunPython(set_default_uuids, reverse_code=migrations.RunPython.noop),
         migrations.AlterField(


### PR DESCRIPTION
## Changes

Prevents needing a lock when adding the uuid field to the user model. 

## How did you test this code?

Ran `python manage.py sqlmigrate users 0037` to ensure that the resultant behaviour is still what we expect.
