### PR TITLE
fix: feature panel url updating url when opening

### DIFF
--- a/frontend/web/components/FeatureRow.tsx
+++ b/frontend/web/components/FeatureRow.tsx
@@ -80,7 +80,10 @@ const FeatureRow: FC<FeatureRowProps> = ({
     const { feature } = Utils.fromParam()
     const { id } = projectFlag
 
-    if (`${id}` === feature) {
+    const isModalOpen = !!document?.getElementsByClassName(
+      'create-feature-modal',
+    )?.length
+    if (`${id}` === feature && !isModalOpen) {
       editFeature(projectFlag, environmentFlags?.[id])
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -145,11 +148,10 @@ const FeatureRow: FC<FeatureRowProps> = ({
     API.trackEvent(Constants.events.VIEW_FEATURE)
     const tabValue = tab || Utils.fromParam().tab || 'value'
 
-    window.history.replaceState(
-      {},
-      '',
-      `${document.location.pathname}?feature=${projectFlag.id}&tab=${tabValue}`,
-    )
+    history.replace({
+      pathname: document.location.pathname,
+      search: `?feature=${projectFlag.id}&tab=${tabValue}`,
+    })
 
     openModal(
       <Row>
@@ -177,7 +179,10 @@ const FeatureRow: FC<FeatureRowProps> = ({
       />,
       'side-modal create-feature-modal',
       () => {
-        window.history.replaceState({}, '', `${document.location.pathname}`)
+        history.replace({
+          pathname: document.location.pathname,
+          search: '',
+        })
       },
     )
   }

--- a/frontend/web/components/FeatureRow.tsx
+++ b/frontend/web/components/FeatureRow.tsx
@@ -145,7 +145,7 @@ const FeatureRow: FC<FeatureRowProps> = ({
     API.trackEvent(Constants.events.VIEW_FEATURE)
     const tabValue = tab || Utils.fromParam().tab || 'value'
 
-    history.replace(
+    window.history.replaceState(
       {},
       '',
       `${document.location.pathname}?feature=${projectFlag.id}&tab=${tabValue}`,
@@ -177,7 +177,7 @@ const FeatureRow: FC<FeatureRowProps> = ({
       />,
       'side-modal create-feature-modal',
       () => {
-        history.replace({}, '', `${document.location.pathname}`)
+        window.history.replaceState({}, '', `${document.location.pathname}`)
       },
     )
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Fixes:
- opening create/edit feature panel was not updating url to match current tab
- [use effect](https://github.com/Flagsmith/flagsmith/blob/3892e364e5faa7eadf8636ab8f0145e549338fee/frontend/web/components/FeatureRow.tsx#L79) was reopening the feature panel modal even when it was already open

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
