### PR TITLE
fix: cast boolean on length environment

### DIFF
--- a/frontend/web/components/pages/CreateEnvironmentPage.tsx
+++ b/frontend/web/components/pages/CreateEnvironmentPage.tsx
@@ -9,8 +9,7 @@ import AddMetadataToEntity from 'components/metadata/AddMetadataToEntity'
 import { getSupportedContentType } from 'common/services/useSupportedContentType'
 import { getStore } from 'common/store'
 import ProjectProvider, {
-  CreateEnvType,
-  ProjectProviderType,
+  CreateEnvType
 } from 'common/providers/ProjectProvider'
 import AccountStore from 'common/stores/account-store'
 import Utils from 'common/utils/utils'
@@ -138,7 +137,7 @@ const CreateEnvironmentPage: React.FC<CreateEnvironmentPageProps> = ({
                       />
                     </CondensedRow>
                     <CondensedRow>
-                      {project?.environments?.length && (
+                      {!!project?.environments?.length && (
                         <InputGroup
                           tooltip='This will copy feature enabled states and remote config values from the selected environment.'
                           title='Clone from environment'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Low hanging fruit.

Reviewed rendering condition of the clone from environment input which displays a "0"

## How did you test this code?
Before
![image](https://github.com/user-attachments/assets/d12d6c4f-d2a5-40cd-a016-19217e8ba3ec)

After
<img width="871" alt="image" src="https://github.com/user-attachments/assets/6e43ba0c-24e9-451c-92f8-be16aad6897d" />
![image](https://github.com/user-attachments/assets/b84711d2-2297-4f6d-a77d-62d1d457ea50)

