### PR TITLE
feat: Make it more visible that user invites can be accepted by logging in, in addition to signing up

### DIFF
--- a/frontend/web/components/pages/HomePage.js
+++ b/frontend/web/components/pages/HomePage.js
@@ -38,12 +38,12 @@ const HomePage = class extends React.Component {
     // can handle always setting the marketing consent.
     API.setCookie('marketing_consent_given', 'true')
     this.state = {
+      allRequirementsMet: false,
       email: '',
       first_name: '',
       last_name: '',
-      password: '',
       marketing_consent_given: true,
-      allRequirementsMet: false,
+      password: '',
     }
 
     this.handlePasswordChange = this.handlePasswordChange.bind(this)
@@ -368,7 +368,7 @@ const HomePage = class extends React.Component {
                                               />
                                             </span>
                                             <p className='notification__text pl-3'>
-                                              Login to accept your invite
+                                              Log in to accept your invite
                                             </p>
                                           </div>
                                         )}
@@ -544,15 +544,30 @@ const HomePage = class extends React.Component {
                                     </FormGroup>
                                   )}
                                   {isInvite && (
-                                    <div className='notification flex-row'>
-                                      <span className='notification__icon mb-2'>
-                                        <IonIcon
-                                          icon={informationCircleOutline}
-                                        />
-                                      </span>
-                                      <p className='notification__text pl-3'>
-                                        Create an account to accept your invite
-                                      </p>
+                                    <div>
+                                      <div className='notification flex-row'>
+                                        <span className='notification__icon mb-2'>
+                                          <IonIcon
+                                            icon={informationCircleOutline}
+                                          />
+                                        </span>
+                                        <p className='notification__text pl-3'>
+                                          Create an account to accept your
+                                          invite
+                                        </p>
+                                      </div>
+                                      <Row className='justify-content-center'>
+                                        Have an account?{' '}
+                                        <Button
+                                          theme='text'
+                                          className='ml-1 fw-bold'
+                                          onClick={() => {
+                                            window.location.href = `/login${redirect}`
+                                          }}
+                                        >
+                                          Log in
+                                        </Button>
+                                      </Row>
                                     </div>
                                   )}
                                   <fieldset id='details' className=''>
@@ -664,18 +679,6 @@ const HomePage = class extends React.Component {
                                 </form>
                               )}
                             </Card>
-                            <Row className='justify-content-center'>
-                              Have an account?{' '}
-                              <Button
-                                theme='text'
-                                className='ml-1 fw-bold'
-                                onClick={() => {
-                                  window.location.href = `/login${redirect}`
-                                }}
-                              >
-                                Log in
-                              </Button>
-                            </Row>
                           </React.Fragment>
                         )}
                       </div>


### PR DESCRIPTION
When a user opens an invite link, by default they are prompted to sign up, which is the most likely course of action. If a user was previously removed from an organisation, or they already belong to a different organisation, they need to log in instead of signing up.

There is a prompt to log in, but it is difficult to see at the bottom of the page. I've had to explain too many times that this is an option - it makes more sense to offer it as an option before showing the sign up fields.

Lastly, "login" is a noun and not a verb. "Log in" is the correct phrasal verb.

<img width="1512" alt="Screenshot 2025-02-06 at 00 30 41" src="https://github.com/user-attachments/assets/46eeb370-d624-4be9-aebc-82649adb1244" />
<img width="1512" alt="Screenshot 2025-02-06 at 00 30 51" src="https://github.com/user-attachments/assets/96d22bb0-ab0a-45d2-8c6f-379576791228" />
