### PR TITLE
fix(project/serializer): limit edit to only fields that make sense

### DIFF
--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -44,6 +44,15 @@ class ProjectListSerializer(serializers.ModelSerializer):
             "stale_flags_limit_days",
             "edge_v2_migration_status",
         )
+        read_only_fields = (
+            "enable_dynamo_db",
+            "edge_v2_migration_status",
+        )
+
+    def update(self, instance: Project, validated_data: dict) -> Project:
+        # Prevent updates to `organisation` field
+        validated_data.pop("organisation", None)
+        return super().update(instance, validated_data)
 
     def get_migration_status(self, obj: Project) -> str:
         if not settings.PROJECT_METADATA_TABLE_NAME_DYNAMO:

--- a/api/projects/serializers.py
+++ b/api/projects/serializers.py
@@ -86,8 +86,11 @@ class ProjectCreateSerializer(ReadOnlyIfNotValidPlanMixin, ProjectListSerializer
             # Organisation should only have a single subscription
             return Subscription.objects.filter(organisation_id=organisation_id).first()
         elif view.action in ("update", "partial_update"):
+            # handle instance not being set
+            # When request comes from yasg2 (as part of schema generation)
+            if not self.instance:
+                return None
             return getattr(self.instance.organisation, "subscription", None)
-
         return None
 
 

--- a/api/projects/views.py
+++ b/api/projects/views.py
@@ -44,9 +44,10 @@ from projects.serializers import (
     CreateUpdateUserProjectPermissionSerializer,
     ListUserPermissionGroupProjectPermissionSerializer,
     ListUserProjectPermissionSerializer,
+    ProjectCreateSerializer,
     ProjectListSerializer,
     ProjectRetrieveSerializer,
-    ProjectUpdateOrCreateSerializer,
+    ProjectUpdateSerializer,
 )
 
 
@@ -75,11 +76,13 @@ class ProjectViewSet(viewsets.ModelViewSet):
     permission_classes = [ProjectPermissions]
 
     def get_serializer_class(self):
-        if self.action == "retrieve":
-            return ProjectRetrieveSerializer
-        elif self.action in ("create", "update", "partial_update"):
-            return ProjectUpdateOrCreateSerializer
-        return ProjectListSerializer
+        serializers = {
+            "retrieve": ProjectRetrieveSerializer,
+            "create": ProjectCreateSerializer,
+            "update": ProjectUpdateSerializer,
+            "partial_update": ProjectUpdateSerializer,
+        }
+        return serializers.get(self.action, ProjectListSerializer)
 
     pagination_class = None
 

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -56,11 +56,13 @@ def organisation_with_persist_trait_data_disabled(organisation):
 
 
 @pytest.fixture()
-def dynamo_enabled_project(admin_client, organisation):
+def dynamo_enabled_project(
+    admin_client: APIClient, organisation: Organisation, settings: SettingsWrapper
+):
+    settings.EDGE_ENABLED = True
     project_data = {
         "name": "Test Project",
         "organisation": organisation,
-        "enable_dynamo_db": True,
     }
     url = reverse("api-v1:projects:project-list")
     response = admin_client.post(url, data=project_data)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Stop User from updating `organisation`, `enable_dynamo_db` and `edge_v2_migration_status`

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Covered by unit tests
