### PR TITLE
fix: Show "Clear all" to the left of feature filters to prevent layout shift

### DIFF
--- a/frontend/web/components/ClearFilters.tsx
+++ b/frontend/web/components/ClearFilters.tsx
@@ -10,7 +10,7 @@ const ClearFilters: FC<ClearFiltersType> = ({ onClick }) => {
   return (
     <div
       onClick={onClick}
-      className='fw-semibold cursor-pointer text-primary  d-flex align-items-center ms-2 gap-1'
+      className='fw-semibold cursor-pointer text-primary  d-flex align-items-center mx-3 gap-1'
     >
       <IonIcon className='h6 mb-0' color='#6837fc' icon={closeCircle} />
       Clear all

--- a/frontend/web/components/pages/FeaturesPage.js
+++ b/frontend/web/components/pages/FeaturesPage.js
@@ -375,6 +375,9 @@ const FeaturesPage = class extends Component {
                                     value={this.state.search}
                                   />
                                   <Row className='flex-fill justify-content-end'>
+                                    {hasFilters && (
+                                      <ClearFilters onClick={clearFilters} />
+                                    )}
                                     <TableTagFilter
                                       useLocalStorage
                                       isLoading={FeatureListStore.isLoading}
@@ -526,9 +529,6 @@ const FeaturesPage = class extends Component {
                                         this.setState({ sort }, this.filter)
                                       }}
                                     />
-                                    {hasFilters && (
-                                      <ClearFilters onClick={clearFilters} />
-                                    )}
                                   </Row>
                                 </div>
                               </Row>

--- a/frontend/web/components/pages/UserPage.tsx
+++ b/frontend/web/components/pages/UserPage.tsx
@@ -495,6 +495,9 @@ const UserPage: FC<UserPageType> = (props) => {
                                       value={filter.search}
                                     />
                                     <Row className='flex-fill justify-content-end'>
+                                      {hasFilters && (
+                                        <ClearFilters onClick={clearFilters} />
+                                      )}
                                       <TableTagFilter
                                         projectId={projectId}
                                         className='me-4'
@@ -609,9 +612,6 @@ const UserPage: FC<UserPageType> = (props) => {
                                           })
                                         }}
                                       />
-                                      {hasFilters && (
-                                        <ClearFilters onClick={clearFilters} />
-                                      )}
                                     </Row>
                                   </div>
                                 </Row>


### PR DESCRIPTION
When selecting the first filter (or removing the last filter) on a list of features, "Clear all" appears/disappears to the right of the filter dropdowns, which causes layout shift. This is especially notable if a dropdown is open:


https://github.com/user-attachments/assets/8d365c95-4926-4b7e-896a-b070c077ada5

By moving "Clear all" to the left of the filters, we prevent most of the layout shift. There is still some layout shift when the number of selected filters (1) appears, but is much less noticeable and does not affect open dropdowns:


https://github.com/user-attachments/assets/2d297c9e-c7ae-4d69-8e6d-d2f033b5ce6d

