### PR TITLE
feat: Hide SAML configuration frontend URL in SaaS

### DIFF
--- a/frontend/web/components/modals/CreateSAML.tsx
+++ b/frontend/web/components/modals/CreateSAML.tsx
@@ -130,7 +130,7 @@ const CreateSAML: FC<CreateSAML> = ({ organisationId, samlName }) => {
       />
 
       <InputGroup
-        className='mt-2 mb-4'
+        className={`mt-2 mb-4 ${Utils.isSaas() ? 'd-none' : ''}`}
         title='Frontend URL*'
         data-test='frontend-url'
         tooltip='The base URL of the Flagsmith dashboard. Users will be redirected here after authenticating successfully.'


### PR DESCRIPTION
Context: https://github.com/Flagsmith/flagsmith/pull/5091#discussion_r1954218636

No reason to ever show the Frontend URL option for SAML configurations in SaaS. This PR hides it while keeping the same underlying behaviour.