### PR TITLE
fix: `track_request` task not backwards compatible

### DIFF
--- a/api/app_analytics/analytics_db_service.py
+++ b/api/app_analytics/analytics_db_service.py
@@ -135,15 +135,16 @@ def get_usage_data_from_local_db(
         .annotate(count=Sum("total_count"))
     )
     data_by_day = {}
-    for row in qs:
+    for row in qs:  # TODO Write proper mappers for this?
         day = row["created_at__date"]
         if day not in data_by_day:
             data_by_day[day] = UsageData(day=day)
-        setattr(
-            data_by_day[day],
-            Resource.get_lowercased_name(row["resource"]),
-            row["count"],
-        )
+        if column_name := Resource(row["resource"]).column_name:
+            setattr(
+                data_by_day[day],
+                column_name,
+                row["count"],
+            )
 
     return data_by_day.values()  # type: ignore[return-value]
 

--- a/api/app_analytics/cache.py
+++ b/api/app_analytics/cache.py
@@ -4,6 +4,7 @@ from threading import Lock
 from django.conf import settings
 from django.utils import timezone
 
+from app_analytics.models import Resource
 from app_analytics.tasks import (
     track_feature_evaluation,
     track_feature_evaluation_influxdb,
@@ -13,7 +14,7 @@ from app_analytics.tasks import (
 
 class APIUsageCache:
     def __init__(self) -> None:
-        self._cache: dict[tuple[str, str, str], int] = {}
+        self._cache: dict[tuple[Resource, str, str], int] = {}
         self._last_flushed_at = timezone.now()
         self._lock = Lock()
 
@@ -21,7 +22,7 @@ class APIUsageCache:
         for key, value in self._cache.items():
             track_request.delay(
                 kwargs={
-                    "resource": key[0],
+                    "resource": key[0].value,
                     "host": key[1],
                     "environment_key": key[2],
                     "count": value,
@@ -33,7 +34,7 @@ class APIUsageCache:
 
     def track_request(
         self,
-        resource: str,
+        resource: Resource,
         host: str,
         environment_key: str,
     ) -> None:

--- a/api/app_analytics/middleware.py
+++ b/api/app_analytics/middleware.py
@@ -1,18 +1,13 @@
 from typing import Callable
 
-from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
-from app_analytics.cache import APIUsageCache
-from app_analytics.tasks import track_request
+from app_analytics.services import track_usage_by_resource_host_and_environment
 
 from .track import (
-    TRACKED_RESOURCE_ACTIONS,
     get_resource_from_uri,
     track_request_googleanalytics_async,
 )
-
-api_usage_cache = APIUsageCache()
 
 
 class GoogleAnalyticsMiddleware:
@@ -36,20 +31,12 @@ class APIUsageMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
-        environment_key = request.headers.get("X-Environment-Key")
-        if environment_key and (
-            (resource := get_resource_from_uri(request.path))
-            in TRACKED_RESOURCE_ACTIONS
-        ):
-            kwargs = {
-                "resource": resource,
-                "host": request.get_host(),
-                "environment_key": environment_key,
-            }
-            if settings.USE_CACHE_FOR_USAGE_DATA:
-                api_usage_cache.track_request(**kwargs)
-            else:
-                track_request.delay(kwargs=kwargs)
+        if environment_key := request.headers.get("X-Environment-Key"):
+            track_usage_by_resource_host_and_environment(
+                resource=get_resource_from_uri(request.path),
+                host=request.get_host(),
+                environment_key=environment_key,
+            )
 
         response = self.get_response(request)
 

--- a/api/app_analytics/models.py
+++ b/api/app_analytics/models.py
@@ -15,20 +15,41 @@ class Resource(models.IntegerChoices):
     TRAITS = 3
     ENVIRONMENT_DOCUMENT = 4
 
-    @classmethod
-    def get_lowercased_name(cls, resource: int) -> str:
-        member = next(filter(lambda member: member.value == resource, cls), None)
-        if not member:
-            raise ValueError(f"Invalid resource: {resource}")
+    @property
+    def is_tracked(self) -> bool:
+        return self in {
+            self.FLAGS,
+            self.IDENTITIES,
+            self.TRAITS,
+            self.ENVIRONMENT_DOCUMENT,
+        }
 
-        return member.name.lower()
+    @property
+    def resource_name(self) -> str | None:
+        return {
+            self.FLAGS: "flags",
+            self.IDENTITIES: "identities",
+            self.TRAITS: "traits",
+            self.ENVIRONMENT_DOCUMENT: "environment-document",
+        }.get(self)
+
+    @property
+    def column_name(self) -> str | None:
+        return {
+            self.FLAGS: "flags",
+            self.IDENTITIES: "identities",
+            self.TRAITS: "traits",
+            self.ENVIRONMENT_DOCUMENT: "environment_document",
+        }.get(self)
 
     @classmethod
-    def get_from_resource_name(cls, resource: str) -> int:
-        try:
-            return getattr(cls, resource.upper().replace("-", "_")).value  # type: ignore[no-any-return]
-        except (KeyError, AttributeError) as err:
-            raise ValueError(f"Invalid resource: {resource}") from err
+    def get_from_name(cls, resource_name: str) -> "Resource | None":
+        return {
+            "flags": cls.FLAGS,
+            "identities": cls.IDENTITIES,
+            "traits": cls.TRAITS,
+            "environment-document": cls.ENVIRONMENT_DOCUMENT,
+        }.get(resource_name)
 
 
 class APIUsageRaw(models.Model):

--- a/api/app_analytics/services.py
+++ b/api/app_analytics/services.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+
+from app_analytics.cache import APIUsageCache
+from app_analytics.models import Resource
+from app_analytics.tasks import track_request
+
+api_usage_cache = APIUsageCache()
+
+
+def track_usage_by_resource_host_and_environment(
+    resource: Resource | None,
+    host: str,
+    environment_key: str,
+) -> None:
+    if resource and resource.is_tracked:
+        if settings.USE_CACHE_FOR_USAGE_DATA:
+            api_usage_cache.track_request(
+                resource=resource,
+                host=host,
+                environment_key=environment_key,
+            )
+        else:
+            track_request.delay(
+                kwargs={
+                    "resource": resource.value,
+                    "host": host,
+                    "environment_key": environment_key,
+                }
+            )

--- a/api/app_analytics/tasks.py
+++ b/api/app_analytics/tasks.py
@@ -109,15 +109,16 @@ def track_feature_evaluation(
 
 @register_task_handler()
 def track_request(
-    resource: str,
+    resource: int,
     host: str,
     environment_key: str,
     count: int = 1,
 ) -> None:
     if environment := Environment.get_from_cache(environment_key):
+        resource = Resource(resource)
         if settings.USE_POSTGRES_FOR_ANALYTICS:
             APIUsageRaw.objects.create(
-                resource=Resource.get_from_resource_name(resource),
+                resource=resource,
                 host=host,
                 environment_id=environment.id,
                 count=count,

--- a/api/app_analytics/track.py
+++ b/api/app_analytics/track.py
@@ -22,15 +22,6 @@ GOOGLE_ANALYTICS_COLLECT_URL = GOOGLE_ANALYTICS_BASE_URL + "/collect"
 GOOGLE_ANALYTICS_BATCH_URL = GOOGLE_ANALYTICS_BASE_URL + "/batch"
 DEFAULT_DATA = "v=1&tid=" + settings.GOOGLE_ANALYTICS_KEY
 
-# dictionary of resources to their corresponding actions
-# when tracking events in GA / Influx
-TRACKED_RESOURCE_ACTIONS = {
-    Resource.FLAGS: "flags",
-    Resource.IDENTITIES: "identity_flags",
-    Resource.TRAITS: "traits",
-    Resource.ENVIRONMENT_DOCUMENT: "environment_document",
-}
-
 
 @postpone
 def track_request_googleanalytics_async(request):  # type: ignore[no-untyped-def]

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -4,6 +4,7 @@ from pytest_django.fixtures import SettingsWrapper
 from pytest_mock import MockerFixture
 
 from app_analytics.middleware import APIUsageMiddleware
+from app_analytics.models import Resource
 
 
 @pytest.mark.parametrize(
@@ -15,7 +16,7 @@ from app_analytics.middleware import APIUsageMiddleware
         ("/api/v1/environment-document", "environment-document"),
     ],
 )
-def test_APIUsageMiddleware_calls_track_request_correctly_with_cache(
+def test_api_usage_middleware__calls_expected(
     rf: RequestFactory,
     mocker: MockerFixture,
     path: str,
@@ -29,7 +30,7 @@ def test_APIUsageMiddleware_calls_track_request_correctly_with_cache(
     settings.USE_CACHE_FOR_USAGE_DATA = True
 
     mocked_api_usage_cache = mocker.patch(
-        "app_analytics.middleware.api_usage_cache", autospec=True
+        "app_analytics.services.api_usage_cache", autospec=True
     )
 
     mocked_get_response = mocker.MagicMock()
@@ -40,7 +41,7 @@ def test_APIUsageMiddleware_calls_track_request_correctly_with_cache(
 
     # Then
     mocked_api_usage_cache.track_request.assert_called_once_with(
-        resource=resource_name,
+        resource=Resource.get_from_name(resource_name),
         host="testserver",
         environment_key=environment_key,
     )
@@ -55,7 +56,7 @@ def test_APIUsageMiddleware_calls_track_request_correctly_with_cache(
         ("/api/v1/environment-document", "environment-document"),
     ],
 )
-def test_APIUsageMiddleware_calls_track_request_correctly_without_cache(
+def test_api_usage_middleware__no_cache__calls_expected(
     rf: RequestFactory,
     mocker: MockerFixture,
     path: str,
@@ -68,7 +69,7 @@ def test_APIUsageMiddleware_calls_track_request_correctly_without_cache(
     request = rf.get(path, **headers)  # type: ignore[arg-type]
     settings.USE_CACHE_FOR_USAGE_DATA = False
 
-    mocked_track_request = mocker.patch("app_analytics.middleware.track_request")
+    mocked_track_request = mocker.patch("app_analytics.services.track_request")
 
     mocked_get_response = mocker.MagicMock()
     middleware = APIUsageMiddleware(mocked_get_response)
@@ -79,14 +80,14 @@ def test_APIUsageMiddleware_calls_track_request_correctly_without_cache(
     # Then
     mocked_track_request.delay.assert_called_once_with(
         kwargs={
-            "resource": resource_name,
+            "resource": Resource.get_from_name(resource_name),
             "environment_key": environment_key,
             "host": "testserver",
         }
     )
 
 
-def test_APIUsageMiddleware_avoids_calling_track_request_if_resoure_is_not_tracked(
+def test_api_usage_middleware__request_not_tracked__not_calls_expected(
     rf: RequestFactory, mocker: MockerFixture, settings: SettingsWrapper
 ) -> None:
     # Given
@@ -96,7 +97,7 @@ def test_APIUsageMiddleware_avoids_calling_track_request_if_resoure_is_not_track
     request = rf.get(path, **headers)  # type: ignore[arg-type]
     settings.USE_CACHE_FOR_USAGE_DATA = False
 
-    mocked_track_request = mocker.patch("app_analytics.middleware.track_request")
+    mocked_track_request = mocker.patch("app_analytics.services.track_request")
 
     mocked_get_response = mocker.MagicMock()
     middleware = APIUsageMiddleware(mocked_get_response)

--- a/api/tests/unit/app_analytics/test_tasks.py
+++ b/api/tests/unit/app_analytics/test_tasks.py
@@ -161,8 +161,7 @@ def test_track_request__postgres__inserts_expected(
     settings.USE_POSTGRES_FOR_ANALYTICS = True
     host = "testserver"
     environment_key = environment.api_key
-    resource = "flags"
-    expected_resource = Resource.FLAGS
+    resource = Resource.FLAGS
 
     # When
     track_request(resource, host, environment_key)
@@ -170,7 +169,7 @@ def test_track_request__postgres__inserts_expected(
     # Then
     assert (
         APIUsageRaw.objects.filter(
-            resource=expected_resource, host=host, environment_id=environment.id
+            resource=resource, host=host, environment_id=environment.id
         ).count()
         == 1
     )
@@ -189,7 +188,7 @@ def test_track_request__influx__calls_expected(
     )
     host = "testserver"
     environment_key = environment.api_key
-    resource = "flags"
+    resource = Resource.FLAGS
 
     # When
     track_request(resource, host, environment_key)

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
@@ -26,12 +26,12 @@ def test_api_usage_cache(
         for _ in range(10):
             for resource in Resource:
                 cache.track_request(
-                    Resource.get_lowercased_name(resource),
+                    resource,
                     host,
                     environment_key_1,
                 )
                 cache.track_request(
-                    Resource.get_lowercased_name(resource),
+                    resource,
                     host,
                     environment_key_2,
                 )
@@ -44,7 +44,7 @@ def test_api_usage_cache(
 
         # let's track another request(to trigger flush)
         cache.track_request(
-            "flags",
+            Resource.FLAGS,
             host,
             environment_key_1,
         )
@@ -55,7 +55,7 @@ def test_api_usage_cache(
             expected_calls.append(
                 mocker.call(
                     kwargs={
-                        "resource": Resource.get_lowercased_name(resource),
+                        "resource": resource.value,
                         "host": host,
                         "environment_key": environment_key_1,
                         "count": 11 if resource == Resource.FLAGS else 10,
@@ -65,7 +65,7 @@ def test_api_usage_cache(
             expected_calls.append(
                 mocker.call(
                     kwargs={
-                        "resource": Resource.get_lowercased_name(resource),
+                        "resource": resource.value,
                         "host": host,
                         "environment_key": environment_key_2,
                         "count": 10,
@@ -79,7 +79,7 @@ def test_api_usage_cache(
 
         # and track another request
         cache.track_request(
-            "flags",
+            Resource.FLAGS,
             host,
             environment_key_1,
         )

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
@@ -107,6 +107,27 @@ def test_track_request_sends_host_data_to_influxdb(
     )
 
 
+def test_track_request_does_not_send_data_to_influxdb_for_not_tracked_uris(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Verify that the correct number of calls are made to InfluxDB for the various uris.
+    """
+    # Given
+    mock_influxdb = mocker.patch("app_analytics.track.InfluxDBWrapper")
+    mock_environment = mocker.MagicMock()
+
+    # When
+    track_request_influxdb(
+        resource=None,
+        host="testserver",
+        environment=mock_environment,
+    )
+
+    # Then
+    mock_influxdb.return_value.assert_not_called()
+
+
 def test_track_feature_evaluation_influxdb(mocker: MockerFixture) -> None:
     # Given
     mock_influxdb_wrapper = mock.MagicMock()

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_track.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from pytest_mock import MockerFixture
 
+from app_analytics.models import Resource
 from app_analytics.track import (
     track_feature_evaluation_influxdb,
     track_request_googleanalytics,
@@ -67,7 +68,7 @@ def test_track_request_sends_data_to_influxdb_for_tracked_uris(  # type: ignore[
 
     # When
     track_request_influxdb(
-        resource=expected_resource,
+        resource=Resource.get_from_name(expected_resource),
         host="testserver",
         environment=mock_environment,
     )
@@ -94,7 +95,7 @@ def test_track_request_sends_host_data_to_influxdb(
 
     # When
     track_request_influxdb(
-        resource="flags",
+        resource=Resource.FLAGS,
         host="testserver",
         environment=mock_environment,
     )
@@ -104,27 +105,6 @@ def test_track_request_sends_host_data_to_influxdb(
         mock_influxdb.return_value.add_data_point.call_args_list[0][1]["tags"]["host"]
         == "testserver"
     )
-
-
-def test_track_request_does_not_send_data_to_influxdb_for_not_tracked_uris(
-    mocker: MockerFixture,
-) -> None:
-    """
-    Verify that the correct number of calls are made to InfluxDB for the various uris.
-    """
-    # Given
-    mock_influxdb = mocker.patch("app_analytics.track.InfluxDBWrapper")
-    mock_environment = mocker.MagicMock()
-
-    # When
-    track_request_influxdb(
-        resource="health",
-        host="testserver",
-        environment=mock_environment,
-    )
-
-    # Then
-    mock_influxdb.return_value.assert_not_called()
 
 
 def test_track_feature_evaluation_influxdb(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we make sure the `track_request` task is backwards compatible by accepting the `resource: int` argument. 
All usage tracking functions are streamlined to use the `Resource` enum.
`TRACKED_RESOURCE_ACTIONS` constant is retired in favour of the `Resource.is_tracked` property.

The change that broke backwards compatibility was introduced in https://github.com/Flagsmith/flagsmith/pull/5330.

## How did you test this code?

Modified the related unit tests.
Will test in staging.