### PR TITLE
fix: has override logic to check enabled state differences

### DIFF
--- a/frontend/web/components/pages/UserPage.tsx
+++ b/frontend/web/components/pages/UserPage.tsx
@@ -634,12 +634,10 @@ const UserPage: FC<UserPageType> = (props) => {
                                             Utils.featureStateToValue(v) ===
                                             actualValue,
                                         )
-                                      const flagDifferent =
-                                        flagEnabledDifferent ||
-                                        flagValueDifferent
 
                                       const hasSegmentOverride =
-                                        flagValueDifferent &&
+                                        (flagEnabledDifferent ||
+                                          flagValueDifferent) &&
                                         !hasUserOverride &&
                                         !isMultiVariateOverride
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The has segment override boolean didn't check for whether the enabled state was different to the defaults.

Before:
![image](https://github.com/user-attachments/assets/71f7324f-540f-4a04-ae2e-d6d2e5f83ae3)

After:
![image](https://github.com/user-attachments/assets/1dfb5daa-e0d2-42f6-8abb-753a5c333c41)



## How did you test this code?

As above
