### PR TITLE
fix: Environment Ready Checker

### DIFF
--- a/frontend/web/components/EnvironmentReadyChecker.tsx
+++ b/frontend/web/components/EnvironmentReadyChecker.tsx
@@ -28,7 +28,7 @@ const EnvironmentReadyChecker: FC<EnvironmentReadyCheckerType> = ({
     if (!!data && !data?.is_creating) {
       setEnvironmentCreated(true)
     }
-  }, [data?.is_creating])
+  }, [data])
   if (!match?.params?.environmentId) {
     return children
   }

--- a/frontend/web/components/EnvironmentReadyChecker.tsx
+++ b/frontend/web/components/EnvironmentReadyChecker.tsx
@@ -13,11 +13,21 @@ const EnvironmentReadyChecker: FC<EnvironmentReadyCheckerType> = ({
   children,
   match,
 }) => {
+  const { data: isCreatingCheck } = useGetEnvironmentQuery(
+    {
+      id: match.params.environmentId,
+    },
+    { skip: true },
+  )
+  const hasCreateEnvironment = !!isCreatingCheck && !isCreatingCheck.is_creating
   const { data, isLoading } = useGetEnvironmentQuery(
     {
       id: match.params.environmentId,
     },
-    { pollingInterval: 1000, skip: !match.params.environmentId },
+    {
+      pollingInterval: 1000,
+      skip: !match.params.environmentId || hasCreateEnvironment,
+    },
   )
   if (!match?.params?.environmentId) {
     return children

--- a/frontend/web/components/EnvironmentReadyChecker.tsx
+++ b/frontend/web/components/EnvironmentReadyChecker.tsx
@@ -19,14 +19,14 @@ const EnvironmentReadyChecker: FC<EnvironmentReadyCheckerType> = ({
     },
     { skip: true },
   )
-  const hasCreateEnvironment = !!isCreatingCheck && !isCreatingCheck.is_creating
+  const environmentCreated = !!isCreatingCheck && !isCreatingCheck.is_creating
   const { data, isLoading } = useGetEnvironmentQuery(
     {
       id: match.params.environmentId,
     },
     {
       pollingInterval: 1000,
-      skip: !match.params.environmentId || hasCreateEnvironment,
+      skip: !match.params.environmentId || environmentCreated,
     },
   )
   if (!match?.params?.environmentId) {

--- a/frontend/web/components/EnvironmentReadyChecker.tsx
+++ b/frontend/web/components/EnvironmentReadyChecker.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { useGetEnvironmentQuery } from 'common/services/useEnvironment'
 
 type EnvironmentReadyCheckerType = {
@@ -13,13 +13,8 @@ const EnvironmentReadyChecker: FC<EnvironmentReadyCheckerType> = ({
   children,
   match,
 }) => {
-  const { data: isCreatingCheck } = useGetEnvironmentQuery(
-    {
-      id: match.params.environmentId,
-    },
-    { skip: true },
-  )
-  const environmentCreated = !!isCreatingCheck && !isCreatingCheck.is_creating
+  const [environmentCreated, setEnvironmentCreated] = useState(false)
+
   const { data, isLoading } = useGetEnvironmentQuery(
     {
       id: match.params.environmentId,
@@ -29,6 +24,11 @@ const EnvironmentReadyChecker: FC<EnvironmentReadyCheckerType> = ({
       skip: !match.params.environmentId || environmentCreated,
     },
   )
+  useEffect(() => {
+    if (!!data && !data?.is_creating) {
+      setEnvironmentCreated(true)
+    }
+  }, [data?.is_creating])
   if (!match?.params?.environmentId) {
     return children
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The environment ready checker will now stop polling once the environment exists and is_creating is false.

## How did you test this code?

- Create an environment
- Validate that the environment goes to the processing screen
- Validate that the environment stops polling

