### PR TITLE
fix: handle fetch github stars errors

### DIFF
--- a/frontend/web/components/GithubStar.tsx
+++ b/frontend/web/components/GithubStar.tsx
@@ -21,6 +21,9 @@ const GithubStar: FC<GithubStarType> = ({}) => {
         .then(function (res) {
           setStars(res.stargazers_count)
         })
+        .catch(() => {
+          setStars(undefined)
+        })
     }
   }, [planName])
 
@@ -28,8 +31,8 @@ const GithubStar: FC<GithubStarType> = ({}) => {
     return <></>
   }
 
-  return (
-    <>
+  if (!stars) {
+    return (
       <a
         style={{ width: 90 }}
         target='_blank'
@@ -37,12 +40,24 @@ const GithubStar: FC<GithubStarType> = ({}) => {
         className='btn btn-sm btn-with-icon text-body'
         rel='noreferrer'
       >
-        <div className='d-flex flex-row justify-content-center align-items-center'>
-          <IonIcon style={{ fontSize: 16 }} icon={logoGithub} />
-          <div className='ms-1'>{stars}</div>
-        </div>
+        <IonIcon style={{ fontSize: 16 }} icon={logoGithub} />
       </a>
-    </>
+    )
+  }
+
+  return (
+    <a
+      style={{ width: 90 }}
+      target='_blank'
+      href='https://github.com/flagsmith/flagsmith'
+      className='btn btn-sm btn-with-icon text-body'
+      rel='noreferrer'
+    >
+      <div className='d-flex flex-row justify-content-center align-items-center'>
+        <IonIcon style={{ fontSize: 16 }} icon={logoGithub} />
+        <div className='ms-1'>{stars}</div>
+      </div>
+    </a>
   )
 }
 

--- a/frontend/web/components/GithubStar.tsx
+++ b/frontend/web/components/GithubStar.tsx
@@ -29,20 +29,6 @@ const GithubStar: FC<GithubStarType> = ({}) => {
     return <></>
   }
 
-  if (!stars) {
-    return (
-      <a
-        style={{ width: 90 }}
-        target='_blank'
-        href='https://github.com/flagsmith/flagsmith'
-        className='btn btn-sm btn-with-icon text-body'
-        rel='noreferrer'
-      >
-        <IonIcon style={{ fontSize: 16 }} icon={logoGithub} />
-      </a>
-    )
-  }
-
   return (
     <a
       style={{ width: 90 }}
@@ -51,9 +37,15 @@ const GithubStar: FC<GithubStarType> = ({}) => {
       className='btn btn-sm btn-with-icon text-body'
       rel='noreferrer'
     >
-      <div className='d-flex flex-row justify-content-center align-items-center'>
+      <div
+        className={
+          stars
+            ? 'd-flex flex-row justify-content-center align-items-center'
+            : ''
+        }
+      >
         <IonIcon style={{ fontSize: 16 }} icon={logoGithub} />
-        <div className='ms-1'>{stars}</div>
+        {stars && <div className='ms-1'>{stars}</div>}
       </div>
     </a>
   )

--- a/frontend/web/components/GithubStar.tsx
+++ b/frontend/web/components/GithubStar.tsx
@@ -21,9 +21,7 @@ const GithubStar: FC<GithubStarType> = ({}) => {
         .then(function (res) {
           setStars(res.stargazers_count)
         })
-        .catch(() => {
-          setStars(undefined)
-        })
+        .catch(() => {})
     }
   }, [planName])
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ref: [#4945](https://github.com/Flagsmith/flagsmith/issues/4945)

- Don't show github star count when gh api fails
- bypass error by adding a `.catch` handler

## How did you test this code?

1. Access flagsmith dashboard, on the top right, stars count should display
2. Access flagsmith dashboard, on the top right, if gh api fails then stars count will not display 

### Success
<img width="387" alt="Screenshot 2025-01-03 at 17 03 03" src="https://github.com/user-attachments/assets/c6e3f8bd-0748-4cf5-8ef0-9670d090d3cc" />


### GitHub API Failure
<img width="365" alt="Screenshot 2025-01-03 at 17 03 21" src="https://github.com/user-attachments/assets/40c2c34a-467e-43c6-b6d0-08f4f0f063ad" />
