### PR TITLE
fix: Dynamically update theme toggle tooltip text based on current mode

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -528,7 +528,7 @@ const App = class extends Component {
                                       </div>
                                     }
                                   >
-                                    Dark Mode
+                                    {Utils.getFlagsmithHasFeature('dark_mode') ? 'Light Mode' : 'Dark Mode'}
                                   </Tooltip>
                                 </Row>
                               </nav>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Bug - Before the change: The tooltip always displayed 'Dark Mode' regardless of the current theme
![image](https://github.com/user-attachments/assets/3eb4a7da-1822-48fe-afed-80165c8727f8)

_Please describe._

I have updated the internal logic to dynamically display 'Light Mode' or 'Dark Mode' based on the current theme.
## How did you test this code?
Manually tested by:
1. Switching between light/dark modes
2. Verifying Tooltip text updates correctly

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
1. Hover over the theme toggle button located at the top-right corner of any page.
_Please describe._
