### PR TITLE
fix: Fix undesired navigation when closing edit feature modal

### DIFF
--- a/frontend/web/components/CompareFeatures.js
+++ b/frontend/web/components/CompareFeatures.js
@@ -147,6 +147,13 @@ class CompareEnvironments extends Component {
                             toggleFlag={toggleFlag}
                             removeFlag={removeFlag}
                             projectFlag={this.state.flag}
+                            onCloseEditModal={() => {
+                              this.context.router.history.replace({
+                                pathname:
+                                  this.context.router.history.location.pathname,
+                                search: '?tab=feature-values',
+                              })
+                            }}
                           />
                         </Row>
                       )}

--- a/frontend/web/components/FeatureRow.tsx
+++ b/frontend/web/components/FeatureRow.tsx
@@ -51,6 +51,7 @@ interface FeatureRowProps {
   hideAudit?: boolean
   hideRemove?: boolean
   history?: RouterChildContext['router']['history']
+  onCloseEditModal?: () => void
 }
 
 const width = [220, 70, 55, 70, 450]
@@ -67,6 +68,7 @@ const FeatureRow: FC<FeatureRowProps> = ({
   hideRemove = false,
   history,
   index,
+  onCloseEditModal,
   permission,
   projectFlag,
   projectId,
@@ -197,6 +199,10 @@ const FeatureRow: FC<FeatureRowProps> = ({
       />,
       'side-modal create-feature-modal',
       () => {
+        if (onCloseEditModal) {
+          return onCloseEditModal()
+        }
+
         history.replace({
           pathname: document.location.pathname,
           search: '',


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ref: #5170 

- Adds prop callback for handling when edit modal closes
- Fix undesired navigation

## How did you test this code?

https://www.loom.com/share/65e6a6ad89384fc2bbd7215d2ffa7c9f?sid=909f4787-9d38-4254-9e32-eecf501f7386