### PR TITLE
fix: Numbers such as 1e100 cannot be retrieved from DynamoDB

### DIFF
--- a/api/environments/dynamodb/wrappers/base.py
+++ b/api/environments/dynamodb/wrappers/base.py
@@ -1,11 +1,18 @@
 import typing
+from decimal import Context
 from functools import partial
 
 import boto3
+import boto3.dynamodb.types
 from botocore.config import Config
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table
+
+
+# Avoid `decimal.Rounded` when reading large numbers
+# See https://github.com/boto/boto3/issues/2500
+boto3.dynamodb.types.DYNAMODB_CONTEXT = Context(prec=100)
 
 
 class BaseDynamoWrapper:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #4915.

## How did you test this code?

I'm planning to test in staging by inserting faulty data in the staging identities table.