### PR TITLE
fix: prevent enabling versioning from affecting scheduled change requests

### DIFF
--- a/api/features/versioning/tasks.py
+++ b/api/features/versioning/tasks.py
@@ -109,7 +109,9 @@ def _create_initial_feature_versions(environment: "Environment"):
             change_request__isnull=False,
             change_request__committed_at__isnull=False,
             change_request__deleted_at__isnull=True,
+            environment=environment,
         ).select_related("change_request")
+
         for feature_state in scheduled_feature_states:
             ef_version = EnvironmentFeatureVersion.objects.create(
                 feature=feature,

--- a/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_tasks.py
@@ -32,6 +32,7 @@ from features.versioning.versioning_service import (
     get_environment_flags_queryset,
 )
 from features.workflows.core.models import ChangeRequest
+from organisations.models import Organisation
 from projects.models import Project
 from segments.models import Segment
 from users.models import FFAdminUser
@@ -233,6 +234,36 @@ def test_enable_v2_versioning_for_scheduled_changes(
         version=None,
     )
 
+    # and a published, scheduled feature state associated with a different project
+    # Note: this additional test clause is to verify an issue found in testing
+    # where enabling feature versioning 'stole' scheduled feature states from other
+    # projects.
+    another_organisation = Organisation.objects.create(name="another organisation")
+    staff_user.add_organisation(another_organisation)
+    another_project = Project.objects.create(
+        name="another project", organisation=another_organisation
+    )
+    another_environment = Environment.objects.create(
+        name="another environment", project=another_project
+    )
+    another_feature = Feature.objects.create(
+        name="another_feature", project=another_project
+    )
+    published_scheduled_cr_another_environment = ChangeRequest.objects.create(
+        environment=another_environment,
+        title="Published, scheduled change in another environment",
+        user=staff_user,
+    )
+    another_environment_fs = FeatureState.objects.create(
+        feature=another_feature,
+        enabled=True,
+        environment=another_environment,
+        live_from=two_hours_from_now,
+        change_request=published_scheduled_cr_another_environment,
+        version=None,
+    )
+    published_scheduled_cr_another_environment.commit(staff_user)
+
     # When
     enable_v2_versioning(environment.id)
 
@@ -259,6 +290,13 @@ def test_enable_v2_versioning_for_scheduled_changes(
             environment_flags_queryset_two_hours_later.first()
             == scheduled_feature_state
         )
+
+    another_environment_fs.refresh_from_db()
+    assert another_environment_fs.environment_feature_version is None
+    assert (
+        another_environment_fs.change_request
+        == published_scheduled_cr_another_environment
+    )
 
 
 def test_publish_version_change_set_sends_email_to_change_request_owner_if_conflicts_when_scheduled(


### PR DESCRIPTION
## Changes

Fixes an issue where _all_ scheduled feature states are 'stolen' when versioning is enabled in any environment in the platform. 

## How did you test this code?

Added additional logic to an existing unit test. 