### PR TITLE
fix: Prevent the frontend from crashing if Chargebee.js failed to load

### DIFF
--- a/frontend/web/components/modals/Payment.js
+++ b/frontend/web/components/modals/Payment.js
@@ -417,7 +417,12 @@ const Payment = class extends Component {
 }
 
 Payment.propTypes = {}
-export const onPaymentLoad = () => {
+export const onPaymentLoad = ({ errored }) => {
+  if (errored) {
+    // TODO: no error details are available https://github.com/dozoisch/react-async-script/issues/58
+    console.error('failed to load chargebee')
+    return
+  }
   if (!Project.chargebee?.site) {
     return
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

To reproduce this issue, block the `https://js.chargebee.com/v2/chargebee.js` request from your browser and try to load the Projects listing page:

![image](https://github.com/user-attachments/assets/ca6e9b18-a03a-4329-ae42-b51ea40a905e)

We now log an error and don't crash the frontend if this request fails.

## How did you test this code?

Tested by blocking the same request and verifying an error is logged, and the frontend doesn't crash.