### PR TITLE
fix: Adds force-2fa to startup plan

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -408,7 +408,6 @@ const Utils = Object.assign({}, require('./base/_utils'), {
       case 'FLAG_OWNERS':
       case 'RBAC':
       case 'AUDIT':
-      case 'FORCE_2FA':
       case '4_EYES': {
         plan = 'scale-up'
         break
@@ -423,7 +422,8 @@ const Utils = Object.assign({}, require('./base/_utils'), {
 
       case 'SCHEDULE_FLAGS':
       case 'CREATE_ADDITIONAL_PROJECT':
-      case '2FA': {
+      case '2FA':
+      case 'FORCE_2FA': {
         plan = 'start-up' // startup or greater
         break
       }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ref: [#4954](https://github.com/Flagsmith/flagsmith/issues/4954)
Adds FORCE_2FA to startup plan, moving 2FA from individual level to organisation level 
<img width="746" alt="Screenshot 2025-01-13 at 16 59 46" src="https://github.com/user-attachments/assets/52a4dbef-808a-42cb-b174-8fc127838807" />


## How did you test this code?

1. Go to `/organisation/<ORG_ID>/settings?tab=general` using an org on startup plan
2. Check if Force 2FA setting is available