### PR TITLE
fix: Use "Flagsmith" as default TOTP issuer

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -777,7 +777,7 @@ TRENCH_AUTH = {
     ),
     "DEFAULT_VALIDITY_PERIOD": 30,
     "CONFIRM_BACKUP_CODES_REGENERATION_WITH_CODE": True,
-    "APPLICATION_ISSUER_NAME": "app.bullet-train.io",
+    "APPLICATION_ISSUER_NAME": "Flagsmith",
     "ENCRYPT_BACKUP_CODES": True,
     "MFA_METHODS": {
         "app": {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Updates the default [TOTP issuer name](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#issuer) to "Flagsmith". This is shown by some authenticator apps to distinguish between TOTP secrets.

## How did you test this code?

Tested by reading a locally-generated QR code into a few authenticator apps:

Google Authenticator

![IMG_5016](https://github.com/user-attachments/assets/f4a78ca1-7a9e-4058-9b61-d90d266e3449)

Microsoft Authenticator

![IMG_5017](https://github.com/user-attachments/assets/22aed73a-9743-4663-8c1a-e8e2561f77a7)

