### PR TITLE
chore: Add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
 # Initial Mypy '# type: ignore' comments dump
 # https://github.com/Flagsmith/flagsmith/pull/5119
 5de0b425b0ee16b16bfb0fb33b067fa314d040fb
+# Linting fixes for frontend
+# https://github.com/Flagsmith/flagsmith/pull/5123 
+1f7083636d3b163588fe9a8b45af289bd40b1a8d

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,3 @@
+# Initial Mypy '# type: ignore' comments dump
+# https://github.com/Flagsmith/flagsmith/pull/5119
 5de0b425b0ee16b16bfb0fb33b067fa314d040fb

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+5de0b425b0ee16b16bfb0fb33b067fa314d040fb


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds a `.git-blame-ignore-revs` file to allow `git blame` to ignore large automated formatting/linting changes, containing the #5119 merge commit SHA.

Note: To take advantage of it, you need to run `git config blame.ignoreRevsFile .git-blame-ignore-revs` once.

## How did you test this code?

1. Ran `git config blame.ignoreRevsFile .git-blame-ignore-revs`
2. Observed relevant `git blame` messages on lines with `# type: ignore` comments