### PR TITLE
fix: Action dropdown not properly overflowing

### DIFF
--- a/frontend/web/components/UserAction.tsx
+++ b/frontend/web/components/UserAction.tsx
@@ -1,10 +1,7 @@
 import { FC, useCallback, useLayoutEffect, useRef, useState } from 'react'
-import classNames from 'classnames'
+import { createPortal } from 'react-dom'
 
 import useOutsideClick from 'common/useOutsideClick'
-import Utils from 'common/utils/utils'
-import Constants from 'common/constants'
-import Permission from 'common/providers/Permission'
 import Button from './base/forms/Button'
 import Icon from './Icon'
 import ActionButton from './ActionButton'
@@ -17,6 +14,15 @@ interface FeatureActionProps {
 }
 
 type ActionType = 'edit' | 'remove'
+
+type ActionDropdownProps = {
+  isOpen: boolean
+  canEdit?: boolean
+  canRemove?: boolean
+  btnRef: React.RefObject<HTMLDivElement>
+  onAction: (action: ActionType) => void
+  onOutsideClick: () => void
+}
 
 function calculateListPosition(
   btnEl: HTMLElement,
@@ -31,6 +37,62 @@ function calculateListPosition(
   }
 }
 
+const ActionDropdown = ({
+  btnRef,
+  canEdit,
+  canRemove,
+  isOpen,
+  onAction,
+  onOutsideClick,
+}: ActionDropdownProps) => {
+  const dropDownRef = useRef<HTMLDivElement>(null)
+
+  useOutsideClick(dropDownRef, onOutsideClick)
+
+  useLayoutEffect(() => {
+    if (!isOpen || !dropDownRef.current || !btnRef.current) return
+    const listPosition = calculateListPosition(
+      btnRef.current,
+      dropDownRef.current,
+    )
+    dropDownRef.current.style.top = `${listPosition.top}px`
+    dropDownRef.current.style.left = `${listPosition.left}px`
+  }, [btnRef, isOpen, dropDownRef])
+
+  if (!isOpen) return null
+
+  return createPortal(
+    <div ref={dropDownRef} className='feature-action__list'>
+      {!!canEdit && (
+        <div
+          className='feature-action__item'
+          onClick={(e) => {
+            e.stopPropagation()
+            onAction('edit')
+          }}
+        >
+          <Icon name='edit' width={18} fill='#9DA4AE' />
+          <span>Manage user</span>
+        </div>
+      )}
+
+      {!!canRemove && (
+        <div
+          className='feature-action__item'
+          onClick={(e) => {
+            e.stopPropagation()
+            onAction('remove')
+          }}
+        >
+          <Icon name='trash-2' width={18} fill='#9DA4AE' />
+          <span>Remove</span>
+        </div>
+      )}
+    </div>,
+    document.body,
+  )
+}
+
 export const FeatureAction: FC<FeatureActionProps> = ({
   canEdit,
   canRemove,
@@ -40,7 +102,6 @@ export const FeatureAction: FC<FeatureActionProps> = ({
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   const btnRef = useRef<HTMLDivElement>(null)
-  const listRef = useRef<HTMLDivElement>(null)
 
   const close = useCallback(() => setIsOpen(false), [])
 
@@ -60,15 +121,6 @@ export const FeatureAction: FC<FeatureActionProps> = ({
     },
     [close, onRemove, onEdit],
   )
-
-  useOutsideClick(listRef, handleOutsideClick)
-
-  useLayoutEffect(() => {
-    if (!isOpen || !listRef.current || !btnRef.current) return
-    const listPosition = calculateListPosition(btnRef.current, listRef.current)
-    listRef.current.style.top = `${listPosition.top}px`
-    listRef.current.style.left = `${listPosition.left}px`
-  }, [isOpen])
 
   if (!canEdit && !!canRemove) {
     return (
@@ -99,36 +151,14 @@ export const FeatureAction: FC<FeatureActionProps> = ({
       <div ref={btnRef}>
         <ActionButton size='small' onClick={() => setIsOpen(true)} />
       </div>
-
-      {isOpen && (
-        <div ref={listRef} className='feature-action__list'>
-          {!!canEdit && (
-            <div
-              className='feature-action__item'
-              onClick={(e) => {
-                e.stopPropagation()
-                handleActionClick('edit')
-              }}
-            >
-              <Icon name='edit' width={18} fill='#9DA4AE' />
-              <span>Manage user</span>
-            </div>
-          )}
-
-          {!!canRemove && (
-            <div
-              className='feature-action__item'
-              onClick={(e) => {
-                e.stopPropagation()
-                handleActionClick('remove')
-              }}
-            >
-              <Icon name='trash-2' width={18} fill='#9DA4AE' />
-              <span>Remove</span>
-            </div>
-          )}
-        </div>
-      )}
+      <ActionDropdown
+        isOpen={isOpen}
+        canEdit={canEdit}
+        canRemove={canRemove}
+        btnRef={btnRef}
+        onAction={handleActionClick}
+        onOutsideClick={handleOutsideClick}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
ref: [#4981](https://github.com/Flagsmith/flagsmith/issues/4981)
Because virtualized lists require an overflow, it requires a react portal to render the dropdown outside of the overflow context.

Single user
<img width="1249" alt="Screenshot 2025-01-14 at 15 25 35" src="https://github.com/user-attachments/assets/275bf9c7-fa92-4a28-bc28-b08f558cfc5b" />


[multiple users] user positioned in the middle of the scrollable container
<img width="1262" alt="Screenshot 2025-01-14 at 15 26 01" src="https://github.com/user-attachments/assets/32475c2b-e5c0-4605-880a-0ba3c6f49625" />

[multiple users] user positioned in the bottom of the scrollable container
<img width="1240" alt="Screenshot 2025-01-14 at 15 26 06" src="https://github.com/user-attachments/assets/3a38fca1-1fc8-45d8-916c-3e677b8ce107" />


## How did you test this code?

1. go to `/organisation/<ORG_ID>/permissions`
2. Make sure you have a members list with 100+ users 
3. click on 3 dots to see actions
