### PR TITLE
fix: adds margin to saml tab

### DIFF
--- a/frontend/web/components/SamlTab.tsx
+++ b/frontend/web/components/SamlTab.tsx
@@ -13,7 +13,7 @@ import CreateSAML from './modals/CreateSAML'
 import Switch from './Switch'
 import { SAMLConfiguration } from 'common/types/responses'
 import PlanBasedBanner from './PlanBasedAccess'
-        
+
 export type SamlTabType = {
   organisationId: number
 }
@@ -36,119 +36,121 @@ const SamlTab: FC<SamlTabType> = ({ organisationId }) => {
   }
 
   return (
-    <PlanBasedBanner feature={'SAML'} theme={'page'} className='mt-3'>
-      <PageTitle
-        title={'SAML Configurations'}
-        cta={
-          <Button
-            className='text-right'
-            onClick={() => {
-              openCreateSAML('Create SAML configuration', organisationId)
-            }}
-          >
-            {'Create a SAML configuration'}
-          </Button>
-        }
-      />
-
-      <FormGroup className='mb-4'>
-        <PanelSearch
-          className='no-pad overflow-visible'
-          id='features-list'
-          renderSearchWithNoResults
-          itemHeight={65}
-          isLoading={false}
-          filterRow={(samlConf: SAMLConfiguration, search: string) =>
-            samlConf.name.toLowerCase().indexOf(search) > -1
-          }
-          header={
-            <Row className='table-header'>
-              <Flex className='table-column'>
-                <div className='font-weight-medium'>Configuration name</div>
-              </Flex>
-              <div
-                className='table-column d-none d-md-block'
-                style={{ width: '150px' }}
-              >
-                Allow IdP-initiated
-              </div>
-              <div style={{ width: 90 }} className='table-column'>
-                Action
-              </div>
-            </Row>
-          }
-          items={data?.results || []}
-          renderRow={(samlConf: SAMLConfiguration) => (
-            <Row
+    <PlanBasedBanner feature='SAML' theme='page'>
+      <div className='mt-4 mb-4'>
+        <PageTitle
+          title={'SAML Configurations'}
+          cta={
+            <Button
+              className='text-right'
               onClick={() => {
-                openCreateSAML(
-                  'Update SAML configuration',
-                  organisationId,
-                  samlConf.name,
-                )
+                openCreateSAML('Create SAML configuration', organisationId)
               }}
-              space
-              className='list-item py-2 py-md-0 clickable cursor-pointer'
-              key={samlConf.name}
             >
-              <Flex className='table-column px-3'>
-                <div className='font-weight-medium mb-1'>{samlConf.name}</div>
-              </Flex>
-              <div
-                className='table-column d-none d-md-flex gap-4 align-items-center'
-                style={{ width: '150px' }}
-              >
-                <Switch checked={samlConf.allow_idp_initiated} />
-              </div>
-              <div className='table-column' style={{ width: 90 }}>
-                <Button
-                  id='delete-invite'
-                  type='button'
-                  onClick={(e) => {
-                    openModal(
-                      'Delete SAML configuration',
-                      <div>
-                        <div>
-                          Are you sure you want to delete the SAML
-                          configuration?
-                        </div>
-                        <div className='text-right'>
-                          <Button
-                            className='mr-2'
-                            onClick={() => {
-                              closeModal()
-                            }}
-                          >
-                            Cancel
-                          </Button>
-                          <Button
-                            theme='danger'
-                            onClick={() => {
-                              deleteSamlConfiguration({
-                                name: samlConf.name,
-                              }).then(() => {
-                                toast('SAML configuration deleted')
-                                closeModal()
-                              })
-                            }}
-                          >
-                            Delete
-                          </Button>
-                        </div>
-                      </div>,
-                    )
-                    e.stopPropagation()
-                    e.preventDefault()
-                  }}
-                  className='btn btn-with-icon'
-                >
-                  <Icon name='trash-2' width={20} fill='#656D7B' />
-                </Button>
-              </div>
-            </Row>
-          )}
+              {'Create a SAML configuration'}
+            </Button>
+          }
         />
-      </FormGroup>
+
+        <FormGroup>
+          <PanelSearch
+            className='no-pad overflow-visible'
+            id='features-list'
+            renderSearchWithNoResults
+            itemHeight={65}
+            isLoading={false}
+            filterRow={(samlConf: SAMLConfiguration, search: string) =>
+              samlConf.name.toLowerCase().indexOf(search) > -1
+            }
+            header={
+              <Row className='table-header'>
+                <Flex className='table-column'>
+                  <div className='font-weight-medium'>Configuration name</div>
+                </Flex>
+                <div
+                  className='table-column d-none d-md-block'
+                  style={{ width: '150px' }}
+                >
+                  Allow IdP-initiated
+                </div>
+                <div style={{ width: 90 }} className='table-column'>
+                  Action
+                </div>
+              </Row>
+            }
+            items={data?.results || []}
+            renderRow={(samlConf: SAMLConfiguration) => (
+              <Row
+                onClick={() => {
+                  openCreateSAML(
+                    'Update SAML configuration',
+                    organisationId,
+                    samlConf.name,
+                  )
+                }}
+                space
+                className='list-item py-2 py-md-0 clickable cursor-pointer'
+                key={samlConf.name}
+              >
+                <Flex className='table-column px-3'>
+                  <div className='font-weight-medium mb-1'>{samlConf.name}</div>
+                </Flex>
+                <div
+                  className='table-column d-none d-md-flex gap-4 align-items-center'
+                  style={{ width: '150px' }}
+                >
+                  <Switch checked={samlConf.allow_idp_initiated} />
+                </div>
+                <div className='table-column' style={{ width: 90 }}>
+                  <Button
+                    id='delete-invite'
+                    type='button'
+                    onClick={(e) => {
+                      openModal(
+                        'Delete SAML configuration',
+                        <div>
+                          <div>
+                            Are you sure you want to delete the SAML
+                            configuration?
+                          </div>
+                          <div className='text-right'>
+                            <Button
+                              className='mr-2'
+                              onClick={() => {
+                                closeModal()
+                              }}
+                            >
+                              Cancel
+                            </Button>
+                            <Button
+                              theme='danger'
+                              onClick={() => {
+                                deleteSamlConfiguration({
+                                  name: samlConf.name,
+                                }).then(() => {
+                                  toast('SAML configuration deleted')
+                                  closeModal()
+                                })
+                              }}
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </div>,
+                      )
+                      e.stopPropagation()
+                      e.preventDefault()
+                    }}
+                    className='btn btn-with-icon'
+                  >
+                    <Icon name='trash-2' width={20} fill='#656D7B' />
+                  </Button>
+                </div>
+              </Row>
+            )}
+          />
+        </FormGroup>
+      </div>
     </PlanBasedBanner>
   )
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes


BEFORE
![Screenshot 2025-02-13 at 11 49 24](https://github.com/user-attachments/assets/2a858ab6-c485-4d4c-a8a8-f1bbc3b4ae0a)

AFTER
![Screenshot 2025-02-13 at 11 48 38](https://github.com/user-attachments/assets/a91be9a9-c3c6-4deb-b139-d79297f07175)


When PlanBasedBanner matches `hasPlan` condition no margin is added to Saml Tab content. In order to fix that and not have an impact in other places that use PlanBasedBanner a div wrapping Sam tab content was added to add margin top and bottom being consistent with all other tabs spacings

## How did you test this code?

Open saml tab configuration validate if margin is added