### PR TITLE
fix(organisation): allow Organisation delete when committed change request present

### DIFF
--- a/api/features/workflows/core/models.py
+++ b/api/features/workflows/core/models.py
@@ -312,7 +312,8 @@ class ChangeRequest(
         # deleted but, since this can have unexpected effects on published
         # feature states, we also want to prevent it at the ORM level.
         if self.committed_at and not (
-            self.environment.deleted_at
+            (self.environment and self.environment.deleted_at)
+            or (self.project and self.project.deleted_at)
             or (self.live_from and self.live_from > timezone.now())
         ):
             raise ChangeRequestDeletionError(

--- a/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
+++ b/api/tests/unit/features/workflows/core/test_unit_workflows_models.py
@@ -38,6 +38,7 @@ from features.workflows.core.models import (
     ChangeRequestApproval,
     ChangeRequestGroupAssignment,
 )
+from organisations.models import Organisation
 from projects.models import Project
 from segments.models import Condition, Segment, SegmentRule
 from users.models import FFAdminUser
@@ -1003,3 +1004,22 @@ def test_url_via_project(project_change_request: ChangeRequest) -> None:
     expected_url = get_current_site_url()
     expected_url += f"/project/{project_id}/change-requests/{project_change_request.id}"
     assert url == expected_url
+
+
+def test_delete_organisation_with_committed_change_request(
+    organisation: Organisation,
+    feature: Feature,
+    change_request_no_required_approvals: ChangeRequest,
+    admin_user: FFAdminUser,
+) -> None:
+    """
+    Specific test to cover https://github.com/Flagsmith/flagsmith/issues/5097
+    """
+    # Given
+    change_request_no_required_approvals.commit(admin_user)
+
+    # When
+    organisation.delete()
+
+    # Then
+    assert organisation.deleted_at is not None


### PR DESCRIPTION
## Changes

Fixes an issue deleting an organisation when a committed change request exists in any project / environment in that organisation. 

This was previously not an issue because of the line which checked if the environment was deleted but, now that we've linked the project, the cascade delete is triggered from the project, before it deletes the environment, and hence the check failed and the exception was raised. 

## How did you test this code?

Added unit test. 
