### PR TITLE
fix: service to use default credentials mode when cookie auth disabled

### DIFF
--- a/frontend/common/service.ts
+++ b/frontend/common/service.ts
@@ -16,7 +16,7 @@ export const baseApiOptions = (queryArgs?: Partial<FetchBaseQueryArgs>) => {
     | 'extractRehydrationInfo'
   > = {
     baseQuery: fetchBaseQuery({
-      credentials: Project.cookieAuthEnabled ? 'include' : 'omit', // 'include' for cookies, 'omit' if not
+      credentials: Project.cookieAuthEnabled ? 'include' : undefined,
       baseUrl: Project.api,
       prepareHeaders: async (headers, { endpoint, getState }) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

There was a problem when the cookie authentication is disabled and we expect some cookies to be send on the requests. This was an issue when using Cloudflare Access, where the authentication sets the `CF_Authentication` cookie that is needed. The refactor add `credentials: omit` to the fetch method, which cause all requests to fail before reaching the flagsmith api.

The change of behaviour was introduced [here](https://github.com/Flagsmith/flagsmith/compare/v2.143.0...v2.144.0#diff-4ae7df25ecd9cba5842dad530754eb9d27309186f9abc82677695d317ca05716R19)

To fix it the service that call api endpoints from the frontend now uses the default value for `credentials` when the cookie authentication is disabled. This is the same behaviour it used to have before the cookie authentication refactor.

## How did you test this code?

I test it manually using the content override feature of the chrome developer tools.