### PR TITLE
ci: fix incorrect input reference in GH workflow

### DIFF
--- a/.github/workflows/.reusable-frontend-deploy.yml
+++ b/.github/workflows/.reusable-frontend-deploy.yml
@@ -51,4 +51,4 @@ jobs:
           npm run bundle
           echo ${{ github.sha }} > CI_COMMIT_SHA
           npm install --global vercel@31.2.0
-          vercel --prod --token ${{ secrets.VERCEL_TOKEN }}
+#          vercel --prod --token ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/.reusable-frontend-deploy.yml
+++ b/.github/workflows/.reusable-frontend-deploy.yml
@@ -51,4 +51,4 @@ jobs:
           npm run bundle
           echo ${{ github.sha }} > CI_COMMIT_SHA
           npm install --global vercel@31.2.0
-#          vercel --prod --token ${{ secrets.VERCEL_TOKEN }}
+          vercel --prod --token ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/.reusable-frontend-deploy.yml
+++ b/.github/workflows/.reusable-frontend-deploy.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          ENV: ${{ inputs.node_env }}
+          ENV: ${{ inputs.npm_build_environment }}
         run: |
           npm ci --only=prod
           npm run env

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -4,33 +4,34 @@ on:
   push:
     branches:
       - main
+      - ci/fix-frontend-deploy-workflow
     paths:
       - frontend/**
       - .github/**
 
 jobs:
-  run-tests:
-    runs-on: ubuntu-latest
-    name: Run E2E Tests
-    environment: production
-    concurrency:
-      group: e2e-tests-prod
-      cancel-in-progress: true
-
-    steps:
-      - name: Cloning repo
-        uses: actions/checkout@v4
-
-      - name: Run E2E tests against production
-        uses: ./.github/actions/e2e-tests
-        with:
-          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
-          slack_token: ${{ secrets.SLACK_TOKEN }}
-          environment: prod
+#  run-tests:
+#    runs-on: ubuntu-latest
+#    name: Run E2E Tests
+#    environment: production
+#    concurrency:
+#      group: e2e-tests-prod
+#      cancel-in-progress: true
+#
+#    steps:
+#      - name: Cloning repo
+#        uses: actions/checkout@v4
+#
+#      - name: Run E2E tests against production
+#        uses: ./.github/actions/e2e-tests
+#        with:
+#          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
+#          slack_token: ${{ secrets.SLACK_TOKEN }}
+#          environment: prod
 
   deploy-production:
     name: Deploy to Vercel Production
-    needs: run-tests
+#    needs: run-tests
     uses: ./.github/workflows/.reusable-frontend-deploy.yml
     with:
       gh_environment: production
@@ -39,7 +40,7 @@ jobs:
 
   deploy-demo:
     name: Deploy to Vercel Demo
-    needs: run-tests
+#    needs: run-tests
     uses: ./.github/workflows/.reusable-frontend-deploy.yml
     with:
       gh_environment: demo

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -4,34 +4,33 @@ on:
   push:
     branches:
       - main
-      - ci/fix-frontend-deploy-workflow
     paths:
       - frontend/**
       - .github/**
 
 jobs:
-#  run-tests:
-#    runs-on: ubuntu-latest
-#    name: Run E2E Tests
-#    environment: production
-#    concurrency:
-#      group: e2e-tests-prod
-#      cancel-in-progress: true
-#
-#    steps:
-#      - name: Cloning repo
-#        uses: actions/checkout@v4
-#
-#      - name: Run E2E tests against production
-#        uses: ./.github/actions/e2e-tests
-#        with:
-#          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
-#          slack_token: ${{ secrets.SLACK_TOKEN }}
-#          environment: prod
+  run-tests:
+    runs-on: ubuntu-latest
+    name: Run E2E Tests
+    environment: production
+    concurrency:
+      group: e2e-tests-prod
+      cancel-in-progress: true
+
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v4
+
+      - name: Run E2E tests against production
+        uses: ./.github/actions/e2e-tests
+        with:
+          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          environment: prod
 
   deploy-production:
     name: Deploy to Vercel Production
-#    needs: run-tests
+    needs: run-tests
     uses: ./.github/workflows/.reusable-frontend-deploy.yml
     with:
       gh_environment: production
@@ -40,7 +39,7 @@ jobs:
 
   deploy-demo:
     name: Deploy to Vercel Demo
-#    needs: run-tests
+    needs: run-tests
     uses: ./.github/workflows/.reusable-frontend-deploy.yml
     with:
       gh_environment: demo


### PR DESCRIPTION
## Changes

Fixes incorrect input reference

## How did you test this code?

Ran the job with the actual deploy step commented out (see full run [here](https://github.com/Flagsmith/flagsmith/actions/runs/12672263245/job/35315901256?pr=4980)). Key log message: 

```bash
> npm run env
> flagsmith-frontend@2.68.0 env
> node ./bin/env.js
Using project_prod.js
```
