### PR TITLE
chore: add `showmigrations` command in migrate function

### DIFF
--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -10,7 +10,7 @@ waitfordb() {
 migrate () {
     waitfordb \
       && python manage.py showmigrations --verbosity 2 \
-      && python manage.py migrate \
+      && python manage.py migrate --verbosity 2 \
       && python manage.py createcachetable
 }
 serve() {

--- a/api/scripts/run-docker.sh
+++ b/api/scripts/run-docker.sh
@@ -8,7 +8,10 @@ waitfordb() {
 }
 
 migrate () {
-    waitfordb && python manage.py migrate && python manage.py createcachetable
+    waitfordb \
+      && python manage.py showmigrations --verbosity 2 \
+      && python manage.py migrate \
+      && python manage.py createcachetable
 }
 serve() {
     # configuration parameters for statsd. Docs can be found here:


### PR DESCRIPTION
## Changes

Add `showmigrations` call when running `./scripts/run-docker.sh migrate` to help in debugging situations. 

## How did you test this code?

Ran the command locally. 
