### PR TITLE
fix: Allow teardown to use FLAGSMITH_API_URL

### DIFF
--- a/frontend/e2e/init.cafe.js
+++ b/frontend/e2e/init.cafe.js
@@ -15,7 +15,7 @@ import versioningTests from './tests/versioning-tests';
 require('dotenv').config()
 
 const url = `http://localhost:${process.env.PORT || 8080}/`
-const e2eTestApi = `${Project.api}e2etests/teardown/`
+const e2eTestApi = `${process.env.FLAGSMITH_API_URL || Project.api}e2etests/teardown/`
 const logger = getLogger()
 
 console.log(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Uses FLAGSMITH_API_URL for the e2e teardown if it is set.


## How did you test this code?

Confirmed FLAGSMITH_API_URL=x npm run test uses the correct teardown.