### PR TITLE
chore: enforce `--name/-n` argument in makemigrations management command

### DIFF
--- a/api/core/management/commands/makemigrations.py
+++ b/api/core/management/commands/makemigrations.py
@@ -4,7 +4,7 @@ from django.core.management.commands.makemigrations import (
 )
 
 
-class Command(MakeMigrationsCommand):
+class Command(MakeMigrationsCommand):  # pragma: no cover
     """
     Customise the makemigrations command to enforce use of `--name/-n` argument.
     """

--- a/api/core/management/commands/makemigrations.py
+++ b/api/core/management/commands/makemigrations.py
@@ -1,0 +1,16 @@
+from django.core.management import CommandError
+from django.core.management.commands.makemigrations import (
+    Command as MakeMigrationsCommand,
+)
+
+
+class Command(MakeMigrationsCommand):
+    """
+    Customise the makemigrations command to enforce use of `--name/-n` argument.
+    """
+
+    def handle(self, *app_labels, **options):
+        if not options.get("name"):
+            raise CommandError("--name/-n is a required argument")
+
+        return super().handle(*app_labels, **options)

--- a/api/core/management/commands/makemigrations.py
+++ b/api/core/management/commands/makemigrations.py
@@ -10,7 +10,9 @@ class Command(MakeMigrationsCommand):
     """
 
     def handle(self, *app_labels, **options):
-        if not options.get("name"):
+        if not options.get("name") and not (
+            options.get("check_changes") or options.get("dry_run")
+        ):
             raise CommandError("--name/-n is a required argument")
 
         return super().handle(*app_labels, **options)

--- a/api/core/management/commands/makemigrations.py
+++ b/api/core/management/commands/makemigrations.py
@@ -9,7 +9,7 @@ class Command(MakeMigrationsCommand):
     Customise the makemigrations command to enforce use of `--name/-n` argument.
     """
 
-    def handle(self, *app_labels, **options):  # pragma: no cover
+    def handle(self, *app_labels, **options):
         if not options.get("name") and not (
             options.get("check_changes") or options.get("dry_run")
         ):

--- a/api/core/management/commands/makemigrations.py
+++ b/api/core/management/commands/makemigrations.py
@@ -4,12 +4,12 @@ from django.core.management.commands.makemigrations import (
 )
 
 
-class Command(MakeMigrationsCommand):  # pragma: no cover
+class Command(MakeMigrationsCommand):
     """
     Customise the makemigrations command to enforce use of `--name/-n` argument.
     """
 
-    def handle(self, *app_labels, **options):
+    def handle(self, *app_labels, **options):  # pragma: no cover
         if not options.get("name") and not (
             options.get("check_changes") or options.get("dry_run")
         ):

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -41,6 +41,11 @@ exclude_also = [
   '@(abc\\.)?abstractmethod',
 ]
 
+[tool.coverage.run]
+omit = [
+  "api/core/management/commands/makemigrations.py"
+]
+
 [tool.isort]
 use_parentheses = true
 multi_line_output = 3

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -41,11 +41,6 @@ exclude_also = [
   '@(abc\\.)?abstractmethod',
 ]
 
-[tool.coverage.run]
-omit = [
-  "api/core/management/commands/makemigrations.py"
-]
-
 [tool.isort]
 use_parentheses = true
 multi_line_output = 3

--- a/api/tests/unit/core/management/test_unit_core_management_makemigrations.py
+++ b/api/tests/unit/core/management/test_unit_core_management_makemigrations.py
@@ -1,0 +1,19 @@
+import pytest
+from django.core.management import CommandError, call_command
+
+
+def test_makemigrations_without_name_raises_error():
+    with pytest.raises(CommandError, match="--name/-n is a required argument"):
+        call_command('makemigrations')
+
+
+def test_makemigrations_with_check_changes_runs_without_error(db: None):
+    call_command('makemigrations', check_changes=True)
+
+
+def test_makemigrations_with_dry_run_runs_without_error(db: None):
+    call_command('makemigrations', dry_run=True)
+
+
+def test_makemigrations_with_name_runs_without_error(db: None):
+    call_command('makemigrations', name="some_useful_name")

--- a/api/tests/unit/core/management/test_unit_core_management_makemigrations.py
+++ b/api/tests/unit/core/management/test_unit_core_management_makemigrations.py
@@ -7,13 +7,16 @@ def test_makemigrations_without_name_raises_error():
         call_command('makemigrations')
 
 
-def test_makemigrations_with_check_changes_runs_without_error(db: None):
+@pytest.mark.django_db(databases=["default", "analytics"])
+def test_makemigrations_with_check_changes_runs_without_error():
     call_command('makemigrations', check_changes=True)
 
 
-def test_makemigrations_with_dry_run_runs_without_error(db: None):
+@pytest.mark.django_db(databases=["default", "analytics"])
+def test_makemigrations_with_dry_run_runs_without_error():
     call_command('makemigrations', dry_run=True)
 
 
-def test_makemigrations_with_name_runs_without_error(db: None):
+@pytest.mark.django_db(databases=["default", "analytics"])
+def test_makemigrations_with_name_runs_without_error():
     call_command('makemigrations', name="some_useful_name")


### PR DESCRIPTION
## Changes

Enforces the use of `--name/-n` when creating migrations. 

## How did you test this code?

Ran `makemigrations` with and without `--name/-n` and verified the correct result. 
