### PR TITLE
Fix/remove type ignore commands in api/conftest file

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -17,17 +17,17 @@ from django.core.cache import caches
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
 from django.test.utils import setup_databases
 from flag_engine.segments.constants import EQUAL
-from moto import mock_dynamodb  # type: ignore[import-untyped]
+from moto import mock_dynamodb
 from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 from pytest_django.fixtures import SettingsWrapper
 from pytest_django.plugin import blocking_manager_key
 from pytest_mock import MockerFixture
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
-from task_processor.task_run_method import TaskRunMethod  # type: ignore[import-untyped]
+from task_processor.task_run_method import TaskRunMethod
 from urllib3 import BaseHTTPResponse
 from urllib3.connectionpool import HTTPConnectionPool
-from xdist import get_xdist_worker_id  # type: ignore[import-untyped]
+from xdist import get_xdist_worker_id
 
 from api_keys.models import MasterAPIKey
 from api_keys.user import APIKeyUser
@@ -96,12 +96,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
-    fix_issue_3869()  # type: ignore[no-untyped-call]
+    fix_issue_3869()
 
 
 @pytest.fixture()
 def post_request_mock(mocker: MockerFixture) -> MagicMock:
-    def mocked_request(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def mocked_request(*args, **kwargs) -> None:
         class MockResponse:
             def __init__(self, json_data: str, status_code: int) -> None:
                 self.json_data = json_data
@@ -113,12 +113,12 @@ def post_request_mock(mocker: MockerFixture) -> MagicMock:
             def json(self) -> str:
                 return self.json_data
 
-        return MockResponse(json_data={"data": "data"}, status_code=200)  # type: ignore[arg-type,return-value]
+        return MockResponse(json_data={"data": "data"}, status_code=200)
 
     return mocker.patch("requests.post", side_effect=mocked_request)
 
 
-@pytest.hookimpl(trylast=True)  # type: ignore[misc]
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config: pytest.Config) -> None:
     if (
         config.option.ci
@@ -145,7 +145,7 @@ def django_db_setup(request: pytest.FixtureRequest) -> None:
         test_db_suffix = str(int(xdist_worker_id_suffix) + 1)
     else:
         # Tests are run on main node, which assumes -n0
-        return request.getfixturevalue("django_db_setup")  # type: ignore[no-any-return] # pragma: no cover
+        return request.getfixturevalue("django_db_setup")  # pragma: no cover
 
     from django.conf import settings
 
@@ -166,7 +166,7 @@ def restrict_http_requests(monkeypatch: pytest.MonkeyPatch) -> None:
     allowed_hosts = {"localhost"}
     original_urlopen = HTTPConnectionPool.urlopen
 
-    def urlopen_mock(  # type: ignore[no-untyped-def]
+    def urlopen_mock(
         self,
         method: str,
         url: str,
@@ -191,24 +191,24 @@ trait_value = "value1"
 
 
 @pytest.fixture()
-def test_user(django_user_model):  # type: ignore[no-untyped-def]
+def test_user(django_user_model):
     return django_user_model.objects.create(email="user@example.com")
 
 
 @pytest.fixture()
-def auth_token(test_user):  # type: ignore[no-untyped-def]
+def auth_token(test_user):
     return Token.objects.create(user=test_user)
 
 
 @pytest.fixture()
-def admin_client_original(admin_user):  # type: ignore[no-untyped-def]
+def admin_client_original(admin_user):
     client = APIClient()
     client.force_authenticate(user=admin_user)
     return client
 
 
 @pytest.fixture()
-def admin_client(admin_client_original):  # type: ignore[no-untyped-def]
+def admin_client(admin_client_original):
     """
     This fixture will eventually be switched over to what is now
     called admin_client_new which will run an admin client as well
@@ -228,13 +228,13 @@ def admin_client(admin_client_original):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
-def test_user_client(api_client, test_user):  # type: ignore[no-untyped-def]
+def test_user_client(api_client, test_user):
     api_client.force_authenticate(test_user)
     return api_client
 
 
 @pytest.fixture()
-def staff_user(django_user_model):  # type: ignore[no-untyped-def]
+def staff_user(django_user_model):
     """
     A non-admin user fixture.
 
@@ -248,14 +248,14 @@ def staff_user(django_user_model):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
-def staff_client(staff_user):  # type: ignore[no-untyped-def]
+def staff_client(staff_user):
     client = APIClient()
     client.force_authenticate(user=staff_user)
     return client
 
 
 @pytest.fixture()
-def organisation(db, admin_user, staff_user):  # type: ignore[no-untyped-def]
+def organisation(db, admin_user, staff_user):
     org = Organisation.objects.create(name="Test Org")
     admin_user.add_organisation(org, role=OrganisationRole.ADMIN)
     staff_user.add_organisation(org, role=OrganisationRole.USER)
@@ -263,14 +263,14 @@ def organisation(db, admin_user, staff_user):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
-def default_user_permission_group(organisation):  # type: ignore[no-untyped-def]
+def default_user_permission_group(organisation):
     return UserPermissionGroup.objects.create(
         organisation=organisation, name="Default user permission group", is_default=True
     )
 
 
 @pytest.fixture()
-def user_permission_group(organisation, admin_user):  # type: ignore[no-untyped-def]
+def user_permission_group(organisation, admin_user):
     user_permission_group = UserPermissionGroup.objects.create(
         organisation=organisation, name="User permission group", is_default=False
     )
@@ -279,7 +279,7 @@ def user_permission_group(organisation, admin_user):  # type: ignore[no-untyped-
 
 
 @pytest.fixture()
-def subscription(organisation):  # type: ignore[no-untyped-def]
+def subscription(organisation):
     subscription = Subscription.objects.get(organisation=organisation)
     # refresh organisation to load subscription
     organisation.refresh_from_db()
@@ -287,7 +287,7 @@ def subscription(organisation):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
-def xero_subscription(organisation):  # type: ignore[no-untyped-def]
+def xero_subscription(organisation):
     subscription = Subscription.objects.get(organisation=organisation)
     subscription.payment_method = XERO
     subscription.subscription_id = "subscription-id"
@@ -308,17 +308,17 @@ def chargebee_subscription(organisation: Organisation) -> Subscription:
 
     # refresh organisation to load subscription
     organisation.refresh_from_db()
-    return subscription  # type: ignore[no-any-return]
+    return subscription
 
 
 @pytest.fixture()
-def tag(project):  # type: ignore[no-untyped-def]
+def tag(project):
     return Tag.objects.create(label="tag", project=project, color="#000000")
 
 
 @pytest.fixture()
 def system_tag(project: Project) -> Tag:
-    return Tag.objects.create(  # type: ignore[no-any-return]
+    return Tag.objects.create(
         label="system-tag", project=project, color="#FFFFFF", is_system_tag=True
     )
 
@@ -360,12 +360,12 @@ def free_subscription(organisation: Organisation) -> Subscription:
 
 
 @pytest.fixture()
-def project(organisation):  # type: ignore[no-untyped-def]
+def project(organisation):
     return Project.objects.create(name="Test Project", organisation=organisation)
 
 
 @pytest.fixture()
-def segment(project: Project):  # type: ignore[no-untyped-def]
+def segment(project: Project):
     _segment = Segment.objects.create(name="segment", project=project)
     # Deep clone the segment to ensure that any bugs around
     # versioning get bubbled up through the test suite.
@@ -376,23 +376,23 @@ def segment(project: Project):  # type: ignore[no-untyped-def]
 
 @pytest.fixture()
 def another_segment(project: Project) -> Segment:
-    return Segment.objects.create(name="another_segment", project=project)  # type: ignore[no-any-return]
+    return Segment.objects.create(name="another_segment", project=project)
 
 
 @pytest.fixture()
-def segment_rule(segment):  # type: ignore[no-untyped-def]
+def segment_rule(segment):
     return SegmentRule.objects.create(segment=segment, type=SegmentRule.ALL_RULE)
 
 
 @pytest.fixture()
 def feature_specific_segment(feature: Feature) -> Segment:
-    return Segment.objects.create(  # type: ignore[no-any-return]
+    return Segment.objects.create(
         feature=feature, name="feature specific segment", project=feature.project
     )
 
 
 @pytest.fixture()
-def environment(project):  # type: ignore[no-untyped-def]
+def environment(project):
     return Environment.objects.create(name="Test Environment", project=project)
 
 
@@ -415,7 +415,7 @@ def with_environment_permissions(
             environment_id=environment_id, user=staff_user, defaults={"admin": admin}
         )
         if permission_keys:
-            uep.permissions.add(*permission_keys)  # type: ignore[arg-type]
+            uep.permissions.add(*permission_keys)
 
         return uep
 
@@ -438,7 +438,7 @@ def with_organisation_permissions(
         uop, __ = UserOrganisationPermission.objects.get_or_create(
             organisation_id=organisation_id, user=staff_user
         )
-        uop.permissions.add(*permission_keys)  # type: ignore[arg-type]
+        uop.permissions.add(*permission_keys)
 
         return uop
 
@@ -465,7 +465,7 @@ def with_project_permissions(
         )
 
         if permission_keys:
-            upp.permissions.add(*permission_keys)  # type: ignore[arg-type]
+            upp.permissions.add(*permission_keys)
 
         return upp
 
@@ -485,21 +485,21 @@ def identity(environment: Environment) -> Identity:
 
 
 @pytest.fixture()
-def identity_featurestate(identity, feature):  # type: ignore[no-untyped-def]
+def identity_featurestate(identity, feature):
     return FeatureState.objects.create(
         identity=identity, feature=feature, environment=identity.environment
     )
 
 
 @pytest.fixture()
-def trait(identity):  # type: ignore[no-untyped-def]
+def trait(identity):
     return Trait.objects.create(
         identity=identity, trait_key=trait_key, string_value=trait_value
     )
 
 
 @pytest.fixture()
-def multivariate_feature(project):  # type: ignore[no-untyped-def]
+def multivariate_feature(project):
     feature = Feature.objects.create(
         name="feature", project=project, type=MULTIVARIATE, initial_value="control"
     )
@@ -524,7 +524,7 @@ def multivariate_options(
 
 
 @pytest.fixture()
-def identity_matching_segment(project, trait):  # type: ignore[no-untyped-def]
+def identity_matching_segment(project, trait):
     segment = Segment.objects.create(name="Matching segment", project=project)
     matching_rule = SegmentRule.objects.create(
         segment=segment, type=SegmentRule.ALL_RULE
@@ -539,32 +539,32 @@ def identity_matching_segment(project, trait):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
-def api_client():  # type: ignore[no-untyped-def]
+def api_client():
     return APIClient()
 
 
 @pytest.fixture()
 def feature(project: Project, environment: Environment) -> Feature:
-    return Feature.objects.create(name="Test Feature1", project=project)  # type: ignore[no-any-return]
+    return Feature.objects.create(name="Test Feature1", project=project)
 
 
 @pytest.fixture()
 def change_request(environment: Environment, admin_user: FFAdminUser) -> ChangeRequest:
-    return ChangeRequest.objects.create(  # type: ignore[no-any-return]
+    return ChangeRequest.objects.create(
         environment=environment, title="Test CR", user_id=admin_user.id
     )
 
 
 @pytest.fixture()
 def project_change_request(project: Project, admin_user: FFAdminUser) -> ChangeRequest:
-    return ChangeRequest.objects.create(  # type: ignore[no-any-return]
+    return ChangeRequest.objects.create(
         project=project, title="Test Project CR", user_id=admin_user.id
     )
 
 
 @pytest.fixture()
 def feature_state(feature: Feature, environment: Environment) -> FeatureState:
-    return FeatureState.objects.get(environment=environment, feature=feature)  # type: ignore[no-any-return]
+    return FeatureState.objects.get(environment=environment, feature=feature)
 
 
 @pytest.fixture()
@@ -575,14 +575,14 @@ def feature_state_with_value(environment: Environment) -> FeatureState:
         default_enabled=True,
         project=environment.project,
     )
-    return FeatureState.objects.get(  # type: ignore[no-any-return]
+    return FeatureState.objects.get(
         environment=environment, feature=feature, feature_segment=None, identity=None
     )
 
 
 @pytest.fixture()
 def feature_with_value(project: Project, environment: Environment) -> Feature:
-    return Feature.objects.create(  # type: ignore[no-any-return]
+    return Feature.objects.create(
         name="feature_with_value",
         initial_value="value",
         default_enabled=False,
@@ -591,24 +591,24 @@ def feature_with_value(project: Project, environment: Environment) -> Feature:
 
 
 @pytest.fixture()
-def change_request_feature_state(feature, environment, change_request, feature_state):  # type: ignore[no-untyped-def]
+def change_request_feature_state(feature, environment, change_request, feature_state):
     feature_state.change_request = change_request
     feature_state.save()
     return feature_state
 
 
 @pytest.fixture()
-def feature_based_segment(project, feature):  # type: ignore[no-untyped-def]
+def feature_based_segment(project, feature):
     return Segment.objects.create(name="segment", project=project, feature=feature)
 
 
 @pytest.fixture()
-def user_password():  # type: ignore[no-untyped-def]
+def user_password():
     return FFAdminUser.objects.make_random_password()
 
 
 @pytest.fixture()
-def reset_cache():  # type: ignore[no-untyped-def]
+def reset_cache():
     # https://groups.google.com/g/django-developers/c/zlaPsP13dUY
     # TL;DR: Use this if your test interacts with cache since django
     # does not clear cache after every test
@@ -624,14 +624,14 @@ def reset_cache():  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
-def feature_segment(feature, segment, environment):  # type: ignore[no-untyped-def]
+def feature_segment(feature, segment, environment):
     return FeatureSegment.objects.create(
         feature=feature, segment=segment, environment=environment
     )
 
 
 @pytest.fixture()
-def segment_featurestate(feature_segment, feature, environment):  # type: ignore[no-untyped-def]
+def segment_featurestate(feature_segment, feature, environment):
     return FeatureState.objects.create(
         feature_segment=feature_segment, feature=feature, environment=environment
     )
@@ -641,7 +641,7 @@ def segment_featurestate(feature_segment, feature, environment):  # type: ignore
 def another_segment_featurestate(
     feature: Feature, environment: Environment, another_segment: Segment
 ) -> FeatureState:
-    return FeatureState.objects.create(  # type: ignore[no-any-return]
+    return FeatureState.objects.create(
         feature_segment=FeatureSegment.objects.create(
             feature=feature, segment=another_segment, environment=environment
         ),
@@ -654,7 +654,7 @@ def another_segment_featurestate(
 def feature_with_value_segment(
     feature_with_value: Feature, segment: Segment, environment: Environment
 ) -> FeatureSegment:
-    return FeatureSegment.objects.create(  # type: ignore[no-any-return]
+    return FeatureSegment.objects.create(
         feature=feature_with_value, segment=segment, environment=environment
     )
 
@@ -665,7 +665,7 @@ def segment_override_for_feature_with_value(
     feature_with_value: Feature,
     environment: Environment,
 ) -> FeatureState:
-    return FeatureState.objects.create(  # type: ignore[no-any-return]
+    return FeatureState.objects.create(
         feature_segment=feature_with_value_segment,
         feature=feature_with_value,
         environment=environment,
@@ -674,7 +674,7 @@ def segment_override_for_feature_with_value(
 
 
 @pytest.fixture()
-def environment_api_key(environment):  # type: ignore[no-untyped-def]
+def environment_api_key(environment):
     return EnvironmentAPIKey.objects.create(
         environment=environment, name="Test API Key"
     )
@@ -690,7 +690,7 @@ def admin_master_api_key(organisation: Organisation) -> typing.Tuple[MasterAPIKe
     master_api_key, key = MasterAPIKey.objects.create_key(
         name="test_key", organisation=organisation, is_admin=True
     )
-    return master_api_key, key  # type: ignore[return-value]
+    return master_api_key, key
 
 
 @pytest.fixture()
@@ -700,7 +700,7 @@ def master_api_key(
     master_api_key, key = MasterAPIKey.objects.create_key(
         name=master_api_key_name, organisation=organisation, is_admin=False
     )
-    return master_api_key, key  # type: ignore[return-value]
+    return master_api_key, key
 
 
 @pytest.fixture()
@@ -722,7 +722,7 @@ def master_api_key_id(master_api_key_object: MasterAPIKey) -> str:
 
 @pytest.fixture
 def admin_user_id(admin_user: FFAdminUser) -> str:
-    return admin_user.id  # type: ignore[return-value]
+    return admin_user.id
 
 
 @pytest.fixture
@@ -750,27 +750,27 @@ def admin_master_api_key_client(
 
 
 @pytest.fixture()
-def view_environment_permission(db):  # type: ignore[no-untyped-def]
+def view_environment_permission(db):
     return PermissionModel.objects.get(key=VIEW_ENVIRONMENT)
 
 
 @pytest.fixture()
-def manage_identities_permission(db):  # type: ignore[no-untyped-def]
+def manage_identities_permission(db):
     return PermissionModel.objects.get(key=MANAGE_IDENTITIES)
 
 
 @pytest.fixture()
-def view_identities_permission(db):  # type: ignore[no-untyped-def]
+def view_identities_permission(db):
     return PermissionModel.objects.get(key=VIEW_IDENTITIES)
 
 
 @pytest.fixture()
-def view_project_permission(db):  # type: ignore[no-untyped-def]
+def view_project_permission(db):
     return PermissionModel.objects.get(key=VIEW_PROJECT)
 
 
 @pytest.fixture()
-def create_project_permission(db):  # type: ignore[no-untyped-def]
+def create_project_permission(db):
     return PermissionModel.objects.get(key=CREATE_PROJECT)
 
 
@@ -780,44 +780,44 @@ def manage_segment_overrides_permission(db: None) -> PermissionModel:
 
 
 @pytest.fixture()
-def user_environment_permission(test_user, environment):  # type: ignore[no-untyped-def]
+def user_environment_permission(test_user, environment):
     return UserEnvironmentPermission.objects.create(
         user=test_user, environment=environment
     )
 
 
 @pytest.fixture()
-def user_environment_permission_group(test_user, user_permission_group, environment):  # type: ignore[no-untyped-def]
+def user_environment_permission_group(test_user, user_permission_group, environment):
     return UserPermissionGroupEnvironmentPermission.objects.create(
         group=user_permission_group, environment=environment
     )
 
 
 @pytest.fixture()
-def user_project_permission(test_user, project):  # type: ignore[no-untyped-def]
+def user_project_permission(test_user, project):
     return UserProjectPermission.objects.create(user=test_user, project=project)
 
 
 @pytest.fixture()
-def user_project_permission_group(project, user_permission_group):  # type: ignore[no-untyped-def]
+def user_project_permission_group(project, user_permission_group):
     return UserPermissionGroupProjectPermission.objects.create(
         group=user_permission_group, project=project
     )
 
 
 @pytest.fixture(autouse=True)
-def task_processor_synchronously(settings):  # type: ignore[no-untyped-def]
+def task_processor_synchronously(settings):
     settings.TASK_RUN_METHOD = TaskRunMethod.SYNCHRONOUSLY
 
 
 @pytest.fixture()
 def a_metadata_field(organisation: Organisation) -> MetadataField:
-    return MetadataField.objects.create(name="a", type="int", organisation=organisation)  # type: ignore[no-any-return]  # noqa: E501
+    return MetadataField.objects.create(name="a", type="int", organisation=organisation)
 
 
 @pytest.fixture()
 def b_metadata_field(organisation: Organisation) -> MetadataField:
-    return MetadataField.objects.create(name="b", type="str", organisation=organisation)  # type: ignore[no-any-return]  # noqa: E501
+    return MetadataField.objects.create(name="b", type="str", organisation=organisation)
 
 
 @pytest.fixture()
@@ -837,7 +837,7 @@ def required_a_environment_metadata_field(
     MetadataModelFieldRequirement.objects.create(
         content_type=project_content_type, object_id=project.id, model_field=model_field
     )
-    return model_field  # type: ignore[no-any-return]
+    return model_field
 
 
 @pytest.fixture()
@@ -857,7 +857,7 @@ def required_a_feature_metadata_field(
         content_type=project_content_type, object_id=project.id, model_field=model_field
     )
 
-    return model_field  # type: ignore[no-any-return]
+    return model_field
 
 
 @pytest.fixture()
@@ -879,7 +879,7 @@ def required_a_feature_metadata_field_using_organisation_content_type(
         model_field=model_field,
     )
 
-    return model_field  # type: ignore[no-any-return]
+    return model_field
 
 
 @pytest.fixture()
@@ -899,7 +899,7 @@ def required_a_segment_metadata_field(
         content_type=project_content_type, object_id=project.id, model_field=model_field
     )
 
-    return model_field  # type: ignore[no-any-return]
+    return model_field
 
 
 @pytest.fixture()
@@ -921,7 +921,7 @@ def required_a_segment_metadata_field_using_organisation_content_type(
         model_field=model_field,
     )
 
-    return model_field  # type: ignore[no-any-return]
+    return model_field
 
 
 @pytest.fixture()
@@ -930,7 +930,7 @@ def optional_b_feature_metadata_field(
 ) -> MetadataModelField:
     feature_type = ContentType.objects.get_for_model(feature)
 
-    return MetadataModelField.objects.create(  # type: ignore[no-any-return]
+    return MetadataModelField.objects.create(
         field=b_metadata_field,
         content_type=feature_type,
     )
@@ -942,7 +942,7 @@ def optional_b_segment_metadata_field(
 ) -> MetadataModelField:
     segment_type = ContentType.objects.get_for_model(segment)
 
-    return MetadataModelField.objects.create(  # type: ignore[no-any-return]
+    return MetadataModelField.objects.create(
         field=b_metadata_field,
         content_type=segment_type,
     )
@@ -956,7 +956,7 @@ def optional_b_environment_metadata_field(
 ) -> MetadataModelField:
     environment_type = ContentType.objects.get_for_model(environment)
 
-    return MetadataModelField.objects.create(  # type: ignore[no-any-return]
+    return MetadataModelField.objects.create(
         field=b_metadata_field,
         content_type=environment_type,
     )
@@ -968,7 +968,7 @@ def environment_metadata_a(
     required_a_environment_metadata_field: MetadataModelField,
 ) -> Metadata:
     environment_type = ContentType.objects.get_for_model(environment)
-    return Metadata.objects.create(  # type: ignore[no-any-return]
+    return Metadata.objects.create(
         object_id=environment.id,
         content_type=environment_type,
         model_field=required_a_environment_metadata_field,
@@ -982,7 +982,7 @@ def environment_metadata_b(
     optional_b_environment_metadata_field: MetadataModelField,
 ) -> Metadata:
     environment_type = ContentType.objects.get_for_model(environment)
-    return Metadata.objects.create(  # type: ignore[no-any-return]
+    return Metadata.objects.create(
         object_id=environment.id,
         content_type=environment_type,
         model_field=optional_b_environment_metadata_field,
@@ -1016,12 +1016,12 @@ def organisation_content_type() -> ContentType:
 
 
 @pytest.fixture
-def manage_user_group_permission(db):  # type: ignore[no-untyped-def]
+def manage_user_group_permission(db):
     return OrganisationPermissionModel.objects.get(key=MANAGE_USER_GROUPS)
 
 
 @pytest.fixture()
-def aws_credentials():  # type: ignore[no-untyped-def]
+def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
@@ -1031,7 +1031,7 @@ def aws_credentials():  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
-def dynamodb(aws_credentials):  # type: ignore[no-untyped-def]
+def dynamodb(aws_credentials):
     # TODO: move all wrapper tests to using moto
     with mock_dynamodb():
         yield boto3.resource("dynamodb")
@@ -1165,7 +1165,7 @@ def feature_with_value_external_resource(
 
 @pytest.fixture()
 def github_configuration(organisation: Organisation) -> GithubConfiguration:
-    return GithubConfiguration.objects.create(  # type: ignore[no-any-return]
+    return GithubConfiguration.objects.create(
         organisation=organisation, installation_id=1234567
     )
 
@@ -1175,7 +1175,7 @@ def github_repository(
     github_configuration: GithubConfiguration,
     project: Project,
 ) -> GitHubRepository:
-    return GitHubRepository.objects.create(  # type: ignore[no-any-return]
+    return GitHubRepository.objects.create(
         github_configuration=github_configuration,
         repository_owner="repositoryownertest",
         repository_name="repositorynametest",
@@ -1184,11 +1184,11 @@ def github_repository(
     )
 
 
-@pytest.fixture(params=AdminClientAuthType.__args__)  # type: ignore[attr-defined]
+@pytest.fixture(params=AdminClientAuthType.__args__)
 def admin_client_auth_type(
     request: pytest.FixtureRequest,
 ) -> AdminClientAuthType:
-    return request.param  # type: ignore[no-any-return]
+    return request.param
 
 
 @pytest.fixture
@@ -1203,15 +1203,15 @@ def admin_client_new(
 
 
 @pytest.fixture()
-def superuser():  # type: ignore[no-untyped-def]
-    return FFAdminUser.objects.create_superuser(  # type: ignore[no-untyped-call]
+def superuser():
+    return FFAdminUser.objects.create_superuser(
         email="superuser@example.com",
         password=FFAdminUser.objects.make_random_password(),
     )
 
 
 @pytest.fixture()
-def superuser_client(superuser: FFAdminUser, client: APIClient):  # type: ignore[no-untyped-def]
+def superuser_client(superuser: FFAdminUser, client: APIClient):
     client.force_login(superuser, backend="django.contrib.auth.backends.ModelBackend")
     return client
 
@@ -1223,11 +1223,11 @@ def inspecting_handler() -> logging.Handler:
     """
 
     class InspectingHandler(logging.Handler):
-        def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
-            self.messages = []  # type: ignore[var-annotated]
+            self.messages = []
 
-        def handle(self, record: logging.LogRecord) -> None:  # type: ignore[override]
+        def handle(self, record: logging.LogRecord) -> None:
             self.messages.append(self.format(record))
 
     return InspectingHandler()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
This adds a bunch of type stubs for dependencies and removes corresponding type: ignore comments for their imports

## How did you test this code?
Verified the typecheck passes.
