### PR TITLE
fix: Gets build version for validating org plan

### DIFF
--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -37,7 +37,7 @@ import HomeAside from './pages/HomeAside'
 import ScrollToTop from './ScrollToTop'
 import AnnouncementPerPage from './AnnouncementPerPage'
 import Announcement from './Announcement'
-import { plugin } from '@amplitude/plugin-session-replay-browser'
+import { getBuildVersion } from 'common/services/useBuildVersion'
 
 const App = class extends Component {
   static propTypes = {
@@ -106,6 +106,7 @@ const App = class extends Component {
       })
       amplitude.add(sessionReplayTracking)
     }
+    getBuildVersion(getStore(), {})
     this.state.projectId = this.getProjectId(this.props)
     if (this.state.projectId) {
       AppActions.getProject(this.state.projectId)


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Ref: https://github.com/Flagsmith/flagsmith/issues/5401

`getBuildVersion()` was removed when it got migrated to RTK [here](https://github.com/Flagsmith/flagsmith/pull/5057/files#diff-2f08f9d4e83b3a95b4b865ad50abd4cf7f072926809d487c757930689e826f83L110), `/version` returns `is_saas` field which is required for validating startup plans in [here](https://github.com/Flagsmith/flagsmith/blob/b3872cff3cacdb316534d78ebab1b22734aa5246/frontend/common/utils/utils.tsx#L448)


## How did you test this code?

Tested using local instance and against staging

<img width="485" alt="image" src="https://github.com/user-attachments/assets/96bb4dd7-6c33-4079-90e1-82b623261a63" />

<img width="1492" alt="image" src="https://github.com/user-attachments/assets/de641ff8-1b3c-4754-8253-d441153f7b5a" />

