### PR TITLE
fix: Selecting build version data from RTK

### DIFF
--- a/frontend/common/services/useBuildVersion.ts
+++ b/frontend/common/services/useBuildVersion.ts
@@ -61,7 +61,8 @@ export async function getBuildVersion(
 }
 // END OF FUNCTION_EXPORTS
 
-export const selectBuildVersion = (state: StoreStateType) => state.buildVersion
+export const selectBuildVersion = (state: StoreStateType) =>
+  buildVersionService.endpoints.getBuildVersion.select({})(state)?.data
 
 export const {
   useGetBuildVersionQuery,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The data is nested within the RTK Query cache structure under the service reducer path, you need to use RTK Query selector in order to get the data, you cannot access it directly.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->


