### PR TITLE
fix: Consistent hover styles for tabs & improved dark mode side menu UX

### DIFF
--- a/frontend/web/styles/project/_project-nav.scss
+++ b/frontend/web/styles/project/_project-nav.scss
@@ -13,8 +13,14 @@ nav a {
     border-radius: $border-radius;
 
     &:hover {
-      color: $body-color;
       background-color: $primary-alfa-8;
+    }
+  }
+  &:hover{
+    svg {
+      path {
+        fill: $link-hover-color;
+      }
     }
   }
   svg {
@@ -122,15 +128,22 @@ nav a {
     font-size: $font-size-base;
   }
 }
-  .collapsible-title {
-    line-height: 32px;
-    cursor: pointer;
-    border-radius: $border-radius;
-    &:hover {
-      color: $primary;
-      background-color: $primary-alfa-8;
+.aside-nav a:hover {
+  svg {
+    path {
+      fill: $primary;
     }
   }
+}
+.collapsible-title {
+  line-height: 32px;
+  cursor: pointer;
+  border-radius: $border-radius;
+  &:hover {
+    color: $primary;
+    background-color: $primary-alfa-8;
+  }
+}
   .collapsible.active {
     .collapsible-title {
       pointer-events: none;
@@ -155,6 +168,19 @@ nav a {
         fill: $body-color-dark;
       }
       opacity: 0.3;
+    }
+  }
+  .aside-nav a {
+    &.active {
+      background-color: $primary-alfa-16;
+    }
+  }
+  .aside-nav a:hover {
+    background-color: $primary-alfa-8;
+    svg {
+      path {
+        fill: $body-color-dark;
+      }
     }
   }
 }


### PR DESCRIPTION
…

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Problem Statement - 
1. On hovering on tabs and side menu items for the primary color gets activated on title but not all the icons with it because we are using icons and jsx randomly causing inconsistent in hover effect on each tabs and sidemenu 
2. In dark mode the sidemenu when user hovers they cannot see any feedback on hovering .

Fix - 
1. I have enabled hover class for all the Tabs and side menu
Before Changes -
![image](https://github.com/user-attachments/assets/be842cdc-9444-43fb-91bd-43c5833a06fe)

After Changes -
![image](https://github.com/user-attachments/assets/3e4d02a7-397d-4f4e-9d1f-f71253304552)
  
2.Have added two different background color on active and hover for improving user experience.
I have added different background colors for active and hover states to enhance the user experience.
Before Changes -
![image](https://github.com/user-attachments/assets/2df2e83f-88ef-4d39-aa90-fb284ea5bac3)

After Changes -
![image](https://github.com/user-attachments/assets/78b36b0b-18ac-40c3-ac8f-39362d2a5cae)

_Please describe._

## How did you test this code?
- These are hover effect and UI fixes, manually tested in both dark and light modes.

_Please describe._
Test hover effects in both dark mode and light mode on the following pages:
a. Organizations Page
- Hover over the tabs and verify that the hover color updates consistently.
b. Projects Page
- Hover over the tabs and ensure uniform hover styling.
- Hover over the side menu and check if the dark mode hover effect is applied correctly.