### PR TITLE
fix: Properly URL-encode "Try It" curl command

### DIFF
--- a/docs/docs/clients/index.md
+++ b/docs/docs/clients/index.md
@@ -362,7 +362,7 @@ are all computed locally.
 
 ```bash
 curl https://edge.api.flagsmith.com/api/v1/environment-document \
-  -H 'x-environment-key: <Your Server-Side Env Key>' \
+  -H 'X-Environment-Key: <Your server-side environment key>' \
   --verbose
 ```
 

--- a/docs/docs/clients/index.md
+++ b/docs/docs/clients/index.md
@@ -369,7 +369,7 @@ curl https://edge.api.flagsmith.com/api/v1/environment-document \
 The `link` response header will contain the url to next page:
 
 ```
-content-type: application/json
+Content-Type: application/json
 ...
 link: </api/v1/environment-document/?page_id=identity_override%3A60074%lastreadid>; rel="next"
 ...

--- a/docs/docs/clients/rest.md
+++ b/docs/docs/clients/rest.md
@@ -71,8 +71,8 @@ For example, to create a new Environment:
 
 ```bash
 curl 'https://api.flagsmith.com/api/v1/environments/' \
-    -H 'content-type: application/json' \
-    -H 'authorization: Api-Key <API TOKEN FROM ORGANISATION PAGE>' \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Api-Key <API TOKEN FROM ORGANISATION PAGE>' \
     --data-binary '{"name":"New Environment","project":"<Project ID>"}'
 ```
 
@@ -286,7 +286,7 @@ curl --request PUT \
   --url https://api.flagsmith.com/api/v1/environments/environments/YOUR_ENVIRONMENT_API_KEY/edge-identities-featurestates \
   --header 'Accept: application/json' \
   --header 'Authorization: Token YOUR_ADMIN_API_KEY' \
-  --header 'content-type: application/json' \
+  --header 'Content-Type: application/json' \
   --data '{"enabled":true,"feature":"custom_background_colour","feature_state_value":"blue", "identifier":"my_user_id"}'
 ```
 

--- a/docs/docs/clients/rest.md
+++ b/docs/docs/clients/rest.md
@@ -88,7 +88,7 @@ These are the two main endpoints that you need to consume the SDK aspect of the 
 ### Get Environment Flags
 
 ```bash
-curl 'https://edge.api.flagsmith.com/api/v1/flags/' -H 'X-Environment-Key: <Your Env Key>'
+curl 'https://edge.api.flagsmith.com/api/v1/flags/' -H 'X-Environment-Key: <Your client-side SDK key>'
 ```
 
 ### Send Identity with Traits and receive Flags
@@ -101,7 +101,7 @@ This command will perform the entire SDK Identity workflow in a single call:
 
 ```bash
 curl --request POST 'https://edge.api.flagsmith.com/api/v1/identities/' \
---header 'X-Environment-Key: <Your Env Key>' \
+--header 'X-Environment-Key: <Your client-side SDK key>' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "identifier":"identifier_5",

--- a/docs/docs/integrations/analytics/amplitude.md
+++ b/docs/docs/integrations/analytics/amplitude.md
@@ -35,7 +35,7 @@ Identity:
 
 ```bash
 curl 'https://edge.api.flagsmith.com/api/v1/identities/?identifier=development_user_123456' \
-  -H 'x-environment-key: 8KzETdDeMY7xkqkSkY3Gsg'
+  -H 'X-Environment-Key: 8KzETdDeMY7xkqkSkY3Gsg'
 ```
 
 And then take a look in our Amplitude dashboard, you can see the user and the flag data that has been sent to the

--- a/docs/docs/integrations/analytics/heap.md
+++ b/docs/docs/integrations/analytics/heap.md
@@ -31,7 +31,7 @@ Identity flag values are passed into Heap. If we make the call to the Flagsmith 
 
 ```bash
 curl 'https://edge.api.flagsmith.com/api/v1/identities/?identifier=development_user_123456' \
-  -H 'x-environment-key: 8KzETdDeMY7xkqkSkY3Gsg'
+  -H 'X-Environment-Key: 8KzETdDeMY7xkqkSkY3Gsg'
 ```
 
 And then take a look in our Heap dashboard, you can see the user and the flag data that has been sent to the Heap

--- a/docs/docs/integrations/analytics/mixpanel.md
+++ b/docs/docs/integrations/analytics/mixpanel.md
@@ -33,7 +33,7 @@ Identity:
 
 ```bash
 curl 'https://edge.api.flagsmith.com/api/v1/identities/?identifier=development_user_123456' \
-  -H 'x-environment-key: 8KzETdDeMY7xkqkSkY3Gsg'
+  -H 'X-Environment-Key: 8KzETdDeMY7xkqkSkY3Gsg'
 ```
 
 And then take a look in our Mixpanel dashboard, you can see the user and the flag data that has been sent to the

--- a/docs/docs/integrations/analytics/rudderstack.md
+++ b/docs/docs/integrations/analytics/rudderstack.md
@@ -35,7 +35,7 @@ Identity:
 
 ```bash
 curl 'https://edge.api.flagsmith.com/api/v1/identities/?identifier=development_user_123456' \
-  -H 'x-environment-key: 8KzETdDeMY7xkqkSkY3Gsg'
+  -H 'X-Environment-Key: 8KzETdDeMY7xkqkSkY3Gsg'
 ```
 
 And then take a look in our RudderStack dashboard, you can see the user and the flag data that has been sent to the

--- a/docs/docs/integrations/analytics/segment.md
+++ b/docs/docs/integrations/analytics/segment.md
@@ -32,7 +32,7 @@ Identity flag values are passed into Segment. If we make the call to the Flagsmi
 
 ```bash
 curl 'https://edge.api.flagsmith.com/api/v1/identities/?identifier=development_user_123456' \
-  -H 'x-environment-key: 8KzETdDeMY7xkqkSkY3Gsg'
+  -H 'X-Environment-Key: 8KzETdDeMY7xkqkSkY3Gsg'
 ```
 
 And then take a look in our Segment dashboard, you can see the user and the flag data that has been sent to the Segment

--- a/frontend/common/code-help/create-user/create-user-curl.js
+++ b/frontend/common/code-help/create-user/create-user-curl.js
@@ -1,9 +1,11 @@
 import Constants from 'common/constants'
 
-module.exports = (envId, { USER_ID }, userId) => `// Identify/create user
+module.exports = (envId, { USER_ID }, userId) => {
+  const url = new URL('identities/', Constants.getFlagsmithSDKUrl())
+  url.searchParams.append('identifier', userId || USER_ID)
 
-curl -i '${Constants.getFlagsmithSDKUrl()}identities/?identifier=${
-  userId || USER_ID
-}' \\
-     -H 'x-environment-key: ${envId}'
-`
+  return `// Identify/create user
+
+curl -i '${url}' \\
+     -H 'X-Environment-Key: ${envId}'`
+}

--- a/frontend/common/code-help/init/init-curl.js
+++ b/frontend/common/code-help/init/init-curl.js
@@ -2,5 +2,5 @@ import Constants from 'common/constants'
 
 module.exports = (envId) => `
 curl -i '${Constants.getFlagsmithSDKUrl()}flags/' \\
-     -H 'x-environment-key: ${envId}'
+     -H 'X-Environment-Key: ${envId}'
 `

--- a/frontend/common/code-help/offline_client/offline-client-curl.js
+++ b/frontend/common/code-help/offline_client/offline-client-curl.js
@@ -2,5 +2,5 @@ import Constants from 'common/constants'
 
 module.exports = (envId) => `
 curl -i '${Constants.getFlagsmithSDKUrl()}flags/' \\
-     -H 'x-environment-key: ${envId}' | tee flagsmith.json
+     -H 'X-Environment-Key: ${envId}' | tee flagsmith.json
 `

--- a/frontend/common/code-help/offline_server/offline-server-curl.js
+++ b/frontend/common/code-help/offline_server/offline-server-curl.js
@@ -2,5 +2,5 @@ import Constants from 'common/constants'
 
 module.exports = (serversideEnvironmentKey) => `
 curl -i '${Constants.getFlagsmithSDKUrl()}environment-document/' \\
-     -H 'x-environment-key: ${serversideEnvironmentKey}' | tee flagsmith.json
+     -H 'X-Environment-Key: ${serversideEnvironmentKey}' | tee flagsmith.json
 `

--- a/frontend/common/code-help/traits/traits-curl.js
+++ b/frontend/common/code-help/traits/traits-curl.js
@@ -5,7 +5,7 @@ module.exports = (
   { TRAIT_NAME, USER_ID },
   userId,
 ) => `curl -i -X POST '${Constants.getFlagsmithSDKUrl()}identities/' \\
-     -H 'x-environment-key: ${envId}' \\
+     -H 'X-Environment-Key: ${envId}' \\
      -H 'Content-Type: application/json; charset=utf-8' \\
      -d $'{
   "traits": [


### PR DESCRIPTION
Tested locally by looking at an environment name with spaces:

![image](https://github.com/user-attachments/assets/1a7447fc-931e-43b7-9311-ef5c1588ee31)

Also makes the casing of `X-Environment-Key` consistent with how we're using other headers such as `Content-Type`.