### PR TITLE
docs: Track cocoapods/github versions separately

### DIFF
--- a/docs/docs/clients/client-side/ios.mdx
+++ b/docs/docs/clients/client-side/ios.mdx
@@ -6,36 +6,47 @@ slug: /clients/ios
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import { IOSVersion } from '@site/src/components/SdkVersions.js';
+import { CocoapodsVersion, SwiftPMVersion } from '@site/src/components/SdkVersions.js';
 
 This library can be used with iOS and Mac applications. The source code for the client is available on
 [GitHub](https://github.com/flagsmith/flagsmith-ios-client).
 
 ## Installation
 
-### CocoaPods
+<details>
+<summary>CocoaPods</summary>
 
-[CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions,
-visit their website. To integrate Flagsmith into your Xcode project using CocoaPods, specify it in your `Podfile`:
+Add the Flagsmith SDK as a dependency to your Podfile:
 
-<CodeBlock>
+<CodeBlock showLineNumbers={true} title={'Podfile'}>
     {`pod 'FlagsmithClient', '~> `}
-    <IOSVersion />
+    <CocoapodsVersion />
     {`'`}
 </CodeBlock>
 
-### Swift Package Manager
+</details>
 
-The Swift Package Manager is a tool for automating the distribution of Swift code and is integrated into the swift
-compiler. You can use it to install Flagsmith by adding the description to your `Package.swift` file:
+<details>
+
+<summary>Swift Package Manager</summary>
+
+Add the Flagsmith SDK as a dependency to your Package.swift file:
 
 <CodeBlock>
     {`dependencies: [
     .package(url: "https://github.com/Flagsmith/flagsmith-ios-client.git", from: "`}
-    <IOSVersion />
+    <SwiftPMVersion />
     {`"),
 ]`}
 </CodeBlock>
+
+Alternatively, you can add the Flagsmith SDK as a dependency from its repository URL using Xcode:
+
+```
+https://github.com/Flagsmith/flagsmith-ios-client.git
+```
+
+</details>
 
 ## Basic Usage
 

--- a/docs/docs/clients/client-side/ios.mdx
+++ b/docs/docs/clients/client-side/ios.mdx
@@ -18,7 +18,7 @@ This library can be used with iOS and Mac applications. The source code for the 
 
 Add the Flagsmith SDK as a dependency to your Podfile:
 
-<CodeBlock showLineNumbers={true} title={'Podfile'}>
+<CodeBlock>
     {`pod 'FlagsmithClient', '~> `}
     <CocoapodsVersion />
     {`'`}

--- a/docs/plugins/flagsmith-versions/index.js
+++ b/docs/plugins/flagsmith-versions/index.js
@@ -26,12 +26,16 @@ const fetchJavaVersions = async () =>
         artifactId: 'flagsmith-java-client',
     });
 
-const fetchAndroidVersions = async () => {
-    const data = await fetchJSON('https://api.github.com/repos/flagsmith/flagsmith-kotlin-android-client/releases');
+const fetchGitHubReleases = async (repo) => {
+    const data = await fetchJSON(`https://api.github.com/repos/${repo}/releases`);
     return data.map((release) => (release.tag_name.startsWith('v') ? release.tag_name.slice(1) : release.tag_name));
 };
 
-const fetchIOSVersions = async () => {
+const fetchAndroidVersions = async () => fetchGitHubReleases('flagsmith/flagsmith-kotlin-android-client');
+
+const fetchSwiftPMVersions = async () => fetchGitHubReleases('Flagsmith/flagsmith-ios-client');
+
+const fetchCocoapodsVersions = async () => {
     // retrieved from https://cocoapods.org/pods/FlagsmithClient
     const data = await fetchJSON('https://api.github.com/repos/CocoaPods/Specs/contents/Specs/2/8/0/FlagsmithClient');
     return data.map((entry) => entry.name);
@@ -65,12 +69,13 @@ export default async function fetchFlagsmithVersions(context, options) {
     return {
         name: 'flagsmith-versions',
         async loadContent() {
-            const [js, java, android, ios, dotnet, rust, elixir] = await Promise.all(
+            const [js, java, android, swiftpm, cocoapods, dotnet, rust, elixir] = await Promise.all(
                 [
                     fetchNpmVersions('flagsmith'),
                     fetchJavaVersions(),
                     fetchAndroidVersions(),
-                    fetchIOSVersions(),
+                    fetchSwiftPMVersions(),
+                    fetchCocoapodsVersions(),
                     fetchDotnetVersions(),
                     fetchRustVersions(),
                     fetchElixirVersions(),
@@ -80,7 +85,8 @@ export default async function fetchFlagsmithVersions(context, options) {
                 js,
                 java,
                 android,
-                ios,
+                swiftpm,
+                cocoapods,
                 dotnet,
                 rust,
                 elixir,

--- a/docs/src/components/SdkVersions.js
+++ b/docs/src/components/SdkVersions.js
@@ -21,7 +21,8 @@ const Version = ({ sdk, spec = '*', options = {} }) => {
 
 export const JavaVersion = ({ spec = '~7' }) => Version({ sdk: 'java', spec });
 export const AndroidVersion = ({ spec = '~1' }) => Version({ sdk: 'android', spec });
-export const IOSVersion = ({ spec = '~3' }) => Version({ sdk: 'ios', spec });
+export const CocoapodsVersion = ({ spec = '~3' }) => Version({ sdk: 'cocoapods', spec });
+export const SwiftPMVersion = ({ spec = '~3' }) => Version({ sdk: 'swiftpm', spec });
 export const DotnetVersion = ({ spec = '~5' }) => Version({ sdk: 'dotnet', spec });
 export const ElixirVersion = ({ spec = '~2' }) => Version({ sdk: 'elixir', spec });
 export const RustVersion = ({ spec = '~2' }) => Version({ sdk: 'rust', spec });


### PR DESCRIPTION
Pull versions for the iOS SDK from CocoaPods and GitHub separately, in case we have differently published versions in one or the other, as is the case today.

Also tidy up the wording/layout for the installation instructions.

See https://docs-git-docs-ios-swiftpm-flagsmith.vercel.app/clients/ios and expand the different install sections.