### PR TITLE
ci: disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,13 @@
 # $schema: https://json.schemastore.org/dependabot-2.0.json
 
+
 version: 2
 updates:
   - package-ecosystem: "pip"
+    # we only want security updates from dependabot, so we set the limit to 0
+    # for regular updates. See documentation for further information here:
+    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-
+    open-pull-requests-limit: 0
     directory: "/api"
     schedule:
       interval: "daily"
@@ -15,6 +20,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "npm"
+    open-pull-requests-limit: 0  # only security updates
     directory: "/frontend"
     schedule:
       interval: "daily"
@@ -27,6 +33,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "npm"
+    open-pull-requests-limit: 0  # only security updates
     directory: "/docs"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Changes

Disable version updates in dependabot.yml. 

See documentation [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-) for further information. 

## How did you test this code?

N/a - hoping documentation is correct. 
