### PR TITLE
feat: Log environment IDs in SDK endpoints

### DIFF
--- a/api/app/settings/common.py
+++ b/api/app/settings/common.py
@@ -572,6 +572,7 @@ CHARGEBEE_API_KEY = env("CHARGEBEE_API_KEY", default=None)
 CHARGEBEE_SITE = env("CHARGEBEE_SITE", default=None)
 
 # Logging configuration
+ACCESS_LOG_EXTRA_ITEMS = env.list("ACCESS_LOG_EXTRA_ITEMS", subcast=str, default=[])
 LOGGING_CONFIGURATION_FILE = env.str("LOGGING_CONFIGURATION_FILE", default=None)
 if LOGGING_CONFIGURATION_FILE:
     with open(LOGGING_CONFIGURATION_FILE, "r") as f:

--- a/api/environments/authentication.py
+++ b/api/environments/authentication.py
@@ -1,3 +1,4 @@
+from common.gunicorn.utils import log_extra
 from django.conf import settings
 from django.core.cache import caches
 from rest_framework.authentication import BaseAuthentication
@@ -37,6 +38,11 @@ class EnvironmentKeyAuthentication(BaseAuthentication):
             RequestOrigin.SERVER
             if api_key.startswith(SERVER_API_KEY_PREFIX)
             else RequestOrigin.CLIENT
+        )
+        log_extra(
+            request=request,
+            key="environment_id",
+            value=environment.id,
         )
 
         # DRF authentication expects a two tuple to be returned containing User, auth

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1927,13 +1927,15 @@ resolved_reference = "303954ba54fd2f402c75806b3b9ba7f2d42aa426"
 
 [[package]]
 name = "flagsmith-common"
-version = "1.9.0"
+version = "1.10.0"
 description = "Flagsmith's common library"
 optional = false
-python-versions = ">=3.11,<4.0"
+python-versions = "<4.0,>=3.11"
 groups = ["main", "dev", "workflows"]
-files = []
-develop = false
+files = [
+    {file = "flagsmith_common-1.10.0-py3-none-any.whl", hash = "sha256:e5c8b593abe3ba9c7bc46d956808bf823aac6c9e500f9ce39af2b36bd76aab25"},
+    {file = "flagsmith_common-1.10.0.tar.gz", hash = "sha256:22f4ef2217b08c3bfa0a8560a976beb11a8d71688b39b3c35140763ae67fb38d"},
+]
 
 [package.dependencies]
 backoff = ">=2.2.1,<3.0.0"
@@ -1953,12 +1955,6 @@ simplejson = ">=3,<4"
 
 [package.extras]
 test-tools = ["pyfakefs (>=5,<6)"]
-
-[package.source]
-type = "git"
-url = "https://github.com/flagsmith/flagsmith-common"
-reference = "feat/log-wsgi-extras"
-resolved_reference = "fa50d5d50354001ba5f4ae300750ae39740b436f"
 
 [[package]]
 name = "flagsmith-flag-engine"
@@ -5199,4 +5195,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "f9e998206f814ebc591ccb0573f0475c8d9286a5cb9605570bd25b8a2577ff86"
+content-hash = "f92dd08337ac31a1af87d371d6e4cb65e753b9e6f98ba9941c39fe9d6f497a35"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1930,12 +1930,10 @@ name = "flagsmith-common"
 version = "1.9.0"
 description = "Flagsmith's common library"
 optional = false
-python-versions = "<4.0,>=3.11"
+python-versions = ">=3.11,<4.0"
 groups = ["main", "dev", "workflows"]
-files = [
-    {file = "flagsmith_common-1.9.0-py3-none-any.whl", hash = "sha256:fa7f6f16691b3c7f81d25ab4c5e240cd1273ea670d3d2cb8ba81705c0e118707"},
-    {file = "flagsmith_common-1.9.0.tar.gz", hash = "sha256:4a88df78aef0ca9a0b826502792382e2d710aa0f256fd955955157f43e546e95"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 backoff = ">=2.2.1,<3.0.0"
@@ -1955,6 +1953,12 @@ simplejson = ">=3,<4"
 
 [package.extras]
 test-tools = ["pyfakefs (>=5,<6)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/flagsmith/flagsmith-common"
+reference = "feat/log-wsgi-extras"
+resolved_reference = "fa50d5d50354001ba5f4ae300750ae39740b436f"
 
 [[package]]
 name = "flagsmith-flag-engine"
@@ -5195,4 +5199,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "91e438de299540b972d062997669891705c4207e07ad8b95bde67db733f33f3e"
+content-hash = "f9e998206f814ebc591ccb0573f0475c8d9286a5cb9605570bd25b8a2577ff86"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -154,7 +154,7 @@ pygithub = "2.1.1"
 hubspot-api-client = "^8.2.1"
 djangorestframework-dataclasses = "^1.3.1"
 pyotp = "^2.9.0"
-flagsmith-common = "^1.9.0"
+flagsmith-common = { git = "https://github.com/flagsmith/flagsmith-common", branch = "feat/log-wsgi-extras" }
 django-stubs = "^5.1.3"
 tzdata = "^2024.1"
 djangorestframework-simplejwt = "^5.3.1"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -154,7 +154,7 @@ pygithub = "2.1.1"
 hubspot-api-client = "^8.2.1"
 djangorestframework-dataclasses = "^1.3.1"
 pyotp = "^2.9.0"
-flagsmith-common = { git = "https://github.com/flagsmith/flagsmith-common", branch = "feat/log-wsgi-extras" }
+flagsmith-common = "^1.10.0"
 django-stubs = "^5.1.3"
 tzdata = "^2024.1"
 djangorestframework-simplejwt = "^5.3.1"
@@ -224,7 +224,7 @@ types-psycopg2 = "^2.9.21.20250121"
 types-python-dateutil = "^2.9.0.20241206"
 types-pytz = "^2025.1.0.20250204"
 ruff = "^0.9.7"
-flagsmith-common = { version = "^1.9.0", extras = ["test-tools"] }
+flagsmith-common = { version = "*", extras = ["test-tools"] }
 
 [build-system]
 requires = ["poetry>=2.0.0"]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we use functionality added by https://github.com/Flagsmith/flagsmith-common/pull/55 to log environment IDs in SDK endpoints.

The resolved environment ID can be aded by adding `%{flagsmith.environment_id}e` to `ACCESS_LOG_FORMAT`, or setting `ACCESS_LOG_JSON_EXTRA_ITEMS` to `"{flagsmith.environment_id}e"` for surfacing it in JSON access logs. 

## How did you test this code?

Ran Core API locally and `curl localhost:8000/api/v1/environment-document/ -H 'X-Environment-Key: <locally created server API key>'`:

```sh
ACCESS_LOG_EXTRA_ITEMS='{flagsmith.environment_id}e' LOG_FORMAT=json ACCESS_LOG_LOCATION=- make serve
poetry run flagsmith start --reload api
{"levelname": "INFO", "message": "Starting gunicorn 23.0.0", "timestamp": "2025-04-21 22:02:12,436", "logger_name": "gunicorn.error", "pid": 17755, "thread_name": "MainThread"}
{"levelname": "INFO", "message": "Listening at: http://0.0.0.0:8000 (17755)", "timestamp": "2025-04-21 22:02:12,436", "logger_name": "gunicorn.error", "pid": 17755, "thread_name": "MainThread"}
{"levelname": "INFO", "message": "Using worker: sync", "timestamp": "2025-04-21 22:02:12,436", "logger_name": "gunicorn.error", "pid": 17755, "thread_name": "MainThread"}
{"levelname": "INFO", "message": "Booting worker with pid: 18117", "timestamp": "2025-04-21 22:02:12,443", "logger_name": "gunicorn.error", "pid": 18117, "thread_name": "MainThread"}
{"levelname": "INFO", "message": "127.0.0.1 - - [21/Apr/2025:22:02:16 +0000] \"GET /api/v1/environment-document/ HTTP/1.1\" 200 805 \"-\" \"curl/8.7.1\" - -", "timestamp": "2025-04-21 22:02:16,961", "logger_name": "gunicorn.access", "pid": 18117, "thread_name": "MainThread", "time": "2025-04-21T22:02:16+00:00", "path": "/api/v1/environment-document/", "remote_ip": "127.0.0.1", "route": "/api/v1/environment-document/", "method": "GET", "status": "200", "user_agent": "curl/8.7.1", "duration_in_ms": 56, "response_size_in_bytes": 805, "environ_variables": {"flagsmith.environment_id": 1}}
```