### PR TITLE
ci: use correct job / image for pushing enterprise api to quay

### DIFF
--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -159,14 +159,14 @@ jobs:
     secrets: inherit
 
   docker-publish-quay-enterprise-api:
-    needs: [ docker-build-private-cloud, run-e2e-tests ]
+    needs: [ docker-build-private-cloud-api, run-e2e-tests ]
     uses: ./.github/workflows/.reusable-docker-publish.yml
     if: github.event_name == 'release'
     with:
       target-registry-url: quay.io
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
       docker-password-secret-name: QUAY_PUBLISH_PASSWORD
-      source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
+      source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
       target-images: quay.io/flagsmithofficial/flagsmith-enterprise-api
     secrets: inherit
 


### PR DESCRIPTION
## Changes

Fixes incorrect references to relevant job when pushing enterprise-api image to quay.io

## How did you test this code?

n/a - to be tested in ci on next build
