### PR TITLE
fix: `RouteLoggerMiddleware` breaks threads accessing Django request object

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -348,13 +348,7 @@ FEATURE_EVALUATION_CACHE_SECONDS = env.int(
 ENABLE_API_USAGE_TRACKING = env.bool("ENABLE_API_USAGE_TRACKING", default=True)
 
 if ENABLE_API_USAGE_TRACKING:
-    # NOTE: Because we use Postgres for analytics data in staging and Influx for tracking SSE data,
-    # we need to support setting the influx configuration alongside using postgres for analytics.
-    if USE_POSTGRES_FOR_ANALYTICS:
-        MIDDLEWARE.append("app_analytics.middleware.APIUsageMiddleware")
-    elif INFLUXDB_TOKEN:
-        MIDDLEWARE.append("app_analytics.middleware.InfluxDBMiddleware")
-
+    MIDDLEWARE.append("app_analytics.middleware.APIUsageMiddleware")
 
 ALLOWED_ADMIN_IP_ADDRESSES = env.list(
     "ALLOWED_ADMIN_IP_ADDRESSES",

--- a/api/app_analytics/cache.py
+++ b/api/app_analytics/cache.py
@@ -12,12 +12,12 @@ from app_analytics.tasks import (
 
 
 class APIUsageCache:
-    def __init__(self):  # type: ignore[no-untyped-def]
-        self._cache = {}
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, str, str], int] = {}
         self._last_flushed_at = timezone.now()
         self._lock = Lock()
 
-    def _flush(self):  # type: ignore[no-untyped-def]
+    def _flush(self) -> None:
         for key, value in self._cache.items():
             track_request.delay(
                 kwargs={
@@ -31,7 +31,12 @@ class APIUsageCache:
         self._cache = {}
         self._last_flushed_at = timezone.now()
 
-    def track_request(self, resource: int, host: str, environment_key: str):  # type: ignore[no-untyped-def]
+    def track_request(
+        self,
+        resource: str,
+        host: str,
+        environment_key: str,
+    ) -> None:
         key = (resource, host, environment_key)
         with self._lock:
             if key not in self._cache:
@@ -41,7 +46,7 @@ class APIUsageCache:
             if (
                 timezone.now() - self._last_flushed_at
             ).seconds > settings.PG_API_USAGE_CACHE_SECONDS:
-                self._flush()  # type: ignore[no-untyped-call]
+                self._flush()
 
 
 class FeatureEvaluationCache:

--- a/api/app_analytics/influxdb_wrapper.py
+++ b/api/app_analytics/influxdb_wrapper.py
@@ -53,7 +53,16 @@ class InfluxDBWrapper:
         self.records = []
         self.write_api = influxdb_client.write_api(write_options=SYNCHRONOUS)
 
-    def add_data_point(self, field_name, field_value, tags=None):  # type: ignore[no-untyped-def]
+    def add_data_point(
+        self,
+        field_name: str,
+        field_value: str | int | float,
+        tags: typing.Mapping[
+            str,
+            str | int | float,
+        ]
+        | None = None,
+    ) -> None:
         point = Point(self.name)
         point.field(field_name, field_value)
 
@@ -63,7 +72,7 @@ class InfluxDBWrapper:
 
         self.records.append(point)
 
-    def write(self):  # type: ignore[no-untyped-def]
+    def write(self) -> None:
         try:
             self.write_api.write(bucket=settings.INFLUXDB_BUCKET, record=self.records)
         except (HTTPError, InfluxDBError) as e:

--- a/api/app_analytics/middleware.py
+++ b/api/app_analytics/middleware.py
@@ -3,15 +3,13 @@ from django.conf import settings
 from app_analytics.cache import APIUsageCache
 from app_analytics.tasks import track_request
 
-from .models import Resource
 from .track import (
     TRACKED_RESOURCE_ACTIONS,
     get_resource_from_uri,
     track_request_googleanalytics_async,
-    track_request_influxdb_async,
 )
 
-api_usage_cache = APIUsageCache()  # type: ignore[no-untyped-call]
+api_usage_cache = APIUsageCache()
 
 
 class GoogleAnalyticsMiddleware:
@@ -27,19 +25,6 @@ class GoogleAnalyticsMiddleware:
         return response
 
 
-class InfluxDBMiddleware:
-    def __init__(self, get_response):  # type: ignore[no-untyped-def]
-        self.get_response = get_response
-
-    def __call__(self, request):  # type: ignore[no-untyped-def]
-        # for each API request, trigger a call to InfluxDB to track the request
-        track_request_influxdb_async(request)
-
-        response = self.get_response(request)
-
-        return response
-
-
 class APIUsageMiddleware:
     def __init__(self, get_response):  # type: ignore[no-untyped-def]
         self.get_response = get_response
@@ -48,7 +33,7 @@ class APIUsageMiddleware:
         resource = get_resource_from_uri(request.path)  # type: ignore[no-untyped-call]
         if resource in TRACKED_RESOURCE_ACTIONS:
             kwargs = {
-                "resource": Resource.get_from_resource_name(resource),
+                "resource": resource,
                 "host": request.get_host(),
                 "environment_key": request.headers.get("X-Environment-Key"),
             }

--- a/api/app_analytics/track.py
+++ b/api/app_analytics/track.py
@@ -36,12 +36,12 @@ def track_request_googleanalytics_async(request):  # type: ignore[no-untyped-def
     return track_request_googleanalytics(request)  # type: ignore[no-untyped-call]
 
 
-def get_resource_from_uri(request_uri):  # type: ignore[no-untyped-def]
+def get_resource_from_uri(request_uri: str) -> str | None:
     """
     Split the uri so we can determine the resource that is being requested
     (note that because it starts with a /, the first item in the list will be a blank string)
 
-    :param request: (HttpRequest) the request being made
+    :param request_uri: (str) django.http.HttpRequest.path
     """
     split_uri = request_uri.split("/")[1:]
     if not (len(split_uri) >= 3 and split_uri[0] == "api"):
@@ -63,7 +63,7 @@ def track_request_googleanalytics(request):  # type: ignore[no-untyped-def]
     # send pageview request
     requests.post(GOOGLE_ANALYTICS_COLLECT_URL, data=pageview_data)
 
-    resource = get_resource_from_uri(request.path)  # type: ignore[no-untyped-call]
+    resource = get_resource_from_uri(request.path)
 
     if resource in TRACKED_RESOURCE_ACTIONS:
         environment = Environment.get_from_cache(

--- a/api/environments/authentication.py
+++ b/api/environments/authentication.py
@@ -25,7 +25,7 @@ class EnvironmentKeyAuthentication(BaseAuthentication):
         if not (api_key and api_key.startswith(self.required_key_prefix)):
             raise AuthenticationFailed("Invalid or missing Environment key")
 
-        environment = Environment.get_from_cache(api_key)  # type: ignore[no-untyped-call]
+        environment = Environment.get_from_cache(api_key)
         if not environment:
             raise AuthenticationFailed("Invalid or missing Environment Key")
 

--- a/api/environments/identities/serializers.py
+++ b/api/environments/identities/serializers.py
@@ -114,7 +114,8 @@ class IdentityAllFeatureStatesSerializer(serializers.Serializer):  # type: ignor
         identity = self.context["identity"]
         environment_api_key = self.context["environment_api_key"]
 
-        environment = Environment.get_from_cache(environment_api_key)  # type: ignore[no-untyped-call]
+        environment = Environment.get_from_cache(environment_api_key)
+        assert environment
         hash_key = identity.get_hash_key(
             environment.use_identity_composite_key_for_hashing
         )

--- a/api/telemetry/serializers.py
+++ b/api/telemetry/serializers.py
@@ -22,5 +22,5 @@ class TelemetrySerializer(serializers.Serializer):  # type: ignore[type-arg]
                 **self.validated_data,
                 "ip_address": get_ip_address_from_request(self.context["request"]),  # type: ignore[no-untyped-call]
             }
-            influxdb.add_data_point("heartbeat", 1, tags=tags)  # type: ignore[no-untyped-call]
-            influxdb.write()  # type: ignore[no-untyped-call]
+            influxdb.add_data_point("heartbeat", 1, tags=tags)
+            influxdb.write()

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -4,23 +4,22 @@ from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 
 from app_analytics.middleware import APIUsageMiddleware
-from app_analytics.models import Resource
 
 
 @pytest.mark.parametrize(
-    "path, enum_resource_value",
+    "path, resource_name",
     [
-        ("/api/v1/flags", Resource.FLAGS),
-        ("/api/v1/traits", Resource.TRAITS),
-        ("/api/v1/identities", Resource.IDENTITIES),
-        ("/api/v1/environment-document", Resource.ENVIRONMENT_DOCUMENT),
+        ("/api/v1/flags", "flags"),
+        ("/api/v1/traits", "traits"),
+        ("/api/v1/identities", "identities"),
+        ("/api/v1/environment-document", "environment-document"),
     ],
 )
 def test_APIUsageMiddleware_calls_track_request_correctly_with_cache(
     rf: RequestFactory,
     mocker: MockerFixture,
     path: str,
-    enum_resource_value: int,
+    resource_name: str,
     settings: SettingsWrapper,
 ) -> None:
     # Given
@@ -41,24 +40,26 @@ def test_APIUsageMiddleware_calls_track_request_correctly_with_cache(
 
     # Then
     mocked_api_usage_cache.track_request.assert_called_once_with(
-        resource=enum_resource_value, host="testserver", environment_key=environment_key
+        resource=resource_name,
+        host="testserver",
+        environment_key=environment_key,
     )
 
 
 @pytest.mark.parametrize(
-    "path, enum_resource_value",
+    "path, resource_name",
     [
-        ("/api/v1/flags", Resource.FLAGS),
-        ("/api/v1/traits", Resource.TRAITS),
-        ("/api/v1/identities", Resource.IDENTITIES),
-        ("/api/v1/environment-document", Resource.ENVIRONMENT_DOCUMENT),
+        ("/api/v1/flags", "flags"),
+        ("/api/v1/traits", "traits"),
+        ("/api/v1/identities", "identities"),
+        ("/api/v1/environment-document", "environment-document"),
     ],
 )
 def test_APIUsageMiddleware_calls_track_request_correctly_without_cache(
     rf: RequestFactory,
     mocker: MockerFixture,
     path: str,
-    enum_resource_value: int,
+    resource_name: str,
     settings: SettingsWrapper,
 ) -> None:
     # Given
@@ -78,7 +79,7 @@ def test_APIUsageMiddleware_calls_track_request_correctly_without_cache(
     # Then
     mocked_track_request.delay.assert_called_once_with(
         kwargs={
-            "resource": enum_resource_value,
+            "resource": resource_name,
             "environment_key": environment_key,
             "host": "testserver",
         }

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -34,7 +34,7 @@ def test_APIUsageMiddleware_calls_track_request_correctly_with_cache(
     )
 
     mocked_get_response = mocker.MagicMock()
-    middleware = APIUsageMiddleware(mocked_get_response)  # type: ignore[no-untyped-call]
+    middleware = APIUsageMiddleware(mocked_get_response)
 
     # When
     middleware(request)
@@ -70,7 +70,7 @@ def test_APIUsageMiddleware_calls_track_request_correctly_without_cache(
     mocked_track_request = mocker.patch("app_analytics.middleware.track_request")
 
     mocked_get_response = mocker.MagicMock()
-    middleware = APIUsageMiddleware(mocked_get_response)  # type: ignore[no-untyped-call]
+    middleware = APIUsageMiddleware(mocked_get_response)
 
     # When
     middleware(request)
@@ -98,7 +98,7 @@ def test_APIUsageMiddleware_avoids_calling_track_request_if_resoure_is_not_track
     mocked_track_request = mocker.patch("app_analytics.middleware.track_request")
 
     mocked_get_response = mocker.MagicMock()
-    middleware = APIUsageMiddleware(mocked_get_response)  # type: ignore[no-untyped-call]
+    middleware = APIUsageMiddleware(mocked_get_response)
 
     # When
     middleware(request)

--- a/api/tests/unit/app_analytics/test_tasks.py
+++ b/api/tests/unit/app_analytics/test_tasks.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.utils import timezone
 from freezegun.api import FrozenDateTimeFactory
 from pytest_django.fixtures import SettingsWrapper
+from pytest_mock import MockerFixture
 
 from app_analytics.models import (
     APIUsageBucket,
@@ -20,6 +21,7 @@ from app_analytics.tasks import (
     track_feature_evaluation,
     track_request,
 )
+from environments.models import Environment
 
 if "analytics" not in settings.DATABASES:
     pytest.skip(
@@ -151,8 +153,12 @@ def test_populate_api_usage_bucket(  # type: ignore[no-untyped-def]
 
 
 @pytest.mark.django_db(databases=["analytics", "default"])
-def test_track_request(environment):  # type: ignore[no-untyped-def]
+def test_track_request__postgres__inserts_expected(
+    settings: SettingsWrapper,
+    environment: Environment,
+) -> None:
     # Given
+    settings.USE_POSTGRES_FOR_ANALYTICS = True
     host = "testserver"
     environment_key = environment.api_key
     resource = "flags"
@@ -167,6 +173,33 @@ def test_track_request(environment):  # type: ignore[no-untyped-def]
             resource=expected_resource, host=host, environment_id=environment.id
         ).count()
         == 1
+    )
+
+
+def test_track_request__influx__calls_expected(
+    settings: SettingsWrapper,
+    mocker: MockerFixture,
+    environment: Environment,
+) -> None:
+    # Given
+    settings.INFLUXDB_TOKEN = "test_token"
+    track_request_influxdb_mock = mocker.patch(
+        "app_analytics.tasks.track_request_influxdb",
+        autospec=True,
+    )
+    host = "testserver"
+    environment_key = environment.api_key
+    resource = "flags"
+
+    # When
+    track_request(resource, host, environment_key)
+
+    # Then
+    track_request_influxdb_mock.assert_called_once_with(
+        resource=resource,
+        host=host,
+        environment=environment,
+        count=1,
     )
 
 

--- a/api/tests/unit/app_analytics/test_tasks.py
+++ b/api/tests/unit/app_analytics/test_tasks.py
@@ -155,7 +155,8 @@ def test_track_request(environment):  # type: ignore[no-untyped-def]
     # Given
     host = "testserver"
     environment_key = environment.api_key
-    resource = Resource.FLAGS
+    resource = "flags"
+    expected_resource = Resource.FLAGS
 
     # When
     track_request(resource, host, environment_key)
@@ -163,7 +164,7 @@ def test_track_request(environment):  # type: ignore[no-untyped-def]
     # Then
     assert (
         APIUsageRaw.objects.filter(
-            resource=resource, host=host, environment_id=environment.id
+            resource=expected_resource, host=host, environment_id=environment.id
         ).count()
         == 1
     )

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
@@ -55,7 +55,7 @@ def test_api_usage_cache(
             expected_calls.append(
                 mocker.call(
                     kwargs={
-                        "resource": resource,
+                        "resource": Resource.get_lowercased_name(resource),
                         "host": host,
                         "environment_key": environment_key_1,
                         "count": 11 if resource == Resource.FLAGS else 10,
@@ -65,7 +65,7 @@ def test_api_usage_cache(
             expected_calls.append(
                 mocker.call(
                     kwargs={
-                        "resource": resource,
+                        "resource": Resource.get_lowercased_name(resource),
                         "host": host,
                         "environment_key": environment_key_2,
                         "count": 10,

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
@@ -14,7 +14,7 @@ def test_api_usage_cache(
     # Given
     settings.PG_API_USAGE_CACHE_SECONDS = 60
 
-    cache = APIUsageCache()  # type: ignore[no-untyped-call]
+    cache = APIUsageCache()
     now = timezone.now()
     mocked_track_request_task = mocker.patch("app_analytics.cache.track_request")
     host = "host"
@@ -25,8 +25,16 @@ def test_api_usage_cache(
         # Make some tracking requests
         for _ in range(10):
             for resource in Resource:
-                cache.track_request(resource, host, environment_key_1)
-                cache.track_request(resource, host, environment_key_2)
+                cache.track_request(
+                    Resource.get_lowercased_name(resource),
+                    host,
+                    environment_key_1,
+                )
+                cache.track_request(
+                    Resource.get_lowercased_name(resource),
+                    host,
+                    environment_key_2,
+                )
 
         # make sure track_request task was not called
         assert not mocked_track_request_task.called
@@ -36,7 +44,7 @@ def test_api_usage_cache(
 
         # let's track another request(to trigger flush)
         cache.track_request(
-            Resource.FLAGS,
+            "flags",
             host,
             environment_key_1,
         )
@@ -71,7 +79,7 @@ def test_api_usage_cache(
 
         # and track another request
         cache.track_request(
-            Resource.FLAGS,
+            "flags",
             host,
             environment_key_1,
         )

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_influxdb_wrapper.py
@@ -57,10 +57,10 @@ def mock_write_api(mock_influxdb_client: MagicMock) -> MagicMock:
 def test_write(mock_write_api: MagicMock) -> None:
     # Given
     influxdb = InfluxDBWrapper("name")  # type: ignore[no-untyped-call]
-    influxdb.add_data_point("field_name", "field_value")  # type: ignore[no-untyped-call]
+    influxdb.add_data_point("field_name", "field_value")
 
     # When
-    influxdb.write()  # type: ignore[no-untyped-call]
+    influxdb.write()
 
     # Then
     mock_write_api.write.assert_called()
@@ -76,10 +76,10 @@ def test_write_handles_errors(
     mock_write_api.write.side_effect = exception_class
 
     influxdb = InfluxDBWrapper("name")  # type: ignore[no-untyped-call]
-    influxdb.add_data_point("field_name", "field_value")  # type: ignore[no-untyped-call]
+    influxdb.add_data_point("field_name", "field_value")
 
     # When
-    influxdb.write()  # type: ignore[no-untyped-call]
+    influxdb.write()
 
     # Then
     # The write API was called

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
@@ -82,7 +82,6 @@ def test_track_request_sends_data_to_influxdb_for_tracked_uris(  # type: ignore[
     )
 
 
-@mock.patch("app_analytics.track.InfluxDBWrapper")
 def test_track_request_sends_host_data_to_influxdb(
     mocker: MockerFixture,
 ) -> None:

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
@@ -46,92 +46,86 @@ def test_track_request_googleanalytics(  # type: ignore[no-untyped-def]
 
 
 @pytest.mark.parametrize(
-    "request_uri, expected_resource",
+    "expected_resource",
     (
-        ("/api/v1/flags/", "flags"),
-        ("/api/v1/identities/", "identities"),
-        ("/api/v1/traits/", "traits"),
-        ("/api/v1/environment-document/", "environment-document"),
+        "flags",
+        "identities",
+        "traits",
+        "environment-document",
     ),
 )
-@mock.patch("app_analytics.track.InfluxDBWrapper")
-@mock.patch("app_analytics.track.Environment")
 def test_track_request_sends_data_to_influxdb_for_tracked_uris(  # type: ignore[no-untyped-def]
-    MockEnvironment, MockInfluxDBWrapper, request_uri, expected_resource
+    mocker: MockerFixture,
+    expected_resource: str,
 ):
     """
     Verify that the correct number of calls are made to InfluxDB for the various uris.
     """
     # Given
-    request = mock.MagicMock()
-    request.path = request_uri
-    environment_api_key = "test"
-    request.headers = {"X-Environment-Key": environment_api_key}
-
-    mock_influxdb = mock.MagicMock()
-    MockInfluxDBWrapper.return_value = mock_influxdb
+    mock_influxdb = mocker.patch("app_analytics.track.InfluxDBWrapper")
+    mock_environment = mocker.MagicMock()
 
     # When
-    track_request_influxdb(request)  # type: ignore[no-untyped-call]
+    track_request_influxdb(
+        resource=expected_resource,
+        host="testserver",
+        environment=mock_environment,
+    )
 
     # Then
-    call_list = MockInfluxDBWrapper.call_args_list
-    assert len(call_list) == 1
+    mock_influxdb.return_value.add_data_point.assert_called_once()
     assert (
-        mock_influxdb.add_data_point.call_args_list[0][1]["tags"]["resource"]
+        mock_influxdb.return_value.add_data_point.call_args_list[0][1]["tags"][
+            "resource"
+        ]
         == expected_resource
     )
 
 
 @mock.patch("app_analytics.track.InfluxDBWrapper")
-@mock.patch("app_analytics.track.Environment")
-def test_track_request_sends_host_data_to_influxdb(  # type: ignore[no-untyped-def]
-    MockEnvironment, MockInfluxDBWrapper, rf
-):
+def test_track_request_sends_host_data_to_influxdb(
+    mocker: MockerFixture,
+) -> None:
     """
     Verify that host is part of the data send to influxDB
     """
     # Given
-    environment_api_key = "test"
-    headers = {"X-Environment-Key": environment_api_key}
-
-    request = rf.get("/api/v1/flags/", headers=headers)
-
-    mock_influxdb = mock.MagicMock()
-    MockInfluxDBWrapper.return_value = mock_influxdb
+    mock_influxdb = mocker.patch("app_analytics.track.InfluxDBWrapper")
+    mock_environment = mocker.MagicMock()
 
     # When
-    track_request_influxdb(request)  # type: ignore[no-untyped-call]
+    track_request_influxdb(
+        resource="flags",
+        host="testserver",
+        environment=mock_environment,
+    )
 
     # Then
     assert (
-        mock_influxdb.add_data_point.call_args_list[0][1]["tags"]["host"]
+        mock_influxdb.return_value.add_data_point.call_args_list[0][1]["tags"]["host"]
         == "testserver"
     )
 
 
-@mock.patch("app_analytics.track.InfluxDBWrapper")
-@mock.patch("app_analytics.track.Environment")
-def test_track_request_does_not_send_data_to_influxdb_for_not_tracked_uris(  # type: ignore[no-untyped-def]
-    MockEnvironment, MockInfluxDBWrapper
-):
+def test_track_request_does_not_send_data_to_influxdb_for_not_tracked_uris(
+    mocker: MockerFixture,
+) -> None:
     """
     Verify that the correct number of calls are made to InfluxDB for the various uris.
     """
     # Given
-    request = mock.MagicMock()
-    request.path = "/health"
-    environment_api_key = "test"
-    request.headers = {"X-Environment-Key": environment_api_key}
-
-    mock_influxdb = mock.MagicMock()
-    MockInfluxDBWrapper.return_value = mock_influxdb
+    mock_influxdb = mocker.patch("app_analytics.track.InfluxDBWrapper")
+    mock_environment = mocker.MagicMock()
 
     # When
-    track_request_influxdb(request)  # type: ignore[no-untyped-call]
+    track_request_influxdb(
+        resource="health",
+        host="testserver",
+        environment=mock_environment,
+    )
 
     # Then
-    MockInfluxDBWrapper.assert_not_called()
+    mock_influxdb.return_value.assert_not_called()
 
 
 def test_track_feature_evaluation_influxdb(mocker: MockerFixture) -> None:

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -407,11 +407,6 @@ def test_set_sdk_analytics_flags_without_identifier(
     assert feature_evaluation_raw.evaluation_count is feature_request_count  # type: ignore[union-attr]
 
 
-@pytest.mark.skipif(
-    "analytics" not in settings.DATABASES,
-    reason="Skip test if analytics DB is not configured",
-)
-@pytest.mark.django_db(databases=["default", "analytics"])
 def test_set_sdk_analytics_flags_with_identifier__influx__calls_expected(
     api_client: APIClient,
     environment: Environment,

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -203,10 +203,10 @@ def test_environment_get_from_cache_stores_environment_in_cache_on_success(
     mock_cache.get.return_value = None
 
     # When
-    environment = Environment.get_from_cache(environment.api_key)  # type: ignore[no-untyped-call]
+    cached_environment = Environment.get_from_cache(environment.api_key)
 
     # Then
-    assert environment == environment
+    assert cached_environment == environment
     mock_cache.set.assert_called_with(environment.api_key, environment, timeout=60)
 
 
@@ -217,7 +217,7 @@ def test_environment_get_from_cache_returns_None_if_no_matching_environment(
     api_key = "no-matching-env"
 
     # When
-    env = Environment.get_from_cache(api_key)  # type: ignore[no-untyped-call]
+    env = Environment.get_from_cache(api_key)
 
     # Then
     assert env is None
@@ -230,7 +230,7 @@ def test_environment_get_from_cache_accepts_environment_api_key_model_key(
     api_key = EnvironmentAPIKey.objects.create(name="Some key", environment=environment)
 
     # When
-    environment_from_cache = Environment.get_from_cache(api_key=api_key.key)  # type: ignore[no-untyped-call]
+    environment_from_cache = Environment.get_from_cache(api_key=api_key.key)
 
     # Then
     assert environment_from_cache == environment
@@ -240,7 +240,7 @@ def test_environment_get_from_cache_with_null_environment_key_returns_null(
     environment: Environment,
 ) -> None:
     # When
-    environment2 = Environment.get_from_cache(None)  # type: ignore[no-untyped-call]
+    environment2 = Environment.get_from_cache(None)
 
     # Then
     assert environment2 is None
@@ -258,7 +258,7 @@ def test_environment_get_from_cache_does_not_hit_database_if_api_key_in_bad_env_
 
     # When
     with django_assert_num_queries(1):
-        [Environment.get_from_cache(api_key) for _ in range(10)]  # type: ignore[no-untyped-call]
+        [Environment.get_from_cache(api_key) for _ in range(10)]
 
 
 def test_environment_api_key_model_is_valid_is_true_for_non_expired_active_key(  # type: ignore[no-untyped-def]
@@ -324,9 +324,9 @@ def test_existence_of_multiple_environment_api_keys_does_not_break_get_from_cach
 
     # When
     retrieved_environments = [
-        Environment.get_from_cache(environment.api_key),  # type: ignore[no-untyped-call]
+        Environment.get_from_cache(environment.api_key),
         *[
-            Environment.get_from_cache(environment_api_key.key)  # type: ignore[no-untyped-call]
+            Environment.get_from_cache(environment_api_key.key)
             for environment_api_key in environment_api_keys
         ],
     ]
@@ -342,7 +342,7 @@ def test_get_from_cache_sets_the_cache_correctly_with_environment_api_key(  # ty
     environment, environment_api_key, mocker
 ):
     # When
-    returned_environment = Environment.get_from_cache(environment_api_key.key)  # type: ignore[no-untyped-call]
+    returned_environment = Environment.get_from_cache(environment_api_key.key)
 
     # Then
     assert returned_environment == environment


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #5327.

In this PR, we refactor the tracking middleware to avoid accessing the `request` object from a thread. InfluxDB request tracking is performed from a `track_request` async task instead, with all the required data extracted from the request synchronously. `InfluxDBMiddleware` is removed, and `APIUsageCache` is acommodated to cache Influx-tracked requests as well as Postgres-tracked ones. As a side effect, we might see less rate limits from Influx Cloud.

Numerous typing errors are fixed as well. 

## How did you test this code?

Existing unit tests are modified to accommodate for new behaviour.
A new `test_track_request__influx__calls_expected` test is added to verify that the `track_request` task supports writing to InfluxDB as expected.