### PR TITLE
docs: Add Ruby to list of SDKs that support real-time updates

### DIFF
--- a/docs/docs/advanced-use/real-time-flags.md
+++ b/docs/docs/advanced-use/real-time-flags.md
@@ -84,6 +84,7 @@ The following SDK clients support subscribing to real-time flag updates:
 - iOS
 - Flutter
 - Python
+- Ruby
 
 ## Implementation details
 


### PR DESCRIPTION
Added in https://github.com/Flagsmith/flagsmith-ruby-client/releases/tag/v4.3.0
