### PR TITLE
chore: Add #5150 to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,6 @@
 # Linting fixes for frontend
 # https://github.com/Flagsmith/flagsmith/pull/5123 
 1f7083636d3b163588fe9a8b45af289bd40b1a8d
+# Migrate to ruff
+# https://github.com/Flagsmith/flagsmith/pull/5150
+f7487ac5278d60e62067e2f4d5976ceb755f4980


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This hides formatting changes introduced in #5150 from `git blame`.

## How did you test this code?

Observed `git blame` results on lines changed in #5150.