### PR TITLE
feat: Add separate liveness and readiness checks

### DIFF
--- a/api/app/urls.py
+++ b/api/app/urls.py
@@ -14,6 +14,8 @@ urlpatterns = [
     re_path(r"^api/v1/", include("api.urls.v1", namespace="api-v1")),
     re_path(r"^api/v2/", include("api.urls.v2", namespace="api-v2")),
     re_path(r"^admin/", admin.site.urls),
+    re_path(r"^health/liveness/?", views.version_info),
+    re_path(r"^health/readiness/?", include("health_check.urls")),
     re_path(r"^health", include("health_check.urls", namespace="health")),
     # Aptible health checks must be on /healthcheck and cannot redirect
     # see https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/health-checks

--- a/api/scripts/healthcheck.py
+++ b/api/scripts/healthcheck.py
@@ -2,7 +2,7 @@ import sys
 
 import requests
 
-url = "http://localhost:8000/health"
+url = "http://localhost:8000/health/liveness"
 status = requests.get(url).status_code
 
 sys.exit(0 if 200 >= status < 300 else 1)


### PR DESCRIPTION
This PR adds separate liveness and readiness checks, to be added later in the Helm charts. The existing `/health` endpoint is maintained with no changes for backwards compatibility.

The liveness check is the same as calling `/version`, which has no external dependencies. It does check that the filesystem is readable, since the version data is read from the filesystem. This is just testing that the API can respond to requests.

The readiness check is the same as the current `/health` endpoint, which checks that all migrations have been applied, and the database is available. We add a separate `/health/readiness` endpoint to make this obvious.

We also modify the `api/scripts/healthcheck.py` script, which is used by the default Docker Compose setup. Docker Compose health checks should effectively be liveness and not readiness health checks.

Tested manually by making requests to all the endpoints, and confirming there are no warnings about URL namespaces.