### PR TITLE
feat(billing): Remove `AUTO_SEAT_UPGRADE_PLANS` setting

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -1187,14 +1187,6 @@ HUBSPOT_IGNORE_ORGANISATION_DOMAINS = env.list(
 # hubspot without a Flagsmith organisation.
 CREATE_HUBSPOT_LEAD_WITHOUT_ORGANISATION_DELAY_MINUTES = 30
 
-# List of plan ids that support seat upgrades
-AUTO_SEAT_UPGRADE_PLANS = env.list(
-    "AUTO_SEAT_UPGRADE_PLANS",
-    subcast=str,
-    default=[],
-)
-
-
 SKIP_MIGRATION_TESTS = env.bool("SKIP_MIGRATION_TESTS", False)
 
 # prevent django-softdelete from performing whole table deletes!

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -4,6 +4,7 @@ import typing
 from unittest.mock import MagicMock
 
 import boto3
+import django
 import pytest
 from common.environments.permissions import (
     MANAGE_IDENTITIES,
@@ -19,6 +20,8 @@ from django.test.utils import setup_databases
 from flag_engine.segments.constants import EQUAL
 from moto import mock_dynamodb  # type: ignore[import-untyped]
 from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pyfakefs.fake_filesystem_unittest import Patcher
 from pytest_django.fixtures import SettingsWrapper
 from pytest_django.plugin import blocking_manager_key
 from pytest_mock import MockerFixture
@@ -131,6 +134,17 @@ def pytest_configure(config: pytest.Config) -> None:
                 interactive=False,
                 parallel=config.option.numprocesses,
             )
+
+
+@pytest.fixture
+def fs() -> typing.Generator[FakeFilesystem | None, None, None]:
+    app_path = os.path.dirname(os.path.abspath(__file__))
+    django_path = os.path.dirname(os.path.abspath(django.__file__))
+
+    with Patcher() as patcher:
+        if fs := patcher.fs:
+            fs.add_real_paths([app_path, django_path])
+        yield fs
 
 
 @pytest.fixture(scope="session")

--- a/api/organisations/invites/views.py
+++ b/api/organisations/invites/views.py
@@ -151,8 +151,7 @@ class InviteViewSet(
         subscription_metadata = organisation.subscription.get_subscription_metadata()
 
         if (
-            len(settings.AUTO_SEAT_UPGRADE_PLANS) > 0
-            and organisation.num_seats >= subscription_metadata.seats
+            organisation.num_seats >= subscription_metadata.seats
             and not organisation.subscription.can_auto_upgrade_seats
         ):
             raise SubscriptionDoesNotSupportSeatUpgrade()

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -138,10 +138,7 @@ class Organisation(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
         self.save()
 
     def is_auto_seat_upgrade_available(self) -> bool:
-        return (
-            len(settings.AUTO_SEAT_UPGRADE_PLANS) > 0
-            and self.subscription.can_auto_upgrade_seats
-        )
+        return self.subscription.can_auto_upgrade_seats
 
     @hook(BEFORE_DELETE)
     def cancel_subscription(self):  # type: ignore[no-untyped-def]
@@ -262,7 +259,7 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
 
     @property
     def can_auto_upgrade_seats(self) -> bool:
-        return self.plan in settings.AUTO_SEAT_UPGRADE_PLANS
+        return self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
 
     @property
     def is_free_plan(self) -> bool:

--- a/api/organisations/models.py
+++ b/api/organisations/models.py
@@ -259,7 +259,10 @@ class Subscription(LifecycleModelMixin, SoftDeleteExportableModel):  # type: ign
 
     @property
     def can_auto_upgrade_seats(self) -> bool:
-        return self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
+        return (
+            is_saas()
+            and self.subscription_plan_family == SubscriptionPlanFamily.SCALE_UP
+        )
 
     @property
     def is_free_plan(self) -> bool:

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -303,6 +303,7 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit(
     )
 
 
+@pytest.mark.saas_mode
 @pytest.mark.parametrize(
     "invite_object, url",
     [

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -1,5 +1,4 @@
 import json
-import typing
 from datetime import timedelta
 
 import pytest
@@ -14,7 +13,7 @@ from rest_framework.test import APIClient
 
 from organisations.invites.models import Invite, InviteLink
 from organisations.models import Organisation, OrganisationRole, Subscription
-from users.models import FFAdminUser, HubspotTracker
+from users.models import HubspotTracker, UserPermissionGroup
 
 
 def test_create_invite_link(
@@ -211,16 +210,12 @@ def test_create_invite_with_permission_groups(  # type: ignore[no-untyped-def]
     assert invite.invited_by == admin_user
 
 
-def test_create_invite_returns_400_if_seats_are_over(  # type: ignore[no-untyped-def]
-    admin_client,
-    organisation,
-    user_permission_group,
-    admin_user,
-    subscription,
-    settings,
-):
+def test_create_invite_returns_400_if_seats_are_over(
+    admin_client: APIClient,
+    organisation: Organisation,
+    user_permission_group: UserPermissionGroup,
+) -> None:
     # Given
-    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
     url = reverse(
         "api-v1:organisations:organisation-invites-list",
         args=[organisation.pk],
@@ -288,18 +283,14 @@ def test_update_invite_returns_405(  # type: ignore[no-untyped-def]
         (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
-def test_join_organisation_returns_400_if_exceeds_plan_limit(  # type: ignore[no-untyped-def]
-    test_user_client,
-    organisation,
-    admin_user,
-    invite_object,
-    url,
-    subscription,
-    settings,
-):
+def test_join_organisation_returns_400_if_exceeds_plan_limit(
+    test_user_client: APIClient,
+    invite_object: Invite | InviteLink,
+    url: str,
+    settings: SettingsWrapper,
+) -> None:
     # Given
     settings.ENABLE_CHARGEBEE = True
-    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
     url = reverse(url, args=[invite_object.hash])
     # When
     response = test_user_client.post(url)
@@ -319,19 +310,16 @@ def test_join_organisation_returns_400_if_exceeds_plan_limit(  # type: ignore[no
         (lazy_fixture("invite_link"), "api-v1:users:user-join-organisation-link"),
     ],
 )
-def test_join_organisation_returns_400_if_payment_fails(  # type: ignore[no-untyped-def]
+def test_join_organisation_returns_400_if_payment_fails(
     test_user_client: APIClient,
-    organisation: Organisation,
-    admin_user: FFAdminUser,
-    invite_object: typing.Union[Invite, InviteLink],
+    invite_object: Invite | InviteLink,
     url: str,
     subscription: Subscription,
     settings: SettingsWrapper,
     mocker: MockerFixture,
-):
+) -> None:
     # Given
     settings.ENABLE_CHARGEBEE = True
-    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
 
     url = reverse(url, args=[invite_object.hash])
 

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -168,7 +168,10 @@ def test_organisation_over_plan_seats_no_subscription(organisation, mocker, admi
     mocked_get_subscription_metadata.assert_not_called()
 
 
-def test_organisation_is_auto_seat_upgrade_available(organisation, settings):  # type: ignore[no-untyped-def]
+@pytest.mark.saas_mode
+def test_organisation_is_auto_seat_upgrade_available(
+    organisation: Organisation,
+) -> None:
     # Given
     plan = "Scale-Up"
     subscription_id = "subscription-id"
@@ -412,6 +415,7 @@ def test_organisation_get_subscription_metadata_for_self_hosted_open_source(
     assert subscription_metadata == FREE_PLAN_SUBSCRIPTION_METADATA
 
 
+@pytest.mark.saas_mode
 def test_organisation_subscription_add_single_seat_calls_correct_chargebee_method_for_upgradable_plan(  # noqa: E501
     mocker: MockerFixture,
 ) -> None:

--- a/api/tests/unit/organisations/test_unit_organisations_models.py
+++ b/api/tests/unit/organisations/test_unit_organisations_models.py
@@ -172,7 +172,6 @@ def test_organisation_is_auto_seat_upgrade_available(organisation, settings):  #
     # Given
     plan = "Scale-Up"
     subscription_id = "subscription-id"
-    settings.AUTO_SEAT_UPGRADE_PLANS = [plan]
 
     Subscription.objects.filter(organisation=organisation).update(
         subscription_id=subscription_id, plan=plan
@@ -413,12 +412,10 @@ def test_organisation_get_subscription_metadata_for_self_hosted_open_source(
     assert subscription_metadata == FREE_PLAN_SUBSCRIPTION_METADATA
 
 
-def test_organisation_subscription_add_single_seat_calls_correct_chargebee_method_for_upgradable_plan(  # type: ignore[no-untyped-def]  # noqa: E501
-    mocker, settings
-):
+def test_organisation_subscription_add_single_seat_calls_correct_chargebee_method_for_upgradable_plan(  # noqa: E501
+    mocker: MockerFixture,
+) -> None:
     # Given
-    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
-
     subscription_id = "subscription-id"
     subscription = Subscription(subscription_id=subscription_id, plan="scale-up")
 
@@ -432,12 +429,10 @@ def test_organisation_subscription_add_single_seat_calls_correct_chargebee_metho
     mocked_add_single_seat.assert_called_once_with(subscription_id)
 
 
-def test_organisation_subscription_add_single_seat_raises_error_for_non_upgradable_plan(  # type: ignore[no-untyped-def]  # noqa: E501
-    mocker, settings
-):
+def test_organisation_subscription_add_single_seat_raises_error_for_non_upgradable_plan(  # noqa: E501
+    mocker: MockerFixture,
+) -> None:
     # Given
-    settings.AUTO_SEAT_UPGRADE_PLANS = ["scale-up"]
-
     subscription_id = "subscription-id"
     subscription = Subscription(
         subscription_id=subscription_id, plan="not-a-scale-up-plan"

--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -180,10 +180,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "AUTO_SEAT_UPGRADE_PLANS",
-                    "value": "scale-up-12-months-v2-gbp,scale-up-12-months-v2-eur,scale-up-12-months-v2,scale-up-quarterly-v2-semiannual,scale-up-quarterly-v2,scale-up-v2,scale-up-24-months-v2"
-                },
-                {
                     "name": "PIPEDRIVE_IGNORE_DOMAINS",
                     "value": "flagsmith.com,solidstategroup.com,restmail.net,bullettrain.io,flagsmithe2etestdomain.io"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -164,10 +164,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "AUTO_SEAT_UPGRADE_PLANS",
-                    "value": "scale-up,scale-up-v2,scale-up-annual-v2,scale-up-24-months-v2"
-                },
-                {
                     "name": "USE_POSTGRES_FOR_ANALYTICS",
                     "value": "False"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we remove the `AUTO_SEAT_UPGRADE_PLANS` setting in favour of centralised `SubscriptionPlanFamily.get_by_plan_id` logic.
 
## How did you test this code?

Made sure all relevant unit tests pass without the setting present.