### PR TITLE
fix: Treat 0 padded number as string

### DIFF
--- a/frontend/common/utils/utils.tsx
+++ b/frontend/common/utils/utils.tsx
@@ -521,7 +521,8 @@ const Utils = Object.assign({}, require('./base/_utils'), {
     }
 
     const typedValue = testWithTrim ? str.trim() : str
-    const isNum = /^-?\d+$/.test(typedValue)
+    // Check if the value is sensible number, returns false if it has leading 0s
+    const isNum = /^-?(0|[1-9]\d*)$/.test(typedValue)
 
     if (isNum && parseInt(typedValue) > Number.MAX_SAFE_INTEGER) {
       return `${str}`


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes https://github.com/Flagsmith/flagsmith/issues/4909, the frontend detects and casts numeric strings for certain requests, it didn't treat strings with leading 0s as a string.


## How did you test this code?

Try to create a segment with a condition value of 0123
