### PR TITLE
feat: render tooltip in portal

### DIFF
--- a/frontend/web/components/Tooltip.tsx
+++ b/frontend/web/components/Tooltip.tsx
@@ -3,6 +3,7 @@ import ReactTooltip, { TooltipProps as _TooltipProps } from 'react-tooltip'
 import Utils from 'common/utils/utils'
 import classNames from 'classnames'
 import { sanitize } from 'dompurify'
+import { createPortal } from 'react-dom'
 
 export type TooltipProps = {
   title: ReactNode
@@ -13,6 +14,11 @@ export type TooltipProps = {
   tooltipClassName?: string
   effect?: _TooltipProps['effect']
   afterShow?: _TooltipProps['afterShow']
+}
+
+const TooltipPortal: FC<{ children: ReactNode }> = ({ children }) => {
+  const portalRoot = document.body
+  return portalRoot ? createPortal(children, portalRoot) : null
 }
 
 const Tooltip: FC<TooltipProps> = ({
@@ -39,22 +45,24 @@ const Tooltip: FC<TooltipProps> = ({
         </span>
       )}
       {!!children && (
-        <ReactTooltip
-          className={classNames('rounded', tooltipClassName)}
-          id={id}
-          place={place || 'top'}
-          effect={effect}
-          afterShow={afterShow}
-        >
-          {plainText ? (
-            `${children}`
-          ) : (
-            <div
-              style={{ wordBreak: 'break-word' }}
-              dangerouslySetInnerHTML={{ __html: sanitize(children) }}
-            />
-          )}
-        </ReactTooltip>
+        <TooltipPortal>
+          <ReactTooltip
+            className={classNames('rounded', tooltipClassName)}
+            id={id}
+            place={place || 'top'}
+            effect={effect}
+            afterShow={afterShow}
+          >
+            {plainText ? (
+              `${children}`
+            ) : (
+              <div
+                style={{ wordBreak: 'break-word' }}
+                dangerouslySetInnerHTML={{ __html: sanitize(children) }}
+              />
+            )}
+          </ReactTooltip>
+        </TooltipPortal>
       )}
     </>
   )

--- a/frontend/web/components/Tooltip.tsx
+++ b/frontend/web/components/Tooltip.tsx
@@ -14,11 +14,18 @@ export type TooltipProps = {
   tooltipClassName?: string
   effect?: _TooltipProps['effect']
   afterShow?: _TooltipProps['afterShow']
+  renderInPortal?: boolean // Controls backwards compatibility for rendering in portal
 }
 
-const TooltipPortal: FC<{ children: ReactNode }> = ({ children }) => {
-  const portalRoot = document.body
-  return portalRoot ? createPortal(children, portalRoot) : null
+const TooltipPortal: FC<{ children: ReactNode; renderInPortal?: boolean }> = ({
+  children,
+  renderInPortal = false,
+}) => {
+  const domNode = document.createElement('div')
+  document.body.appendChild(domNode)
+
+  if (!renderInPortal) return <>{children}</>
+  return domNode ? createPortal(children, domNode) : null
 }
 
 const Tooltip: FC<TooltipProps> = ({
@@ -27,6 +34,7 @@ const Tooltip: FC<TooltipProps> = ({
   effect,
   place,
   plainText,
+  renderInPortal,
   title,
   titleClassName,
   tooltipClassName,
@@ -45,7 +53,7 @@ const Tooltip: FC<TooltipProps> = ({
         </span>
       )}
       {!!children && (
-        <TooltipPortal>
+        <TooltipPortal renderInPortal={renderInPortal}>
           <ReactTooltip
             className={classNames('rounded', tooltipClassName)}
             id={id}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Ideally tooltips must often be rendered outside their parent to avoid clipping by parent boundaries and that can be easily achieved by rendering in portals using `createPortal`.

## How did you test this code?

Tested by checking every existing tooltip, for tooltips inside of inline modals it did not work properly due to inconsistent z-index management in the app, a future task will be created for creating consistent z-index values when handling hierarchy between modals, tooltips, etc 
