### PR TITLE
chore: show deleted organisations in sales dashboard

### DIFF
--- a/api/sales_dashboard/templates/sales_dashboard/home.html
+++ b/api/sales_dashboard/templates/sales_dashboard/home.html
@@ -29,6 +29,8 @@
 
       <div class="sort-form">
         <form action="{% url 'sales_dashboard:index' %}" method="get" class="form-inline float-right">
+        <label for="include-deleted" class="mr-1">Include deleted:</label>
+        <input type="checkbox" name="include_deleted" id="include-deleted" class="mr-1" {% if include_deleted %}checked{% endif %}>
         <label for="filter-plan">Filter: </label>
           <select name="filter_plan" id="filter-plan" class="custom-select m-1">
             <option value="" {% if not filter_plan %}selected{% endif %}>Filter Plan</option>
@@ -82,7 +84,7 @@
               {% endif %}"
               >
               <td>{{org.id}}</td>
-              <td><a href="/sales-dashboard/organisations/{{org.id}}">{{org.name}}</a></td>
+              <td><a href="/sales-dashboard/organisations/{{org.id}}">{{org.name}} {% if org.deleted_at %}<span class="badge badge-danger">Deleted</span>{% endif %}</a></td>
               <td>{{ org.subscription.plan|default:"Free" }}{% if org.subscription.payment_method %} - {{ org.subscription.payment_method|capfirst }}{% endif %}</td>
               <td><span class="{% if org.num_users > org.subscription_information_cache.allowed_seats %}badge badge-danger{% endif %}">{{org.num_users}}</span></td>
               <td>{{org.subscription_information_cache.allowed_seats|default:1}}</td>

--- a/api/sales_dashboard/templates/sales_dashboard/organisation.html
+++ b/api/sales_dashboard/templates/sales_dashboard/organisation.html
@@ -16,7 +16,8 @@
                 <h1 class="h2 float-left">
                     Organisation: <strong>{{organisation.name}}</strong>
                     - Plan: <strong>{{ organisation.subscription.plan|default:"Free"}}</strong>
-                    {% if organisation.has_paid_subscription and not organisation.is_paid %}<span class="badge badge-danger">Subscription Cancelled</button>{% endif %}
+                    {% if organisation.deleted_at %}<span class="badge badge-danger">Deleted</span>{% endif %}
+                    {% if organisation.has_paid_subscription and not organisation.is_paid %}<span class="badge badge-danger">Subscription Cancelled</span>{% endif %}
                 </h1>
                 <div class="float-right"><a href="/admin/organisations/organisation/{{organisation.id}}/change">Django Admin</a></div>
                 <div class="float-right">

--- a/api/sales_dashboard/views.py
+++ b/api/sales_dashboard/views.py
@@ -5,7 +5,7 @@ import re2 as re  # type: ignore[import-untyped]
 from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models import Count, F, Func, Q, Value
+from django.db.models import Count, F, Q, Value
 from django.db.models.functions import Greatest
 from django.http import (
     HttpRequest,
@@ -66,17 +66,6 @@ class OrganisationList(ListView):  # type: ignore[type-arg]
     paginate_by = OBJECTS_PER_PAGE
     template_name = "sales_dashboard/home.html"
 
-    _annotations = {
-        "num_projects": Count("projects", distinct=True),
-        "num_users": Count("users", distinct=True),
-        "num_features": Count("projects__features", distinct=True),
-        "overage": Greatest(
-            Value(0),
-            F("subscription_information_cache__api_calls_30d")
-            - F("subscription_information_cache__allowed_30d_api_calls"),
-        ),
-    }
-
     def get_queryset(self):  # type: ignore[no-untyped-def]
         if self.request.GET.get("include_deleted") == "on" or self.request.GET.get(
             "search"
@@ -84,6 +73,17 @@ class OrganisationList(ListView):  # type: ignore[type-arg]
             queryset = Organisation.objects.all_with_deleted()
         else:
             queryset = Organisation.objects.all()
+
+        queryset = queryset.annotate(
+            num_projects=Count("projects", distinct=True),
+            num_users=Count("users", distinct=True),
+            num_features=Count("projects__features", distinct=True),
+            overage=Greatest(
+                Value(0),
+                F("subscription_information_cache__api_calls_30d")
+                - F("subscription_information_cache__allowed_30d_api_calls"),
+            ),
+        ).select_related("subscription", "subscription_information_cache")
 
         if search_term := self.request.GET.get("search"):
             queryset = queryset.filter(self._build_search_query(search_term))
@@ -93,12 +93,6 @@ class OrganisationList(ListView):  # type: ignore[type-arg]
             queryset = queryset.filter(subscription__plan__icontains=filter_plan)
 
         sort_field = self.request.GET.get("sort_field") or DEFAULT_ORGANISATION_SORT
-
-        # in order to reduce the load on the database / query time, only annotate the
-        # queryset before pagination with any annotation needed for sorting
-        if required_sort_annotation := self._annotations.get(sort_field):
-            queryset = queryset.annotate(**{sort_field: required_sort_annotation})
-
         sort_direction = (
             self.request.GET.get("sort_direction")
             or DEFAULT_ORGANISATION_SORT_DIRECTION
@@ -109,24 +103,14 @@ class OrganisationList(ListView):  # type: ignore[type-arg]
             else queryset.order_by(F(sort_field).desc(nulls_last=True))
         )
 
-        return queryset.select_related("subscription", "subscription_information_cache")
+        return queryset
 
     def get_context_data(self, **kwargs):  # type: ignore[no-untyped-def]
         data = super().get_context_data(**kwargs)
 
-        sort_field = self.request.GET.get("sort_field")
-
-        # in order to reduce load on the database / query time, we only annotate the queryset
-        # after pagination with any annotations that weren't already needed for sorting
-        queryset = data["object_list"]
-        queryset = queryset.annotate(
-            **{k: v for k, v in self._annotations.items() if k != sort_field}
-        )
-        data["object_list"] = queryset
-
         data["search"] = self.request.GET.get("search", "")
         data["filter_plan"] = self.request.GET.get("filter_plan")
-        data["sort_field"] = sort_field
+        data["sort_field"] = self.request.GET.get("sort_field")
         data["sort_direction"] = self.request.GET.get("sort_direction")
         data["include_deleted"] = self.request.GET.get("include_deleted", "off") == "on"
 
@@ -174,9 +158,6 @@ class OrganisationList(ListView):  # type: ignore[type-arg]
                 | Q(name__icontains=search_term)
                 | Q(subscription__subscription_id__iexact=search_term)
             )
-
-    def _get_pre_sort_annotation(self, sort_field: str) -> Func | None:
-        return self._annotations.get(sort_field)
 
 
 @staff_member_required


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- ~[ ] I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

The main purpose of this PR was to add the ability to show deleted organisations in the sales dashboard. Since I was already working in the area, I also tried to tackle something that has been bothering me for a while, which is the performance of the sales dashboard. As such, I tried to optimise the annotations to only annotate the queryset with any annotation that was needed for sorting (as you can see [here](https://github.com/Flagsmith/flagsmith/commit/116f5c975d807094f9fa079cdc100e98b795b5c0)) but this didn't actually change anything due to the behaviour of django's lazily evaluated querysets. Without diving deeper into the pagination logic, I'm not sure there's an option here to optimise the queries that are needed. 

## How did you test this code?

Validated the 'include deleted' logic locally when running the API. 
