### PR TITLE
fix: incorrect URL generated when copying invite link to clipboard

### DIFF
--- a/frontend/web/components/pages/UsersAndPermissionsPage.tsx
+++ b/frontend/web/components/pages/UsersAndPermissionsPage.tsx
@@ -389,7 +389,7 @@ const UsersAndPermissionsInner: FC<UsersAndPermissionsInnerType> = ({
                                             Utils.copyToClipboard(
                                               `${
                                                 document.location.origin
-                                              }/invite/${
+                                              }/invite-link/${
                                                 inviteLinks?.find(
                                                   (f) => f.role === role,
                                                 )?.hash


### PR DESCRIPTION
## Changes

Fixes an issue identified when copying an invite link to the clipboard. 

## How did you test this code?

Ran the FE locally and verified that the URL copied matches the one shown. 
