### PR TITLE
fix: Frontend can crash if query string is invalid

### DIFF
--- a/frontend/common/utils/base/_utils.js
+++ b/frontend/common/utils/base/_utils.js
@@ -393,19 +393,20 @@ const Utils = {
 emailRegex: /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/i,
 
   fromParam(str) {
-    // {min:100,max:200} <- ?min=100&max=200
-    const documentSearch =
-      typeof document === 'undefined' ? '' : document.location.search
+    const searchParams = new URLSearchParams(str || document?.location.search)
+    const result = {}
 
-    if (!str && !documentSearch) {
-      return {}
+    for (const [key, value] of searchParams.entries()) {
+      if (key) {
+        try {
+          result[key] = decodeURIComponent(value)
+        } catch (e) {
+          result[key] = value
+        }
+      }
     }
-    // eslint-disable-next-line
-        const urlString = (str || documentSearch).replace(/(^\?)/, '');
-    return JSON.parse(
-      `{"${urlString.replace(/&/g, '","').replace(/=/g, '":"')}"}`,
-      (key, value) => (key === '' ? value : decodeURIComponent(value)),
-    )
+
+    return result
   },
 
   getPaging(currentPage, totalPages, rangeAround) {


### PR DESCRIPTION
Trying to load a URL with a malformed query string currently crashes the frontend. For example (note the extra `=` at the end):

https://app.flagsmith.com/project/16945/environment/ihAHot7taBsh6hbHJKdYHs/features?is_archived=false&tag_strategy=INTERSECTION&page=1&search=&sortBy=name&sortOrder=asc=

Fails with:

```
Uncaught SyntaxError: JSON.parse: expected ',' or '}' after property value in object at line 1 column 110 of the JSON data
    fromParam 
```

At least one customer ran into this when using the ClearURLs Firefox add-on: https://addons.mozilla.org/en/firefox/addon/clearurls/

It's probably better to use a dedicated hook for accessing the query string instead of parsing it on every `fromParam` call, but this is a stop-gap solution to at least stop the frontend crashing.

Tested by trying to load an equivalent URL locally.