### PR TITLE
feat: Support `--exclusive-start-key` option for `ensure_identity_traits_blanks`

### DIFF
--- a/api/environments/dynamodb/wrappers/base.py
+++ b/api/environments/dynamodb/wrappers/base.py
@@ -4,9 +4,8 @@ from functools import partial
 
 import boto3
 import boto3.dynamodb.types
-import structlog
 from botocore.config import Config
-from sentry_sdk import set_context
+from sentry_sdk import set_context  # TODO @kgustyr: Replace with OTel
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table
@@ -25,15 +24,11 @@ if typing.TYPE_CHECKING:
 boto3.dynamodb.types.DYNAMODB_CONTEXT = Context(prec=100)
 
 
-logger: structlog.BoundLogger = structlog.get_logger()
-
-
 class BaseDynamoWrapper:
     table_name: str = None
 
     def __init__(self) -> None:
         self._table: typing.Optional["Table"] = None
-        self._log = logger.bind(table_name=self.table_name)
 
     @property
     def table(self) -> typing.Optional["Table"]:

--- a/api/environments/dynamodb/wrappers/base.py
+++ b/api/environments/dynamodb/wrappers/base.py
@@ -4,15 +4,28 @@ from functools import partial
 
 import boto3
 import boto3.dynamodb.types
+import structlog
 from botocore.config import Config
+from sentry_sdk import set_context
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table
+    from mypy_boto3_dynamodb.type_defs import (
+        QueryOutputTableTypeDef,
+        ScanOutputTableTypeDef,
+        TableAttributeValueTypeDef,
+    )
 
+    DynamoDBOutput = QueryOutputTableTypeDef | ScanOutputTableTypeDef
+
+    P = typing.ParamSpec("P")
 
 # Avoid `decimal.Rounded` when reading large numbers
 # See https://github.com/boto/boto3/issues/2500
 boto3.dynamodb.types.DYNAMODB_CONTEXT = Context(prec=100)
+
+
+logger: structlog.BoundLogger = structlog.get_logger()
 
 
 class BaseDynamoWrapper:
@@ -20,6 +33,7 @@ class BaseDynamoWrapper:
 
     def __init__(self) -> None:
         self._table: typing.Optional["Table"] = None
+        self._log = logger.bind(table_name=self.table_name)
 
     @property
     def table(self) -> typing.Optional["Table"]:
@@ -40,14 +54,20 @@ class BaseDynamoWrapper:
     def is_enabled(self) -> bool:
         return self.table is not None
 
-    def query_get_all_items(self, **kwargs: dict) -> typing.Generator[dict, None, None]:
-        if kwargs:
-            response_getter = partial(self.table.query, **kwargs)
-        else:
-            response_getter = partial(self.table.scan)
+    def _iter_all_items(
+        self,
+        response_getter_method: "typing.Callable[[P], DynamoDBOutput]",
+        **kwargs: "P.kwargs",
+    ) -> typing.Generator[dict[str, "TableAttributeValueTypeDef"], None, None]:
+        response_getter = partial(response_getter_method, **kwargs)
+        set_context(
+            "dynamodb",
+            {"table_name": self.table_name, **kwargs},
+        )
 
         while True:
             query_response = response_getter()
+
             for item in query_response["Items"]:
                 yield item
 
@@ -56,3 +76,19 @@ class BaseDynamoWrapper:
                 break
 
             response_getter.keywords["ExclusiveStartKey"] = last_evaluated_key
+            set_context(
+                "dynamodb",
+                {"table_name": self.table_name, **response_getter.keywords},
+            )
+
+    def scan_iter_all_items(
+        self,
+        **kwargs: typing.Any,
+    ) -> typing.Generator[dict[str, "TableAttributeValueTypeDef"], None, None]:
+        return self._iter_all_items(self.table.scan, **kwargs)
+
+    def query_iter_all_items(
+        self,
+        **kwargs: typing.Any,
+    ) -> typing.Generator[dict[str, "TableAttributeValueTypeDef"], None, None]:
+        return self._iter_all_items(self.table.query, **kwargs)

--- a/api/environments/dynamodb/wrappers/environment_wrapper.py
+++ b/api/environments/dynamodb/wrappers/environment_wrapper.py
@@ -69,7 +69,7 @@ class DynamoEnvironmentV2Wrapper(BaseDynamoEnvironmentWrapper):
     ) -> typing.List[dict[str, Any]]:
         try:
             return list(
-                self.query_get_all_items(
+                self.query_iter_all_items(
                     KeyConditionExpression=Key(ENVIRONMENTS_V2_PARTITION_KEY).eq(
                         str(environment_id),
                     )
@@ -122,7 +122,7 @@ class DynamoEnvironmentV2Wrapper(BaseDynamoEnvironmentWrapper):
             "ProjectionExpression": "document_key",
         }
         with self.table.batch_writer() as writer:
-            for item in self.query_get_all_items(**query_kwargs):
+            for item in self.query_iter_all_items(**query_kwargs):
                 writer.delete_item(
                     Key={
                         ENVIRONMENTS_V2_PARTITION_KEY: environment_id,

--- a/api/tests/integration/edge_api/identities/conftest.py
+++ b/api/tests/integration/edge_api/identities/conftest.py
@@ -34,7 +34,7 @@ def identity_overrides_v2(
     edge_identity.save(admin_user)
     return [
         item["document_key"]
-        for item in dynamodb_wrapper_v2.query_get_all_items(
+        for item in dynamodb_wrapper_v2.query_iter_all_items(
             KeyConditionExpression=Key("environment_id").eq(
                 str(dynamo_enabled_environment)
             ),

--- a/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
+++ b/api/tests/integration/edge_api/identities/test_edge_identity_viewset.py
@@ -163,7 +163,7 @@ def test_delete_identity(
         KeyConditionExpression=Key("identity_uuid").eq(identity_uuid),
     )["Count"]
     assert not list(
-        dynamodb_wrapper_v2.query_get_all_items(
+        dynamodb_wrapper_v2.query_iter_all_items(
             KeyConditionExpression=Key("environment_id").eq(
                 str(dynamo_enabled_environment)
             )

--- a/api/tests/unit/edge_api/test_unit_edge_api_commands.py
+++ b/api/tests/unit/edge_api/test_unit_edge_api_commands.py
@@ -218,3 +218,25 @@ def test_ensure_identity_traits_blanks__logs_expected(
             "total_count": 11,
         },
     ]
+
+
+def test_ensure_identity_traits_blanks__exclusive_start_key__calls_expected(
+    flagsmith_identities_table: "Table",
+    mocker: "MockerFixture",
+) -> None:
+    # Given
+    exclusive_start_key = '{"composite_key":"test_hello"}'
+    expected_kwargs = {"ExclusiveStartKey": {"composite_key": "test_hello"}}
+
+    identity_wrapper_mock = mocker.patch(
+        "edge_api.management.commands.ensure_identity_traits_blanks.identity_wrapper"
+    )
+
+    # When
+    call_command(
+        "ensure_identity_traits_blanks",
+        exclusive_start_key=exclusive_start_key,
+    )
+
+    # Then
+    identity_wrapper_mock.scan_get_all_items.assert_called_once_with(**expected_kwargs)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Added an option to retrieve the exclusive start key for the heal identities command from Sentry in case if an exception raised during command runtime. We also allow to start the scanning from an exclusive start key by providing a command argument. Additionally, there's a bit of a refactoring to clearly segregate table scans and table queries.

## How did you test this code?

Added unit tests to cover new code.
