### PR TITLE
ci: Don't bump Helm chart version when updating Flagsmith release version

### DIFF
--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -163,12 +163,6 @@ jobs:
         with:
           file_path: './chart/charts/flagsmith/Chart.yaml'
 
-      - uses: us-ignite/action-bump-semver@main
-        id: bump-semver
-        with:
-          current_version: ${{ steps.yaml-output.outputs.version }}
-          level: minor
-
       - name: Update flagsmith-charts values.yaml with latest docker version
         uses: fjogeleit/yaml-update-action@main
         with:
@@ -185,6 +179,5 @@ jobs:
           valueFile: 'charts/flagsmith/Chart.yaml'
           changes: |
             {
-              "appVersion": "${{ steps.version-trim.outputs.version }}",
-              "version": "${{ steps.bump-semver.outputs.new_version }}"
+              "appVersion": "${{ steps.version-trim.outputs.version }}"
             }


### PR DESCRIPTION
In https://github.com/Flagsmith/flagsmith-charts/pull/313, we made Helm chart releases manual, which means each PR doesn't need to bump the Helm chart version.

This is not tested.