### PR TITLE
feat: Adds plus indicator when `is_num_identity_overrides_complete` is false

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -436,6 +436,7 @@ export type ProjectFlag = {
   id: number
   initial_value: FlagsmithValue
   is_archived: boolean
+  is_num_identity_overrides_complete: boolean
   is_server_key_only: boolean
   multivariate_options: MultivariateOption[]
   name: string

--- a/frontend/web/components/CompareIdentities.tsx
+++ b/frontend/web/components/CompareIdentities.tsx
@@ -314,6 +314,9 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
                       />
                       <IdentityOverridesIcon
                         count={data.num_identity_overrides}
+                        showPlusIndicator={
+                          data.is_num_identity_overrides_complete === false
+                        }
                       />
                     </Row>
                   </div>

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -141,6 +141,9 @@ class TheComponent extends Component {
     const changeRequestsEnabled = Utils.changeRequestsEnabled(
       environment && environment.minimum_change_request_approvals,
     )
+    const showPlusIndicator =
+      projectFlag?.is_num_identity_overrides_complete === false
+
     const onChange = () => {
       if (disableControls) {
         return
@@ -230,6 +233,7 @@ class TheComponent extends Component {
                   )
                 }}
                 count={projectFlag.num_identity_overrides}
+                showPlusIndicator={showPlusIndicator}
               />
             </Row>
           </Flex>
@@ -292,6 +296,7 @@ class TheComponent extends Component {
                     this.editFeature(projectFlag, environmentFlags[id], 1)
                   }}
                   count={projectFlag.num_identity_overrides}
+                  showPlusIndicator={showPlusIndicator}
                 />
                 {projectFlag.is_server_key_only && (
                   <Tooltip

--- a/frontend/web/components/IdentityOverridesIcon.tsx
+++ b/frontend/web/components/IdentityOverridesIcon.tsx
@@ -4,16 +4,19 @@ import UsersIcon from './svg/UsersIcon'
 
 type IdentityOverridesIconType = {
   count: number | null
+  showPlusIndicator?: boolean
   onClick?: (e: FormEvent) => void
 }
 
 const IdentityOverridesIcon: FC<IdentityOverridesIconType> = ({
   count,
   onClick,
+  showPlusIndicator,
 }) => {
   if (!count) {
     return null
   }
+  const plusIndicatorText = showPlusIndicator ? '+' : ''
   return (
     <div onClick={onClick}>
       <Tooltip
@@ -23,12 +26,17 @@ const IdentityOverridesIcon: FC<IdentityOverridesIconType> = ({
             style={{ border: 'none' }}
           >
             <UsersIcon className='chip-svg-icon' />
-            <span>{count}</span>
+            <span>
+              {count}
+              {plusIndicatorText}
+            </span>
           </span>
         }
         place='top'
       >
-        {`${count} Identity Override${count !== 1 ? 's' : ''}`}
+        {`${count}${plusIndicatorText} Identity Override${
+          count !== 1 || showPlusIndicator ? 's' : ''
+        }`}
       </Tooltip>
     </div>
   )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Adds plus indicator when is_num_identity_overrides_complete is false implemented in https://github.com/Flagsmith/flagsmith/pull/4840

ref: #4931


## How did you test this code?

Mannualy
![Screenshot 2024-12-23 at 12 20 18](https://github.com/user-attachments/assets/c8b6e3fe-7e0d-459c-9648-3c9d39ce29bb)

