### PR TITLE
fix: Integrations list is empty when self-hosting

### DIFF
--- a/frontend/common/services/useProject.ts
+++ b/frontend/common/services/useProject.ts
@@ -10,7 +10,7 @@ export const projectService = service
       getProject: builder.query<Res['project'], Req['getProject']>({
         providesTags: (res) => [{ id: res?.id, type: 'Project' }],
         query: (query: Req['getProject']) => ({
-          url: `projects/${query.id}`,
+          url: `projects/${query.id}/`,
         }),
       }),
       getProjects: builder.query<Res['projects'], Req['getProjects']>({


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The self-hosted api for get project expects a trailing /, this breaks the integration page and project usage tab.


## How did you test this code?

Verified that get projects/:id/ works vs projects/:id