### PR TITLE
fix: Display an error message if trying to create a server-side SDK key while not being an environment admin

### DIFF
--- a/frontend/web/components/ServerSideSDKKeys.js
+++ b/frontend/web/components/ServerSideSDKKeys.js
@@ -9,6 +9,11 @@ import {
   deleteServersideEnvironmentKeys,
   getServersideEnvironmentKeys,
 } from 'common/services/useServersideEnvironmentKey'
+import Utils from 'common/utils/utils'
+import Constants from 'common/constants'
+import { useHasPermission } from 'common/providers/Permission'
+import Button from 'components/base/forms/Button'
+import Tooltip from 'components/Tooltip'
 
 class CreateServerSideKeyModal extends Component {
   state = {}
@@ -79,6 +84,7 @@ class ServerSideSDKKeys extends Component {
 
   static propTypes = {
     environmentId: propTypes.string.isRequired,
+    isAdmin: propTypes.bool.isRequired,
   }
 
   componentDidMount() {
@@ -168,13 +174,22 @@ class ServerSideSDKKeys extends Component {
             Server-side SDKs should be initialised with a Server-side
             Environment Key.
           </p>
-          <Button
-            onClick={this.createKey}
-            className='my-4'
-            disabled={this.state.isSaving}
-          >
-            Create Server-side Environment Key
-          </Button>
+          {this.props.isAdmin ? (
+            <Button onClick={this.createKey} className='my-4'>
+              Create Server-side Environment Key
+            </Button>
+          ) : (
+            <Tooltip
+              title={
+                <Button className='my-4' disabled>
+                  Create Server-side Environment Key
+                </Button>
+              }
+              place='right'
+            >
+              {Constants.environmentPermissions('ADMIN')}
+            </Tooltip>
+          )}
         </div>
         {this.state.isLoading && (
           <div className='text-center'>
@@ -227,4 +242,15 @@ class ServerSideSDKKeys extends Component {
     )
   }
 }
-export default ServerSideSDKKeys
+
+const ServerSideSDKKeysWrapper = ({ environmentId }) => {
+  const { permission: isAdmin } = useHasPermission({
+    id: environmentId,
+    level: 'environment',
+    permission: 'ADMIN',
+  })
+
+  return <ServerSideSDKKeys environmentId={environmentId} isAdmin={isAdmin} />
+}
+
+export default ServerSideSDKKeysWrapper


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Trying to create a server-side key while not being an environment admin fails with no error message. This PR disables the button to create server-side keys if the user is not an environment admin.

![image](https://github.com/user-attachments/assets/54ecf3fb-1fa7-4489-8cff-5ed9f88fa9b4)

`ServerSideSDKKeysWrapper` was added in order to use `useHasPermissions` from a class component and not a functional component.


## How did you test this code?

Manually and locally, with a user that has view-only permissions for the project and environment.
