### PR TITLE
docs: .NET client 7.1.0

### DIFF
--- a/docs/docs/clients/server-side.mdx
+++ b/docs/docs/clients/server-side.mdx
@@ -243,9 +243,11 @@ private static FlagsmithClient flagsmith = FlagsmithClient
 ```csharp
 using Flagsmith;
 
-FlagsmithClient _flagsmithClient;
-
-_flagsmithClient = new("FLAGSMITH_SERVER_SIDE_ENVIRONMENT_KEY");
+var flagsmithClient = new FlagsmithClient(
+  new FlagsmithConfiguration {
+    EnvironmentKey = "YOUR_FLAGSMITH_SERVER_SIDE_ENVIRONMENT_KEY",
+  }
+);
 ```
 
 </TabItem>
@@ -472,12 +474,10 @@ var traitValue = "robin_reliant";
 var traitList = new List<Trait> { new Trait(traitKey, traitValue) };
 
 # Sync
-# The method below triggers a network request
 var flags = _flagsmithClient.GetIdentityFlags(identifier, traitList).Result;
 var showButton = flags.IsFeatureEnabled("secret_button").Result;
 
 # Async
-# The method below triggers a network request
 var flags = await _flagsmithClient.GetIdentityFlags(identifier, traitList);
 var showButton = await flags.IsFeatureEnabled("secret_button");
 ```
@@ -652,13 +652,15 @@ private static DefaultFlag defaultFlagHandler(String featureName) {
 ```csharp
 using Flagsmith;
 
-FlagsmithClient _flagsmithClient;
-_flagsmithClient = new("FLAGSMITH_SERVER_SIDE_ENVIRONMENT_KEY", defaultFlagHandler: defaultFlagHandler);
+var config = new FlagsmithConfiguration
+{
+    EnvironmentKey = "YOUR_SERVER_SIDE_ENVIRONMENT_KEY",
+    DefaultFlagHandler = defaultFlagHandler
+}
+var flagsmithClient = new FlagsmithClient(config);
 
 static Flag defaultFlagHandler(string featureName)
 {
-    // Function that will be used if the API doesn't respond, or an unknown
-    // feature is requested
     if (featureName == "secret_button")
         return new Flag(new Feature("secret_button"), enabled: false, value: JsonConvert.SerializeObject(new { colour = "#b8b8b8" }).ToString());
     else return new Flag() { };
@@ -840,10 +842,11 @@ public class MyCustomOfflineHandler implements IOfflineHandler:
 ```csharp
 // Using the built-in local file handler
 var localFileHandler = new LocalFileHandler("path_to_environment_file/environment_file.json");
-
 var flagsmithClient = new FlagsmithClient(
-    offlineMode: true,
-    offlineHandler: localFileHandler
+    new FlagsmithConfiguration {
+      OfflineMode = true,
+      OfflineHandler = localFileHandler
+    }
 );
 
 // Defining a custom offline handler
@@ -1245,120 +1248,43 @@ private static FlagsmithClient flagsmith = FlagsmithClient
 <TabItem value="dotnet" label=".NET">
 
 ```csharp
-_flagsmithClient = new FlagsmithClient(
-    # Your API Token.
-    # Note that this is either the `Environment API` key or the `Server Side SDK Token`
-    # depending on if you are using Local or Remote Evaluation
-    # Required.
-    environmentKey: "FLAGSMITH_SERVER_SIDE_ENVIRONMENT_KEY",
+var flagsmithClient = new FlagsmithClient(
+    new FlagsmithConfiguration {
+        # Your environment's SDK key. This should be a client-side key if you are using remote evaluation or a
+        # server-side key if you are using local evaluation.
+        # Required.
+        EnvironmentKey = "FLAGSMITH_SERVER_SIDE_ENVIRONMENT_KEY",
 
-    # Pass in a default Flag Handler method
-    # Optional
-    defaultFlagHandler: defaultFlagHandler,
+        # An optional flag handler used as a fallback if the client is unable to evaluate flags for any reason.
+        DefaultFlagHandler = defaultFlagHandler,
 
-    # Override the default Flagsmith API URL if you are self-hosting.
-    # Optional.
-    # Defaults to https://edge.api.flagsmith.com/api/v1/
-    apiUrl: "https://flagsmith.myproject.com"
+        # If you are not using Flagsmith SaaS, set this to your Flagsmith API URL.
+        # Defaults to https://edge.api.flagsmith.com/api/v1/
+        ApiUri: new Uri("https://flagsmith.myproject.com"),
 
-    # Controls which mode to run in; local or remote evaluation.
-    # See the `SDKs Overview Page` for more info
-    # Optional.
-    # Defaults to False.
-    enableClientSideEvaluation: false;
+        # Controls which mode to run in; local or remote evaluation. Defaults to false (remote evaluation).
+        # See the `SDKs Overview Page` for more info.
+        EnableLocalEvaluation = false,
 
-    # Controls whether Flag Analytics data is sent to the Flagsmith API
-    # See https://docs.flagsmith.com/advanced-use/flag-analytics
-    # Optional
-    # Defaults to false
-    enableAnalytics: false
+        # Controls whether flag analytics data is sent to the Flagsmith API. Defaults to false.
+        # See https://docs.flagsmith.com/advanced-use/flag-analytics
+        EnableAnalytics = false,
 
-    # When running in local evaluation mode, defines
-    # how often to request an updated Environment document in seconds
-    # Optional
-    # Defaults to 60 seconds
-    environmentRefreshIntervalSeconds: 60
+        # When running in local evaluation mode, defines how often to update the environment document.
+        # Defaults to 60 seconds.
+        EnvironmentRefreshInterval = TimeSpan.FromSeconds(60),
 
-    # You can pass custom headers to the Flagsmith API with this Dictionary.
-    # This can be helpful, for example, when sending request IDs to help trace requests.
-    # Optional
-    # Defaults to None
-    customHeaders: <Dictionary>
+        # All HTTP requests made by this client will include these additional headers.
+        # This can be helpful, for example, if you are self-hosting Flagsmith and want to add trace IDs to all requests.
+        CustomHeaders = new Dictionary<string, string>(),
 
-    # How often to retry failed HTTP requests
-    # Optional
-    # Defaults to 1
-    retries: 1
+        # How many times to retry failed HTTP requests. Defaults to 1.
+        Retries = 1,
 
-    # The network timeout in seconds.
-    # Optional.
-    # Defaults to null (http client default)
-    requestTimeout: null,
-)
-```
-
-<h3>Singleton Initialisation</h3>
-
-Singleton ensures a single instance of FlagsmithClient throughout the application, optimizing resources and maintaining
-consistency in configuration.
-
-Below you can find an example implementation of the client instantiated as a Singleton with its configuration defined in
-a file called `FlagsmithSettings.cs` (found below), which stores Flagsmith-specific settings.
-
-```csharp
-
-builder.Services.AddOptions<FlagsmithSettings>().Bind(builder.Configuration.GetSection(FlagsmithSettings.ConfigSection));
-builder.Services.AddSingleton(provider => provider.GetRequiredService<IOptions<FlagsmithSettings>>().Value);
-builder.Services.AddSingleton<IFlagsmithClient, FlagsmithClient>(provider =>
-{
-    var settings = provider.GetService<FlagsmithSettings>();
-    return new FlagsmithClient(settings);
-});
-
-
-```
-
-`FlagsmithSettings.cs`
-
-```csharp
-using Example.Controllers;
-using Flagsmith;
-using Newtonsoft.Json;
-
-namespace Example.Settings
-{
-    public class FlagsmithSettings : IFlagsmithConfiguration
-    {
-        public static string ConfigSection => "FlagsmithConfiguration";
-        public string ApiUrl { get; set; } = "https://edge.api.flagsmith.com/api/v1/";
-        public string EnvironmentKey { get; set; } = String.Empty;
-        public bool EnableClientSideEvaluation { get; set; } = false;
-        public int EnvironmentRefreshIntervalSeconds { get; set; } = 60;
-        public ILogger Logger { get; set; }
-        public bool EnableAnalytics { get; set; } = false;
-        public Double? RequestTimeout { get; set; }
-        public Dictionary<string, string> CustomHeaders { get; set; }
-        public int? Retries { get; set; } = 1;
-        public CacheConfig CacheConfig { get; set; } = new(false);
+        # The network timeout in seconds. If not specified, the HTTP client's default timeout is used.
+        RequestTimeout = 10,
     }
-}
-
-```
-
-In the `appsettings.json` file you can configure the necessary flagsmith values.
-
-```json
-{
-    "AllowedHosts": "*",
-    "FlagsmithConfiguration": {
-        "EnvironmentKey": "FLAGSMITH_SERVER_SIDE_ENVIRONMENT_KEY",
-        "EnableClientSideEvaluation": false,
-        "EnvironmentRefreshIntervalSeconds": 60,
-        "EnableAnalytics": true,
-        "RequestTimeout": 10,
-        "Retries": 3
-    }
-}
+);
 ```
 
 </TabItem>


### PR DESCRIPTION
Do not merge until .NET SDK 7.1.0 is released.

* Overall wording improvements
* Removed section about singleton initialisation - this is specific to ASP.NET and not something generic to .NET that we need to document, and is not relevant to how you configure or use the client.