### PR TITLE
fix: Task processor overload when handling high volume SDK traffic

### DIFF
--- a/api/app_analytics/cache.py
+++ b/api/app_analytics/cache.py
@@ -20,7 +20,7 @@ class APIUsageCache:
 
     def _flush(self) -> None:
         for key, value in self._cache.items():
-            track_request.delay(
+            track_request.run_in_thread(
                 kwargs={
                     "resource": key[0].value,
                     "host": key[1],

--- a/api/app_analytics/services.py
+++ b/api/app_analytics/services.py
@@ -20,7 +20,7 @@ def track_usage_by_resource_host_and_environment(
                 environment_key=environment_key,
             )
         else:
-            track_request.delay(
+            track_request.run_in_thread(
                 kwargs={
                     "resource": resource.value,
                     "host": host,

--- a/api/tests/unit/app_analytics/test_middleware.py
+++ b/api/tests/unit/app_analytics/test_middleware.py
@@ -78,7 +78,7 @@ def test_api_usage_middleware__no_cache__calls_expected(
     middleware(request)
 
     # Then
-    mocked_track_request.delay.assert_called_once_with(
+    mocked_track_request.run_in_thread.assert_called_once_with(
         kwargs={
             "resource": Resource.get_from_name(resource_name),
             "environment_key": environment_key,

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_cache.py
@@ -72,7 +72,7 @@ def test_api_usage_cache(
                     }
                 )
             )
-        mocked_track_request_task.delay.assert_has_calls(expected_calls)
+        mocked_track_request_task.run_in_thread.assert_has_calls(expected_calls)
 
         # Next, let's reset the mock
         mocked_track_request_task.reset_mock()


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

After changes introduced in #5356 and #5330, we've been seeing noticeable task processor congestion. In this PR, we force request tracking to a threaded mode to avoid it.

## How did you test this code?

Made sure the unit test suite passes. 