### PR TITLE
fix: Restore `make docker-up`

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -2,7 +2,7 @@
 
 DOCKER_TAG ?= flagsmith/flagsmith-api:local
 
-COMPOSE_FILE ?= ../docker/db.yml
+COMPOSE_FILE ?= ../docker/api/docker-compose.local.yml
 COMPOSE_PROJECT_NAME ?= flagsmith
 
 DOTENV_OVERRIDE_FILE ?= .env

--- a/docker/api/docker-compose.local.yml
+++ b/docker/api/docker-compose.local.yml
@@ -1,0 +1,19 @@
+# A Compose file with minimal dependencies to be able to run Flagsmith, including its test suite, locally.
+
+name: flagsmith
+
+volumes:
+  pg_11_data:
+
+services:
+  db:
+    image: postgres:15.5-alpine
+    pull_policy: always
+    restart: unless-stopped
+    volumes:
+      - pg_11_data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_DB: flagsmith
+      POSTGRES_PASSWORD: password

--- a/docker/api/docker-compose.local.yml
+++ b/docker/api/docker-compose.local.yml
@@ -1,4 +1,4 @@
-# A Compose file with minimal dependencies to be able to run Flagsmith, including its test suite, locally.
+# A Compose file with minimal dependencies to be able to run Flagsmith, including its test suite, locally (not in Docker).
 
 name: flagsmith
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Restores the `docker-up` Make target removed in #4747. Adds conventional file name and a bit of documentation.

## How did you test this code?

Ran `make docker-up test` to verify the local Postgres db is created correctly.