### PR TITLE
fix: Disable invite button when email config is not set

### DIFF
--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -4,6 +4,12 @@ from functools import lru_cache
 from typing import TypedDict
 
 import shortuuid
+from app.settings.common import (
+    EMAIL_BACKEND,
+    EMAIL_HOST_USER,
+    SENDGRID_API_KEY,
+    AWS_SES_REGION_ENDPOINT,
+)
 
 UNKNOWN = "unknown"
 VERSIONS_INFO_FILE_LOCATION = ".versions.json"
@@ -12,6 +18,7 @@ VERSIONS_INFO_FILE_LOCATION = ".versions.json"
 class VersionInfo(TypedDict):
     ci_commit_sha: str
     image_tag: str
+    has_email_provider: bool
     is_enterprise: bool
     is_saas: bool
 
@@ -29,6 +36,17 @@ def is_saas() -> bool:
     return pathlib.Path("./SAAS_DEPLOYMENT").exists()
 
 
+def has_email_provider() -> bool:
+    match EMAIL_BACKEND:
+        case "django.core.mail.backends.smtp.EmailBackend":
+            return EMAIL_HOST_USER is not None
+        case "sgbackend.SendGridBackend":
+            return SENDGRID_API_KEY is not None
+        case "django_ses.SESBackend":
+            return AWS_SES_REGION_ENDPOINT is not None
+        case _:
+            return False
+
 @lru_cache
 def get_version_info() -> VersionInfo:
     """Reads the version info baked into src folder of the docker container"""
@@ -45,6 +63,7 @@ def get_version_info() -> VersionInfo:
     version_json = version_json | {
         "ci_commit_sha": _get_file_contents("./CI_COMMIT_SHA"),
         "image_tag": image_tag,
+        "has_email_provider": has_email_provider(),
         "is_enterprise": is_enterprise(),
         "is_saas": is_saas(),
     }

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 from typing import TypedDict
 
 import shortuuid
-
 from django.conf import settings
 
 UNKNOWN = "unknown"
@@ -42,6 +41,7 @@ def has_email_provider() -> bool:
             return settings.AWS_SES_REGION_ENDPOINT is not None
         case _:
             return False
+
 
 @lru_cache
 def get_version_info() -> VersionInfo:

--- a/api/app/utils.py
+++ b/api/app/utils.py
@@ -4,12 +4,8 @@ from functools import lru_cache
 from typing import TypedDict
 
 import shortuuid
-from app.settings.common import (
-    EMAIL_BACKEND,
-    EMAIL_HOST_USER,
-    SENDGRID_API_KEY,
-    AWS_SES_REGION_ENDPOINT,
-)
+
+from django.conf import settings
 
 UNKNOWN = "unknown"
 VERSIONS_INFO_FILE_LOCATION = ".versions.json"
@@ -37,13 +33,13 @@ def is_saas() -> bool:
 
 
 def has_email_provider() -> bool:
-    match EMAIL_BACKEND:
+    match settings.EMAIL_BACKEND:
         case "django.core.mail.backends.smtp.EmailBackend":
-            return EMAIL_HOST_USER is not None
+            return settings.EMAIL_HOST_USER is not None
         case "sgbackend.SendGridBackend":
-            return SENDGRID_API_KEY is not None
+            return settings.SENDGRID_API_KEY is not None
         case "django_ses.SESBackend":
-            return AWS_SES_REGION_ENDPOINT is not None
+            return settings.AWS_SES_REGION_ENDPOINT is not None
         case _:
             return False
 

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -3024,6 +3024,18 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pyfakefs"
+version = "5.7.4"
+description = "pyfakefs implements a fake file system that mocks the Python file system modules."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyfakefs-5.7.4-py3-none-any.whl", hash = "sha256:3e763d700b91c54ade6388be2cfa4e521abc00e34f7defb84ee511c73031f45f"},
+    {file = "pyfakefs-5.7.4.tar.gz", hash = "sha256:4971e65cc80a93a1e6f1e3a4654909c0c493186539084dc9301da3d68c8878fe"},
+]
+
+[[package]]
 name = "pygithub"
 version = "2.1.1"
 description = "Use the full Github API v3"
@@ -4445,4 +4457,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.13"
-content-hash = "f84f3af64a1c29bc2abe064d3cf08ce75dfe1541d9dc8370a78e41183d09c2fc"
+content-hash = "1d3c289404e691bbe2c044d0794e81a46fc982104960f1edcfd8a07c2100c49e"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -228,6 +228,7 @@ django-extensions = "^3.2.3"
 pdbpp = "^0.10.3"
 mypy-boto3-dynamodb = "^1.33.0"
 pytest-structlog = "^1.1"
+pyfakefs = "^5.7.4"
 
 [build-system]
 requires = ["poetry>=2.0.0"]

--- a/api/tests/unit/app/conftest.py
+++ b/api/tests/unit/app/conftest.py
@@ -1,0 +1,11 @@
+from typing import Generator
+
+import pytest
+
+from app.utils import get_version_info
+
+
+@pytest.fixture(autouse=True)
+def clear_get_version_info_cache() -> Generator[None, None, None]:
+    yield
+    get_version_info.cache_clear()

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -1,17 +1,10 @@
 import json
-from typing import Generator
 
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_django.fixtures import SettingsWrapper
 
 from app.utils import get_version_info
-
-
-@pytest.fixture(autouse=True)
-def clear_get_version_info_cache() -> Generator[None, None, None]:
-    yield
-    get_version_info.cache_clear()
 
 
 def test_get_version_info(fs: FakeFilesystem) -> None:

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 from pytest_mock import MockerFixture
+from pytest_django.fixtures import SettingsWrapper
 
 from app.utils import get_version_info
 
@@ -83,16 +84,13 @@ def test_get_version_info_with_missing_files(mocker: MockerFixture) -> None:
     }
 
 
-def test_get_version_info_with_email_config_smtp(mocker: MockerFixture) -> None:
+def test_get_version_info_with_email_config_smtp(settings: SettingsWrapper) -> None:
 
-    mocker.patch(
-        "app.utils.EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
-    )
-    mocker.patch("app.utils.EMAIL_HOST_USER", "user")
-    # When
+    settings.EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    settings.EMAIL_HOST_USER = "user"
+
     result = get_version_info()
 
-    # Then
     assert result == {
         "ci_commit_sha": "unknown",
         "image_tag": "unknown",
@@ -102,14 +100,13 @@ def test_get_version_info_with_email_config_smtp(mocker: MockerFixture) -> None:
     }
 
 
-def test_get_version_info_with_email_config_sendgrid(mocker: MockerFixture) -> None:
+def test_get_version_info_with_email_config_sendgrid(settings: SettingsWrapper) -> None:
 
-    mocker.patch("app.utils.EMAIL_BACKEND", "sgbackend.SendGridBackend")
-    mocker.patch("app.utils.SENDGRID_API_KEY", "key")
-    # When
+    settings.EMAIL_BACKEND = "sgbackend.SendGridBackend"
+    settings.SENDGRID_API_KEY = "key"
+
     result = get_version_info()
 
-    # Then
     assert result == {
         "ci_commit_sha": "unknown",
         "image_tag": "unknown",
@@ -119,14 +116,13 @@ def test_get_version_info_with_email_config_sendgrid(mocker: MockerFixture) -> N
     }
 
 
-def test_get_version_info_with_email_config_ses(mocker: MockerFixture) -> None:
+def test_get_version_info_with_email_config_ses(settings: SettingsWrapper) -> None:
 
-    mocker.patch("app.utils.EMAIL_BACKEND", "django_ses.SESBackend")
-    mocker.patch("app.utils.AWS_SES_REGION_ENDPOINT", "endpoint")
-    # When
+    settings.EMAIL_BACKEND = "django_ses.SESBackend"
+    settings.AWS_SES_REGION_ENDPOINT = "endpoint"
+
     result = get_version_info()
 
-    # Then
     assert result == {
         "ci_commit_sha": "unknown",
         "image_tag": "unknown",
@@ -136,7 +132,7 @@ def test_get_version_info_with_email_config_ses(mocker: MockerFixture) -> None:
     }
 
 
-def test_get_version_info_without_email_config(mocker: MockerFixture) -> None:
+def test_get_version_info_without_email_config(settings: SettingsWrapper) -> None:
     expected = {
         "ci_commit_sha": "unknown",
         "image_tag": "unknown",
@@ -145,22 +141,25 @@ def test_get_version_info_without_email_config(mocker: MockerFixture) -> None:
         "is_saas": False,
     }
 
-    mocker.patch(
-        "app.utils.EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
-    )
-    mocker.patch("app.utils.EMAIL_HOST_USER", None)
+    settings.EMAIL_BACKEND = None
 
     result = get_version_info()
     assert result == expected
 
-    mocker.patch("app.utils.EMAIL_BACKEND", "django_ses.SESBackend")
-    mocker.patch("app.utils.AWS_SES_REGION_ENDPOINT", None)
+    settings.EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    settings.EMAIL_HOST_USER = None
 
     result = get_version_info()
     assert result == expected
 
-    mocker.patch("app.utils.EMAIL_BACKEND", "sgbackend.SendGridBackend")
-    mocker.patch("app.utils.SENDGRID_API_KEY", None)
+    settings.EMAIL_BACKEND = "django_ses.SESBackend"
+    settings.AWS_SES_REGION_ENDPOINT = None
+
+    result = get_version_info()
+    assert result == expected
+
+    settings.EMAIL_BACKEND = "sgbackend.SendGridBackend"
+    settings.SENDGRID_API_KEY = None
 
     result = get_version_info()
     assert result == expected

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -45,6 +45,7 @@ def test_get_version_info(mocker: MockerFixture) -> None:
     assert result == {
         "ci_commit_sha": "some_sha",
         "image_tag": "2.66.2",
+        "has_email_provider": False,
         "is_enterprise": True,
         "is_saas": False,
         "package_versions": {".": "2.66.2"},
@@ -76,6 +77,75 @@ def test_get_version_info_with_missing_files(mocker: MockerFixture) -> None:
     assert result == {
         "ci_commit_sha": "unknown",
         "image_tag": "unknown",
+        "has_email_provider": False,
         "is_enterprise": True,
+        "is_saas": False,
+    }
+
+
+def test_get_version_info_with_email_config_smtp(mocker: MockerFixture) -> None:
+
+    mocker.patch(
+        "app.utils.EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
+    )
+    mocker.patch("app.utils.EMAIL_HOST_USER", "user")
+    # When
+    result = get_version_info()
+
+    # Then
+    assert result == {
+        "ci_commit_sha": "unknown",
+        "image_tag": "unknown",
+        "has_email_provider": True,
+        "is_enterprise": False,
+        "is_saas": False,
+    }
+
+
+def test_get_version_info_with_email_config_sendgrid(mocker: MockerFixture) -> None:
+
+    mocker.patch("app.utils.EMAIL_BACKEND", "sgbackend.SendGridBackend")
+    mocker.patch("app.utils.SENDGRID_API_KEY", "key")
+    # When
+    result = get_version_info()
+
+    # Then
+    assert result == {
+        "ci_commit_sha": "unknown",
+        "image_tag": "unknown",
+        "has_email_provider": True,
+        "is_enterprise": False,
+        "is_saas": False,
+    }
+
+
+def test_get_version_info_with_email_config_ses(mocker: MockerFixture) -> None:
+
+    mocker.patch("app.utils.EMAIL_BACKEND", "django_ses.SESBackend")
+    mocker.patch("app.utils.AWS_SES_REGION_ENDPOINT", "endpoint")
+    # When
+    result = get_version_info()
+
+    # Then
+    assert result == {
+        "ci_commit_sha": "unknown",
+        "image_tag": "unknown",
+        "has_email_provider": True,
+        "is_enterprise": False,
+        "is_saas": False,
+    }
+
+
+def test_get_version_info_without_email_config(mocker: MockerFixture) -> None:
+
+    # When
+    result = get_version_info()
+
+    # Then
+    assert result == {
+        "ci_commit_sha": "unknown",
+        "image_tag": "unknown",
+        "has_email_provider": False,
+        "is_enterprise": False,
         "is_saas": False,
     }

--- a/api/tests/unit/app/test_unit_app_utils.py
+++ b/api/tests/unit/app/test_unit_app_utils.py
@@ -48,46 +48,25 @@ def test_get_version_info_with_missing_files(fs: FakeFilesystem) -> None:
     }
 
 
-def test_get_version_info_with_email_config_smtp(settings: SettingsWrapper) -> None:
+EMAIL_BACKENDS_AND_SETTINGS = [
+    ("django.core.mail.backends.smtp.EmailBackend", "EMAIL_HOST_USER"),
+    ("django_ses.SESBackend", "AWS_SES_REGION_ENDPOINT"),
+    ("sgbackend.SendGridBackend", "SENDGRID_API_KEY"),
+]
+
+
+@pytest.mark.parametrize(
+    "email_backend,expected_setting_name",
+    EMAIL_BACKENDS_AND_SETTINGS,
+)
+def test_get_version_info__email_config_enabled__return_expected(
+    settings: SettingsWrapper,
+    email_backend: str,
+    expected_setting_name: str,
+) -> None:
     # Given
-    settings.EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    settings.EMAIL_HOST_USER = "user"
-
-    # When
-    result = get_version_info()
-
-    # Then
-    assert result == {
-        "ci_commit_sha": "unknown",
-        "image_tag": "unknown",
-        "has_email_provider": True,
-        "is_enterprise": False,
-        "is_saas": False,
-    }
-
-
-def test_get_version_info_with_email_config_sendgrid(settings: SettingsWrapper) -> None:
-    # Given
-    settings.EMAIL_BACKEND = "sgbackend.SendGridBackend"
-    settings.SENDGRID_API_KEY = "key"
-
-    # When
-    result = get_version_info()
-
-    # Then
-    assert result == {
-        "ci_commit_sha": "unknown",
-        "image_tag": "unknown",
-        "has_email_provider": True,
-        "is_enterprise": False,
-        "is_saas": False,
-    }
-
-
-def test_get_version_info_with_email_config_ses(settings: SettingsWrapper) -> None:
-    # Given
-    settings.EMAIL_BACKEND = "django_ses.SESBackend"
-    settings.AWS_SES_REGION_ENDPOINT = "endpoint"
+    settings.EMAIL_BACKEND = email_backend
+    setattr(settings, expected_setting_name, "value")
 
     # When
     result = get_version_info()
@@ -97,23 +76,21 @@ def test_get_version_info_with_email_config_ses(settings: SettingsWrapper) -> No
 
 
 @pytest.mark.parametrize(
-    "email_backend,expected_empty_setting_name",
+    "email_backend,expected_setting_name",
     [
         (None, None),
-        ("django.core.mail.backends.smtp.EmailBackend", "EMAIL_HOST_USER"),
-        ("django_ses.SESBackend", "AWS_SES_REGION_ENDPOINT"),
-        ("sgbackend.SendGridBackend", "SENDGRID_API_KEY"),
+        *EMAIL_BACKENDS_AND_SETTINGS,
     ],
 )
-def test_get_version_info_without_email_config(
+def test_get_version_info__email_config_disabled__return_expected(
     settings: SettingsWrapper,
     email_backend: str | None,
-    expected_empty_setting_name: str | None,
+    expected_setting_name: str | None,
 ) -> None:
     # Given
     settings.EMAIL_BACKEND = email_backend
-    if expected_empty_setting_name:
-        setattr(settings, expected_empty_setting_name, None)
+    if expected_setting_name:
+        setattr(settings, expected_setting_name, None)
 
     # When
     result = get_version_info()

--- a/api/tests/unit/app/test_unit_app_views.py
+++ b/api/tests/unit/app/test_unit_app_views.py
@@ -15,6 +15,7 @@ def test_get_version_info(api_client: APIClient) -> None:
     assert response.json() == {
         "ci_commit_sha": "unknown",
         "image_tag": "unknown",
+        "has_email_provider": False,
         "is_enterprise": False,
         "is_saas": False,
     }

--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -552,6 +552,8 @@ const Utils = Object.assign({}, require('./base/_utils'), {
   getViewIdentitiesPermission() {
     return 'VIEW_IDENTITIES'
   },
+  hasEmailProvider: () =>
+    global.flagsmithVersion?.backend?.has_email_provider ?? false,
   isEnterpriseImage: () => global.flagsmithVersion?.backend.is_enterprise,
   isMigrating() {
     const model = ProjectStore.model as null | ProjectType

--- a/frontend/web/components/pages/UsersAndPermissionsPage.tsx
+++ b/frontend/web/components/pages/UsersAndPermissionsPage.tsx
@@ -45,6 +45,7 @@ type UsersAndPermissionsPageType = {
 }
 
 const widths = [300, 200, 80]
+const noEmailProvider = `You must configure an email provider before using email invites. Please read our documentation on how to configure an email provider.`
 
 type UsersAndPermissionsInnerType = {
   organisation: Organisation
@@ -73,6 +74,7 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
   const verifySeatsLimit = Utils.getFlagsmithHasFeature(
     'verify_seats_limit_for_invite_links',
   )
+  const hasEmailProvider = Utils.hasEmailProvider()
   const manageUsersPermission = useHasPermission({
     id: AccountStore.getOrganisation()?.id,
     level: 'organisation',
@@ -83,6 +85,12 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
     level: 'organisation',
     permission: 'MANAGE_USER_GROUPS',
   })
+
+  const hasInvitePermission =
+    hasEmailProvider && manageUsersPermission.permission
+  const tooltTipText = !hasEmailProvider
+    ? noEmailProvider
+    : Constants.organisationPermissions('Admin')
 
   const roleChanged = (id: number, { value: role }: { value: string }) => {
     AppActions.updateUserRole(id, role)
@@ -229,10 +237,11 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
                       <Row space className='mt-4'>
                         <h5 className='mb-0'>Team Members</h5>
                         {Utils.renderWithPermission(
-                          !manageUsersPermission.permission,
-                          Constants.organisationPermissions('Admin'),
+                          hasInvitePermission,
+                          tooltTipText,
                           <Button
                             disabled={
+                              !hasEmailProvider ||
                               needsUpgradeForAdditionalSeats ||
                               !manageUsersPermission.permission
                             }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Disables button when email provider is not set
- Shows tooltip text
- adds `has_email_provider` field to /version, that checks if email config was set.
<img width="660" alt="Screenshot 2025-01-20 at 18 14 58" src="https://github.com/user-attachments/assets/55eae58e-1fb2-4d92-a6e3-39a3855c5e33" />


## How did you test this code?

- API test for /version
- Manually tested in UI, access `/account` with no email config set in API, invite member button should be disabled and tooltip is shown when hovering.
