### PR TITLE
fix: Handle github star errors

### DIFF
--- a/frontend/web/components/GithubStar.tsx
+++ b/frontend/web/components/GithubStar.tsx
@@ -25,7 +25,9 @@ const GithubStar: FC<GithubStarType> = ({}) => {
       fetch('https://api.github.com/repos/flagsmith/flagsmith')
         .then((res) => res.json())
         .then((res) => {
-          setStars(res.stargazers_count)
+          if (res.stargazers_count) {
+            setStars(res.stargazers_count)
+          }
         })
         .catch(() => {})
     }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Somehow my user is being rate-limited to fetch the amount of stars in our repository which causes a nasty crash, this handles the error - we'll probably need a better approach to getting this data.

## How did you test this code?

Ran the app