### PR TITLE
ci: publish frontend image to Quay

### DIFF
--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -170,6 +170,18 @@ jobs:
       target-images: quay.io/flagsmithofficial/flagsmith-enterprise-api
     secrets: inherit
 
+  docker-publish-quay-frontend:
+    needs: [ docker-build-frontend, run-e2e-tests ]
+    uses: ./.github/workflows/.reusable-docker-publish.yml
+    if: github.event_name == 'release'
+    with:
+      target-registry-url: quay.io
+      docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
+      docker-password-secret-name: QUAY_PUBLISH_PASSWORD
+      source-images: ${{ needs.docker-build-frontend.outputs.image }}
+      target-images: quay.io/flagsmithofficial/flagsmith-frontend
+    secrets: inherit
+
   update-charts:
     needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]
     runs-on: ubuntu-latest

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -155,7 +155,7 @@ jobs:
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
       docker-password-secret-name: QUAY_PUBLISH_PASSWORD
       source-images: ${{ needs.docker-build-private-cloud.outputs.image }}
-      target-images: quay.io/flagsmithofficial/flagsmith-enterprise
+      target-images: quay.io/${{ vars.QUAY_ORGANISATION_NAME }}/flagsmith-enterprise
     secrets: inherit
 
   docker-publish-quay-enterprise-api:
@@ -167,7 +167,7 @@ jobs:
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
       docker-password-secret-name: QUAY_PUBLISH_PASSWORD
       source-images: ${{ needs.docker-build-private-cloud-api.outputs.image }}
-      target-images: quay.io/flagsmithofficial/flagsmith-enterprise-api
+      target-images: quay.io/${{ vars.QUAY_ORGANISATION_NAME }}/flagsmith-enterprise-api
     secrets: inherit
 
   docker-publish-quay-frontend:
@@ -179,7 +179,7 @@ jobs:
       docker-username: ${{ vars.QUAY_PUBLISH_USERNAME }}
       docker-password-secret-name: QUAY_PUBLISH_PASSWORD
       source-images: ${{ needs.docker-build-frontend.outputs.image }}
-      target-images: quay.io/flagsmithofficial/flagsmith-frontend
+      target-images: quay.io/${{ vars.QUAY_ORGANISATION_NAME }}/flagsmith-frontend
     secrets: inherit
 
   update-charts:


### PR DESCRIPTION
## Changes

As discussed with @rolodato , we think that the frontend image should also be published to Quay, to reduce complications for customers. 

Also bonus change to use a variable to define the Quay organisation name since we're now using it in flagsmith-sse as well. 

## How did you test this code?

Since the other images deploy successfully to quay, and I've tested manually pushing an image to the quay.io/flagsmithofficial/flagsmith-frontend repository. As such, I think we can rely on the next release to test this behaviour. 
