### PR TITLE
docs: add clarification about SaaS async trait storage

### DIFF
--- a/docs/docs/basic-features/managing-identities.md
+++ b/docs/docs/basic-features/managing-identities.md
@@ -88,6 +88,13 @@ engine runs.
 There are some [exceptions to this rule](/clients#server-side-sdks) with Server Side SDKs running in local evaluation
 mode.
 
+:::info
+
+Note that, when using our SaaS platform, there might be a short delay from the initial request to write or update traits
+for an identity and them being used in subsequent evaluations.
+
+:::
+
 ### Using Traits as a data-store
 
 Traits can also be used to store additional data about your users that would be cumbersome to store within your


### PR DESCRIPTION
## Changes

Adds a minor clarification about the async nature of trait storage in our SaaS platform. 

See https://github.com/Flagsmith/flagsmith-dotnet-client/issues/123 for more context. 

## How did you test this code?

Ran docs locally and verified that the info message displays correctly. 
