### PR TITLE
fix(typing): Add missing type stubs for dependencies

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 from importlib import reload
 
 import dj_database_url  # type: ignore[import-untyped]
-import pytz  # type: ignore[import-untyped]
+import pytz
 from corsheaders.defaults import default_headers  # type: ignore[import-untyped]
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key

--- a/api/app_analytics/analytics_db_service.py
+++ b/api/app_analytics/analytics_db_service.py
@@ -2,7 +2,9 @@ from datetime import date, datetime, timedelta
 from typing import List
 
 from app_analytics.dataclasses import FeatureEvaluationData, UsageData
-from app_analytics.influxdb_wrapper import get_events_for_organisation
+from app_analytics.influxdb_wrapper import (
+    get_events_for_organisation,
+)
 from app_analytics.influxdb_wrapper import (
     get_feature_evaluation_data as get_feature_evaluation_data_from_influxdb,
 )
@@ -14,7 +16,7 @@ from app_analytics.models import (
     FeatureEvaluationBucket,
     Resource,
 )
-from dateutil.relativedelta import relativedelta  # type: ignore[import-untyped]
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db.models import Sum
 from django.utils import timezone
@@ -76,7 +78,7 @@ def get_usage_data(
 
         if date_start:
             assert date_stop
-            kwargs["date_start"] = date_start
+            kwargs["date_start"] = date_start  # type: ignore[assignment]
             kwargs["date_stop"] = date_stop  # type: ignore[assignment]
 
         return get_usage_data_from_local_db(**kwargs)  # type: ignore[arg-type]
@@ -89,7 +91,7 @@ def get_usage_data(
 
     if date_start:
         assert date_stop
-        kwargs["date_start"] = date_start
+        kwargs["date_start"] = date_start  # type: ignore[assignment]
         kwargs["date_stop"] = date_stop  # type: ignore[assignment]
 
     return get_usage_data_from_influxdb(**kwargs)  # type: ignore[arg-type]

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -5,9 +5,9 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.utils import timezone
-from influxdb_client import InfluxDBClient, Point  # type: ignore[import-untyped]
-from influxdb_client.client.exceptions import InfluxDBError  # type: ignore[import-untyped]
-from influxdb_client.client.write_api import SYNCHRONOUS  # type: ignore[import-untyped]
+from influxdb_client import InfluxDBClient, Point
+from influxdb_client.client.exceptions import InfluxDBError
+from influxdb_client.client.write_api import SYNCHRONOUS
 from sentry_sdk import capture_exception
 from urllib3 import Retry
 from urllib3.exceptions import HTTPError

--- a/api/app_analytics/management/commands/sendapiusagetoinflux.py
+++ b/api/app_analytics/management/commands/sendapiusagetoinflux.py
@@ -3,8 +3,8 @@ from datetime import datetime
 
 from django.conf import settings
 from django.core.management import BaseCommand
-from influxdb_client import InfluxDBClient, Point  # type: ignore[import-untyped]
-from influxdb_client.client.write_api import SYNCHRONOUS  # type: ignore[import-untyped]
+from influxdb_client import InfluxDBClient, Point
+from influxdb_client.client.write_api import SYNCHRONOUS
 
 
 class Command(BaseCommand):

--- a/api/organisations/chargebee/chargebee.py
+++ b/api/organisations/chargebee/chargebee.py
@@ -4,9 +4,11 @@ from contextlib import suppress
 from datetime import datetime
 
 import chargebee  # type: ignore[import-untyped]
-from chargebee.api_error import APIError as ChargebeeAPIError  # type: ignore[import-untyped]
+from chargebee.api_error import (  # type: ignore[import-untyped]
+    APIError as ChargebeeAPIError,
+)
 from django.conf import settings
-from pytz import UTC  # type: ignore[import-untyped]
+from pytz import UTC
 
 from ..subscriptions.constants import CHARGEBEE
 from ..subscriptions.exceptions import (

--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from app_analytics.influxdb_wrapper import get_current_api_usage
 from core.helpers import get_current_site_url
-from dateutil.relativedelta import relativedelta  # type: ignore[import-untyped]
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -3,7 +3,7 @@ import math
 from datetime import timedelta
 
 from app_analytics.influxdb_wrapper import get_current_api_usage
-from dateutil.relativedelta import relativedelta  # type: ignore[import-untyped]
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.mail import send_mail
 from django.db.models import F, Max, Q

--- a/api/organisations/views.py
+++ b/api/organisations/views.py
@@ -9,7 +9,7 @@ from app_analytics.influxdb_wrapper import (
     get_multiple_event_list_for_organisation,
 )
 from core.helpers import get_current_site_url
-from dateutil.relativedelta import relativedelta  # type: ignore[import-untyped]
+from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from drf_yasg.utils import swagger_auto_schema  # type: ignore[import-untyped]
 from rest_framework import status, viewsets

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2776,6 +2776,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -4099,6 +4109,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -4106,8 +4117,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -4124,6 +4142,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -4131,6 +4150,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -4714,6 +4734,97 @@ files = [
 ]
 
 [[package]]
+name = "types-docutils"
+version = "0.21.0.20241128"
+description = "Typing stubs for docutils"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "types_docutils-0.21.0.20241128-py3-none-any.whl", hash = "sha256:e0409204009639e9b0bf4521eeabe58b5e574ce9c0db08421c2ac26c32be0039"},
+    {file = "types_docutils-0.21.0.20241128.tar.gz", hash = "sha256:4dd059805b83ac6ec5a223699195c4e9eeb0446a4f7f2aeff1759a4a7cc17473"},
+]
+
+[[package]]
+name = "types-influxdb-client"
+version = "1.45.0.20241221"
+description = "Typing stubs for influxdb-client"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "types_influxdb_client-1.45.0.20241221-py3-none-any.whl", hash = "sha256:599a40595e5ccdda2d396357cbc586f21bc06e26ead5ed9e27c36ce02adaa505"},
+    {file = "types_influxdb_client-1.45.0.20241221.tar.gz", hash = "sha256:9a643c3cbc2e607179858bf3cf888355e522ad9e358149d53107aa2c9d1a3ec8"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
+name = "types-markdown"
+version = "3.7.0.20241204"
+description = "Typing stubs for Markdown"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "types_Markdown-3.7.0.20241204-py3-none-any.whl", hash = "sha256:f96146c367ea9c82bfe9903559d72706555cc2a1a3474c58ebba03b418ab18da"},
+    {file = "types_markdown-3.7.0.20241204.tar.gz", hash = "sha256:ecca2b25cd23163fd28ed5ba34d183d731da03e8a5ed3a20b60daded304c5410"},
+]
+
+[[package]]
+name = "types-psycopg2"
+version = "2.9.21.20250121"
+description = "Typing stubs for psycopg2"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_psycopg2-2.9.21.20250121-py3-none-any.whl", hash = "sha256:b890dc6f5a08b6433f0ff73a4ec9a834deedad3e914f2a4a6fd43df021f745f1"},
+    {file = "types_psycopg2-2.9.21.20250121.tar.gz", hash = "sha256:2b0e2cd0f3747af1ae25a7027898716d80209604770ef3cbf350fe055b9c349b"},
+]
+
+[[package]]
+name = "types-pygments"
+version = "2.19.0.20250107"
+description = "Typing stubs for Pygments"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "types_Pygments-2.19.0.20250107-py3-none-any.whl", hash = "sha256:34a555ed327f249daed18c6309e6e62770cdb8b9c321029ba7fd852d10b16f10"},
+    {file = "types_pygments-2.19.0.20250107.tar.gz", hash = "sha256:94de72c7f09b956c518f566e056812c698272a7a03a9cd81f0065576c6bd3219"},
+]
+
+[package.dependencies]
+types-docutils = "*"
+types-setuptools = "*"
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20241206"
+description = "Typing stubs for python-dateutil"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "types_python_dateutil-2.9.0.20241206-py3-none-any.whl", hash = "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53"},
+    {file = "types_python_dateutil-2.9.0.20241206.tar.gz", hash = "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb"},
+]
+
+[[package]]
+name = "types-pytz"
+version = "2025.1.0.20250204"
+description = "Typing stubs for pytz"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_pytz-2025.1.0.20250204-py3-none-any.whl", hash = "sha256:32ca4a35430e8b94f6603b35beb7f56c32260ddddd4f4bb305fdf8f92358b87e"},
+    {file = "types_pytz-2025.1.0.20250204.tar.gz", hash = "sha256:00f750132769f1c65a4f7240bc84f13985b4da774bd17dfbe5d9cd442746bd49"},
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20241230"
 description = "Typing stubs for PyYAML"
@@ -4750,6 +4861,18 @@ groups = ["dev"]
 files = [
     {file = "types_s3transfer-0.11.2-py3-none-any.whl", hash = "sha256:09c31cff8c79a433fcf703b840b66d1f694a6c70c410ef52015dd4fe07ee0ae2"},
     {file = "types_s3transfer-0.11.2.tar.gz", hash = "sha256:3ccb8b90b14434af2fb0d6c08500596d93f3a83fb804a2bb843d9bf4f7c2ca60"},
+]
+
+[[package]]
+name = "types-setuptools"
+version = "75.8.0.20250210"
+description = "Typing stubs for setuptools"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_setuptools-75.8.0.20250210-py3-none-any.whl", hash = "sha256:a217d7b4d59be04c29e23d142c959a0f85e71292fd3fc4313f016ca11f0b56dc"},
+    {file = "types_setuptools-75.8.0.20250210.tar.gz", hash = "sha256:c1547361b2441f07c94e25dce8a068e18c611593ad4b6fdd727b1a8f5d1fda33"},
 ]
 
 [[package]]
@@ -5047,4 +5170,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "b7b757b6fefebd392a4deba08c16f08afbf685df6fb54e845c04c304441ea250"
+content-hash = "60a5db12be1dfd07ad05960881b0491b1e5623331d50012a0b215b67c4026aa9"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -249,6 +249,12 @@ django-stubs = "^5.1.3"
 djangorestframework-stubs = "^3.15.2"
 boto3-stubs = "^1.36.20"
 types-requests = "^2.32.0.20241016"
+types-markdown = "^3.7.0.20241204"
+types-pygments = "^2.19.0.20250107"
+types-influxdb-client = "^1.45.0.20241221"
+types-psycopg2 = "^2.9.21.20250121"
+types-python-dateutil = "^2.9.0.20241206"
+types-pytz = "^2025.1.0.20250204"
 
 [build-system]
 requires = ["poetry>=2.0.0"]

--- a/api/sse/tasks.py
+++ b/api/sse/tasks.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import requests
 from app_analytics.influxdb_wrapper import influxdb_client
 from django.conf import settings
-from influxdb_client import Point, WriteOptions  # type: ignore[import-untyped]
+from influxdb_client import Point, WriteOptions
 from task_processor.decorators import (  # type: ignore[import-untyped]
     register_recurring_task,
     register_task_handler,

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
@@ -21,8 +21,8 @@ from app_analytics.influxdb_wrapper import (
 )
 from django.conf import settings
 from django.utils import timezone
-from influxdb_client.client.exceptions import InfluxDBError  # type: ignore[import-untyped]
-from influxdb_client.rest import ApiException  # type: ignore[import-untyped]
+from influxdb_client.client.exceptions import InfluxDBError
+from influxdb_client.rest import ApiException
 from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 from urllib3.exceptions import HTTPError

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -5,14 +5,17 @@ from datetime import date, datetime, timedelta
 from unittest import mock
 
 import pytest
-import pytz  # type: ignore[import-untyped]
+import pytz
 from app_analytics.dataclasses import FeatureEvaluationData
 from common.environments.permissions import (  # type: ignore[import-untyped]
     MANAGE_SEGMENT_OVERRIDES,
     UPDATE_FEATURE_STATE,
     VIEW_ENVIRONMENT,
 )
-from common.projects.permissions import CREATE_FEATURE, VIEW_PROJECT  # type: ignore[import-untyped]
+from common.projects.permissions import (  # type: ignore[import-untyped]
+    CREATE_FEATURE,
+    VIEW_PROJECT,
+)
 from core.constants import FLAGSMITH_UPDATED_AT_HEADER
 from django.conf import settings
 from django.forms import model_to_dict

--- a/api/tests/unit/integrations/lead_tracking/hubspot/_hubspot_responses.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/_hubspot_responses.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dateutil.tz import tzlocal  # type: ignore[import-untyped]
+from dateutil.tz import tzlocal
 
 
 class FakeHubspotResponse:

--- a/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
+++ b/api/tests/unit/organisations/chargebee/test_unit_chargebee_chargebee.py
@@ -4,9 +4,11 @@ from unittest import mock
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from chargebee import APIError  # type: ignore[import-untyped]
-from chargebee.api_error import APIError as ChargebeeAPIError  # type: ignore[import-untyped]
+from chargebee.api_error import (  # type: ignore[import-untyped]
+    APIError as ChargebeeAPIError,
+)
 from pytest_mock import MockerFixture
-from pytz import UTC  # type: ignore[import-untyped]
+from pytz import UTC
 
 from organisations.chargebee import (  # type: ignore[attr-defined]
     add_100k_api_calls,

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 from core.helpers import get_current_site_url
-from dateutil.relativedelta import relativedelta  # type: ignore[import-untyped]
+from dateutil.relativedelta import relativedelta
 from django.core.mail.message import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils import timezone

--- a/api/tests/unit/organisations/test_unit_organisations_views.py
+++ b/api/tests/unit/organisations/test_unit_organisations_views.py
@@ -16,9 +16,12 @@ from freezegun import freeze_time
 from pytest_django.fixtures import SettingsWrapper
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
-from pytz import UTC  # type: ignore[import-untyped]
+from pytz import UTC
 from rest_framework import status
-from rest_framework.test import APIClient, override_settings  # type: ignore[attr-defined]
+from rest_framework.test import (  # type: ignore[attr-defined]
+    APIClient,
+    override_settings,
+)
 
 from environments.models import Environment
 from environments.permissions.models import UserEnvironmentPermission

--- a/api/tests/unit/users/test_unit_users_views.py
+++ b/api/tests/unit/users/test_unit_users_views.py
@@ -2,7 +2,7 @@ import json
 import typing
 
 import pytest
-from dateutil.relativedelta import relativedelta  # type: ignore[import-untyped]
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.models import AbstractUser

--- a/api/tests/unit/util/mappers/test_unit_mappers_engine.py
+++ b/api/tests/unit/util/mappers/test_unit_mappers_engine.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import pytest
-import pytz  # type: ignore[import-untyped]
+import pytz
 from django.utils import timezone
 from flag_engine.environments.integrations.models import IntegrationModel
 from flag_engine.environments.models import (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds a bunch of type stubs for dependencies and removes corresponding `type: ignore` comments for their imports.

## How did you test this code?

Verified the typecheck passes.