### PR TITLE
fix: Feature value overflowing container

### DIFF
--- a/frontend/web/components/CompareIdentities.tsx
+++ b/frontend/web/components/CompareIdentities.tsx
@@ -325,9 +325,10 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
                   >
                     <Switch checked={featureStateLeft?.enabled} />
                   </div>
-                  <Flex
+                  <div
                     onClick={goUserLeft}
                     className={`table-column ${!valueDifferent && 'faded'}`}
+                    style={{ width: '220px' }}
                   >
                     {featureStateLeft && (
                       <FeatureValue
@@ -335,7 +336,7 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
                         value={featureStateLeft?.feature_state_value}
                       />
                     )}
-                  </Flex>
+                  </div>
                   <div
                     onClick={goUserRight}
                     className={`table-column ${!enabledDifferent && 'faded'}`}
@@ -343,9 +344,10 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
                   >
                     <Switch checked={featureStateRight?.enabled} />
                   </div>
-                  <Flex
+                  <div
                     onClick={goUserRight}
-                    className={`table-column ${!valueDifferent && 'faded'}`}
+                    className={`table-column  ${!valueDifferent && 'faded'}`}
+                    style={{ width: '220px' }}
                   >
                     {featureStateRight && (
                       <FeatureValue
@@ -353,7 +355,7 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
                         value={featureStateRight?.feature_state_value}
                       />
                     )}
-                  </Flex>
+                  </div>
                 </Flex>
               )
             }}

--- a/frontend/web/components/CondensedFeatureRow.tsx
+++ b/frontend/web/components/CondensedFeatureRow.tsx
@@ -91,7 +91,8 @@ const CondensedFeatureRow: React.FC<CondensedFeatureRowProps> = ({
               !readOnly &&
               editFeature(projectFlag, environmentFlags?.[id])
             }
-            className={`flex-fill ${fadeValue ? 'faded' : ''}`}
+            style={{ flex: 1 }}
+            className={`overflow-hidden ${fadeValue ? 'faded' : ''}`}
           >
             <FeatureValue
               value={environmentFlags?.[id]?.feature_state_value ?? null}

--- a/frontend/web/components/FeatureRow.tsx
+++ b/frontend/web/components/FeatureRow.tsx
@@ -53,7 +53,7 @@ interface FeatureRowProps {
   history?: RouterChildContext['router']['history']
 }
 
-const width = [200, 70, 55, 70, 450]
+const width = [220, 70, 55, 70, 450]
 
 const FeatureRow: FC<FeatureRowProps> = ({
   className,

--- a/frontend/web/components/FeatureValue.tsx
+++ b/frontend/web/components/FeatureValue.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
 import { FlagsmithValue } from 'common/types/responses'
-import Format from 'common/utils/format'
 import Utils from 'common/utils/utils'
 import { getViewMode } from 'common/useViewMode'
 import classNames from 'classnames' // we need this to make JSX compile
@@ -23,22 +22,22 @@ const FeatureValue: FC<FeatureValueType> = (props) => {
   }
   const isCompact = getViewMode() === 'compact'
   return (
-    <span
-      className={classNames(`chip ${props.className || ''}`, {
-        'chip--sm justify-content-start d-inline': isCompact,
+    <div
+      className={classNames(`chip flex-row ${props.className || ''}`, {
+        'chip--sm justify-content-start': isCompact,
       })}
       onClick={props.onClick}
       data-test={props['data-test']}
+      style={{ maxWidth: 'fit-content' }}
     >
-      {type == 'string' && <span className='quot'>"</span>}
-      <span className='feature-value'>
-        {Format.truncateText(
-          `${Utils.getTypedValue(props.value)}`,
-          isCompact ? 24 : 20,
-        )}
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        {type == 'string' && <span className='quot'>"</span>}
+        <span className='feature-value'>
+          {`${Utils.getTypedValue(props.value)}`}
+        </span>
+        {type == 'string' && <span className='quot'>"</span>}
       </span>
-      {type == 'string' && <span className='quot'>"</span>}
-    </span>
+    </div>
   )
 }
 

--- a/frontend/web/components/FeatureValue.tsx
+++ b/frontend/web/components/FeatureValue.tsx
@@ -24,23 +24,24 @@ const FeatureValue: FC<FeatureValueType> = (props) => {
   const isCompact = getViewMode() === 'compact'
   return (
     <div
-      className={classNames(`chip flex-row ${props.className || ''}`, {
+      className={classNames(`chip flex-row no-wrap ${props.className || ''}`, {
         'chip--sm justify-content-start': isCompact,
       })}
       onClick={props.onClick}
       data-test={props['data-test']}
       style={{ maxWidth: 'fit-content' }}
     >
-      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-        {type == 'string' && <span className='quot'>"</span>}
-        <span className='feature-value'>
-          {Format.truncateText(
-            `${Utils.getTypedValue(props.value)}`,
-            isCompact ? 24 : 20,
-          )}
-        </span>
-        {type == 'string' && <span className='quot'>"</span>}
+      {type == 'string' && <span className='quot'>"</span>}
+      <span
+        className='feature-value'
+        style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+      >
+        {Format.truncateText(
+          `${Utils.getTypedValue(props.value)}`,
+          isCompact ? 24 : 20,
+        )}
       </span>
+      {type == 'string' && <span className='quot'>"</span>}
     </div>
   )
 }

--- a/frontend/web/components/FeatureValue.tsx
+++ b/frontend/web/components/FeatureValue.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 import { FlagsmithValue } from 'common/types/responses'
+import Format from 'common/utils/format'
 import Utils from 'common/utils/utils'
 import { getViewMode } from 'common/useViewMode'
 import classNames from 'classnames' // we need this to make JSX compile
@@ -33,7 +34,10 @@ const FeatureValue: FC<FeatureValueType> = (props) => {
       <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
         {type == 'string' && <span className='quot'>"</span>}
         <span className='feature-value'>
-          {`${Utils.getTypedValue(props.value)}`}
+          {Format.truncateText(
+            `${Utils.getTypedValue(props.value)}`,
+            isCompact ? 24 : 20,
+          )}
         </span>
         {type == 'string' && <span className='quot'>"</span>}
       </span>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

ref: [#5280](https://github.com/Flagsmith/flagsmith/issues/5280)

- Fixes FeatureValue overflowing container

#### Features Page
Before
<img width="1221" alt="Screenshot 2025-04-03 at 16 10 13" src="https://github.com/user-attachments/assets/e6d67ebe-a255-4f04-ab23-244618a54586" />

After
<img width="1211" alt="Screenshot 2025-04-03 at 16 09 55" src="https://github.com/user-attachments/assets/d3ecc4bb-49da-480c-a24f-34a3ae12b1cf" />


#### Compare Environments
Before
<img width="1246" alt="Screenshot 2025-04-03 at 12 06 48" src="https://github.com/user-attachments/assets/9a258dd1-fa55-4ff6-8a55-ac50c10b4152" />

After
<img width="1259" alt="Screenshot 2025-04-03 at 13 31 01" src="https://github.com/user-attachments/assets/d5a8b21e-71e6-47df-b273-7e358a831cc4" />

#### Compare Identities
Before
<img width="1247" alt="Screenshot 2025-04-03 at 16 06 16" src="https://github.com/user-attachments/assets/c13f6d6c-30d2-49e4-a0a2-062616ba97a7" />

After
<img width="1265" alt="Screenshot 2025-04-03 at 16 06 32" src="https://github.com/user-attachments/assets/b7426d4d-a934-4089-9776-10ec06408dd2" />



## How did you test this code?

Tested in all places that implement FeatureValue component
