### PR TITLE
test: fix incorrect assertions

### DIFF
--- a/api/tests/unit/features/versioning/test_unit_versioning_models.py
+++ b/api/tests/unit/features/versioning/test_unit_versioning_models.py
@@ -486,13 +486,13 @@ def test_version_change_set_get_conflicts(
     assert conflict_dict[change_request_1.id].segment_id is None
     assert conflict_dict[change_request_1.id].is_environment_default
 
-    assert conflict_dict[change_request_2.id].segment_id is new_segment.id
+    assert conflict_dict[change_request_2.id].segment_id == new_segment.id
     assert not conflict_dict[change_request_2.id].is_environment_default
 
-    assert conflict_dict[change_request_3.id].segment_id is segment.id
+    assert conflict_dict[change_request_3.id].segment_id == segment.id
     assert not conflict_dict[change_request_3.id].is_environment_default
 
-    assert conflict_dict[change_request_4.id].segment_id is another_segment.id
+    assert conflict_dict[change_request_4.id].segment_id == another_segment.id
     assert not conflict_dict[change_request_4.id].is_environment_default
 
 


### PR DESCRIPTION
## Changes

Fixes some incorrect test assertions which have caused issues in the SAML workflow [here](https://github.com/Flagsmith/flagsmith-saml/pull/50). I'm not entirely sure why these are passing here, but not there, but they are definitely incorrect so should be fixed regardless. 

## How did you test this code?

Ran updated test to confirm that it passes. 
