### PR TITLE
feat: Displays what entity is being edited in side modal

### DIFF
--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -836,6 +836,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                       Administrator
                     </div>
                   </Flex>
+
                   <Switch
                     disabled={saving}
                     data-test={`admin-switch-${level}`}

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -467,7 +467,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
           })
       }
       //eslint-disable-next-line
-  }, [])
+    }, [])
 
     const admin = () => entityPermissions && entityPermissions.admin
 
@@ -804,8 +804,23 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
         })
     }
 
+    const getEditText = () => {
+      if (isGroup) {
+        return `the ${group?.name || ''} group`
+      }
+      if (user) {
+        return `${user.first_name || ''} ${user.last_name || ''}`
+      }
+      if (role) {
+        return role.name
+      }
+      return name
+    }
+
     const rolesAdded = getRoles(roles, rolesSelected || [])
     const isAdmin = admin()
+
+    console.log('aosidjaosijaosijosi', level)
 
     return !permissions || !entityPermissions ? (
       <div className='modal-body text-center'>
@@ -826,15 +841,15 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                   <Switch
                     disabled={saving}
                     data-test={`admin-switch-${level}`}
-                  onChange={() => {
-                    toggleAdmin()
-                    setValueChanged(true)
-                  }}
-                  checked={isAdmin}
-                />
-              </Row>
-            </div>
-          )}
+                    onChange={() => {
+                      toggleAdmin()
+                      setValueChanged(true)
+                    }}
+                    checked={isAdmin}
+                  />
+                </Row>
+              </div>
+            )}
             <PanelSearch
               filterRow={(item: AvailablePermission, search: string) => {
                 const name = Format.enumeration.get(item.key).toLowerCase()
@@ -844,24 +859,24 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
               className='no-pad mb-2 overflow-visible'
               items={permissions}
               renderRow={(p: AvailablePermission, index: number) => {
-              const levelUpperCase = level.toUpperCase()
-              const disabled =
-                level !== 'organisation' &&
-                p.key !== `VIEW_${levelUpperCase}` &&
-                !hasPermission(`VIEW_${levelUpperCase}`)
+                const levelUpperCase = level.toUpperCase()
+                const disabled =
+                  level !== 'organisation' &&
+                  p.key !== `VIEW_${levelUpperCase}` &&
+                  !hasPermission(`VIEW_${levelUpperCase}`)
                 const permission = entityPermissions.permissions.find(
                   (v) => v.permission_key === p.key,
                 )
                 const permissionType = getPermissionType(p.key)
-              return (
-                <Row
-                  key={p.key}
-                  style={admin() ? { opacity: 0.5 } : undefined}
+                return (
+                  <Row
+                    key={p.key}
+                    style={admin() ? { opacity: 0.5 } : undefined}
                     className='list-item list-item-sm px-3 py-2'
-                >
-                  <Row space>
-                    <Flex>
-                      <strong>{Format.enumeration.get(p.key)}</strong>
+                  >
+                    <Row space>
+                      <Flex>
+                        <strong>{Format.enumeration.get(p.key)}</strong>
                         <div className='list-item-subtitle'>
                           {p.description}
                         </div>
@@ -875,7 +890,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                             }}
                           />
                         )}
-                    </Flex>
+                      </Flex>
                       {tagBasedPermissions ? (
                         <div className='ms-2' style={{ width: 200 }}>
                           <Select
@@ -899,8 +914,8 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                           />
                         </div>
                       ) : (
-                    <Switch
-                      data-test={`permission-switch-${level}-${index}`}
+                        <Switch
+                          data-test={`permission-switch-${level}-${index}`}
                           onChange={() => {
                             setValueChanged(true)
                             togglePermission(p.key)
@@ -917,20 +932,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
 
             <p className='text-right mt-5 text-dark'>
               This will edit the permissions for{' '}
-              <strong>
-                {isGroup ? (
-                  `the ${group?.name || ''} group`
-                ) : user ? (
-                  <>
-                    {user.first_name || ''} {user.last_name || ''}
-                  </>
-                ) : role ? (
-                  ` ${role.name}`
-                ) : (
-                  ` ${name}`
-                )}
-              </strong>
-              .
+              <strong>{getEditText()}</strong>.
             </p>
 
             {!!parentWarning && (

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -839,15 +839,15 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                   <Switch
                     disabled={saving}
                     data-test={`admin-switch-${level}`}
-                    onChange={() => {
-                      toggleAdmin()
-                      setValueChanged(true)
-                    }}
-                    checked={isAdmin}
-                  />
-                </Row>
-              </div>
-            )}
+                  onChange={() => {
+                    toggleAdmin()
+                    setValueChanged(true)
+                  }}
+                  checked={isAdmin}
+                />
+              </Row>
+            </div>
+          )}
             <PanelSearch
               filterRow={(item: AvailablePermission, search: string) => {
                 const name = Format.enumeration.get(item.key).toLowerCase()
@@ -857,24 +857,24 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
               className='no-pad mb-2 overflow-visible'
               items={permissions}
               renderRow={(p: AvailablePermission, index: number) => {
-                const levelUpperCase = level.toUpperCase()
-                const disabled =
-                  level !== 'organisation' &&
-                  p.key !== `VIEW_${levelUpperCase}` &&
-                  !hasPermission(`VIEW_${levelUpperCase}`)
+              const levelUpperCase = level.toUpperCase()
+              const disabled =
+                level !== 'organisation' &&
+                p.key !== `VIEW_${levelUpperCase}` &&
+                !hasPermission(`VIEW_${levelUpperCase}`)
                 const permission = entityPermissions.permissions.find(
                   (v) => v.permission_key === p.key,
                 )
                 const permissionType = getPermissionType(p.key)
-                return (
-                  <Row
-                    key={p.key}
-                    style={admin() ? { opacity: 0.5 } : undefined}
+              return (
+                <Row
+                  key={p.key}
+                  style={admin() ? { opacity: 0.5 } : undefined}
                     className='list-item list-item-sm px-3 py-2'
-                  >
-                    <Row space>
-                      <Flex>
-                        <strong>{Format.enumeration.get(p.key)}</strong>
+                >
+                  <Row space>
+                    <Flex>
+                      <strong>{Format.enumeration.get(p.key)}</strong>
                         <div className='list-item-subtitle'>
                           {p.description}
                         </div>
@@ -888,7 +888,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                             }}
                           />
                         )}
-                      </Flex>
+                    </Flex>
                       {tagBasedPermissions ? (
                         <div className='ms-2' style={{ width: 200 }}>
                           <Select
@@ -912,8 +912,8 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                           />
                         </div>
                       ) : (
-                        <Switch
-                          data-test={`permission-switch-${level}-${index}`}
+                    <Switch
+                      data-test={`permission-switch-${level}-${index}`}
                           onChange={() => {
                             setValueChanged(true)
                             togglePermission(p.key)

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -467,7 +467,7 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
           })
       }
       //eslint-disable-next-line
-    }, [])
+  }, [])
 
     const admin = () => entityPermissions && entityPermissions.admin
 

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -836,7 +836,6 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
                       Administrator
                     </div>
                   </Flex>
-
                   <Switch
                     disabled={saving}
                     data-test={`admin-switch-${level}`}

--- a/frontend/web/components/EditPermissions.tsx
+++ b/frontend/web/components/EditPermissions.tsx
@@ -820,8 +820,6 @@ const _EditPermissionsModal: FC<EditPermissionModalType> = withAdminPermissions(
     const rolesAdded = getRoles(roles, rolesSelected || [])
     const isAdmin = admin()
 
-    console.log('aosidjaosijaosijosi', level)
-
     return !permissions || !entityPermissions ? (
       <div className='modal-body text-center'>
         <Loader />

--- a/frontend/web/components/PermissionsTabs.tsx
+++ b/frontend/web/components/PermissionsTabs.tsx
@@ -173,6 +173,10 @@ const PermissionsTabs: FC<PermissionsTabsType> = ({
               />
             )}
           </div>
+          <p className='text-right mt-5 text-dark'>
+            This will edit the permissions for{' '}
+            <strong>the {group?.name} group</strong>.
+          </p>
         </TabItem>
       </Tabs>
     </PlanBasedAccess>

--- a/frontend/web/components/RolePermissionsList.tsx
+++ b/frontend/web/components/RolePermissionsList.tsx
@@ -6,7 +6,7 @@ import {
   useGetRoleProjectPermissionsQuery,
 } from 'common/services/useRolePermission'
 import { PermissionLevel } from 'common/types/requests'
-import { Role, User, UserGroup, UserGroupSummary } from 'common/types/responses'
+import { Role, User, UserGroupSummary } from 'common/types/responses'
 import PanelSearch from './PanelSearch'
 import PermissionsSummaryList from './PermissionsSummaryList'
 

--- a/frontend/web/components/modals/CreateRole.tsx
+++ b/frontend/web/components/modals/CreateRole.tsx
@@ -511,6 +511,9 @@ const CreateRole: FC<CreateRoleType> = ({
                 ))}
               </div>
             </div>
+            <p className='text-right mt-5 text-dark'>
+              This will edit the members for <strong>{role?.name}</strong>.
+            </p>
           </div>
         </TabItem>
         <TabItem


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Displays bottom text to inform users which entity is being edited when they're editing roles, members, permissions.
- Removes an unused import `UserGroup`

Ref: [#4894](https://github.com/Flagsmith/flagsmith/issues/4894)

## How did you test this code?

manually tested
<img width="728" alt="Screenshot 2024-12-17 at 10 52 58" src="https://github.com/user-attachments/assets/b87fb157-fe6c-4b4b-b83e-c300be57433e" />

<img width="1472" alt="Screenshot 2024-12-17 at 11 08 29" src="https://github.com/user-attachments/assets/ce0b2c68-4c4c-43d1-b2b8-9fd12570e58c" />


