### PR TITLE
fix(self-hosted onboarding): add hubspot access token to API instances

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -260,6 +260,10 @@
                 {
                     "name": "GITHUB_PEM",
                     "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:GITHUB_PEM-E1Ot8p"
+                },
+                {
+                    "name": "HUBSPOT_ACCESS_TOKEN",
+                    "valueFrom": "arn:aws:secretsmanager:eu-west-2:084060095745:secret:ECS-API-LxUiIQ:HUBSPOT_ACCESS_TOKEN::"
                 }
             ],
             "logConfiguration": {


### PR DESCRIPTION
## Changes

Currently, requests generated by the onboarding process to the Flagsmith API are being rejected with a 400 error because the `HUBSPOT_ACCESS_TOKEN` doesn't exist in the API (it only currently exists in the task processor definition). This PR adds the access token to the task definition for the API instances. 

## How did you test this code?

I haven't tested the solution, but we can be fairly confident that it is valid by the following example of the error being received when hitting the endpoint: 

<img width="984" alt="image" src="https://github.com/user-attachments/assets/8a4ac866-471b-428b-b6bc-6efa184fc2ee" />

