### PR TITLE
feat: add asynchronous task for rebuilding environment caches

### DIFF
--- a/api/environments/managers.py
+++ b/api/environments/managers.py
@@ -1,9 +1,15 @@
+import typing
+
 from django.db.models import Prefetch
 from softdelete.models import SoftDeleteManager  # type: ignore[import-untyped]
 
+from environments.constants import IDENTITY_INTEGRATIONS_RELATION_NAMES
 from features.models import FeatureSegment, FeatureState
 from features.multivariate.models import MultivariateFeatureStateValue
 from segments.models import Segment
+
+if typing.TYPE_CHECKING:
+    from environments.models import Environment
 
 
 class EnvironmentManager(SoftDeleteManager):  # type: ignore[misc]
@@ -51,6 +57,20 @@ class EnvironmentManager(SoftDeleteManager):  # type: ignore[misc]
             )
             .filter(*args, **kwargs)
         )
+
+    def get_for_cache(self, api_key: str) -> "Environment":
+        select_related_args = (
+            "project",
+            "project__organisation",
+            *IDENTITY_INTEGRATIONS_RELATION_NAMES,
+        )
+        base_qs = self.select_related(*select_related_args).defer("description")
+        qs_for_embedded_api_key = base_qs.filter(api_key=api_key)
+        qs_for_fk_api_key = base_qs.filter(api_keys__key=api_key)
+        environment: Environment = qs_for_embedded_api_key.union(
+            qs_for_fk_api_key
+        ).get()
+        return environment
 
     def get_queryset(self):  # type: ignore[no-untyped-def]
         return super().get_queryset().select_related("project", "project__organisation")

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -392,14 +392,10 @@ def test_change_request_audit_logs_does_not_update_updated_at(environment):  # t
 
 def test_save_environment_clears_environment_cache(mocker, project):  # type: ignore[no-untyped-def]
     # Given
-    mock_environment_cache = mocker.patch("environments.models.environment_cache")
+    mock_environment_cache = mocker.patch("environments.tasks.environment_cache")
     environment = Environment.objects.create(name="test environment", project=project)
 
-    # perform an update of the name to verify basic functionality
-    environment.name = "updated"
-    environment.save()
-
-    # and update the api key to verify that the original api key is used to clear cache
+    # update the api key to verify that the original api key is used to clear cache
     old_key = copy(environment.api_key)
     new_key = "some-new-key"
     environment.api_key = new_key
@@ -409,8 +405,8 @@ def test_save_environment_clears_environment_cache(mocker, project):  # type: ig
 
     # Then
     mock_calls = mock_environment_cache.delete.mock_calls
-    assert len(mock_calls) == 2
-    assert mock_calls[0][1][0] == mock_calls[1][1][0] == old_key
+    assert len(mock_calls) == 1
+    assert mock_calls[0][1][0] == old_key
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Update the logic to rebuild caches used by `Environment.get_from_cache()` instead of just clearing them when an update is made to an environment. 

## How did you test this code?

Updated existing tests. 
