### PR TITLE
fix: Dashboard alias not updating in safari

### DIFF
--- a/frontend/common/services/useIdentity.ts
+++ b/frontend/common/services/useIdentity.ts
@@ -141,7 +141,7 @@ export const identityService = service
             query.environmentId
           }/${Utils.getIdentitiesEndpoint()}/${
             query.data.identity_uuid || query.data.id
-          }`,
+          }/`,
         }),
       }),
       // END OF ENDPOINTS

--- a/frontend/web/components/EditIdentity.tsx
+++ b/frontend/web/components/EditIdentity.tsx
@@ -47,20 +47,19 @@ const EditIdentity: FC<EditIdentityType> = ({ data, environmentId }) => {
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value.toLowerCase()
-    setAlias(newValue.replace(/\n/g, ' ')
-      .trim())
-
+    setAlias(newValue.replace(/\n/g, ' ').trim())
   }
+
   return (
     <>
-    <GhostInput
-      ref={aliasRef}
-      value={alias}
-      onChange={handleInput}
-      onBlur={handleBlur}
-      onKeyDown={handleKeyDown}
-      placeholder='None'
-    />
+      <GhostInput
+        ref={aliasRef}
+        value={alias}
+        onChange={handleInput}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        placeholder='None'
+      />
       <Button
         disabled={!data}
         iconSize={18}

--- a/frontend/web/components/base/forms/GhostInput.tsx
+++ b/frontend/web/components/base/forms/GhostInput.tsx
@@ -1,0 +1,64 @@
+import React, { forwardRef, useEffect, useState } from 'react'
+import classNames from 'classnames'
+
+type GhostInputProps = {
+  value?: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur?: () => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  placeholder?: string
+  className?: string
+  width?: number
+  'aria-label'?: string
+}
+
+const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
+  ({ 
+    'aria-label': ariaLabel, 
+    className, 
+    onBlur, 
+    onChange, 
+    onKeyDown, 
+    placeholder = '',
+    value,
+  }, ref) => {
+  const [width, setWidth] = useState(5);
+  
+  useEffect(() => {
+    setWidth(value?.length || 5)
+  }, [value])
+
+    return (
+      <input
+        ref={ref}
+        className={classNames('fw-normal', className, { 
+          'text-muted': !value 
+        })}
+        value={value}
+        placeholder={placeholder}
+        onChange={onChange}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+        role='textbox'
+        aria-label={ariaLabel}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          boxShadow: 'none',
+          color: 'inherit',
+          cursor: 'text',
+          fontFamily: 'inherit',
+          fontSize: 'inherit',
+          margin: 0,
+          outline: 'none',
+          padding: 0,
+          width: width ? `${width}ch` : 'auto'
+        }}
+      />
+    )
+  }
+)
+
+GhostInput.displayName = 'GhostInput'
+
+export default GhostInput

--- a/frontend/web/components/base/forms/GhostInput.tsx
+++ b/frontend/web/components/base/forms/GhostInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useState } from 'react'
+import React, { forwardRef, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 
 type GhostInputProps = {
@@ -6,60 +6,86 @@ type GhostInputProps = {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   onBlur?: () => void
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
-  placeholder?: string
+  placeholder: string
   className?: string
   width?: number
   'aria-label'?: string
 }
 
 const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
-  ({ 
-    'aria-label': ariaLabel, 
-    className, 
-    onBlur, 
-    onChange, 
-    onKeyDown, 
-    placeholder = '',
-    value,
-  }, ref) => {
-  const [width, setWidth] = useState(5);
-  
-  useEffect(() => {
-    setWidth((value?.length || 5) * 0.88)
-  }, [value])
+  (
+    {
+      'aria-label': ariaLabel,
+      className,
+      onBlur,
+      onChange,
+      onKeyDown,
+      placeholder = '',
+      value,
+    },
+    ref,
+  ) => {
+    const spanRef = useRef<HTMLSpanElement>(null)
+    const [inputWidth, setInputWidth] = useState(5)
+
+    useEffect(() => {
+      if (spanRef.current) {
+        setInputWidth(spanRef.current.offsetWidth * 0.95)
+      }
+    }, [value])
 
     return (
-      <input
-        ref={ref}
-        maxLength={100}
-        className={classNames('fw-normal', className, { 
-          'text-muted': !value 
-        })}
-        value={value}
-        placeholder={placeholder}
-        onChange={onChange}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-        role='textbox'
-        aria-label={ariaLabel}
-        style={{
-          background: 'transparent',
-          border: 'none',
-          boxShadow: 'none',
-          color: 'inherit',
-          cursor: 'text',
-          fontFamily: 'inherit',
-          fontSize: 'inherit',
-          margin: 0,
-          maxWidth: 420,
-          minWidth: 45,
-          outline: 'none',
-          padding: 0,
-          width: width ? `${width}ch` : 'auto'
-        }}
-      />
+      <div style={{ display: 'inline-block', position: 'relative' }}>
+        <span
+          ref={spanRef}
+          style={{
+            border: 0,
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            fontWeight: 'inherit',
+            letterSpacing: 'inherit',
+            lineHeight: 'inherit',
+            margin: 0,
+            padding: 0,
+            position: 'absolute',
+            visibility: 'hidden',
+            whiteSpace: 'pre',
+          }}
+        >
+          {value || placeholder}
+        </span>
+        <input
+          ref={ref}
+          maxLength={100}
+          className={classNames('fw-normal', className, {
+            'text-muted': !value,
+          })}
+          value={value}
+          placeholder={placeholder}
+          onChange={onChange}
+          onBlur={onBlur}
+          onKeyDown={onKeyDown}
+          role='textbox'
+          aria-label={ariaLabel}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            boxShadow: 'none',
+            color: 'inherit',
+            cursor: 'text',
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            margin: 0,
+            // maxWidth: 700,
+            // minWidth: 45,
+            outline: 'none',
+            padding: 0,
+            width: inputWidth,
+          }}
+        />
+      </div>
     )
-  }
+  },
 )
 
 GhostInput.displayName = 'GhostInput'

--- a/frontend/web/components/base/forms/GhostInput.tsx
+++ b/frontend/web/components/base/forms/GhostInput.tsx
@@ -25,7 +25,7 @@ const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
   const [width, setWidth] = useState(5);
   
   useEffect(() => {
-    setWidth((value?.length || 5) * 0.85)
+    setWidth((value?.length || 5) * 0.88)
   }, [value])
 
     return (
@@ -51,7 +51,7 @@ const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
           fontFamily: 'inherit',
           fontSize: 'inherit',
           margin: 0,
-          maxWidth: 360,
+          maxWidth: 420,
           minWidth: 45,
           outline: 'none',
           padding: 0,

--- a/frontend/web/components/base/forms/GhostInput.tsx
+++ b/frontend/web/components/base/forms/GhostInput.tsx
@@ -25,12 +25,13 @@ const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
   const [width, setWidth] = useState(5);
   
   useEffect(() => {
-    setWidth(value?.length || 5)
+    setWidth((value?.length || 5) * 0.85)
   }, [value])
 
     return (
       <input
         ref={ref}
+        maxLength={100}
         className={classNames('fw-normal', className, { 
           'text-muted': !value 
         })}
@@ -50,6 +51,8 @@ const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
           fontFamily: 'inherit',
           fontSize: 'inherit',
           margin: 0,
+          maxWidth: 360,
+          minWidth: 45,
           outline: 'none',
           padding: 0,
           width: width ? `${width}ch` : 'auto'

--- a/frontend/web/components/base/forms/GhostInput.tsx
+++ b/frontend/web/components/base/forms/GhostInput.tsx
@@ -67,6 +67,7 @@ const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
           onKeyDown={onKeyDown}
           role='textbox'
           aria-label={ariaLabel}
+          spellCheck={false}
           style={{
             background: 'transparent',
             border: 'none',
@@ -76,8 +77,6 @@ const GhostInput = forwardRef<HTMLInputElement, GhostInputProps>(
             fontFamily: 'inherit',
             fontSize: 'inherit',
             margin: 0,
-            // maxWidth: 700,
-            // minWidth: 45,
             outline: 'none',
             padding: 0,
             width: inputWidth,

--- a/frontend/web/components/pages/HomeAside.tsx
+++ b/frontend/web/components/pages/HomeAside.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, FC, useEffect, useMemo, useState } from 'react'
+import React, { ComponentProps, FC, useEffect, useState } from 'react'
 import ProjectStore from 'common/stores/project-store'
 import ChangeRequestStore from 'common/stores/change-requests-store'
 import Utils from 'common/utils/utils'
@@ -355,7 +355,7 @@ const HomeAside: FC<HomeAsideType> = ({
                                       exact
                                       to={`/project/${project.id}/environment/${environment.api_key}/split-tests`}
                                     >
-                                      <IonIcon className='mr-2' icon={flask} />
+                                      <IonIcon className='mr-2' icon={flask} color={'#9DA4AE'} />
                                       Split Tests
                                     </NavLink>
                                   )}

--- a/frontend/web/components/pages/UserPage.tsx
+++ b/frontend/web/components/pages/UserPage.tsx
@@ -332,7 +332,7 @@ const UserPage: FC<UserPageType> = (props) => {
                           }
                         />
                         {showAliases && (
-                          <h6>
+                          <h6 className='d-flex align-items-center gap-1'>
                             <Tooltip
                               title={
                                 <span className='user-select-none'>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Changed implementation from content-editable (not safari-compatible as of) to input component using ghost span to handle width
- Fixed locally crashing error ` Failed to execute 'setStart' on 'Range': parameter 1 is not of type 'Node'.` preventing from removing alias
- Fixed split test icon color
- Added max-length 100 on input (to avoid 400 from API)

## How did you test this code?
- Go to Environments -> Identities -> X User
- Update alias in safari and other browsers

_Please describe._
https://www.loom.com/share/c933e8a20dfe417f841f4e2da44991fb