### PR TITLE
docs(android): remove jitpack from kotlin docs

### DIFF
--- a/docs/docs/clients/client-side/android.md
+++ b/docs/docs/clients/client-side/android.md
@@ -25,12 +25,6 @@ In your project path `app/build.gradle` add a new dependency:
 
 <CodeBlock>{`implementation("com.flagsmith:flagsmith-kotlin-android-client:`}<AndroidVersion />"{`)`}</CodeBlock>
 
-:::info
-
-Note: jitpack support has been deprecated as of `v1.7.1`.
-
-:::
-
 ## Basic Usage
 
 The SDK is initialised against a single environment within a project on [https://flagsmith.com](https://flagsmith.com),

--- a/docs/docs/clients/client-side/android.md
+++ b/docs/docs/clients/client-side/android.md
@@ -23,7 +23,7 @@ repositories {
 
 In your project path `app/build.gradle` add a new dependency:
 
-<CodeBlock>{`implementation("io.flagsmith:flagsmith-kotlin-android-client:`}<AndroidVersion />"{`)`}</CodeBlock>
+<CodeBlock>{`implementation("com.flagsmith:flagsmith-kotlin-android-client:`}<AndroidVersion />"{`)`}</CodeBlock>
 
 :::info
 

--- a/docs/docs/clients/client-side/android.md
+++ b/docs/docs/clients/client-side/android.md
@@ -14,19 +14,22 @@ This SDK can be used for Android applications written in Kotlin. The source code
 
 ### Gradle
 
-Make sure your `settings.gradle` includes JitPack as a repository:
-
 ```groovy
 repositories {
     google()
     mavenCentral()
-    maven("https://jitpack.io")
 }
 ```
 
 In your project path `app/build.gradle` add a new dependency:
 
-<CodeBlock>{`implementation("com.flagsmith:flagsmith-kotlin-android-client:`}<AndroidVersion />"{`)`}</CodeBlock>
+<CodeBlock>{`implementation("io.flagsmith:flagsmith-kotlin-android-client:`}<AndroidVersion />"{`)`}</CodeBlock>
+
+:::info
+
+Note: jitpack support has been deprecated as of `v1.7.1`.
+
+:::
 
 ## Basic Usage
 

--- a/docs/plugins/flagsmith-versions/index.js
+++ b/docs/plugins/flagsmith-versions/index.js
@@ -31,7 +31,11 @@ const fetchGitHubReleases = async (repo) => {
     return data.map((release) => (release.tag_name.startsWith('v') ? release.tag_name.slice(1) : release.tag_name));
 };
 
-const fetchAndroidVersions = async () => fetchGitHubReleases('flagsmith/flagsmith-kotlin-android-client');
+const fetchAndroidVersions = async () =>
+    fetchMavenVersions({
+        groupId: 'com.flagsmith',
+        artifactId: 'flagsmith-kotlin-android-client',
+    });
 
 const fetchSwiftPMVersions = async () => fetchGitHubReleases('Flagsmith/flagsmith-ios-client');
 


### PR DESCRIPTION
## Changes

Removes jitpack from the docs in favour of maven. 

Note - relies on the following PR (and subsequent release)

https://github.com/Flagsmith/flagsmith-kotlin-android-client/pull/61

The docs build will continue to fail until that is completed

## How did you test this code?

n/a
