### PR TITLE
fix: alert modal on Identity page incorrectly uses title case

### DIFF
--- a/frontend/web/styles/project/_alert.scss
+++ b/frontend/web/styles/project/_alert.scss
@@ -25,6 +25,7 @@
   .icon-alert {
     margin-right: 0.75rem;
   }
+  text-transform: none;
 }
 
 .alert-danger {


### PR DESCRIPTION
## Changes

Overrides the `text-transform` value set by any parent to ensure that the content is not modified incorrectly. For example, since the alert on the identity page is in the panel header section, it is inheriting `text-transform: capitalize` from it's styling. 

Before: 

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/687e41e8-3a9f-49ff-92cb-7721e50cd58d" />

After:

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/4408ea4c-f701-47b8-ad48-cca2833515fb" />

## How did you test this code?

Verified that the problematic alert was fixed, and that others remained unaffected. 
