### PR TITLE
fix: `POST /identities` incorrectly applies segment overrides when using null or empty identifier, only in Core API

### DIFF
--- a/api/environments/identities/models.py
+++ b/api/environments/identities/models.py
@@ -76,7 +76,11 @@ class Identity(models.Model):
 
         # define sub queries
         belongs_to_environment_query = Q(environment=self.environment)
-        overridden_for_identity_query = Q(identity=self)
+        if self.id:
+            overridden_for_identity_query = Q(identity=self)
+        else:
+            # skip identity overrides for transient identities
+            overridden_for_identity_query = Q()
         overridden_for_segment_query = Q(
             feature_segment__segment__in=segments,
             feature_segment__environment=self.environment,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #4976.

The problem boiled down to transient identities not having a primary key, which caused the query for fetching identity feature states to include segment overrides that don't belong there.  

## How did you test this code?

Added a unit test reproducing the exact problem reported.