### PR TITLE
fix: save versioned segment overrides

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1414,8 +1414,10 @@ const CreateFlag = class extends Component {
                                                               identity,
                                                             ),
                                                             <Button
-                                                              onClick={
-                                                                saveFeatureSegments
+                                                              onClick={() =>
+                                                                saveFeatureSegments(
+                                                                  false,
+                                                                )
                                                               }
                                                               type='button'
                                                               data-test='update-feature-segments-btn'
@@ -1477,8 +1479,10 @@ const CreateFlag = class extends Component {
                                                                 </>
                                                               )}
                                                             <Button
-                                                              onClick={
-                                                                saveFeatureSegments
+                                                              onClick={() =>
+                                                                saveFeatureSegments(
+                                                                  false,
+                                                                )
                                                               }
                                                               type='button'
                                                               data-test='update-feature-segments-btn'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Combining segment and value change requests in a single request brought up a bug in saving segment overrides where applied logic as if it was attempting to schedule them - this is because button presses send a truthy value by default.

```
              const saveFeatureSegments = saveFeatureWithValidation(
                (schedule) => {...}
```

## How did you test this code?

Removed / added / adjusted segment overrides on a versioned environment