### PR TITLE
fix: Force environments to be different names

### DIFF
--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -111,6 +111,15 @@ class CreateUpdateEnvironmentSerializer(
     invalid_plans = ("free",)
     field_names = ("minimum_change_request_approvals",)
 
+    class Meta(EnvironmentSerializerWithMetadata.Meta):
+        validators = [
+            serializers.UniqueTogetherValidator(
+                queryset=EnvironmentSerializerWithMetadata.Meta.model.objects.all(),
+                fields=("name", "project"),
+                message="An environment with this name already exists.",
+            )
+        ]
+
     def get_subscription(self) -> typing.Optional[Subscription]:
         view = self.context["view"]
 

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -140,6 +140,11 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
         return queryset
 
     def perform_create(self, serializer):
+        existing_environment = Environment.objects.filter(
+            name=serializer.validated_data["name"]
+        )
+        if existing_environment:
+            raise ValidationError("Existing environment for given name.")
         environment = serializer.save()
         if getattr(self.request.user, "is_master_api_key_user", False) is False:
             UserEnvironmentPermission.objects.create(

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -141,7 +141,8 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         existing_environment = Environment.objects.filter(
-            name=serializer.validated_data["name"]
+            name=serializer.validated_data["name"],
+            project=serializer.validated_data["project"],
         )
         if existing_environment:
             raise ValidationError("Existing environment for given name.")

--- a/api/environments/views.py
+++ b/api/environments/views.py
@@ -140,12 +140,6 @@ class EnvironmentViewSet(viewsets.ModelViewSet):
         return queryset
 
     def perform_create(self, serializer):
-        existing_environment = Environment.objects.filter(
-            name=serializer.validated_data["name"],
-            project=serializer.validated_data["project"],
-        )
-        if existing_environment:
-            raise ValidationError("Existing environment for given name.")
         environment = serializer.save()
         if getattr(self.request.user, "is_master_api_key_user", False) is False:
             UserEnvironmentPermission.objects.create(

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -588,6 +588,31 @@ def test_should_create_environments(
         ).exists()
 
 
+def test_environment_matches_existing_environment_name(
+    project: Project,
+    admin_client: APIClient,
+) -> None:
+    # Given
+    url = reverse("api-v1:environments:environment-list")
+    description = "This is the description"
+    name = "Test environment"
+    data = {
+        "name": name,
+        "project": project.id,
+        "description": description,
+    }
+    Environment.objects.create(name=name, description=description, project=project)
+
+    # When
+    response = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == 400
+    assert response.json() == ["Existing environment for given name."]
+
+
 def test_create_environment_without_required_metadata_returns_400(
     project,
     admin_client_new,

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -610,7 +610,9 @@ def test_environment_matches_existing_environment_name(
 
     # Then
     assert response.status_code == 400
-    assert response.json() == ["Existing environment for given name."]
+    assert response.json() == {
+        "non_field_errors": ["An environment with this name already exists."]
+    }
 
 
 def test_create_environment_without_required_metadata_returns_400(


### PR DESCRIPTION
## Changes

This forces new environments to have unique names. This was not intentionally done at the model level because some existing integrations rely on environment names and could break if they were updated to different names to solve existing conflicts.

## How did you test this code?

One new test.
