### PR TITLE
fix: Don't display password managers on irrelevant input fields

### DIFF
--- a/frontend/web/components/SimpleTwoFactor/prompt.js
+++ b/frontend/web/components/SimpleTwoFactor/prompt.js
@@ -28,6 +28,7 @@ export default class TheComponent extends PureComponent {
         >
           <InputGroup
             inputProps={{
+              autocomplete: 'one-time-code',
               className: 'full-width',
               style: { paddingLeft: 10, textIndent: 0 },
             }}

--- a/frontend/web/components/base/forms/Input.js
+++ b/frontend/web/components/base/forms/Input.js
@@ -153,7 +153,9 @@ const Input = class extends React.Component {
             value={this.props.value}
             className={innerClassName}
             disabled={disabled}
-            autoComplete={this.props.enableAutoComplete}
+            autoComplete={
+              this.props.enableAutoComplete ?? this.props.autocomplete
+            }
           />
         )}
         {this.props.type === 'password' && (
@@ -212,6 +214,7 @@ Input.defaultProps = {
 }
 
 Input.propTypes = {
+  autocomplete: propTypes.string,
   className: propTypes.any,
   inputClassName: OptionalString,
   isValid: propTypes.any,

--- a/frontend/web/components/base/forms/Input.js
+++ b/frontend/web/components/base/forms/Input.js
@@ -153,9 +153,7 @@ const Input = class extends React.Component {
             value={this.props.value}
             className={innerClassName}
             disabled={disabled}
-            autoComplete={
-              this.props.enableAutoComplete ? undefined : 'one-time-code'
-            }
+            autoComplete={this.props.enableAutoComplete}
           />
         )}
         {this.props.type === 'password' && (

--- a/frontend/web/components/modals/ChangeEmailAddress.tsx
+++ b/frontend/web/components/modals/ChangeEmailAddress.tsx
@@ -85,6 +85,7 @@ const ChangeEmailAddress: FC<ChangeEmailAddressType> = ({ onComplete }) => {
                 setPassword(Utils.safeParseEventValue(event))
               }}
               type='password'
+              autocomplete='current-password'
               name='password'
             />
             {isError && (

--- a/frontend/web/components/pages/AccountSettingsPage.js
+++ b/frontend/web/components/pages/AccountSettingsPage.js
@@ -387,6 +387,7 @@ class TheComponent extends Component {
                             }
                             type='password'
                             name='Current Password*'
+                            autocomplete='current-password'
                           />
                           <InputGroup
                             className='mt-4'
@@ -404,6 +405,7 @@ class TheComponent extends Component {
                             }
                             isValid={new_password1 && new_password1.length}
                             type='password'
+                            autocomplete='new-password'
                             name='New Password*'
                           />
                           <InputGroup
@@ -422,6 +424,7 @@ class TheComponent extends Component {
                             }
                             isValid={new_password2 && new_password2.length}
                             type='password'
+                            autocomplete='new-password'
                             name='Confirm New Password*'
                           />
                           {passwordError && (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

All Input components by default have `one-time-code` autocomplete. This causes password managers such as 1Password to display a prompt on all kinds of inputs where it makes no sense and is annoying:

![image](https://github.com/user-attachments/assets/35c8f609-2631-43ce-9dd4-8508aa34bb59)

![image](https://github.com/user-attachments/assets/7a2cb80e-c4b7-4970-9b71-8ba92ed662b2)

This change removes this default.

The only place where `one-time-code` should be used is in the MFA code input, which is added by this change:

![image](https://github.com/user-attachments/assets/229b5589-1e9b-4839-910f-ce7eb3a9b07d)

Note that at MFA autocomplete still works (at least in 1Password) without setting `autocomplete=one-time-code`.

Lastly, this change also sets explicit `autocomplete` values for changing passwords. These also still work in 1Password currently, but is good practice to have them.

## How did you test this code?

Manually tested different input fields in the frontend.
