### PR TITLE
fix: Feature tags not showing up in tag selection UI 

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -72,7 +72,7 @@ const CreateFlag = class extends Component {
           multivariate_options: [],
         }
     const { allowEditDescription } = this.props
-    const hideTagsByType = this.props.hideTagsByType || []
+    const hideTags = this.props.hideTags || []
     if (this.props.projectFlag) {
       this.userOverridesPage(1)
     }
@@ -107,7 +107,7 @@ const CreateFlag = class extends Component {
       name,
       period: 30,
       selectedIdentity: null,
-      tags: tags?.filter((tag) => hideTagsByType.includes(tag.type)) || [],
+      tags: tags?.filter((tag) => !hideTags.includes(tag)) || [],
     }
   }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The following change caused a regression where tags were not shown here:

![image](https://github.com/user-attachments/assets/5e936746-54a4-49c5-9217-b9cb318337d8)


The code in question looks to try to hide unhealthy tags since they are automated however:

- Tags come through as an array of ids so the code would have never worked
- The condition is the wrong way around this would have only shown the unhealthy tags

## How did you test this code?

View a feature that has tags and go to the settings tab

