### PR TITLE
docs: Add Help and Support page

### DIFF
--- a/docs/docs/support/index.mdx
+++ b/docs/docs/support/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Help and Support
+sidebar_position: 130
+sidebar_label: Help and Support
+---
+
+We are here to help! You can contact us for support through any of these channels:
+
+* Click the <a class="open-chat">chat bubble (💬)</a> at the bottom right of this page, or from the Flagsmith dashboard.
+* Email [support@flagsmith.com](mailto:support@flagsmith.com).
+
+## Enterprise support
+
+[Flagsmith Enterprise](https://www.flagsmith.com/pricing) customers can also use these support channels:
+
+* Dedicated Customer Success manager for personalised assistance and training.
+* Shared Slack channel for real-time group support between your organisation and the Flagsmith team.
+
+## Bug reports and pull requests
+
+Flagsmith is open source, and we encourage contributions from the community. If you want to submit a specific bug
+report or code change, you can open an issue or pull request directly in the relevant GitHub repository:
+
+* [Flagsmith API, dashboard and documentation](https://github.com/Flagsmith/flagsmith)
+* Client-side SDKs:
+  - [JavaScript, React](https://github.com/Flagsmith/flagsmith-js-client)
+  - [iOS](https://github.com/Flagsmith/flagsmith-ios-client)
+  - [Android](https://github.com/Flagsmith/flagsmith-kotlin-android-client)
+  - [Flutter](https://github.com/flagsmith/flagsmith-flutter-client)
+* [Server-side SDKs](/clients/server-side)
+* [Edge Proxy](https://github.com/Flagsmith/edge-proxy)
+* [Terraform provider](https://github.com/Flagsmith/terraform-provider-flagsmith)
+* [Flagsmith CLI](https://github.com/Flagsmith/flagsmith-cli)
+* [Kubernetes Helm charts](https://github.com/Flagsmith/flagsmith-charts)

--- a/docs/plugins/crisp-chat-links.js
+++ b/docs/plugins/crisp-chat-links.js
@@ -4,6 +4,7 @@ import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 const enableCrispLinks = () => {
     document.querySelectorAll('.open-chat').forEach((oc) => {
+        oc.style.cursor = 'pointer';
         oc.onclick = ({ target }) => {
             if (typeof $crisp !== 'undefined') {
                 $crisp.push(['do', 'chat:open']);


### PR DESCRIPTION
We have action items in docs such as "contact support" but not an actual place that describes how to do that. This PR adds a docs section that describes what our support actually is.

Context: https://github.com/Flagsmith/flagsmith/pull/5091#discussion_r1954231615