### PR TITLE
fix: Raise if `environment_feature_version` is `None`

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -478,7 +478,7 @@ def environment_v2_versioning(environment: Environment):
 
 
 @pytest.fixture()
-def identity(environment: Environment):
+def identity(environment: Environment) -> Identity:
     return Identity.objects.create(identifier="test_identity", environment=environment)
 
 

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -471,14 +471,14 @@ def with_project_permissions(
 
 
 @pytest.fixture()
-def environment_v2_versioning(environment):
+def environment_v2_versioning(environment: Environment):
     enable_v2_versioning(environment.id)
     environment.refresh_from_db()
     return environment
 
 
 @pytest.fixture()
-def identity(environment):
+def identity(environment: Environment):
     return Identity.objects.create(identifier="test_identity", environment=environment)
 
 

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -471,7 +471,7 @@ def with_project_permissions(
 
 
 @pytest.fixture()
-def environment_v2_versioning(environment: Environment):
+def environment_v2_versioning(environment: Environment) -> Environment:
     enable_v2_versioning(environment.id)
     environment.refresh_from_db()
     return environment

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -533,6 +533,14 @@ class FeatureState(
 
         if self.type == other.type:
             if self.environment.use_v2_feature_versioning:
+                if (
+                    self.environment_feature_version is None
+                    or other.environment_feature_version is None
+                ):
+                    raise ValueError(
+                        "Cannot compare feature states as they are missing environment_feature_version."
+                    )
+
                 return (
                     self.environment_feature_version > other.environment_feature_version
                 )

--- a/api/tests/unit/features/test_unit_features_models.py
+++ b/api/tests/unit/features/test_unit_features_models.py
@@ -367,6 +367,36 @@ def test_feature_state_gt_operator_order(
     assert segment_2_state > default_env_state
 
 
+def test_feature_state_gt_operator_order_when_environment_feature_version_is_none(
+    identity: Identity,
+    feature: Feature,
+    feature_state: FeatureState,
+    environment: Environment,
+    environment_v2_versioning: Environment,
+    mocker: MockerFixture,
+) -> None:
+    # Given
+    feature_state2 = FeatureState.objects.create(
+        identity=identity, feature=feature, environment=environment
+    )
+    mocker.patch.object(
+        FeatureState,
+        "type",
+        new_callable=mocker.PropertyMock,
+        return_value="ENVIRONMENT",
+    )
+
+    # When
+    with pytest.raises(ValueError) as exception:
+        assert feature_state > feature_state2
+
+    # Then
+    assert (
+        exception.value.args[0]
+        == "Cannot compare feature states as they are missing environment_feature_version."
+    )
+
+
 def test_feature_state_gt_operator_throws_value_error_if_different_environments(
     project: Project,
     environment: Environment,

--- a/api/tests/unit/users/test_unit_users_views.py
+++ b/api/tests/unit/users/test_unit_users_views.py
@@ -926,7 +926,13 @@ def test_list_user_groups(
     group_2 = response_json["results"][1]
     group_2_users = group_2["users"]
     assert len(group_2_users) == 2
-    assert tuple((user["id"], user["group_admin"]) for user in group_2_users) == (
-        (user1.pk, False),
-        (user2.pk, True),
-    )
+
+    for user in group_2_users:
+        if user["id"] == user1.pk:
+            assert user["group_admin"] is False
+            continue
+        if user["id"] == user2.pk:
+            assert user["group_admin"] is True
+            continue
+        # We should only match the two users.
+        assert False

--- a/api/tests/unit/users/test_unit_users_views.py
+++ b/api/tests/unit/users/test_unit_users_views.py
@@ -926,13 +926,7 @@ def test_list_user_groups(
     group_2 = response_json["results"][1]
     group_2_users = group_2["users"]
     assert len(group_2_users) == 2
-
-    for user in group_2_users:
-        if user["id"] == user1.pk:
-            assert user["group_admin"] is False
-            continue
-        if user["id"] == user2.pk:
-            assert user["group_admin"] is True
-            continue
-        # We should only match the two users.
-        assert False
+    assert set((user["id"], user["group_admin"]) for user in group_2_users) == {
+        (user1.pk, False),
+        (user2.pk, True),
+    }


### PR DESCRIPTION
## Changes

[Solves this Sentry alert](https://flagsmith.sentry.io/issues/6234460650/?alert_rule_id=14542360&alert_type=issue&environment=production&notification_uuid=4c43be3a-55a9-48a9-8374-cb8654767711&project=5544478&referrer=slack). Elsewhere in this part of the codebase we raise value errors to deal with bad input. Rather than erroring out with a type error that looks like a bug, we should raise an error of our own to deal with it.

## How did you test this code?
One new test.
