### PR TITLE
fix(feature-export): handle unsuccessful feature export download exception

### DIFF
--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -10,7 +10,11 @@ from rest_framework.test import APIClient
 
 from environments.models import Environment
 from environments.permissions.models import UserEnvironmentPermission
-from features.import_export.constants import OVERWRITE_DESTRUCTIVE, PROCESSING
+from features.import_export.constants import (
+    FAILED,
+    OVERWRITE_DESTRUCTIVE,
+    PROCESSING,
+)
 from features.import_export.models import (
     FeatureExport,
     FeatureImport,
@@ -164,6 +168,29 @@ def test_download_feature_export_unauthorized(
 
     # Then
     assert response.status_code == 403
+
+
+@pytest.mark.parametrize("status", (PROCESSING, FAILED))
+def test_cannot_download_non_success_feature_export(
+    admin_client_new: APIClient,
+    environment: Environment,
+    status: str,
+) -> None:
+    # Given
+    feature_export = FeatureExport.objects.create(
+        environment=environment,
+        status=status,
+    )
+    url = reverse("api-v1:features:download-feature-export", args=[feature_export.id])
+
+    # When
+    response = admin_client_new.get(url)
+
+    # Then
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": f"Unable to download export with status '{status}'."
+    }
 
 
 def test_feature_import(

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -14,6 +14,7 @@ from features.import_export.constants import (
     FAILED,
     OVERWRITE_DESTRUCTIVE,
     PROCESSING,
+    SUCCESS,
 )
 from features.import_export.models import (
     FeatureExport,
@@ -140,6 +141,7 @@ def test_download_feature_export(
     feature_export = FeatureExport.objects.create(
         environment=environment,
         data='[{"feature": "data"}]',
+        status=SUCCESS,
     )
     url = reverse("api-v1:features:download-feature-export", args=[feature_export.id])
     # When


### PR DESCRIPTION
## Changes

Handle exception thrown when trying to download a feature export that is not yet complete. 

Fixes sentry error https://flagsmith.sentry.io/issues/5800328361

## How did you test this code?

Added specific test cases. 
