### PR TITLE
fix: Fix Docker Compose healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,5 @@ services:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
       USE_POSTGRES_FOR_ANALYTICS: 'true'
     depends_on:
-      flagsmith:
-        condition: service_healthy
+      - flagsmith
     command: run-task-processor


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith/issues/5197.

Docker Compose `depends_on` with `condition: service_healthy` [only looks at the `healthcheck` defined in Compose](https://docs.docker.com/compose/how-tos/startup-order/#control-startup), and not the `HEALTHCHECK` defined in the Dockerfile.

Several alternatives to fix this:

* Duplicate the current `HEALTHCHECK` into `healthcheck`
* Remove the current `HEALTHCHECK` and only use `healthcheck`
* Ignore health in Docker Compose and only use startup dependencies. I chose this since it avoids duplicating healthcheck logic while still letting us detect container health outside of Compose, and it's closer to how production-ready deployments work (e.g. Kubernetes, which doesn't let you specify service dependencies by design)