### PR TITLE
fix: link to segment and identity override

### DIFF
--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -21,6 +21,17 @@ import { getTags } from 'common/services/useTag'
 import { getStore } from 'common/store'
 
 export const width = [200, 70, 55, 70, 450]
+
+export const TABS = {
+  ANALYTICS: 'analytics',
+  HISTORY: 'history',
+  IDENTITY_OVERRIDES: 'identity-overrides',
+  LINKS: 'links',
+  SEGMENT_OVERRIDES: 'segment-overrides',
+  SETTINGS: 'settings',
+  VALUE: 'value',
+}
+
 class TheComponent extends Component {
   static contextTypes = {
     router: propTypes.object.isRequired,
@@ -238,7 +249,7 @@ class TheComponent extends Component {
                   this.editFeature(
                     projectFlag,
                     environmentFlags[id],
-                    'segment-overrides',
+                    TABS.SEGMENT_OVERRIDES,
                   )
                 }}
                 count={projectFlag.num_segment_overrides}
@@ -249,7 +260,7 @@ class TheComponent extends Component {
                   this.editFeature(
                     projectFlag,
                     environmentFlags[id],
-                    'identity-overrides',
+                    TABS.IDENTITY_OVERRIDES,
                   )
                 }}
                 count={projectFlag.num_identity_overrides}
@@ -313,7 +324,7 @@ class TheComponent extends Component {
                     this.editFeature(
                       projectFlag,
                       environmentFlags[id],
-                      'segment-overrides',
+                      TABS.SEGMENT_OVERRIDES,
                     )
                   }}
                   count={projectFlag.num_segment_overrides}
@@ -324,7 +335,7 @@ class TheComponent extends Component {
                     this.editFeature(
                       projectFlag,
                       environmentFlags[id],
-                      'identity-overrides',
+                      TABS.IDENTITY_OVERRIDES,
                     )
                   }}
                   count={projectFlag.num_identity_overrides}
@@ -424,7 +435,7 @@ class TheComponent extends Component {
             hideHistory={!environment?.use_v2_feature_versioning}
             onShowHistory={() => {
               if (disableControls) return
-              this.editFeature(projectFlag, environmentFlags[id], 'history')
+              this.editFeature(projectFlag, environmentFlags[id], TABS.HISTORY)
             }}
             onShowAudit={() => {
               if (disableControls) return

--- a/frontend/web/components/FeatureRow.js
+++ b/frontend/web/components/FeatureRow.js
@@ -310,14 +310,22 @@ class TheComponent extends Component {
                 <SegmentOverridesIcon
                   onClick={(e) => {
                     e.stopPropagation()
-                    this.editFeature(projectFlag, environmentFlags[id], 1)
+                    this.editFeature(
+                      projectFlag,
+                      environmentFlags[id],
+                      'segment-overrides',
+                    )
                   }}
                   count={projectFlag.num_segment_overrides}
                 />
                 <IdentityOverridesIcon
                   onClick={(e) => {
                     e.stopPropagation()
-                    this.editFeature(projectFlag, environmentFlags[id], 1)
+                    this.editFeature(
+                      projectFlag,
+                      environmentFlags[id],
+                      'identity-overrides',
+                    )
                   }}
                   count={projectFlag.num_identity_overrides}
                   showPlusIndicator={showPlusIndicator}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

Ref: #5009


## Changes

- Fix links to segment and identity overrides tab


## How did you test this code?

Click on a segment override or identity override icon and check if the feature pane opens in the respective tab

https://github.com/user-attachments/assets/9fb1da57-3f61-40bd-ab29-a95161ceb499


