### PR TITLE
chore: add demo2 environment

### DIFF
--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -49,7 +49,7 @@ jobs:
 
   deploy-demo2:
     name: Deploy to Vercel Demo2
-    needs: run-tests
+#    needs: run-tests
     uses: ./.github/workflows/.reusable-frontend-deploy.yml
     with:
       gh_environment: demo2

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -4,52 +4,51 @@ on:
   push:
     branches:
       - main
-      - chore/add-demo2-environment
     paths:
       - frontend/**
       - .github/**
 
 jobs:
-#  run-tests:
-#    runs-on: ubuntu-latest
-#    name: Run E2E Tests
-#    environment: production
-#    concurrency:
-#      group: e2e-tests-prod
-#      cancel-in-progress: true
-#
-#    steps:
-#      - name: Cloning repo
-#        uses: actions/checkout@v4
-#
-#      - name: Run E2E tests against production
-#        uses: ./.github/actions/e2e-tests
-#        with:
-#          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
-#          slack_token: ${{ secrets.SLACK_TOKEN }}
-#          environment: prod
+  run-tests:
+    runs-on: ubuntu-latest
+    name: Run E2E Tests
+    environment: production
+    concurrency:
+      group: e2e-tests-prod
+      cancel-in-progress: true
 
-#  deploy-production:
-#    name: Deploy to Vercel Production
-#    needs: run-tests
-#    uses: ./.github/workflows/.reusable-frontend-deploy.yml
-#    with:
-#      gh_environment: production
-#      npm_build_environment: prod
-#    secrets: inherit
-#
-#  deploy-demo:
-#    name: Deploy to Vercel Demo
-#    needs: run-tests
-#    uses: ./.github/workflows/.reusable-frontend-deploy.yml
-#    with:
-#      gh_environment: demo
-#      npm_build_environment: prod
-#    secrets: inherit
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v4
+
+      - name: Run E2E tests against production
+        uses: ./.github/actions/e2e-tests
+        with:
+          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          environment: prod
+
+  deploy-production:
+    name: Deploy to Vercel Production
+    needs: run-tests
+    uses: ./.github/workflows/.reusable-frontend-deploy.yml
+    with:
+      gh_environment: production
+      npm_build_environment: prod
+    secrets: inherit
+
+  deploy-demo:
+    name: Deploy to Vercel Demo
+    needs: run-tests
+    uses: ./.github/workflows/.reusable-frontend-deploy.yml
+    with:
+      gh_environment: demo
+      npm_build_environment: prod
+    secrets: inherit
 
   deploy-demo2:
     name: Deploy to Vercel Demo2
-#    needs: run-tests
+    needs: run-tests
     uses: ./.github/workflows/.reusable-frontend-deploy.yml
     with:
       gh_environment: demo2

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -4,44 +4,54 @@ on:
   push:
     branches:
       - main
+      - chore/add-demo2-environment
     paths:
       - frontend/**
       - .github/**
 
 jobs:
-  run-tests:
-    runs-on: ubuntu-latest
-    name: Run E2E Tests
-    environment: production
-    concurrency:
-      group: e2e-tests-prod
-      cancel-in-progress: true
+#  run-tests:
+#    runs-on: ubuntu-latest
+#    name: Run E2E Tests
+#    environment: production
+#    concurrency:
+#      group: e2e-tests-prod
+#      cancel-in-progress: true
+#
+#    steps:
+#      - name: Cloning repo
+#        uses: actions/checkout@v4
+#
+#      - name: Run E2E tests against production
+#        uses: ./.github/actions/e2e-tests
+#        with:
+#          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
+#          slack_token: ${{ secrets.SLACK_TOKEN }}
+#          environment: prod
 
-    steps:
-      - name: Cloning repo
-        uses: actions/checkout@v4
+#  deploy-production:
+#    name: Deploy to Vercel Production
+#    needs: run-tests
+#    uses: ./.github/workflows/.reusable-frontend-deploy.yml
+#    with:
+#      gh_environment: production
+#      npm_build_environment: prod
+#    secrets: inherit
+#
+#  deploy-demo:
+#    name: Deploy to Vercel Demo
+#    needs: run-tests
+#    uses: ./.github/workflows/.reusable-frontend-deploy.yml
+#    with:
+#      gh_environment: demo
+#      npm_build_environment: prod
+#    secrets: inherit
 
-      - name: Run E2E tests against production
-        uses: ./.github/actions/e2e-tests
-        with:
-          e2e_test_token: ${{ secrets.E2E_TEST_TOKEN }}
-          slack_token: ${{ secrets.SLACK_TOKEN }}
-          environment: prod
-
-  deploy-production:
-    name: Deploy to Vercel Production
+  deploy-demo2:
+    name: Deploy to Vercel Demo2
     needs: run-tests
     uses: ./.github/workflows/.reusable-frontend-deploy.yml
     with:
-      gh_environment: production
-      npm_build_environment: prod
-    secrets: inherit
-
-  deploy-demo:
-    name: Deploy to Vercel Demo
-    needs: run-tests
-    uses: ./.github/workflows/.reusable-frontend-deploy.yml
-    with:
-      gh_environment: demo
+      gh_environment: demo2
       npm_build_environment: prod
     secrets: inherit


### PR DESCRIPTION
## Changes

Add job to production FE workflow to deploy to demo2.flagsmith.com. This environment was set up to allow external teams to demo Flagsmith. 

## How did you test this code?

Added this branch to the workflow triggers and ensured that the deployment succeeded in Vercel. 
