### PR TITLE
chore: Optimise segment override calls

### DIFF
--- a/frontend/common/providers/withSegmentOverrides.js
+++ b/frontend/common/providers/withSegmentOverrides.js
@@ -72,12 +72,17 @@ export default (WrappedComponent) => {
             }
           })
           const resResults = res.results || []
-          const segmentOverrides = results.concat(
-            (this.props.newSegmentOverrides || []).map((v, i) => ({
+          const segmentOverrides = results
+            .concat(
+              (this.props.newSegmentOverrides || []).map((v, i) => ({
+                ...v,
+              })),
+            )
+            .map((v, i) => ({
               ...v,
-              priority: resResults.length + i,
-            })),
-          )
+              originalPriority: i,
+              priority: i,
+            }))
           const originalSegmentOverrides = _.cloneDeep(segmentOverrides)
           this.setState({
             environmentVariations:

--- a/frontend/common/stores/feature-list-store.ts
+++ b/frontend/common/stores/feature-list-store.ts
@@ -280,15 +280,7 @@ const controller = {
               feature_segment: {
                 segment: v.segment,
               },
-              feature_state_value: {
-                boolean_value:
-                  v.feature_segment_value.feature_state_value.boolean_value,
-                integer_value:
-                  v.feature_segment_value.feature_state_value.integer_value,
-                string_value:
-                  v.feature_segment_value.feature_state_value.string_value,
-                type: v.feature_segment_value.feature_state_value.type,
-              },
+              feature_state_value: Utils.valueToFeatureState(v.value),
               multivariate_feature_state_values: v.multivariate_options,
             },
             { forceRefetch: true },

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -178,6 +178,7 @@ export type Req = {
     environmentId: string
     featureId: string
     enabled: boolean
+    multivariate_feature_state_values: MultivariateOption[] | null
     feature_segment: {
       segment: number
     }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Adds multivariate options create segment override so that it doesn't need to put to feature states
- Detects original order of segment override priorities, only calls update priorities if it has changed


## How did you test this code?

For an environment that doesn't have feature versioning: 

- Created and re-prioritised segment overrides
- Created segment overrides with mv adjusting the values