### PR TITLE
ci: add steps to push to quay

### DIFF
--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -4,11 +4,6 @@ name: Publish Docker Image
 on:
   workflow_call:
     inputs:
-      source-registry-url:
-        type: string
-        description: Github Container Registry base URL
-        required: false
-        default: ghcr.io
       source-images:
         type: string
         description: Source image to publish
@@ -53,7 +48,7 @@ jobs:
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ inputs.source-registry-url }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -70,7 +70,8 @@ jobs:
         with:
           images: ${{ inputs.target-images }}
           tags: |
-            type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       # Setup Docker buildx with Depot builder so imagetools have access to Depot cache
       - uses: depot/use-action@v1

--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -4,7 +4,7 @@ name: Publish Docker Image
 on:
   workflow_call:
     inputs:
-      registry-url:
+      source-registry-url:
         type: string
         description: Github Container Registry base URL
         required: false
@@ -17,16 +17,21 @@ on:
         type: string
         description: Target image names
         required: true
+      target-registry-url:
+        type: string
+        description: URL of the target docker registry
+        required: false
+        default: docker.io
       docker-username:
         type: string
         description: Username for docker authentication
         required: false
-        default: ${{ secrets.DOCKERHUB_USERNAME }}
-      docker-password:
+        default: ${{ vars.DOCKERHUB_USERNAME_WRITE }}
+      docker-password-secret-name:
         type: string
-        description: Password for docker authentication
+        description: The name of the secret holding the docker password
         required: false
-        default: ${{ secrets.DOCKERHUB_TOKEN }}
+        default: DOCKERHUB_TOKEN_WRITE
 
 jobs:
   publish:
@@ -48,15 +53,16 @@ jobs:
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ inputs.registry-url }}
+          registry: ${{ inputs.source-registry-url }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
+          registry: ${{ inputs.target-registry-url }}
           username: ${{ inputs.docker-username }}
-          password: ${{ inputs.docker-password }}
+          password: ${{ secrets[inputs.docker-password-secret-name] }}
 
       - name: Docker metadata
         id: meta

--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -17,6 +17,16 @@ on:
         type: string
         description: Target image names
         required: true
+      docker-username:
+        type: string
+        description: Username for docker authentication
+        required: false
+        default: ${{ secrets.DOCKERHUB_USERNAME }}
+      docker-password:
+        type: string
+        description: Password for docker authentication
+        required: false
+        default: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
   publish:
@@ -45,8 +55,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ inputs.docker-username }}
+          password: ${{ inputs.docker-password }}
 
       - name: Docker metadata
         id: meta

--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -70,8 +70,7 @@ jobs:
         with:
           images: ${{ inputs.target-images }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=sha
 
       # Setup Docker buildx with Depot builder so imagetools have access to Depot cache
       - uses: depot/use-action@v1

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -4,31 +4,32 @@ on:
   push:
     branches:
       - main
+      - ci/push-to-quay
   release:
     types:
       - released
 
 jobs:
-  docker-build-api:
-    name: Build API Image
-    uses: ./.github/workflows/.reusable-docker-build.yml
-    with:
-      target: oss-api
-      image-name: flagsmith-api
-
-  docker-build-frontend:
-    name: Build Frontend Image
-    uses: ./.github/workflows/.reusable-docker-build.yml
-    with:
-      target: oss-frontend
-      image-name: flagsmith-frontend
-
-  docker-build-unified:
-    name: Build Unified Image
-    uses: ./.github/workflows/.reusable-docker-build.yml
-    with:
-      target: oss-unified
-      image-name: flagsmith
+#  docker-build-api:
+#    name: Build API Image
+#    uses: ./.github/workflows/.reusable-docker-build.yml
+#    with:
+#      target: oss-api
+#      image-name: flagsmith-api
+#
+#  docker-build-frontend:
+#    name: Build Frontend Image
+#    uses: ./.github/workflows/.reusable-docker-build.yml
+#    with:
+#      target: oss-frontend
+#      image-name: flagsmith-frontend
+#
+#  docker-build-unified:
+#    name: Build Unified Image
+#    uses: ./.github/workflows/.reusable-docker-build.yml
+#    with:
+#      target: oss-unified
+#      image-name: flagsmith
 
   docker-build-private-cloud-api:
     name: Build Private Cloud API Image
@@ -50,106 +51,106 @@ jobs:
       secrets: |
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
-  docker-build-api-test:
-    name: Build API Test Image
-    uses: ./.github/workflows/.reusable-docker-build.yml
-    with:
-      target: api-test
-      image-name: flagsmith-api-test
-      scan: false
+#  docker-build-api-test:
+#    name: Build API Test Image
+#    uses: ./.github/workflows/.reusable-docker-build.yml
+#    with:
+#      target: api-test
+#      image-name: flagsmith-api-test
+#      scan: false
+#
+#  docker-build-e2e:
+#    name: Build E2E Image
+#    uses: ./.github/workflows/.reusable-docker-build.yml
+#    with:
+#      file: frontend/Dockerfile.e2e
+#      image-name: flagsmith-e2e
+#      scan: false
 
-  docker-build-e2e:
-    name: Build E2E Image
-    uses: ./.github/workflows/.reusable-docker-build.yml
-    with:
-      file: frontend/Dockerfile.e2e
-      image-name: flagsmith-e2e
-      scan: false
-
-  run-e2e-tests:
-    needs: [docker-build-api, docker-build-private-cloud-api, docker-build-e2e]
-    uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
-      api-image: ${{ matrix.api-image }}
-      concurrency: ${{ matrix.args.concurrency }}
-      tests: ${{ matrix.args.tests }}
-    secrets:
-      GCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-
-    strategy:
-      matrix:
-        runs-on: [ubuntu-latest, ARM64-2c]
-        api-image:
-          - ${{ needs.docker-build-api.outputs.image }}
-          - ${{ needs.docker-build-private-cloud-api.outputs.image }}
-        args:
-          - tests: segment-part-1 environment
-            concurrency: 1
-          - tests: segment-part-2
-            concurrency: 1
-          - tests: segment-part-3 signup flag invite project
-            concurrency: 2
-          - tests: versioning
-            concurrency: 1
-          - tests: organisation-permission environment-permission project-permission roles
-            concurrency: 1
+#  run-e2e-tests:
+#    needs: [docker-build-api, docker-build-private-cloud-api, docker-build-e2e]
+#    uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
+#    with:
+#      runs-on: ${{ matrix.runs-on }}
+#      e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
+#      api-image: ${{ matrix.api-image }}
+#      concurrency: ${{ matrix.args.concurrency }}
+#      tests: ${{ matrix.args.tests }}
+#    secrets:
+#      GCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+#
+#    strategy:
+#      matrix:
+#        runs-on: [ubuntu-latest, ARM64-2c]
+#        api-image:
+#          - ${{ needs.docker-build-api.outputs.image }}
+#          - ${{ needs.docker-build-private-cloud-api.outputs.image }}
+#        args:
+#          - tests: segment-part-1 environment
+#            concurrency: 1
+#          - tests: segment-part-2
+#            concurrency: 1
+#          - tests: segment-part-3 signup flag invite project
+#            concurrency: 2
+#          - tests: versioning
+#            concurrency: 1
+#          - tests: organisation-permission environment-permission project-permission roles
+#            concurrency: 1
 
   # Publish to dockerhub
 
-  docker-publish-api:
-    needs: [docker-build-api, run-e2e-tests]
-    uses: ./.github/workflows/.reusable-docker-publish.yml
-    if: github.event_name == 'release'
-    with:
-      source-images: ${{ needs.docker-build-api.outputs.image }}
-      target-images: flagsmith/flagsmith-api
-    secrets: inherit
-
-  docker-publish-frontend:
-    needs: [docker-build-frontend, run-e2e-tests]
-    uses: ./.github/workflows/.reusable-docker-publish.yml
-    if: github.event_name == 'release'
-    with:
-      source-images: ${{ needs.docker-build-frontend.outputs.image }}
-      target-images: flagsmith/flagsmith-frontend
-    secrets: inherit
-
-  docker-publish-unified:
-    needs: [docker-build-unified, run-e2e-tests]
-    uses: ./.github/workflows/.reusable-docker-publish.yml
-    if: github.event_name == 'release'
-    with:
-      source-images: ${{ needs.docker-build-unified.outputs.image }}
-      target-images: flagsmith/flagsmith
-    secrets: inherit
-
-  docker-publish-private-cloud-api:
-    needs: [docker-build-private-cloud-api, run-e2e-tests]
-    uses: ./.github/workflows/.reusable-docker-publish.yml
-    if: github.event_name == 'release'
-    with:
-      source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
-      target-images: flagsmith/flagsmith-private-cloud-api
-    secrets: inherit
-
-  docker-publish-private-cloud:
-    needs: [docker-build-private-cloud, run-e2e-tests]
-    uses: ./.github/workflows/.reusable-docker-publish.yml
-    if: github.event_name == 'release'
-    with:
-      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
-      target-images: flagsmith/flagsmith-private-cloud
-    secrets: inherit
+#  docker-publish-api:
+#    needs: [docker-build-api, run-e2e-tests]
+#    uses: ./.github/workflows/.reusable-docker-publish.yml
+#    if: github.event_name == 'release'
+#    with:
+#      source-images: ${{ needs.docker-build-api.outputs.image }}
+#      target-images: flagsmith/flagsmith-api
+#    secrets: inherit
+#
+#  docker-publish-frontend:
+#    needs: [docker-build-frontend, run-e2e-tests]
+#    uses: ./.github/workflows/.reusable-docker-publish.yml
+#    if: github.event_name == 'release'
+#    with:
+#      source-images: ${{ needs.docker-build-frontend.outputs.image }}
+#      target-images: flagsmith/flagsmith-frontend
+#    secrets: inherit
+#
+#  docker-publish-unified:
+#    needs: [docker-build-unified, run-e2e-tests]
+#    uses: ./.github/workflows/.reusable-docker-publish.yml
+#    if: github.event_name == 'release'
+#    with:
+#      source-images: ${{ needs.docker-build-unified.outputs.image }}
+#      target-images: flagsmith/flagsmith
+#    secrets: inherit
+#
+#  docker-publish-private-cloud-api:
+#    needs: [docker-build-private-cloud-api, run-e2e-tests]
+#    uses: ./.github/workflows/.reusable-docker-publish.yml
+#    if: github.event_name == 'release'
+#    with:
+#      source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
+#      target-images: flagsmith/flagsmith-private-cloud-api
+#    secrets: inherit
+#
+#  docker-publish-private-cloud:
+#    needs: [docker-build-private-cloud, run-e2e-tests]
+#    uses: ./.github/workflows/.reusable-docker-publish.yml
+#    if: github.event_name == 'release'
+#    with:
+#      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
+#      target-images: flagsmith/flagsmith-private-cloud
+#    secrets: inherit
 
   # Publish to Quay.io
 
   docker-publish-quay-enterprise:
-    needs: [ docker-build-private-cloud, run-e2e-tests ]
+    needs: [ docker-build-private-cloud ]
     uses: ./.github/workflows/.reusable-docker-publish.yml
-    if: github.event_name == 'release'
+#    if: github.event_name == 'release'
     with:
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
       docker-password: ${{ secrets.QUAY_PUBLISH_PASSWORD }}
@@ -158,54 +159,54 @@ jobs:
     secrets: inherit
 
   docker-publish-quay-enterprise-api:
-    needs: [ docker-build-private-cloud, run-e2e-tests ]
+    needs: [ docker-build-private-cloud-api ]
     uses: ./.github/workflows/.reusable-docker-publish.yml
-    if: github.event_name == 'release'
+#    if: github.event_name == 'release'
     with:
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
       docker-password: ${{ secrets.QUAY_PUBLISH_PASSWORD }}
-      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
+      source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
       target-images: quay.io/flagsmithofficial/flagsmith-enterprise-api
     secrets: inherit
 
-  update-charts:
-    needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Target Charts Repository to update yaml
-        uses: actions/checkout@v4
-        with:
-          repository: flagsmith/flagsmith-charts
-          path: chart
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up release tag variables
-        id: version-trim
-        run: |
-          TAG=${{github.ref_name}}
-          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-
-      - name: Run YAML to Github Output Action
-        id: yaml-output
-        uses: christian-ci/action-yaml-github-output@v2
-        with:
-          file_path: './chart/charts/flagsmith/Chart.yaml'
-
-      - name: Update flagsmith-charts values.yaml with latest docker version
-        uses: fjogeleit/yaml-update-action@main
-        with:
-          token: ${{ secrets.FLAGSMITH_CHARTS_GITHUB_TOKEN }}
-          repository: flagsmith/flagsmith-charts
-          workDir: chart
-          masterBranchName: 'main'
-          targetBranch: 'main'
-          branch: docker-image-version-bump-${{ steps.version-trim.outputs.version }}
-          commitChange: true
-          createPR: true
-          message: 'Flagsmith docker image version bump'
-          description: 'Automated PR generated by a release event in https://github.com/Flagsmith/flagsmith'
-          valueFile: 'charts/flagsmith/Chart.yaml'
-          changes: |
-            {
-              "appVersion": "${{ steps.version-trim.outputs.version }}"
-            }
+#  update-charts:
+#    needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Target Charts Repository to update yaml
+#        uses: actions/checkout@v4
+#        with:
+#          repository: flagsmith/flagsmith-charts
+#          path: chart
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Set up release tag variables
+#        id: version-trim
+#        run: |
+#          TAG=${{github.ref_name}}
+#          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+#
+#      - name: Run YAML to Github Output Action
+#        id: yaml-output
+#        uses: christian-ci/action-yaml-github-output@v2
+#        with:
+#          file_path: './chart/charts/flagsmith/Chart.yaml'
+#
+#      - name: Update flagsmith-charts values.yaml with latest docker version
+#        uses: fjogeleit/yaml-update-action@main
+#        with:
+#          token: ${{ secrets.FLAGSMITH_CHARTS_GITHUB_TOKEN }}
+#          repository: flagsmith/flagsmith-charts
+#          workDir: chart
+#          masterBranchName: 'main'
+#          targetBranch: 'main'
+#          branch: docker-image-version-bump-${{ steps.version-trim.outputs.version }}
+#          commitChange: true
+#          createPR: true
+#          message: 'Flagsmith docker image version bump'
+#          description: 'Automated PR generated by a release event in https://github.com/Flagsmith/flagsmith'
+#          valueFile: 'charts/flagsmith/Chart.yaml'
+#          changes: |
+#            {
+#              "appVersion": "${{ steps.version-trim.outputs.version }}"
+#            }

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -152,8 +152,9 @@ jobs:
     uses: ./.github/workflows/.reusable-docker-publish.yml
 #    if: github.event_name == 'release'
     with:
+      target-registry-url: quay.io
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
-      docker-password: ${{ secrets.QUAY_PUBLISH_PASSWORD }}
+      docker-password-secret-name: QUAY_PUBLISH_PASSWORD
       source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
       target-images: quay.io/flagsmithofficial/flagsmith-enterprise
     secrets: inherit
@@ -163,8 +164,9 @@ jobs:
     uses: ./.github/workflows/.reusable-docker-publish.yml
 #    if: github.event_name == 'release'
     with:
+      target-registry-url: quay.io
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
-      docker-password: ${{ secrets.QUAY_PUBLISH_PASSWORD }}
+      docker-password-secret-name: QUAY_PUBLISH_PASSWORD
       source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
       target-images: quay.io/flagsmithofficial/flagsmith-enterprise-api
     secrets: inherit

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -97,6 +97,8 @@ jobs:
           - tests: organisation-permission environment-permission project-permission roles
             concurrency: 1
 
+  # Publish to dockerhub
+
   docker-publish-api:
     needs: [docker-build-api, run-e2e-tests]
     uses: ./.github/workflows/.reusable-docker-publish.yml
@@ -140,6 +142,30 @@ jobs:
     with:
       source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
       target-images: flagsmith/flagsmith-private-cloud
+    secrets: inherit
+
+  # Publish to Quay.io
+
+  docker-publish-quay-enterprise:
+    needs: [ docker-build-private-cloud, run-e2e-tests ]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
+      docker-password: ${{ secrets.QUAY_PUBLISH_PASSWORD }}
+      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
+      target-images: quay.io/flagsmithofficial/flagsmith-enterprise
+    secrets: inherit
+
+  docker-publish-quay-enterprise-api:
+    needs: [ docker-build-private-cloud, run-e2e-tests ]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
+      docker-password: ${{ secrets.QUAY_PUBLISH_PASSWORD }}
+      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
+      target-images: quay.io/flagsmithofficial/flagsmith-enterprise-api
     secrets: inherit
 
   update-charts:

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -4,32 +4,31 @@ on:
   push:
     branches:
       - main
-      - ci/push-to-quay
   release:
     types:
       - released
 
 jobs:
-#  docker-build-api:
-#    name: Build API Image
-#    uses: ./.github/workflows/.reusable-docker-build.yml
-#    with:
-#      target: oss-api
-#      image-name: flagsmith-api
-#
-#  docker-build-frontend:
-#    name: Build Frontend Image
-#    uses: ./.github/workflows/.reusable-docker-build.yml
-#    with:
-#      target: oss-frontend
-#      image-name: flagsmith-frontend
-#
-#  docker-build-unified:
-#    name: Build Unified Image
-#    uses: ./.github/workflows/.reusable-docker-build.yml
-#    with:
-#      target: oss-unified
-#      image-name: flagsmith
+  docker-build-api:
+    name: Build API Image
+    uses: ./.github/workflows/.reusable-docker-build.yml
+    with:
+      target: oss-api
+      image-name: flagsmith-api
+
+  docker-build-frontend:
+    name: Build Frontend Image
+    uses: ./.github/workflows/.reusable-docker-build.yml
+    with:
+      target: oss-frontend
+      image-name: flagsmith-frontend
+
+  docker-build-unified:
+    name: Build Unified Image
+    uses: ./.github/workflows/.reusable-docker-build.yml
+    with:
+      target: oss-unified
+      image-name: flagsmith
 
   docker-build-private-cloud-api:
     name: Build Private Cloud API Image
@@ -51,106 +50,106 @@ jobs:
       secrets: |
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
-#  docker-build-api-test:
-#    name: Build API Test Image
-#    uses: ./.github/workflows/.reusable-docker-build.yml
-#    with:
-#      target: api-test
-#      image-name: flagsmith-api-test
-#      scan: false
-#
-#  docker-build-e2e:
-#    name: Build E2E Image
-#    uses: ./.github/workflows/.reusable-docker-build.yml
-#    with:
-#      file: frontend/Dockerfile.e2e
-#      image-name: flagsmith-e2e
-#      scan: false
+  docker-build-api-test:
+    name: Build API Test Image
+    uses: ./.github/workflows/.reusable-docker-build.yml
+    with:
+      target: api-test
+      image-name: flagsmith-api-test
+      scan: false
 
-#  run-e2e-tests:
-#    needs: [docker-build-api, docker-build-private-cloud-api, docker-build-e2e]
-#    uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
-#    with:
-#      runs-on: ${{ matrix.runs-on }}
-#      e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
-#      api-image: ${{ matrix.api-image }}
-#      concurrency: ${{ matrix.args.concurrency }}
-#      tests: ${{ matrix.args.tests }}
-#    secrets:
-#      GCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-#
-#    strategy:
-#      matrix:
-#        runs-on: [ubuntu-latest, ARM64-2c]
-#        api-image:
-#          - ${{ needs.docker-build-api.outputs.image }}
-#          - ${{ needs.docker-build-private-cloud-api.outputs.image }}
-#        args:
-#          - tests: segment-part-1 environment
-#            concurrency: 1
-#          - tests: segment-part-2
-#            concurrency: 1
-#          - tests: segment-part-3 signup flag invite project
-#            concurrency: 2
-#          - tests: versioning
-#            concurrency: 1
-#          - tests: organisation-permission environment-permission project-permission roles
-#            concurrency: 1
+  docker-build-e2e:
+    name: Build E2E Image
+    uses: ./.github/workflows/.reusable-docker-build.yml
+    with:
+      file: frontend/Dockerfile.e2e
+      image-name: flagsmith-e2e
+      scan: false
+
+  run-e2e-tests:
+    needs: [docker-build-api, docker-build-private-cloud-api, docker-build-e2e]
+    uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
+    with:
+      runs-on: ${{ matrix.runs-on }}
+      e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
+      api-image: ${{ matrix.api-image }}
+      concurrency: ${{ matrix.args.concurrency }}
+      tests: ${{ matrix.args.tests }}
+    secrets:
+      GCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, ARM64-2c]
+        api-image:
+          - ${{ needs.docker-build-api.outputs.image }}
+          - ${{ needs.docker-build-private-cloud-api.outputs.image }}
+        args:
+          - tests: segment-part-1 environment
+            concurrency: 1
+          - tests: segment-part-2
+            concurrency: 1
+          - tests: segment-part-3 signup flag invite project
+            concurrency: 2
+          - tests: versioning
+            concurrency: 1
+          - tests: organisation-permission environment-permission project-permission roles
+            concurrency: 1
 
   # Publish to dockerhub
 
-#  docker-publish-api:
-#    needs: [docker-build-api, run-e2e-tests]
-#    uses: ./.github/workflows/.reusable-docker-publish.yml
-#    if: github.event_name == 'release'
-#    with:
-#      source-images: ${{ needs.docker-build-api.outputs.image }}
-#      target-images: flagsmith/flagsmith-api
-#    secrets: inherit
-#
-#  docker-publish-frontend:
-#    needs: [docker-build-frontend, run-e2e-tests]
-#    uses: ./.github/workflows/.reusable-docker-publish.yml
-#    if: github.event_name == 'release'
-#    with:
-#      source-images: ${{ needs.docker-build-frontend.outputs.image }}
-#      target-images: flagsmith/flagsmith-frontend
-#    secrets: inherit
-#
-#  docker-publish-unified:
-#    needs: [docker-build-unified, run-e2e-tests]
-#    uses: ./.github/workflows/.reusable-docker-publish.yml
-#    if: github.event_name == 'release'
-#    with:
-#      source-images: ${{ needs.docker-build-unified.outputs.image }}
-#      target-images: flagsmith/flagsmith
-#    secrets: inherit
-#
-#  docker-publish-private-cloud-api:
-#    needs: [docker-build-private-cloud-api, run-e2e-tests]
-#    uses: ./.github/workflows/.reusable-docker-publish.yml
-#    if: github.event_name == 'release'
-#    with:
-#      source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
-#      target-images: flagsmith/flagsmith-private-cloud-api
-#    secrets: inherit
-#
-#  docker-publish-private-cloud:
-#    needs: [docker-build-private-cloud, run-e2e-tests]
-#    uses: ./.github/workflows/.reusable-docker-publish.yml
-#    if: github.event_name == 'release'
-#    with:
-#      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
-#      target-images: flagsmith/flagsmith-private-cloud
-#    secrets: inherit
+  docker-publish-api:
+    needs: [docker-build-api, run-e2e-tests]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      source-images: ${{ needs.docker-build-api.outputs.image }}
+      target-images: flagsmith/flagsmith-api
+    secrets: inherit
+
+  docker-publish-frontend:
+    needs: [docker-build-frontend, run-e2e-tests]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      source-images: ${{ needs.docker-build-frontend.outputs.image }}
+      target-images: flagsmith/flagsmith-frontend
+    secrets: inherit
+
+  docker-publish-unified:
+    needs: [docker-build-unified, run-e2e-tests]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      source-images: ${{ needs.docker-build-unified.outputs.image }}
+      target-images: flagsmith/flagsmith
+    secrets: inherit
+
+  docker-publish-private-cloud-api:
+    needs: [docker-build-private-cloud-api, run-e2e-tests]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
+      target-images: flagsmith/flagsmith-private-cloud-api
+    secrets: inherit
+
+  docker-publish-private-cloud:
+    needs: [docker-build-private-cloud, run-e2e-tests]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
+      target-images: flagsmith/flagsmith-private-cloud
+    secrets: inherit
 
   # Publish to Quay.io
 
   docker-publish-quay-enterprise:
-    needs: [ docker-build-private-cloud ]
+    needs: [ docker-build-private-cloud, run-e2e-tests ]
     uses: ./.github/workflows/.reusable-docker-publish.yml
-#    if: github.event_name == 'release'
+    if: github.event_name == 'release'
     with:
       target-registry-url: quay.io
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
@@ -160,55 +159,55 @@ jobs:
     secrets: inherit
 
   docker-publish-quay-enterprise-api:
-    needs: [ docker-build-private-cloud-api ]
+    needs: [ docker-build-private-cloud, run-e2e-tests ]
     uses: ./.github/workflows/.reusable-docker-publish.yml
-#    if: github.event_name == 'release'
+    if: github.event_name == 'release'
     with:
       target-registry-url: quay.io
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
       docker-password-secret-name: QUAY_PUBLISH_PASSWORD
-      source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
+      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
       target-images: quay.io/flagsmithofficial/flagsmith-enterprise-api
     secrets: inherit
 
-#  update-charts:
-#    needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Target Charts Repository to update yaml
-#        uses: actions/checkout@v4
-#        with:
-#          repository: flagsmith/flagsmith-charts
-#          path: chart
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Set up release tag variables
-#        id: version-trim
-#        run: |
-#          TAG=${{github.ref_name}}
-#          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-#
-#      - name: Run YAML to Github Output Action
-#        id: yaml-output
-#        uses: christian-ci/action-yaml-github-output@v2
-#        with:
-#          file_path: './chart/charts/flagsmith/Chart.yaml'
-#
-#      - name: Update flagsmith-charts values.yaml with latest docker version
-#        uses: fjogeleit/yaml-update-action@main
-#        with:
-#          token: ${{ secrets.FLAGSMITH_CHARTS_GITHUB_TOKEN }}
-#          repository: flagsmith/flagsmith-charts
-#          workDir: chart
-#          masterBranchName: 'main'
-#          targetBranch: 'main'
-#          branch: docker-image-version-bump-${{ steps.version-trim.outputs.version }}
-#          commitChange: true
-#          createPR: true
-#          message: 'Flagsmith docker image version bump'
-#          description: 'Automated PR generated by a release event in https://github.com/Flagsmith/flagsmith'
-#          valueFile: 'charts/flagsmith/Chart.yaml'
-#          changes: |
-#            {
-#              "appVersion": "${{ steps.version-trim.outputs.version }}"
-#            }
+  update-charts:
+    needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Target Charts Repository to update yaml
+        uses: actions/checkout@v4
+        with:
+          repository: flagsmith/flagsmith-charts
+          path: chart
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up release tag variables
+        id: version-trim
+        run: |
+          TAG=${{github.ref_name}}
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Run YAML to Github Output Action
+        id: yaml-output
+        uses: christian-ci/action-yaml-github-output@v2
+        with:
+          file_path: './chart/charts/flagsmith/Chart.yaml'
+
+      - name: Update flagsmith-charts values.yaml with latest docker version
+        uses: fjogeleit/yaml-update-action@main
+        with:
+          token: ${{ secrets.FLAGSMITH_CHARTS_GITHUB_TOKEN }}
+          repository: flagsmith/flagsmith-charts
+          workDir: chart
+          masterBranchName: 'main'
+          targetBranch: 'main'
+          branch: docker-image-version-bump-${{ steps.version-trim.outputs.version }}
+          commitChange: true
+          createPR: true
+          message: 'Flagsmith docker image version bump'
+          description: 'Automated PR generated by a release event in https://github.com/Flagsmith/flagsmith'
+          valueFile: 'charts/flagsmith/Chart.yaml'
+          changes: |
+            {
+              "appVersion": "${{ steps.version-trim.outputs.version }}"
+            }


### PR DESCRIPTION
## Changes

Adds relevant steps to publish workflow to publish enterprise images to quay.io.

## How did you test this code?

Tested by temporarily modifying the workflow - see [this commit](https://github.com/Flagsmith/flagsmith/pull/5293/commits/10f28a7367773ec9b11190ffc1b105fa2cd9175f) and [this commit](https://github.com/Flagsmith/flagsmith/pull/5293/commits/b0d53f2cd4708de01e4eab2b36e3ba3bd1a5668f) and [this workflow run](https://github.com/Flagsmith/flagsmith/actions/runs/14224809230/job/39861735794).
