### PR TITLE
feat: Adds Licensing upload tab

### DIFF
--- a/frontend/common/services/useOrganisationLicensing.ts
+++ b/frontend/common/services/useOrganisationLicensing.ts
@@ -1,0 +1,50 @@
+import { Res } from 'common/types/responses'
+import { Req } from 'common/types/requests'
+import { service } from 'common/service'
+
+export const organisationLicensingService = service
+  .enhanceEndpoints({ addTagTypes: ['OrganisationLicensing'] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      uploadOrganisationLicence: builder.mutation<
+        Res['organisationLicence'],
+        Req['uploadOrganisationLicence']
+      >({
+        query: (query: Req['uploadOrganisationLicence']) => {
+          const formData = new FormData()
+          formData.append('licence_signature', query.body.licence_signature)
+          formData.append('licence', query.body.licence)
+          return {
+            body: formData,
+            method: 'PUT',
+            url: `organisations/${query.id}/licence`,
+          }
+        },
+      }),
+      // END OF ENDPOINTS
+    }),
+  })
+
+export async function uploadOrganisationLicence(
+  store: any,
+  data: Req['uploadOrganisationLicence'],
+  options?: Parameters<
+    typeof organisationLicensingService.endpoints.uploadOrganisationLicence.initiate
+  >[1],
+) {
+  store.dispatch(
+    organisationLicensingService.endpoints.uploadOrganisationLicence.initiate(
+      data,
+      options,
+    ),
+  )
+  return Promise.all(
+    store.dispatch(organisationLicensingService.util.getRunningQueriesThunk()),
+  )
+}
+// END OF FUNCTION_EXPORTS
+
+export const {
+  useUploadOrganisationLicenceMutation,
+  // END OF EXPORTS
+} = organisationLicensingService

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -69,6 +69,13 @@ export type Req = {
     environments?: string
   }>
   getOrganisations: {}
+  uploadOrganisationLicence: {
+    id: number
+    body: {
+      licence_signature: File
+      licence: File
+    }
+  }
   getProjects: {
     organisationId: string
   }

--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -641,6 +641,7 @@ export type Res = {
   segments: PagedResponse<Segment>
   segment: Segment
   auditLogs: PagedResponse<AuditLogItem>
+  organisationLicence: {}
   organisations: PagedResponse<Organisation>
   projects: ProjectSummary[]
   project: Project

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -354,10 +354,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     if (plan && plan.includes('start-up')) {
       return planNames.startup
     }
-    if (
-      global.flagsmithVersion?.backend.is_enterprise ||
-      (plan && plan.includes('enterprise'))
-    ) {
+    if (Utils.isEnterpriseImage() || (plan && plan.includes('enterprise'))) {
       return planNames.enterprise
     }
     return planNames.free
@@ -555,6 +552,7 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   getViewIdentitiesPermission() {
     return 'VIEW_IDENTITIES'
   },
+  isEnterpriseImage: () => global.flagsmithVersion?.backend.is_enterprise,
   isMigrating() {
     const model = ProjectStore.model as null | ProjectType
     if (
@@ -566,7 +564,6 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     return false
   },
   isSaas: () => global.flagsmithVersion?.backend?.is_saas,
-
   isValidNumber(value: any) {
     return /^-?\d*\.?\d+$/.test(`${value}`)
   },

--- a/frontend/web/components/LicensingTabContent.tsx
+++ b/frontend/web/components/LicensingTabContent.tsx
@@ -1,0 +1,110 @@
+import { useUploadOrganisationLicenceMutation } from 'common/services/useOrganisationLicensing'
+import React, { useEffect, useRef, useState } from 'react'
+import Button from './base/forms/Button'
+import Utils from 'common/utils/utils'
+
+type LicensingTabContentProps = {
+  organisationId: number
+}
+
+const LicensingTabContent: React.FC<LicensingTabContentProps> = ({
+  organisationId,
+}) => {
+  const [uploadOrganisationLicence, { error, isLoading, isSuccess }] =
+    useUploadOrganisationLicenceMutation()
+
+  const [licence, setLicence] = useState<File | null>(null)
+  const [licenceSignature, setLicenceSignature] = useState<File | null>(null)
+
+  const licenceInputRef = useRef<HTMLInputElement>(null)
+  const licenceSignatureInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (isSuccess) {
+      toast('Licence uploaded successfully')
+    }
+
+    if (!isSuccess && error?.data) {
+      toast(
+        Array.isArray(error?.data)
+          ? error?.data[0]
+          : 'Upload was not successful',
+        'danger',
+      )
+    }
+  }, [isSuccess, error])
+
+  const handleUpload = () => {
+    if (!licence || !licenceSignature) return
+    uploadOrganisationLicence({
+      body: { licence, licence_signature: licenceSignature },
+      id: organisationId,
+    })
+  }
+
+  return (
+    <div className='mt-4'>
+      <h5 className='mb-5'>Upload Licensing Files</h5>
+      <form
+        className='upload-licensing-tab'
+        onSubmit={(e) => {
+          Utils.preventDefault(e)
+          handleUpload()
+        }}
+      >
+        <FormGroup>
+          <input
+            type='file'
+            ref={licenceInputRef}
+            style={{ display: 'none' }}
+            onChange={() =>
+              setLicence(licenceInputRef.current?.files?.[0] ?? null)
+            }
+          />
+          <input
+            type='file'
+            ref={licenceSignatureInputRef}
+            style={{ display: 'none' }}
+            onChange={() =>
+              setLicenceSignature(
+                licenceSignatureInputRef.current?.files?.[0] ?? null,
+              )
+            }
+          />
+          <div className='flex-row'>
+            <Button onClick={() => licenceInputRef.current?.click()}>
+              Select Licence File
+            </Button>
+            {!!licence?.name && (
+              <p className='mt-auto mb-auto ml-2 fs-small lh-sm'>
+                {licence.name}
+              </p>
+            )}
+          </div>
+          <div className='flex-row mt-4'>
+            <Button onClick={() => licenceSignatureInputRef.current?.click()}>
+              Select Signature File
+            </Button>
+            {!!licenceSignature?.name && (
+              <p className='mt-auto mb-auto ml-2 fs-small lh-sm'>
+                {licenceSignature.name}
+              </p>
+            )}
+          </div>
+          <div className='text-right'>
+            <Button
+              type='submit'
+              data-test='create-feature-btn'
+              id='create-feature-btn'
+              disabled={!licence || !licenceSignature}
+            >
+              {isLoading ? 'Uploading' : 'Upload Licensing Files'}
+            </Button>
+          </div>
+        </FormGroup>
+      </form>
+    </div>
+  )
+}
+
+export default LicensingTabContent

--- a/frontend/web/components/pages/OrganisationSettingsPage.js
+++ b/frontend/web/components/pages/OrganisationSettingsPage.js
@@ -18,11 +18,14 @@ import PageTitle from 'components/PageTitle'
 import SamlTab from 'components/SamlTab'
 import Setting from 'components/Setting'
 import AccountProvider from 'common/providers/AccountProvider'
+import LicensingTabContent from 'components/LicensingTabContent'
+import Utils from 'common/utils/utils'
 
 const SettingsTab = {
   'Billing': 'billing',
   'General': 'general',
   'Keys': 'keys',
+  'Licensing': 'licensing',
   'SAML': 'saml',
   'Usage': 'usage',
   'Webhooks': 'webhooks',
@@ -228,7 +231,7 @@ const OrganisationSettingsPage = class extends Component {
                   const { chargebee_email } = subscriptionMeta || {}
 
                   const displayedTabs = []
-
+                  const isEnterprise = Utils.isEnterpriseImage()
                   if (
                     AccountStore.getUser() &&
                     AccountStore.getOrganisationRole() === 'ADMIN'
@@ -237,6 +240,7 @@ const OrganisationSettingsPage = class extends Component {
                       ...[
                         SettingsTab.General,
                         paymentsEnabled && !isAWS ? SettingsTab.Billing : null,
+                        isEnterprise ? SettingsTab.Licensing : null,
                         SettingsTab.Keys,
                         SettingsTab.Webhooks,
                         SettingsTab.SAML,
@@ -460,6 +464,14 @@ const OrganisationSettingsPage = class extends Component {
                               <h5>Manage Payment Plan</h5>
                               <Payment viewOnly={false} />
                             </div>
+                          </TabItem>
+                        )}
+
+                        {displayedTabs.includes(SettingsTab.Licensing) && (
+                          <TabItem tabLabel='Licensing'>
+                            <LicensingTabContent
+                              organisationId={organisation.id}
+                            />
                           </TabItem>
                         )}
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Reference: https://github.com/Flagsmith/flagsmith/issues/4923

This pull request introduces a new feature for uploading organization licensing files. The changes primarily focus on adding new endpoints, updating types, and integrating the new functionality into the existing UI components.

* Added a new service for uploading organization licenses, including a mutation endpoint and a function to dispatch the upload action.
* Created a new component for the Licensing tab content, allowing users to select and upload license files.
* Integrated the Licensing tab into the organization settings page, making it visible for enterprise users (not SaaS).
* Added optional chaining to safely access the `focus` method.

<img width="1624" alt="Screenshot 2024-12-19 at 17 04 28" src="https://github.com/user-attachments/assets/0b198d76-51ec-472f-949e-44cd77ccef4b" />


## How did you test this code?

Tested mannualy
