### PR TITLE
fix: Preserve Page number in URL at AuditLogs page

### DIFF
--- a/frontend/web/components/AuditLog.tsx
+++ b/frontend/web/components/AuditLog.tsx
@@ -21,6 +21,7 @@ type AuditLogType = {
   projectId: string
   pageSize: number
   onSearchChange?: (search: string) => void
+  onPageChange?: (page: number) => void
   searchPanel?: ReactNode
   onErrorChange?: (err: boolean) => void
   match: {
@@ -33,11 +34,15 @@ type AuditLogType = {
 
 const widths = [210, 310, 150]
 const AuditLog: FC<AuditLogType> = (props) => {
-  const [page, setPage] = useState(1)
+  const [page, setPage] = useState(Utils.fromParam().page ?? 1)
   const { search, searchInput, setSearchInput } = useSearchThrottle(
     Utils.fromParam().search,
     () => {
-      setPage(1)
+      if (searchInput !== search) {
+        return setPage(1)
+      }
+
+      setPage(Utils.fromParam().page)
     },
   )
   const { data: subscriptionMeta } = useGetSubscriptionMetadataQuery({
@@ -57,6 +62,11 @@ const AuditLog: FC<AuditLogType> = (props) => {
     }
     //eslint-disable-next-line
   }, [search])
+
+  useEffect(() => {
+    props.onPageChange?.(page)
+    //eslint-disable-next-line
+  }, [page])
 
   const hasHadResults = useRef(false)
 

--- a/frontend/web/components/pages/AuditLogPage.tsx
+++ b/frontend/web/components/pages/AuditLogPage.tsx
@@ -29,6 +29,7 @@ const AuditLogPage: FC<AuditLogType> = (props) => {
       props.router.history.replace(
         `${document.location.pathname}?${Utils.toParam({
           env: environment,
+          page: currentParams.page,
           search: currentParams.search,
         })}`,
       )
@@ -52,7 +53,17 @@ const AuditLogPage: FC<AuditLogType> = (props) => {
                       props.router.history.replace(
                         `${document.location.pathname}?${Utils.toParam({
                           env: environment,
+                          page: Utils.fromParam().page,
                           search,
+                        })}`,
+                      )
+                    }}
+                    onPageChange={(page: number) => {
+                      props.router.history.replace(
+                        `${document.location.pathname}?${Utils.toParam({
+                          env: environment,
+                          page,
+                          search: Utils.fromParam().search,
                         })}`,
                       )
                     }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Reference: https://github.com/Flagsmith/flagsmith/issues/4445

* Use Case 1: loads results and initial page is 1
  - page number is set to 1
  - page number is set in url
  - existing query params are kept in url
* Use Case 2: user goes to page n > 1
  - page number is set to n
  - page number is set in url
  - existing query params are kept in url
* Use Case 3: user searches
  - search text is set in url
  - page number is set to 1
  - page number is set in url
  - existing query params are kept in url
* Use Case 4: results are filtered by search and user goes to page n > 1
  - page number is set to n
  - page number is set in url
  - existing query params are kept in url

https://github.com/user-attachments/assets/64495dde-a339-4ffb-ad30-92c24bc5730a



## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
