### PR TITLE
ci: add deps to release notes and add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# $schema: https://json.schemastore.org/dependabot-2.0.json
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/api"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "flagsmith/flagsmith-back-end"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "api"
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "flagsmith/flagsmith-front-end"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "front-end"
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "flagsmith/flagsmith-docs"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "docs"
+      - "dependencies"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,11 @@
             "section": "Infrastructure (Flagsmith SaaS Only)"
         },
         {
+            "type": "deps",
+            "hidden": false,
+            "section": "Dependency Updates"
+        },
+        {
             "type": "ci",
             "hidden": true,
             "section": "CI"
@@ -37,11 +42,6 @@
             "type": "docs",
             "hidden": true,
             "section": "Docs"
-        },
-        {
-            "type": "deps",
-            "hidden": true,
-            "section": "Dependency Updates"
         },
         {
             "type": "perf",


### PR DESCRIPTION
## Changes

2-fold: 

 1. Add dependabot.yml for configuring dependabot programmatically
 2. Add `deps` scoped PRs to release notes in release please 

## How did you test this code?

I've not been able to find a way to really test this, but I've validated that the YAML is correct. 
