### PR TITLE
fix(ci): E2E builds Docker images unneccessarily on publish

### DIFF
--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -75,7 +75,9 @@ jobs:
       api-image: ${{ matrix.api-image }}
       concurrency: ${{ matrix.args.concurrency }}
       tests: ${{ matrix.args.tests }}
-    secrets: inherit
+    secrets:
+      GCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

As seen [here](https://github.com/Flagsmith/flagsmith/actions/runs/13785307411), the E2E job starts building a Core API Docker image because it fails to pull the already built private cloud image.

The fix is to pass required tokens explicitly so the job is properly authorised to pull the already built image.

## How did you test this code?

This is a CI change.