### PR TITLE
fix: Remove AWS IMDS endpoint request on API startup

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -20,7 +20,6 @@ from importlib import reload
 
 import dj_database_url
 import pytz
-import requests
 from corsheaders.defaults import default_headers
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key
@@ -66,15 +65,6 @@ USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST", default=False)
 CSRF_TRUSTED_ORIGINS = env.list("DJANGO_CSRF_TRUSTED_ORIGINS", default=[])
 
 INTERNAL_IPS = ["127.0.0.1"]
-
-# In order to run a load balanced solution, we need to whitelist the internal ip
-try:
-    internal_ip = requests.get("http://instance-data/latest/meta-data/local-ipv4").text
-except requests.exceptions.ConnectionError:
-    pass
-else:
-    ALLOWED_HOSTS.append(internal_ip)
-del requests
 
 if sys.version[0] == "2":
     reload(sys)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Flagsmith always performs a request to the [AWS Instance Metadata Service (IMDS)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html) on startup, whether it is running on AWS or not. This was presumably used in an older infrastructure configuration which is no longer required.

## How did you test this code?

Not tested - going to validate this in staging.