### PR TITLE
fix: Segment override permissions

### DIFF
--- a/frontend/web/components/SegmentOverrideActions.tsx
+++ b/frontend/web/components/SegmentOverrideActions.tsx
@@ -1,10 +1,6 @@
 import { FC, useCallback, useLayoutEffect, useRef, useState } from 'react'
-import classNames from 'classnames'
 
 import useOutsideClick from 'common/useOutsideClick'
-import Utils from 'common/utils/utils'
-import Constants from 'common/constants'
-import Permission from 'common/providers/Permission'
 import Button from './base/forms/Button'
 import Icon from './Icon'
 import ActionButton from './ActionButton'

--- a/frontend/web/components/SegmentOverrides.js
+++ b/frontend/web/components/SegmentOverrides.js
@@ -47,13 +47,13 @@ const SegmentOverrideInner = class Override extends React.Component {
       confirmRemove,
       controlValue,
       disabled,
+      environmentId,
       hideViewSegment,
       index,
       multivariateOptions,
       name,
       onSortEnd,
       projectFlag,
-      projectId,
       readOnly,
       setSegmentEditId,
       setShowCreateSegment,
@@ -176,9 +176,9 @@ const SegmentOverrideInner = class Override extends React.Component {
               )}
               <Row className='gap-2'>
                 <Permission
-                  id={projectId}
-                  permission={'MANAGE_SEGMENTS'}
-                  level={'project'}
+                  id={environmentId}
+                  permission={'MANAGE_SEGMENT_OVERRIDES'}
+                  level={'environment'}
                 >
                   {({ permission }) =>
                     Utils.renderWithPermission(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Removing segment overrides was based on the MANAGE_SEGMENTS permission rather than segment override permissions.

## How did you test this code?

Viewed and modified segment overrides as a user with appropriate permissions.
