### PR TITLE
ci: Migrate GHA to Depot runners

### DIFF
--- a/.github/workflows/.reusable-deploy-ecs.yml
+++ b/.github/workflows/.reusable-deploy-ecs.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   docker-build-saas-api:
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       image-url: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.saas-image-name }}:${{ steps.meta.outputs.version }}
 
@@ -70,7 +70,7 @@ jobs:
   deploy:
     needs: docker-build-saas-api
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - name: Cloning repo
         uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
 
   run-tests:
     needs: deploy
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     name: Run E2E Tests
     environment: ${{ inputs.environment }}
     concurrency:

--- a/.github/workflows/.reusable-docker-build.yml
+++ b/.github/workflows/.reusable-docker-build.yml
@@ -71,7 +71,7 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.scan && 'and verify ' || '' }}${{ inputs.image-name }} image
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       image: ${{ steps.image-tag.outputs.image-tag }}
 

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -24,9 +24,9 @@ on:
         default: 3
       runs-on:
         type: string
-        description: The runner label to use. Defaults to `ubuntu-latest`
+        description: The runner label to use. Defaults to `depot-ubuntu-latest`
         required: false
-        default: ubuntu-latest
+        default: depot-ubuntu-latest
     secrets:
       GCR_TOKEN:
         description: A token to use for logging into Github Container Registry. If not provided, login does not occur.

--- a/.github/workflows/.reusable-docker-publish.yml
+++ b/.github/workflows/.reusable-docker-publish.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   publish:
     name: Publish ${{ inputs.source-images }} to ${{ inputs.target-images }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/.reusable-frontend-deploy.yml
+++ b/.github/workflows/.reusable-frontend-deploy.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     environment: ${{ inputs.gh_environment }}
 
     permissions:

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   test:
-    runs-on: General-Purpose-8c-Runner
+    runs-on: depot-ubuntu-latest-16
     name: API Unit Tests
 
     services:

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   test:
     if: ${{ github.event.label.name == 'api' }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     name: API Tests
 
     services:

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   conventional-commit:
     name: Conventional Commit
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - name: Check PR Conventional Commit title
         uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/docs-cron-vercel-deploy.yml
+++ b/.github/workflows/docs-cron-vercel-deploy.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 12 * * 2'
 jobs:
   vercel-deploy:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - name: Run Vercel deploy hook
         run: curl -X POST "${{ secrets.VERCEL_SDK_VERSIONS_DEPLOY_HOOKS_URL }}"

--- a/.github/workflows/docs-pull-request.yml
+++ b/.github/workflows/docs-pull-request.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     name: Link Check Docs
 
     steps:

--- a/.github/workflows/frontend-deploy-production.yml
+++ b/.github/workflows/frontend-deploy-production.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     name: Run E2E Tests
     environment: production
     concurrency:

--- a/.github/workflows/frontend-test-staging.yml
+++ b/.github/workflows/frontend-test-staging.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   run-staging-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     name: Run E2E Tests
     environment: staging
     concurrency:

--- a/.github/workflows/github-labeler.yml
+++ b/.github/workflows/github-labeler.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
 
     steps:
       - name: Run labeler

--- a/.github/workflows/manual-e2e-tests.yml
+++ b/.github/workflows/manual-e2e-tests.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   run-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        runs-on: [depot-ubuntu-latest, depot-ubuntu-latest-arm]
+        runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
         api-image:
           - ${{ needs.docker-build-api.outputs.image }}
           - ${{ needs.docker-build-private-cloud-api.outputs.image }}

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -73,8 +73,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ matrix.api-image }}
-      concurrency: ${{ matrix.args.concurrency || 16 }}
-      tests: ${{ matrix.args.tests }}
+      concurrency: 16
     secrets:
       GCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
@@ -85,12 +84,6 @@ jobs:
         api-image:
           - ${{ needs.docker-build-api.outputs.image }}
           - ${{ needs.docker-build-private-cloud-api.outputs.image }}
-        args:
-          - tests: segment-part-1 environment
-          - tests: segment-part-2
-          - tests: segment-part-3 signup flag invite project
-          - tests: versioning
-          - tests: organisation-permission environment-permission project-permission roles
 
   # Publish to dockerhub
 

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -184,7 +184,7 @@ jobs:
 
   update-charts:
     needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout Target Charts Repository to update yaml
         uses: actions/checkout@v4

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -73,7 +73,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ matrix.api-image }}
-      concurrency: ${{ matrix.args.concurrency }}
+      concurrency: ${{ matrix.args.concurrency || 16 }}
       tests: ${{ matrix.args.tests }}
     secrets:
       GCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,15 +87,10 @@ jobs:
           - ${{ needs.docker-build-private-cloud-api.outputs.image }}
         args:
           - tests: segment-part-1 environment
-            concurrency: 1
           - tests: segment-part-2
-            concurrency: 1
           - tests: segment-part-3 signup flag invite project
-            concurrency: 2
           - tests: versioning
-            concurrency: 1
           - tests: organisation-permission environment-permission project-permission roles
-            concurrency: 1
 
   # Publish to dockerhub
 

--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, ARM64-2c]
+        runs-on: [depot-ubuntu-latest, depot-ubuntu-latest-arm]
         api-image:
           - ${{ needs.docker-build-api.outputs.image }}
           - ${{ needs.docker-build-private-cloud-api.outputs.image }}

--- a/.github/workflows/platform-docker-trivy-scan.yml
+++ b/.github/workflows/platform-docker-trivy-scan.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   pull-trivy-db:
     name: Pull and republish Trivy databases
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
 
     permissions:
       packages: write
@@ -72,7 +72,7 @@ jobs:
 
   scan-images:
     name: Scan image
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: pull-trivy-db
 
     permissions:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -137,7 +137,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ needs.docker-build-api.outputs.image }}
-      concurrency: ${{ matrix.args.concurrency }}
+      concurrency: ${{ matrix.args.concurrency || 16 }}
       tests: ${{ matrix.args.tests }}
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
@@ -148,13 +148,9 @@ jobs:
         runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
         args:
           - tests: segment-part-1 environment
-            concurrency: 1
           - tests: segment-part-2
-            concurrency: 1
           - tests: segment-part-3 signup flag invite project
-            concurrency: 2
           - tests: versioning
-            concurrency: 1
 
   run-e2e-tests-private-cloud:
     if: needs.permissions-check.outputs.can-write == 'true' && !cancelled()
@@ -164,7 +160,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ needs.docker-build-private-cloud.outputs.image }}
-      concurrency: ${{ matrix.args.concurrency }}
+      concurrency: ${{ matrix.args.concurrency || 16 }}
       tests: ${{ matrix.args.tests }}
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
@@ -175,4 +171,3 @@ jobs:
         runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
         args:
           - tests: organisation-permission environment-permission project-permission roles
-            concurrency: 1

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -137,8 +137,17 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ needs.docker-build-api.outputs.image }}
-      concurrency: ${{ matrix.args.concurrency || 16 }}
-      tests: ${{ matrix.args.tests }}
+      concurrency: 16
+      tests: >-
+        segment-part-1 
+        segment-part-2
+        segment-part-3
+        environment
+        signup
+        flag
+        invite
+        project
+        versioning
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
       SLACK_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.SLACK_TOKEN || '' }}
@@ -146,11 +155,6 @@ jobs:
     strategy:
       matrix:
         runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
-        args:
-          - tests: segment-part-1 environment
-          - tests: segment-part-2
-          - tests: segment-part-3 signup flag invite project
-          - tests: versioning
 
   run-e2e-tests-private-cloud:
     if: needs.permissions-check.outputs.can-write == 'true' && !cancelled()
@@ -160,8 +164,12 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ needs.docker-build-private-cloud.outputs.image }}
-      concurrency: ${{ matrix.args.concurrency || 16 }}
-      tests: ${{ matrix.args.tests }}
+      concurrency: 16
+      tests: >-
+        organisation-permission
+        environment-permission
+        project-permission
+        roles
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
       SLACK_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.SLACK_TOKEN || '' }}
@@ -169,5 +177,3 @@ jobs:
     strategy:
       matrix:
         runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
-        args:
-          - tests: organisation-permission environment-permission project-permission roles

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -145,7 +145,7 @@ jobs:
 
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, ARM64-2c]
+        runs-on: [depot-ubuntu-latest, depot-ubuntu-latest-arm]
         args:
           - tests: segment-part-1 environment
             concurrency: 1
@@ -172,7 +172,7 @@ jobs:
 
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, ARM64-2c]
+        runs-on: [depot-ubuntu-latest, depot-ubuntu-latest-arm]
         args:
           - tests: organisation-permission environment-permission project-permission roles
             concurrency: 1

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   permissions-check:
     name: Check actor permissions
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       can-write: ${{ steps.check.outputs.require-result }}
     steps:
@@ -23,7 +23,7 @@ jobs:
     if: needs.permissions-check.outputs.can-write == 'true'
     name: Add Conventional Commit labels
     needs: permissions-check
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       pull-requests: write
     steps:
@@ -49,7 +49,7 @@ jobs:
     if: github.event.pull_request.draft == false && needs.permissions-check.outputs.can-write == 'true'
     name: Prepare Docker report comment
     needs: permissions-check
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -145,7 +145,7 @@ jobs:
 
     strategy:
       matrix:
-        runs-on: [depot-ubuntu-latest, depot-ubuntu-latest-arm]
+        runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
         args:
           - tests: segment-part-1 environment
             concurrency: 1
@@ -172,7 +172,7 @@ jobs:
 
     strategy:
       matrix:
-        runs-on: [depot-ubuntu-latest, depot-ubuntu-latest-arm]
+        runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
         args:
           - tests: organisation-permission environment-permission project-permission roles
             concurrency: 1

--- a/.github/workflows/platform-release-please.yml
+++ b/.github/workflows/platform-release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
 
     steps:
       - uses: googleapis/release-please-action@v4

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-flagsmith:
     name: Build and push `Flagsmith`
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
 
     permissions:
       id-token: write
@@ -50,7 +50,7 @@ jobs:
   render-compose-file:
     name: Render Docker Compose File
     # Pass output of this workflow to another triggered by `workflow_run` event.
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs:
       - build-flagsmith
     outputs:
@@ -76,7 +76,7 @@ jobs:
 
   delete-preview:
     name: Call for Preview Deletion
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: ${{ github.event.action == 'closed' }}
     steps:
       # If this PR is closing, we will not render a compose file nor pass it to the next workflow.

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cache-compose-file:
     name: Cache Compose File
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       compose-file-cache-key: ${{ steps.hash.outputs.COMPOSE_FILE_HASH }}

--- a/.github/workflows/update-flagsmith-environment.yml
+++ b/.github/workflows/update-flagsmith-environment.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   update_server_defaults:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     name: Update API Flagsmith Defaults
     env:
       FLAGSMITH_ON_FLAGSMITH_SERVER_API_URL: https://edge.api.flagsmith.com/api/v1


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we're migrating all jobs to run on depot.dev runners.

Currently, the migration path is as follows:

| GHA runner name           | Action/job | New depot.dev runner name |
| --------------------------|------------|---------------------------|
| ubuntu-latest             | *          | depot-ubuntu-latest       |
| ubuntu-latest             | E2E        | depot-ubuntu-latest-16    |
| ARM64-2c                  | E2E        | depot-ubuntu-latest-arm-16|
| General-Purpose-8c-Runner | Unit Tests | depot-ubuntu-latest-16    |

TODO:
- [x] Consider moving E2E jobs to larger depot runners
- [x] Consider moving Unit Tests jobs to larger depot runners

## How did you test this code?

This is a CI change. We're testing the PR pipelines first, and, currently, intend to check the rest of the workflows live. The testing strategy is subject to change.