### PR TITLE
fix(billing): Organisation overage compared to other organisations' overages when trying to charge for overages

### DIFF
--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -401,7 +401,8 @@ def get_top_organisations(
 
 
 def get_current_api_usage(
-    organisation_id: int, date_start: datetime | None = None
+    organisation_id: int,
+    date_start: datetime,
 ) -> int:
     """
     Query influx db for api usage
@@ -411,10 +412,6 @@ def get_current_api_usage(
 
     :return: number of current api calls
     """
-    now = timezone.now()
-    if date_start is None:
-        date_start = now - timedelta(days=30)
-
     bucket = read_bucket
     results = InfluxDBWrapper.influx_query_manager(
         date_start=date_start,

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -211,7 +211,10 @@ def charge_for_api_call_count_overages():  # type: ignore[no-untyped-def]
             continue
 
         subscription_cache = organisation.subscription_information_cache
-        api_usage = get_current_api_usage(organisation.id)
+        api_usage = get_current_api_usage(
+            organisation_id=organisation.id,
+            date_start=subscription_cache.current_billing_term_starts_at,
+        )
 
         # Grace period for organisations < 200% of usage.
         if (
@@ -343,7 +346,10 @@ def restrict_use_due_to_api_limit_grace_period_over() -> None:
         OrganisationBreachedGracePeriod.objects.get_or_create(organisation=organisation)
 
         subscription_cache = organisation.subscription_information_cache
-        api_usage = get_current_api_usage(organisation.id)
+        api_usage = get_current_api_usage(
+            organisation_id=organisation.id,
+            date_start=now - timedelta(days=30),
+        )
         if api_usage / subscription_cache.allowed_30d_api_calls < 1.0:
             logger.info(
                 f"API use for organisation {organisation.id} has fallen to below limit, so not restricting use."

--- a/api/organisations/tasks.py
+++ b/api/organisations/tasks.py
@@ -228,7 +228,8 @@ def charge_for_api_call_count_overages():  # type: ignore[no-untyped-def]
             continue
 
         api_billings = OrganisationAPIBilling.objects.filter(
-            billed_at__gte=subscription_cache.current_billing_term_starts_at
+            organisation=organisation,
+            billed_at__gte=subscription_cache.current_billing_term_starts_at,
         )
         previous_api_overage = sum([ap.api_overage for ap in api_billings])
 

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
@@ -545,7 +545,10 @@ def test_get_current_api_usage(mocker: MockerFixture) -> None:
     influx_mock.return_value = [result]
 
     # When
-    result = get_current_api_usage(organisation_id=1)  # type: ignore[assignment]
+    result = get_current_api_usage(
+        organisation_id=1,
+        date_start=timezone.now() - timedelta(days=30),
+    )  # type: ignore[assignment]
 
     # Then
     assert result == 43

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -1232,13 +1232,14 @@ def test_charge_for_api_call_count_overages_start_up(
 ) -> None:
     # Given
     now = timezone.now()
+    current_billing_term_starts_at = now - timedelta(days=30)
     OrganisationSubscriptionInformationCache.objects.create(
         organisation=organisation,
         allowed_seats=10,
         allowed_projects=3,
         allowed_30d_api_calls=100_000,
         chargebee_email="test@example.com",
-        current_billing_term_starts_at=now - timedelta(days=30),
+        current_billing_term_starts_at=current_billing_term_starts_at,
         current_billing_term_ends_at=now + timedelta(minutes=30),
     )
     organisation.subscription.subscription_id = "fancy_sub_id23"
@@ -1265,6 +1266,15 @@ def test_charge_for_api_call_count_overages_start_up(
     mock_api_usage.return_value = 202_005
     assert OrganisationAPIBilling.objects.count() == 0
 
+    # address a bug where we didn't filter for the current organisation
+    # when selecting related billing records
+    unrelated_organisation = Organisation.objects.create(name="Unrelated Organisation")
+    OrganisationAPIBilling.objects.create(
+        organisation=unrelated_organisation,
+        api_overage=123_000_000,
+        billed_at=current_billing_term_starts_at + timedelta(minutes=60),
+    )
+
     # When
     charge_for_api_call_count_overages()  # type: ignore[no-untyped-call]
 
@@ -1283,19 +1293,22 @@ def test_charge_for_api_call_count_overages_start_up(
         },
     )
 
-    assert OrganisationAPIBilling.objects.count() == 1
-    api_billing = OrganisationAPIBilling.objects.first()
-    assert api_billing.organisation == organisation  # type: ignore[union-attr]
-    assert api_billing.api_overage == 200_000  # type: ignore[union-attr]
-    assert api_billing.immediate_invoice is False  # type: ignore[union-attr]
-    assert api_billing.billed_at == now  # type: ignore[union-attr]
+    assert OrganisationAPIBilling.objects.count() == 2
+    api_billing = OrganisationAPIBilling.objects.filter(
+        organisation=organisation
+    ).first()
+    assert api_billing
+    assert api_billing.organisation == organisation
+    assert api_billing.api_overage == 200_000
+    assert api_billing.immediate_invoice is False
+    assert api_billing.billed_at == now
 
     # Now attempt to rebill the account should fail
     calls_mock = mocker.patch(
         "organisations.tasks.add_100k_api_calls_start_up",
     )
     charge_for_api_call_count_overages()  # type: ignore[no-untyped-call]
-    assert OrganisationAPIBilling.objects.count() == 1
+    assert OrganisationAPIBilling.objects.filter(organisation=organisation).count() == 1
     calls_mock.assert_not_called()
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Contributes to #5070.

Fixes an issue where we were comparing one org overage against all of the org overages when trying to determine whether we should bill for overage.

Additionally, `get_current_api_usage` utility function usage is clarified:
- Take current billing term starting date into account when getting API usage for overages
- Remove default `start_date` argument value for `get_current_api_usage` to discourange misuse

## How did you test this code?

Updated one of the unit tests with reproducing code.