### PR TITLE
fix: delete identity overrides from environments_v2 table on feature delete

### DIFF
--- a/api/edge_api/identities/tasks.py
+++ b/api/edge_api/identities/tasks.py
@@ -162,7 +162,7 @@ def update_flagsmith_environments_v2_identity_overrides(
 
 
 @register_task_handler()
-def delete_environments_v2_identity_overrides_from_for_feature(feature_id: int) -> None:
+def delete_environments_v2_identity_overrides_by_feature(feature_id: int) -> None:
     dynamodb_wrapper_v2 = DynamoEnvironmentV2Wrapper()
 
     feature = Feature.objects.all_with_deleted().get(id=feature_id)

--- a/api/edge_api/identities/tasks.py
+++ b/api/edge_api/identities/tasks.py
@@ -159,3 +159,14 @@ def update_flagsmith_environments_v2_identity_overrides(
         identifier=identifier,
     )
     dynamodb_wrapper_v2.update_identity_overrides(identity_override_changeset)
+
+
+@register_task_handler()
+def delete_environments_v2_identity_overrides_from_for_feature(feature_id: int) -> None:
+    dynamodb_wrapper_v2 = DynamoEnvironmentV2Wrapper()
+
+    feature = Feature.objects.all_with_deleted().get(id=feature_id)
+    for environment in feature.project.environments.all():
+        dynamodb_wrapper_v2.delete_identity_overrides(
+            environment_id=environment.id, feature_id=feature_id
+        )

--- a/api/environments/dynamodb/wrappers/environment_wrapper.py
+++ b/api/environments/dynamodb/wrappers/environment_wrapper.py
@@ -183,7 +183,7 @@ class DynamoEnvironmentV2Wrapper(BaseDynamoEnvironmentWrapper):
 
     def delete_identity_overrides(self, environment_id: int, feature_id: int) -> None:
         filter_expression = self.get_identity_overrides_key_condition_expression(
-            environment_id, feature_id
+            environment_id=environment_id, feature_id=feature_id
         )
         query_kwargs: "QueryInputRequestTypeDef" = {
             "KeyConditionExpression": filter_expression,
@@ -193,7 +193,7 @@ class DynamoEnvironmentV2Wrapper(BaseDynamoEnvironmentWrapper):
         for item in self.query_iter_all_items(**query_kwargs):
             self.table.delete_item(
                 Key={
-                    ENVIRONMENTS_V2_PARTITION_KEY: environment_id,
+                    ENVIRONMENTS_V2_PARTITION_KEY: str(environment_id),
                     ENVIRONMENTS_V2_SORT_KEY: item["document_key"],
                 }
             )

--- a/api/environments/dynamodb/wrappers/environment_wrapper.py
+++ b/api/environments/dynamodb/wrappers/environment_wrapper.py
@@ -190,10 +190,11 @@ class DynamoEnvironmentV2Wrapper(BaseDynamoEnvironmentWrapper):
             "ProjectionExpression": "document_key",
         }
 
-        for item in self.query_iter_all_items(**query_kwargs):
-            self.table.delete_item(
-                Key={
-                    ENVIRONMENTS_V2_PARTITION_KEY: str(environment_id),
-                    ENVIRONMENTS_V2_SORT_KEY: item["document_key"],
-                }
-            )
+        with self.table.batch_writer() as writer:
+            for item in self.query_iter_all_items(**query_kwargs):
+                writer.delete_item(
+                    Key={
+                        ENVIRONMENTS_V2_PARTITION_KEY: str(environment_id),
+                        ENVIRONMENTS_V2_SORT_KEY: item["document_key"],
+                    }
+                )

--- a/api/environments/dynamodb/wrappers/environment_wrapper.py
+++ b/api/environments/dynamodb/wrappers/environment_wrapper.py
@@ -180,3 +180,20 @@ class DynamoEnvironmentV2Wrapper(BaseDynamoEnvironmentWrapper):
                         ENVIRONMENTS_V2_SORT_KEY: item["document_key"],
                     },
                 )
+
+    def delete_identity_overrides(self, environment_id: int, feature_id: int) -> None:
+        filter_expression = self.get_identity_overrides_key_condition_expression(
+            environment_id, feature_id
+        )
+        query_kwargs: "QueryInputRequestTypeDef" = {
+            "KeyConditionExpression": filter_expression,
+            "ProjectionExpression": "document_key",
+        }
+
+        for item in self.query_iter_all_items(**query_kwargs):
+            self.table.delete_item(
+                Key={
+                    ENVIRONMENTS_V2_PARTITION_KEY: environment_id,
+                    ENVIRONMENTS_V2_SORT_KEY: item["document_key"],
+                }
+            )

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -170,10 +170,10 @@ class Feature(
         # we already define as a field on the model class.
         if self.deleted_at and self.project.enable_dynamo_db:
             from edge_api.identities.tasks import (
-                delete_environments_v2_identity_overrides_from_for_feature,
+                delete_environments_v2_identity_overrides_by_feature,
             )
 
-            delete_environments_v2_identity_overrides_from_for_feature.delay(
+            delete_environments_v2_identity_overrides_by_feature.delay(
                 kwargs={"feature_id": self.id}
             )
 

--- a/api/features/models.py
+++ b/api/features/models.py
@@ -162,8 +162,12 @@ class Feature(
     def create_feature_states(self):
         FeatureState.create_initial_feature_states_for_feature(feature=self)
 
-    @hook(AFTER_SAVE, when="deleted_at", was=None, is_not=None)
+    @hook(AFTER_SAVE)
     def delete_identity_overrides(self) -> None:
+        # Note that we have to use conditional logic on self.deleted_at inside
+        # the hook method because the django-lifecycle logic for when / was / is_not
+        # doesn't work due to it relying on a method called initial_value, which
+        # we already define as a field on the model class.
         if self.deleted_at and self.project.enable_dynamo_db:
             from edge_api.identities.tasks import (
                 delete_environments_v2_identity_overrides_from_for_feature,

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3564,11 +3564,10 @@ def test_delete_feature_deletes_any_related_identity_overrides(
     # Then
     assert delete_feature_response.status_code == status.HTTP_204_NO_CONTENT
 
+    kce = dynamodb_wrapper_v2.get_identity_overrides_key_condition_expression(
+        environment_id=environment.id, feature_id=feature.id
+    )
+
     assert (
-        flagsmith_environments_v2_table.query(
-            KeyConditionExpression=dynamodb_wrapper_v2.get_identity_overrides_key_condition_expression(
-                environment_id=environment.id, feature_id=feature.id
-            )
-        )["Count"]
-        == 0
+        flagsmith_environments_v2_table.query(KeyConditionExpression=kce)["Count"] == 0
     )

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -3564,10 +3564,11 @@ def test_delete_feature_deletes_any_related_identity_overrides(
     # Then
     assert delete_feature_response.status_code == status.HTTP_204_NO_CONTENT
 
-    kce = dynamodb_wrapper_v2.get_identity_overrides_key_condition_expression(
-        environment_id=environment.id, feature_id=feature.id
-    )
-
     assert (
-        flagsmith_environments_v2_table.query(KeyConditionExpression=kce)["Count"] == 0
+        flagsmith_environments_v2_table.query(
+            KeyConditionExpression=dynamodb_wrapper_v2.get_identity_overrides_key_condition_expression(
+                environment_id=environment.id, feature_id=feature.id
+            )
+        )["Count"]
+        == 0
     )


### PR DESCRIPTION
## Changes

Adds logic to delete identity override documents from flagsmith_environments_v2 table when a feature is deleted. 

## How did you test this code?

Added an end-to-end style test to delete a feature from the view. 

Note: the test isn't passing and I can't understand why - I can see that the code is being hit in the task, but the item is still in the table when we query it in the test code