### PR TITLE
fix(export): fixes issue exporting identity feature states with missing attributes

### DIFF
--- a/api/edge_api/identities/export.py
+++ b/api/edge_api/identities/export.py
@@ -67,7 +67,7 @@ def export_edge_identity_and_overrides(  # noqa: C901
                 )
 
                 # We always want to create the FeatureStateValue, but if there is none in the
-                # dynamo object, we just create a default class with a value of null.
+                # dynamo object, we just create a default object with a value of null.
                 featurestate_value = override.get("feature_state_value")
                 identity_override_export.append(
                     export_featurestate_value(featurestate_value, featurestate_uuid)

--- a/api/edge_api/identities/export.py
+++ b/api/edge_api/identities/export.py
@@ -65,13 +65,15 @@ def export_edge_identity_and_overrides(  # noqa: C901
                         override["enabled"],
                     )
                 )
-                featurestate_value = override["feature_state_value"]
-                if featurestate_value is not None:
-                    # export feature state value
-                    identity_override_export.append(
-                        export_featurestate_value(featurestate_value, featurestate_uuid)
-                    )
-                if mvfsv_overrides := override["multivariate_feature_state_values"]:
+
+                # We always want to create the FeatureStateValue, but if there is none in the
+                # dynamo object, we just create a default class with a value of null.
+                featurestate_value = override.get("feature_state_value")
+                identity_override_export.append(
+                    export_featurestate_value(featurestate_value, featurestate_uuid)
+                )
+
+                if mvfsv_overrides := override.get("multivariate_feature_state_values"):
                     for mvfsv_override in mvfsv_overrides:
                         mv_feature_option_id = mvfsv_override[
                             "multivariate_feature_option"


### PR DESCRIPTION
## Changes

This fixes a bug found in the export process for old identities that have overrides with missing `"feature_state_value"`. 

## How did you test this code?

Updated existing unit test. 
