### PR TITLE
docs: Mention adding user groups during invite

### DIFF
--- a/docs/docs/system-administration/rbac.md
+++ b/docs/docs/system-administration/rbac.md
@@ -85,7 +85,8 @@ If you are self-hosting Flagsmith, you must
 :::
 
 To send invitation emails to specific users, click on **Invite members**. Then, fill in the email address and built-in
-role of each user you want to invite.
+role of each user you want to invite. You can also add these users to any groups at this time, so that they have the 
+permissions they need as soon as they log in for the first time.
 
 When a user accepts their email invitation, they will be prompted to sign up for a Flagsmith account, or they can choose
 to log in if they already have an account with the same email address.

--- a/frontend/web/components/modals/InviteUsers.tsx
+++ b/frontend/web/components/modals/InviteUsers.tsx
@@ -123,13 +123,13 @@ const InviteUsers: FC = () => {
             >
               <Row>
                 <Flex>
-                  <label>Email Address</label>
+                  <label>Email</label>
                 </Flex>
                 <Flex>
-                  <label className='ml-3'>Select Role</label>
+                  <label className='ml-3'>Built-in role</label>
                 </Flex>
                 <Flex>
-                  <label className='ml-3'>Select Group</label>
+                  <label className='ml-3'>Groups</label>
                 </Flex>
               </Row>
               {invites.map((invite, index) => (
@@ -155,7 +155,7 @@ const InviteUsers: FC = () => {
                       value={invite.emailAddress}
                       isValid={isValid}
                       type='text'
-                      placeholder='E-mail address'
+                      placeholder='Email'
                     />
                   </Flex>
                   <Flex className='mb-2'>


### PR DESCRIPTION
"Email" and not "E-mail" or "Email address" is preferred, at least per https://developers.google.com/style/word-list#email