### PR TITLE
fix: Set project change requests url

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -277,7 +277,7 @@ class ChangeRequest(
             url += f"/project/{self.environment.project_id}"
             url += f"/environment/{self.environment.api_key}"
         else:
-            url += f"/projects/{self.project_id}"
+            url += f"/project/{self.project_id}"
         url += f"/change-requests/{self.id}"
         return url
 

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -1001,7 +1001,5 @@ def test_url_via_project(project_change_request: ChangeRequest) -> None:
     # Then
     project_id = project_change_request.project_id
     expected_url = get_current_site_url()
-    expected_url += (
-        f"/projects/{project_id}/change-requests/{project_change_request.id}"
-    )
+    expected_url += f"/project/{project_id}/change-requests/{project_change_request.id}"
     assert url == expected_url


### PR DESCRIPTION
## Changes

The frontend uses the singular `project` for URLs, so this updates to what our emails around change requests for projects have in them.

## How did you test this code?

Updated a model unit test.