### PR TITLE
docs: remove duplicate info message

### DIFF
--- a/docs/docs/clients/server-side.mdx
+++ b/docs/docs/clients/server-side.mdx
@@ -1033,15 +1033,6 @@ Evaluation mode. Please see [caching](#caching) below.
 
 ### Offline Mode
 
-:::info
-
-Offline mode is still in active development for some SDKs. We are building it for all our SDKs; those that are
-production ready are listed below.
-
-Progress on the remaining SDKs can be seen [here](https://github.com/Flagsmith/flagsmith/issues/2024).
-
-:::
-
 To run the SDK in a fully offline mode, you can set the client to offline mode. This will prevent the SDK from making
 any calls to the Flagsmith API. To use offline mode, you must also provide an
 [offline handler](server-side#using-an-offline-handler). See [Configuring the SDK](server-side#configuring-the-sdk) for


### PR DESCRIPTION
## Changes

Remove duplicate info message about offline mode being in active development. This message is already included in the `Offline Handler` section where it actually makes sense (because it says 'those that are production ready are listed below.'). 

## How did you test this code?

Reviewed the preview link once deployed against this PR. 
