### PR TITLE
fix: bad API usage URL rendering in email template

### DIFF
--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -78,7 +78,7 @@ def _send_api_usage_notification(
         "matched_threshold": matched_threshold,
         "grace_period": not hasattr(organisation, "breached_grace_period"),
         "url": url,
-        "usage_url": f"{url}/organisations/{organisation.id}/usage",
+        "usage_url": f"{url}/organisation/{organisation.id}/usage",
     }
 
     send_mail(

--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -72,11 +72,13 @@ def _send_api_usage_notification(
         message = "organisations/api_usage_notification_limit.txt"
         html_message = "organisations/api_usage_notification_limit.html"
 
+    url = get_current_site_url()
     context = {
         "organisation": organisation,
         "matched_threshold": matched_threshold,
         "grace_period": not hasattr(organisation, "breached_grace_period"),
-        "url": get_current_site_url(),
+        "url": url,
+        "usage_url": f"{url}/organisations/{organisation.id}/usage",
     }
 
     send_mail(

--- a/api/organisations/templates/organisations/api_usage_notification.html
+++ b/api/organisations/templates/organisations/api_usage_notification.html
@@ -22,9 +22,7 @@
                  support@flagsmith.com in order to upgrade your account.
                  {% endif %}
 
-                 {% with usage_url="{{ url }}/organisation/{{ organisation.id | urlencode }}/usage" %}
                  You can view the details of your organisation's API usage at <a href="{{ usage_url }}">{{ usage_url }}</a>.
-                 {% endwith %}
                </td>
 
 

--- a/api/organisations/templates/organisations/api_usage_notification_limit.txt
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.txt
@@ -12,9 +12,7 @@ grace period{% endif %} until the next subscription period. If you'd like to con
 organisation's account (see pricing page).
 {% endif %}
 
-{% with usage_url="{{ url }}/organisation/{{ organisation.id | urlencode }}/usage" %}
 You can view the details of your organisation's API usage at {{ usage_url }}.
-{% endwith %}
 
 Thank you!
 

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -453,6 +453,7 @@ def test_handle_api_usage_notifications_below_100(
             "organisation": organisation,
             "matched_threshold": 90,
             "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
 
@@ -466,6 +467,7 @@ def test_handle_api_usage_notifications_below_100(
             "organisation": organisation,
             "matched_threshold": 90,
             "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
 
@@ -602,6 +604,7 @@ def test_handle_api_usage_notifications_above_100(
             "organisation": organisation,
             "matched_threshold": 100,
             "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
 
@@ -615,6 +618,7 @@ def test_handle_api_usage_notifications_above_100(
             "organisation": organisation,
             "matched_threshold": 100,
             "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
 
@@ -744,6 +748,7 @@ def test_handle_api_usage_notifications_for_free_accounts(
             "matched_threshold": 100,
             "grace_period": True,
             "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
 
@@ -758,6 +763,7 @@ def test_handle_api_usage_notifications_for_free_accounts(
             "matched_threshold": 100,
             "grace_period": True,
             "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
 


### PR DESCRIPTION
## Changes

Fixes (well, removes) incorrect template syntax for rendering usage URL in API usage limit emails. 

## How did you test this code?

Updated the existing unit tests and also manually verified that the render was correct. We should though, consider changing the test to verify the output, rather than using render_to_string in the test. 

Before: 

<img width="847" alt="image" src="https://github.com/user-attachments/assets/cbece8ed-31ce-4218-90db-42f4d89b8177" />

After:

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/34441817-e679-4993-a591-2b0b9f96446b" />


