### PR TITLE
deps: Bump task-processor from 1.2.1 to 1.2.2

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2006,8 +2006,8 @@ simplejson = "~3.19.1"
 [package.source]
 type = "git"
 url = "https://github.com/Flagsmith/flagsmith-task-processor"
-reference = "v1.2.1"
-resolved_reference = "21cf8ac5f15e57c415416f03851346b04f695c46"
+reference = "v1.2.2"
+resolved_reference = "c833e2239b40d9aca813e7a2aedfb55751b031c2"
 
 [[package]]
 name = "freezegun"
@@ -5198,4 +5198,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "7eb9cdf46b0be2785338bab0a697d9ae8210237e91fc2a7c69b36843beb9f8d0"
+content-hash = "1e9641df3e4e44aab9ed2537d8130695837c5ef5b0bd57f2d1acdb78efe397a2"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -46,9 +46,9 @@ ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 # Need the * prefix to work with pre-commit which runs from the root of the repo
-"*app/settings/local.py"= ["F403", "F405"]
-"*app/settings/production.py"= ["F403", "F405"]
-"*app/settings/saas.py"= ["F403", "F405"]
+"*app/settings/local.py" = ["F403", "F405"]
+"*app/settings/production.py" = ["F403", "F405"]
+"*app/settings/saas.py" = ["F403", "F405"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -146,7 +146,7 @@ pygithub = "2.1.1"
 hubspot-api-client = "^8.2.1"
 djangorestframework-dataclasses = "^1.3.1"
 pyotp = "^2.9.0"
-flagsmith-task-processor = { git = "https://github.com/Flagsmith/flagsmith-task-processor", tag = "v1.2.1" }
+flagsmith-task-processor = { git = "https://github.com/Flagsmith/flagsmith-task-processor", tag = "v1.2.2" }
 flagsmith-common = { git = "https://github.com/Flagsmith/flagsmith-common", tag = "v1.4.2" }
 tzdata = "^2024.1"
 djangorestframework-simplejwt = "^5.3.1"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Bumps Task processor to 1.2.2 which includes the [reduced update load on the recurring task table](https://github.com/Flagsmith/flagsmith-task-processor/pull/23).
 
## How did you test this code?

CI.