### PR TITLE
chore: update docker proxy URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       start_period: 20s
 
   flagsmith:
-    image: flagsmith.docker.scarf.sh/flagsmith/flagsmith:latest
+    image: docker.flagsmith.com/flagsmith/flagsmith:latest
     environment:
       # All environments variables are available here:
       # API: https://docs.flagsmith.com/deployment/locally-api#environment-variables
@@ -64,7 +64,7 @@ services:
   # The flagsmith_processor service is only needed if TASK_RUN_METHOD set to TASK_PROCESSOR
   # in the application environment
   flagsmith_processor:
-    image: flagsmith.docker.scarf.sh/flagsmith/flagsmith:latest
+    image: docker.flagsmith.com/flagsmith/flagsmith:latest
     environment:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/flagsmith
       USE_POSTGRES_FOR_ANALYTICS: 'true'


### PR DESCRIPTION
## Changes

Update the docker proxy URL to a flagsmith.com domain. This is necessary in our move from scarf -> reo.dev. 

## How did you test this code?

Verified that the following commands worked

```bash
# Pull a public image
docker pull docker.flagsmith.com/flagsmith/flagsmith

# Login via dockerhub credentials
docker login docker.flagsmith.com

# Pull a private image
docker pull docker.flagsmith.com/flagsmith/flagsmith-private-cloud
```
