### PR TITLE
fix: version endpoint

### DIFF
--- a/frontend/common/services/useBuildVersion.ts
+++ b/frontend/common/services/useBuildVersion.ts
@@ -14,9 +14,7 @@ export const buildVersionService = service
         queryFn: async (args, _, _2, baseQuery) => {
           // Fire both requests concurrently
           const [frontendRes, backendRes] = await Promise.all([
-            baseQuery(
-              `${new URL('/version/', Project.api.replace('api/v1/', ''))}`,
-            ),
+            baseQuery(`/version`),
             baseQuery(`${Project.api.replace('api/v1/', '')}version/`),
           ])
 

--- a/frontend/common/services/useBuildVersion.ts
+++ b/frontend/common/services/useBuildVersion.ts
@@ -1,9 +1,9 @@
 import { Req } from 'common/types/requests'
 import { service } from 'common/service'
-
 import { Version } from 'common/types/responses'
 import Project from 'common/project'
 import { StoreStateType } from 'common/store'
+import data from 'common/data/base/_data'
 export const defaultVersionTag = 'Unknown'
 export const buildVersionService = service
   .enhanceEndpoints({ addTagTypes: ['BuildVersion'] })
@@ -12,20 +12,14 @@ export const buildVersionService = service
       getBuildVersion: builder.query<Version, Req['getBuildVersion']>({
         providesTags: () => [{ id: 'BuildVersion', type: 'BuildVersion' }],
         queryFn: async (args, _, _2, baseQuery) => {
-          // Fire both requests concurrently
           const [frontendRes, backendRes] = await Promise.all([
-            baseQuery(`/version`),
-            baseQuery(`${Project.api.replace('api/v1/', '')}version/`),
+            data.get(`/version/`).catch(() => ({})),
+            data.get(`${Project.api.replace('api/v1/', '')}version/`),
           ])
 
-          if (backendRes.error) {
-            return { error: backendRes.error }
-          }
-
-          const frontend = (frontendRes.data || {}) as Version['frontend']
+          const frontend = (frontendRes || {}) as Version['frontend']
           const backend =
-            (backendRes.data as Version['backend']) ||
-            ({} as Version['backend'])
+            (backendRes as Version['backend']) || ({} as Version['backend'])
 
           const tag = backend?.image_tag || defaultVersionTag
           const backend_sha = backend?.ci_commit_sha || defaultVersionTag


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Sometimes Project.api is a relative path rather than a URL, this means:
- We cant use native URL functionality to build requests to /version
- We can't use the RTK service to fetch the frontend build version since RTK has a base URL, we always want to fetch /version

## How did you test this code?
- Build the docker image locally on this branch with API_URL http://localhost:8000/api/v1
- Build the docker image locally on this branch with API_URL /api/v1

