### PR TITLE
fix: Set Hubspot cookie name from request body

### DIFF
--- a/api/integrations/lead_tracking/hubspot/services.py
+++ b/api/integrations/lead_tracking/hubspot/services.py
@@ -9,23 +9,21 @@ logger = logging.getLogger(__name__)
 
 
 def register_hubspot_tracker(request: Request) -> None:
-    hubspot_cookie = request.COOKIES.get(HUBSPOT_COOKIE_NAME)
+    hubspot_cookie = request.data.get(HUBSPOT_COOKIE_NAME)
 
-    # TODO: Remove this temporary debugging logger statement.
-    logger.info(f"Request cookies for user {request.user.email}: {request.COOKIES}")
-
-    if hubspot_cookie:
+    if not hubspot_cookie:
         logger.info(
-            f"Creating HubspotTracker instance for user {request.user.email} with cookie {hubspot_cookie}"
+            f"Request did not included Hubspot data for user {request.user.email}"
         )
+        return
 
-        HubspotTracker.objects.update_or_create(
-            user=request.user,
-            defaults={
-                "hubspot_cookie": hubspot_cookie,
-            },
-        )
-    else:
-        logger.info(
-            f"Could not create HubspotTracker instance for user {request.user.email} since no cookie"
-        )
+    logger.info(
+        f"Creating HubspotTracker instance for user {request.user.email} with cookie {hubspot_cookie}"
+    )
+
+    HubspotTracker.objects.update_or_create(
+        user=request.user,
+        defaults={
+            "hubspot_cookie": hubspot_cookie,
+        },
+    )

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -14,7 +14,7 @@ from rest_framework.test import APIClient
 
 from organisations.invites.models import Invite, InviteLink
 from organisations.models import Organisation, OrganisationRole, Subscription
-from users.models import FFAdminUser
+from users.models import FFAdminUser, HubspotTracker
 
 
 def test_create_invite_link(
@@ -166,13 +166,17 @@ def test_join_organisation_with_permission_groups(
     subscription.save()
 
     url = reverse("api-v1:users:user-join-organisation", args=[invite.hash])
+    data = {"hubspotutk": "somehubspotdata"}
 
     # When
-    response = test_user_client.post(url)
+    response = test_user_client.post(url, data)
     test_user.refresh_from_db()
 
     # Then
     assert response.status_code == status.HTTP_200_OK
+    hubspot_tracker = HubspotTracker.objects.first()
+    assert hubspot_tracker.user == test_user
+
     assert organisation in test_user.organisations.all()
     assert user_permission_group in test_user.permission_groups.all()
     # and invite is deleted

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -82,8 +82,9 @@ def test_non_superuser_can_create_new_organisation_by_default(
     data = {
         "name": org_name,
         "webhook_notification_email": webhook_notification_email,
+        HUBSPOT_COOKIE_NAME: "test_cookie_tracker",
     }
-    staff_client.cookies[HUBSPOT_COOKIE_NAME] = "test_cookie_tracker"
+
     assert not HubspotTracker.objects.filter(user=staff_user).exists()
 
     # When

--- a/api/tests/unit/users/test_unit_users_views.py
+++ b/api/tests/unit/users/test_unit_users_views.py
@@ -35,11 +35,11 @@ def test_join_organisation(
     organisation = Organisation.objects.create(name="test org")
     invite = Invite.objects.create(email=staff_user.email, organisation=organisation)
     url = reverse("api-v1:users:user-join-organisation", args=[invite.hash])
-    staff_client.cookies[HUBSPOT_COOKIE_NAME] = "test_cookie_tracker"
+    data = {HUBSPOT_COOKIE_NAME: "test_cookie_tracker"}
     assert not HubspotTracker.objects.filter(user=staff_user).exists()
 
     # When
-    response = staff_client.post(url)
+    response = staff_client.post(url, data)
     staff_user.refresh_from_db()
 
     # Then
@@ -56,11 +56,11 @@ def test_join_organisation_via_link(
     organisation = Organisation.objects.create(name="test org")
     invite = InviteLink.objects.create(organisation=organisation)
     url = reverse("api-v1:users:user-join-organisation-link", args=[invite.hash])
-    staff_client.cookies[HUBSPOT_COOKIE_NAME] = "test_cookie_tracker"
+    data = {HUBSPOT_COOKIE_NAME: "test_cookie_tracker"}
     assert not HubspotTracker.objects.filter(user=staff_user).exists()
 
     # When
-    response = staff_client.post(url)
+    response = staff_client.post(url, data)
     staff_user.refresh_from_db()
 
     # Then


### PR DESCRIPTION
## Changes

This allows setting Hubspot from the request body of the related API calls in order to work around a cookie limitation of CORS.

## How did you test this code?

Altered a number of tests.
