### PR TITLE
fix: URL parameter parsing for url parameters that don't contain =

### DIFF
--- a/frontend/common/utils/base/_utils.js
+++ b/frontend/common/utils/base/_utils.js
@@ -400,12 +400,12 @@ emailRegex: /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|
     if (!str && !documentSearch) {
       return {}
     }
-    // eslint-disable-next-line
-        const urlString = (str || documentSearch).replace(/(^\?)/, '');
-    return JSON.parse(
-      `{"${urlString.replace(/&/g, '","').replace(/=/g, '":"')}"}`,
-      (key, value) => (key === '' ? value : decodeURIComponent(value)),
-    )
+    const params = new URLSearchParams(str || documentSearch)
+    const paramsObject = {}
+    for (const [key, value] of params.entries()) {
+      paramsObject[key] = value
+    }
+    return paramsObject
   },
 
   getPaging(currentPage, totalPages, rangeAround) {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes the conversion of url parameters to an object where the following would throw an exception: ?a=1&b&c=3. This replaces the current implementation with built in URLSearchParams since browser support is now acceptable.

## How did you test this code?

Navigated to a features page with the following params 

```
features?is_archived=false&tag_strategy=INTERSECTION&page=1&search&sortBy=name&sortOrder=asc
```
