### PR TITLE
feat: TCP health check integration + ECS health checks on staging

### DIFF
--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/ecs-health-checks
     paths:
       - api/**
       - .github/**

--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/ecs-health-checks
     paths:
       - api/**
       - .github/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ FROM wolfi-base AS api-runtime
 
 # Install Python and make it available to venv entrypoints
 ARG PYTHON_VERSION
-RUN apk add curl python-${PYTHON_VERSION} && \
+RUN apk add python-${PYTHON_VERSION} && \
   mkdir /build/ && ln -s /usr/local/ /build/.venv
 
 WORKDIR /app
@@ -140,7 +140,7 @@ ENTRYPOINT ["/app/scripts/run-docker.sh"]
 CMD ["migrate-and-serve"]
 
 HEALTHCHECK --interval=2s --timeout=2s --retries=3 --start-period=20s \
-  CMD curl -f http://localhost:8000/health/liveness || exit 1
+  CMD flagsmith healthcheck tcp
 
 # * api-runtime-private [api-runtime]
 FROM api-runtime AS api-runtime-private

--- a/api/manage.py
+++ b/api/manage.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python
 import os
-import sys
 
 from common.core.main import main
 
 if __name__ == "__main__":
-    # Backwards compatibility for task-processor health checks
-    # See https://github.com/Flagsmith/flagsmith-task-processor/issues/24
-    if "checktaskprocessorthreadhealth" in sys.argv:
-        import scripts.healthcheck
-
-        scripts.healthcheck.main()
-
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.local")
 
     main()

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -714,7 +714,7 @@ version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "saml"]
+groups = ["main", "dev", "saml", "workflows"]
 files = [
     {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
     {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
@@ -830,7 +830,7 @@ version = "3.2.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
-groups = ["main", "dev", "saml"]
+groups = ["main", "dev", "saml", "workflows"]
 files = [
     {file = "charset-normalizer-3.2.0.tar.gz", hash = "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"},
     {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710"},
@@ -1930,12 +1930,10 @@ name = "flagsmith-common"
 version = "1.10.0"
 description = "Flagsmith's common library"
 optional = false
-python-versions = "<4.0,>=3.11"
+python-versions = ">=3.11,<4.0"
 groups = ["main", "dev", "workflows"]
-files = [
-    {file = "flagsmith_common-1.10.0-py3-none-any.whl", hash = "sha256:e5c8b593abe3ba9c7bc46d956808bf823aac6c9e500f9ce39af2b36bd76aab25"},
-    {file = "flagsmith_common-1.10.0.tar.gz", hash = "sha256:22f4ef2217b08c3bfa0a8560a976beb11a8d71688b39b3c35140763ae67fb38d"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 backoff = ">=2.2.1,<3.0.0"
@@ -1951,10 +1949,17 @@ gunicorn = ">=19.1"
 prometheus-client = ">=0.0.16"
 psycopg2-binary = ">=2.9,<3"
 pyfakefs = {version = ">=5,<6", optional = true, markers = "extra == \"test-tools\""}
+requests = "*"
 simplejson = ">=3,<4"
 
 [package.extras]
 test-tools = ["pyfakefs (>=5,<6)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/flagsmith/flagsmith-common"
+reference = "ff53ad7cf4babe551cf3f2d911cd576bfaff2822"
+resolved_reference = "ff53ad7cf4babe551cf3f2d911cd576bfaff2822"
 
 [[package]]
 name = "flagsmith-flag-engine"
@@ -2516,7 +2521,7 @@ version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
-groups = ["main", "dev", "saml"]
+groups = ["main", "dev", "saml", "workflows"]
 files = [
     {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
     {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
@@ -4178,7 +4183,7 @@ version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "saml"]
+groups = ["main", "dev", "saml", "workflows"]
 files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
@@ -4954,7 +4959,7 @@ version = "2.3.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "saml"]
+groups = ["main", "dev", "saml", "workflows"]
 files = [
     {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
     {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
@@ -5195,4 +5200,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "f92dd08337ac31a1af87d371d6e4cb65e753b9e6f98ba9941c39fe9d6f497a35"
+content-hash = "46e1de9285f1999b6c5eab9c458c80a3692cc266f2964fa9df6930182f596688"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1927,13 +1927,15 @@ resolved_reference = "303954ba54fd2f402c75806b3b9ba7f2d42aa426"
 
 [[package]]
 name = "flagsmith-common"
-version = "1.10.0"
+version = "1.11.0"
 description = "Flagsmith's common library"
 optional = false
-python-versions = ">=3.11,<4.0"
+python-versions = "<4.0,>=3.11"
 groups = ["main", "dev", "workflows"]
-files = []
-develop = false
+files = [
+    {file = "flagsmith_common-1.11.0-py3-none-any.whl", hash = "sha256:ba91e69152a3a3b9eecd3ca3f73939561356badb68776aa4d7a615187a41349f"},
+    {file = "flagsmith_common-1.11.0.tar.gz", hash = "sha256:0aeda071e7a93e57a864c0c31481c988b068714380cfdd5ea4b647b2bfe782a3"},
+]
 
 [package.dependencies]
 backoff = ">=2.2.1,<3.0.0"
@@ -1948,17 +1950,12 @@ flagsmith-flag-engine = "*"
 gunicorn = ">=19.1"
 prometheus-client = ">=0.0.16"
 psycopg2-binary = ">=2.9,<3"
+pyfakefs = {version = ">=5,<6", optional = true, markers = "extra == \"test-tools\""}
 requests = "*"
 simplejson = ">=3,<4"
 
 [package.extras]
 test-tools = ["pyfakefs (>=5,<6)"]
-
-[package.source]
-type = "git"
-url = "https://github.com/flagsmith/flagsmith-common"
-reference = "feat/flagsmith-healthcheck"
-resolved_reference = "467f30d71af762313f67b8d0c8bb3e590e8857f9"
 
 [[package]]
 name = "flagsmith-flag-engine"
@@ -5199,4 +5196,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "46e1de9285f1999b6c5eab9c458c80a3692cc266f2964fa9df6930182f596688"
+content-hash = "003044b80789fa08dbaed58b48f7720c8347c6f38b7b18be8d4b2a2f6cc404f8"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1948,7 +1948,6 @@ flagsmith-flag-engine = "*"
 gunicorn = ">=19.1"
 prometheus-client = ">=0.0.16"
 psycopg2-binary = ">=2.9,<3"
-pyfakefs = {version = ">=5,<6", optional = true, markers = "extra == \"test-tools\""}
 requests = "*"
 simplejson = ">=3,<4"
 
@@ -1958,8 +1957,8 @@ test-tools = ["pyfakefs (>=5,<6)"]
 [package.source]
 type = "git"
 url = "https://github.com/flagsmith/flagsmith-common"
-reference = "ff53ad7cf4babe551cf3f2d911cd576bfaff2822"
-resolved_reference = "ff53ad7cf4babe551cf3f2d911cd576bfaff2822"
+reference = "feat/flagsmith-healthcheck"
+resolved_reference = "467f30d71af762313f67b8d0c8bb3e590e8857f9"
 
 [[package]]
 name = "flagsmith-flag-engine"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -66,13 +66,7 @@ exclude_also = [
 omit = ["scripts/*", "manage.py"]
 
 [tool.pytest.ini_options]
-addopts = [
-  '--ds=app.settings.test',
-  '-vvvv',
-  '-p',
-  'no:warnings',
-  '--dist=worksteal',
-]
+addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings', '--dist=worksteal']
 console_output_style = 'count'
 
 [tool.mypy]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -160,7 +160,7 @@ pygithub = "2.1.1"
 hubspot-api-client = "^8.2.1"
 djangorestframework-dataclasses = "^1.3.1"
 pyotp = "^2.9.0"
-flagsmith-common = { git = "https://github.com/flagsmith/flagsmith-common", branch = "feat/flagsmith-healthcheck" }
+flagsmith-common = "^1.11.0"
 django-stubs = "^5.1.3"
 tzdata = "^2024.1"
 djangorestframework-simplejwt = "^5.3.1"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -66,7 +66,13 @@ exclude_also = [
 omit = ["scripts/*", "manage.py"]
 
 [tool.pytest.ini_options]
-addopts = ['--ds=app.settings.test', '-vvvv', '-p', 'no:warnings', '--dist=worksteal']
+addopts = [
+  '--ds=app.settings.test',
+  '-vvvv',
+  '-p',
+  'no:warnings',
+  '--dist=worksteal',
+]
 console_output_style = 'count'
 
 [tool.mypy]
@@ -154,7 +160,7 @@ pygithub = "2.1.1"
 hubspot-api-client = "^8.2.1"
 djangorestframework-dataclasses = "^1.3.1"
 pyotp = "^2.9.0"
-flagsmith-common = "^1.10.0"
+flagsmith-common = { git = "https://github.com/flagsmith/flagsmith-common", branch = "feat/flagsmith-healthcheck" }
 django-stubs = "^5.1.3"
 tzdata = "^2024.1"
 djangorestframework-simplejwt = "^5.3.1"

--- a/api/scripts/healthcheck.py
+++ b/api/scripts/healthcheck.py
@@ -1,32 +1,11 @@
-import argparse
-import socket
+import logging
+import sys
 
-parser = argparse.ArgumentParser(
-    description="Check if the API is able to accept local TCP connections.",
-)
-parser.add_argument(
-    "--port",
-    "-p",
-    type=int,
-    default=8000,
-    help="Port to check the API on (default: 8000)",
-)
-parser.add_argument(
-    "--timeout",
-    "-t",
-    type=int,
-    default=1,
-    help="Socket timeout for the connection attempt in seconds (default: 1)",
-)
-
-
-def main() -> None:
-    args = parser.parse_args()
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(args.timeout)
-    sock.connect(("localhost", args.port))
-    sock.close()
-
+from common.core.main import main
 
 if __name__ == "__main__":
-    main()
+    logging.getLogger(__name__).warning(
+        f"This healthcheck, invoked by `{' '.join(sys.argv)}``, is deprecated. "
+        "Please use one of the `flagsmith healthcheck` commands instead."
+    )
+    main(["flagsmith", "healthcheck", "http"])

--- a/api/scripts/healthcheck.py
+++ b/api/scripts/healthcheck.py
@@ -1,25 +1,31 @@
-import logging
-import sys
+import argparse
+import socket
 
-import requests
-
-HEALTH_LIVENESS_URL = "http://localhost:8000/health/liveness"
-
-
-logger = logging.getLogger(__name__)
+parser = argparse.ArgumentParser(
+    description="Check if the API is running and accessible.",
+)
+parser.add_argument(
+    "--port",
+    "-p",
+    type=int,
+    default=8000,
+    help="Port to check the API on (default: 8000)",
+)
+parser.add_argument(
+    "--timeout",
+    "-t",
+    type=int,
+    default=1,
+    help="Socket timeout for the connection attempt in seconds (default: 1)",
+)
 
 
 def main() -> None:
-    logger.warning(
-        f"This healthcheck, invoked by {' '.join(sys.argv)}, is deprecated. "
-        f"Use the `{HEALTH_LIVENESS_URL}` endpoint instead."
-    )
-    status_code = requests.get(HEALTH_LIVENESS_URL).status_code
-
-    if status_code != 200:
-        logger.error(f"Health check failed with status {status_code}")
-
-    sys.exit(0 if 200 >= status_code < 300 else 1)
+    args = parser.parse_args()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(args.timeout)
+    sock.connect(("localhost", args.port))
+    sock.close()
 
 
 if __name__ == "__main__":

--- a/api/scripts/healthcheck.py
+++ b/api/scripts/healthcheck.py
@@ -2,7 +2,7 @@ import argparse
 import socket
 
 parser = argparse.ArgumentParser(
-    description="Check if the API is running and accessible.",
+    description="Check if the API is able to accept local TCP connections.",
 )
 parser.add_argument(
     "--port",

--- a/infrastructure/aws/production/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/production/ecs-task-definition-task-processor.json
@@ -6,7 +6,9 @@
     "containerDefinitions": [
         {
             "name": "flagsmith-task-processor",
-            "command": ["run-task-processor"],
+            "command": [
+                "run-task-processor"
+            ],
             "essential": true,
             "environment": [
                 {
@@ -20,6 +22,10 @@
                 {
                     "name": "AWS_DEFAULT_REGION",
                     "value": "eu-west-2"
+                },
+                {
+                    "name": "DJANGO_ALLOWED_HOSTS",
+                    "value": "*"
                 },
                 {
                     "name": "DJANGO_SETTINGS_MODULE",

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -6,7 +6,26 @@
     "containerDefinitions": [
         {
             "name": "flagsmith-task-processor",
-            "command": ["run-task-processor"],
+            "command": [
+                "run-task-processor"
+            ],
+            "portMappings": [
+                {
+                    "containerPort": 8000,
+                    "hostPort": 8000,
+                    "protocol": "tcp"
+                }
+            ],
+            "healthCheck": {
+                "command": [
+                    "CMD-SHELL",
+                    "python scripts/healthcheck.py"
+                ],
+                "interval": 10,
+                "timeout": 2,
+                "retries": 5,
+                "startPeriod": 5
+            },
             "essential": true,
             "environment": [
                 {

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -19,7 +19,7 @@
             "healthCheck": {
                 "command": [
                     "CMD-SHELL",
-                    "python scripts/healthcheck.py"
+                    "flagsmith healthcheck tcp"
                 ],
                 "interval": 10,
                 "timeout": 2,

--- a/infrastructure/aws/staging/ecs-task-definition-task-processor.json
+++ b/infrastructure/aws/staging/ecs-task-definition-task-processor.json
@@ -41,6 +41,10 @@
                     "value": "eu-west-2"
                 },
                 {
+                    "name": "DJANGO_ALLOWED_HOSTS",
+                    "value": "*"
+                },
+                {
                     "name": "DJANGO_SETTINGS_MODULE",
                     "value": "app.settings.production"
                 },

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -17,6 +17,16 @@
                     "protocol": "tcp"
                 }
             ],
+            "healthCheck": {
+                "command": [
+                    "CMD-SHELL",
+                    "python scripts/healthcheck.py"
+                ],
+                "interval": 10,
+                "timeout": 2,
+                "retries": 5,
+                "startPeriod": 5
+            },
             "essential": true,
             "environment": [
                 {

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -20,7 +20,7 @@
             "healthCheck": {
                 "command": [
                     "CMD-SHELL",
-                    "python scripts/healthcheck.py"
+                    "flagsmith healthcheck tcp"
                 ],
                 "interval": 10,
                 "timeout": 2,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This picks the `flagsmith healthcheck` command implemented in https://github.com/Flagsmith/flagsmith-common/pull/60 and adds it to ECS task definitions on staging. This is required for service discovery (and metric collection) to work.

## How did you test this code?

Tasks now show up as healthy in ECS console:

<img width="491" alt="image" src="https://github.com/user-attachments/assets/7afaa9f6-b09c-404b-9a07-9241996798ac" />
