### PR TITLE
fix: Catch errors when failing to verify JWTs

### DIFF
--- a/api/api_keys/models.py
+++ b/api/api_keys/models.py
@@ -33,6 +33,8 @@ class MasterAPIKey(AbstractAPIKey, LifecycleModelMixin, SoftDeleteObject):  # ty
         self,
     ):
         if settings.IS_RBAC_INSTALLED:
-            from rbac.models import MasterAPIKeyRole  # type: ignore[import-not-found]
+            from rbac.models import (  # type: ignore[import-not-found,unused-ignore]
+                MasterAPIKeyRole,
+            )
 
             MasterAPIKeyRole.objects.filter(master_api_key=self.id).delete()

--- a/api/custom_auth/jwt_cookie/authentication.py
+++ b/api/custom_auth/jwt_cookie/authentication.py
@@ -1,5 +1,10 @@
 from rest_framework.request import Request
 from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import (
+    AuthenticationFailed,
+    InvalidToken,
+    TokenError,
+)
 from rest_framework_simplejwt.tokens import Token
 
 from custom_auth.jwt_cookie.constants import JWT_SLIDING_COOKIE_KEY
@@ -12,6 +17,9 @@ class JWTCookieAuthentication(JWTAuthentication):
 
     def authenticate(self, request: Request) -> tuple[FFAdminUser, Token] | None:
         if raw_token := request.COOKIES.get(JWT_SLIDING_COOKIE_KEY):
-            validated_token = self.get_validated_token(raw_token)  # type: ignore[arg-type]
-            return self.get_user(validated_token), validated_token  # type: ignore[return-value]
+            try:
+                validated_token = self.get_validated_token(raw_token)  # type: ignore[arg-type]
+                return self.get_user(validated_token), validated_token  # type: ignore[return-value]
+            except (InvalidToken, TokenError, AuthenticationFailed):
+                return None
         return None

--- a/api/organisations/urls.py
+++ b/api/organisations/urls.py
@@ -171,7 +171,7 @@ if settings.LICENSING_INSTALLED:  # pragma: no cover
 
 
 if settings.IS_RBAC_INSTALLED:
-    from rbac.views import (  # type: ignore[import-not-found]
+    from rbac.views import (  # type: ignore[import-not-found,unused-ignore]
         GroupRoleViewSet,
         MasterAPIKeyRoleViewSet,
         RoleEnvironmentPermissionsViewSet,

--- a/api/permissions/rbac_wrapper.py
+++ b/api/permissions/rbac_wrapper.py
@@ -9,10 +9,10 @@ from organisations.models import Organisation
 from projects.models import Project
 
 if settings.IS_RBAC_INSTALLED:  # pragma: no cover
-    from rbac.permission_service import (  # type: ignore[import-not-found]
+    from rbac.permission_service import (  # type: ignore[import-not-found,unused-ignore]
         get_role_permission_filter,
     )
-    from rbac.permissions_calculator import (  # type: ignore[import-not-found]
+    from rbac.permissions_calculator import (  # type: ignore[import-not-found,unused-ignore]
         RolePermissionData,
         get_roles_permission_data_for_environment,
         get_roles_permission_data_for_organisation,

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -46,9 +46,9 @@ ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 # Need the * prefix to work with pre-commit which runs from the root of the repo
-"*app/settings/local.py"= ["F403", "F405"]
-"*app/settings/production.py"= ["F403", "F405"]
-"*app/settings/saas.py"= ["F403", "F405"]
+"*app/settings/local.py" = ["F403", "F405"]
+"*app/settings/production.py" = ["F403", "F405"]
+"*app/settings/saas.py" = ["F403", "F405"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -75,6 +75,14 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = ["admin_sso.models"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["rbac.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["saml.*"]
 ignore_missing_imports = true
 
 [tool.django-stubs]

--- a/api/tests/unit/custom_auth/jwt_cookie/test_unit_jwt_cookie_authentication.py
+++ b/api/tests/unit/custom_auth/jwt_cookie/test_unit_jwt_cookie_authentication.py
@@ -1,0 +1,73 @@
+from typing import Type
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rest_framework.request import Request
+from rest_framework_simplejwt.exceptions import (
+    AuthenticationFailed,
+    InvalidToken,
+    TokenError,
+)
+from rest_framework_simplejwt.tokens import Token
+
+from custom_auth.jwt_cookie.authentication import JWTCookieAuthentication
+from custom_auth.jwt_cookie.constants import JWT_SLIDING_COOKIE_KEY
+from users.models import FFAdminUser
+
+
+def test_authenticate_without_cookie() -> None:
+    # Given
+    auth = JWTCookieAuthentication()
+    request = MagicMock(spec=Request)
+    request.COOKIES = {}
+
+    # When
+    result = auth.authenticate(request)
+
+    # Then
+    assert result is None
+
+
+def test_authenticate_valid_cookie() -> None:
+    # Given
+    auth = JWTCookieAuthentication()
+    request = MagicMock(spec=Request)
+    raw_token = "valid_token"
+    request.COOKIES = {JWT_SLIDING_COOKIE_KEY: raw_token}
+
+    validated_token = MagicMock(spec=Token)
+    user = MagicMock(spec=FFAdminUser)
+
+    # Mock the validation and user retrieval
+    with patch.object(
+        auth, "get_validated_token", return_value=validated_token
+    ) as mock_validate:
+        with patch.object(auth, "get_user", return_value=user) as mock_get_user:
+            # When
+            result = auth.authenticate(request)
+
+            # Then
+            assert result == (user, validated_token)
+            mock_validate.assert_called_once_with(raw_token)
+            mock_get_user.assert_called_once_with(validated_token)
+
+
+@pytest.mark.parametrize(
+    "exception_class", [InvalidToken, TokenError, AuthenticationFailed]
+)
+def test_authenticate_invalid_cookie(exception_class: Type[Exception]) -> None:
+    # Given
+    auth = JWTCookieAuthentication()
+    request = MagicMock(spec=Request)
+    raw_token = "invalid_token"
+    request.COOKIES = {JWT_SLIDING_COOKIE_KEY: raw_token}
+
+    # Test that no further exceptions are raised if the token is invalid in any way
+    with patch.object(
+        auth, "get_validated_token", side_effect=exception_class("Error")
+    ):
+        # When
+        result = auth.authenticate(request)
+
+        # Then
+        assert result is None


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith/issues/4982.

The issue as described is incorrect, as the SAML routes already use [`AllowAny`](https://github.com/Flagsmith/flagsmith-saml/blob/cd925492ce8bf76a0bd46d5c36755b8118eb20a4/saml/views.py#L164). The problem is actually caused by `get_validated_token` returning an exception when called with an invalid JWT. We now catch any of these expected errors and gracefully fail the authentication instead.

This is completely untested.