### PR TITLE
fix: Unstyled content could be shown while the frontend loads

### DIFF
--- a/frontend/web/index.handlebars
+++ b/frontend/web/index.handlebars
@@ -100,9 +100,13 @@
             font-weight:600;
             font-display:swap;
         }
+
+        .display-none {
+          display: none !important;
+        }
     </style>
 
-    <title>Flagsmith - Feature Flags, Feature Toggles and Remote Config</title>
+    <title>Flagsmith</title>
     <link rel="shortcut icon" href="/static/images/favicon.ico">
 </head>
 <body>

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="description" content="Manage your Feature Flags, Feature Toggles and Remote Config in your Mobile, React, React Native, Java, Javascript (Node) and Python projects." />
     <meta property="og:image" content="https://flagsmith.com/static/aa08b77a1a9bca99643945f1f3eeb027/b2d24/social-preview.jpg" />
-    <meta property="og:title" content="Flagsmith - Feature Flags, Feature Toggles and Remote Config" />
+    <meta property="og:title" content="Flagsmith" />
     <!--Project.js overrides-->
     <script src="/config/project-overrides"></script>
     <style>
@@ -100,9 +100,13 @@
             font-weight:600;
             font-display:swap;
         }
+
+        .display-none {
+          display: none !important;
+        }
     </style>
 
-    <title>Flagsmith - Feature Flags, Feature Toggles and Remote Config</title>
+    <title>Flagsmith</title>
     <link rel="shortcut icon" href="/static/images/favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
Fixes this being shown on loading/crashing:

![image](https://github.com/user-attachments/assets/ca8572ca-77df-4203-bf20-c85bfb3c7389)

And also addresses part of https://github.com/Flagsmith/flagsmith/issues/5249