### PR TITLE
fix: remove-pipedrive

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,7 @@
         "cors": "^2.8.3",
         "cross-env": "7.0.3",
         "css-loader": "6.8.1",
-        "data-relay": "^0.0.15",
+        "data-relay": "^0.0.13",
         "dompurify": "^3.2.4",
         "dotenv": "6.2.0",
         "express": "4.21.2",
@@ -7745,9 +7745,9 @@
       }
     },
     "node_modules/data-relay": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/data-relay/-/data-relay-0.0.15.tgz",
-      "integrity": "sha512-Nkx406FVVyu9uR5KawFM8KlkUcbMShpadaaB/uHvQeACRduX2qMEcPHALg/wiA01XLsbM2eCg4sE6fB4LIUbaQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/data-relay/-/data-relay-0.0.13.tgz",
+      "integrity": "sha512-poKt8M8cNfv+JJQk6f+0AOYMJyY/f8jPraR5aknAsCcwB+sozMTcYMjISgDp/F042c66DGaIua0Eejvp8Yd2dg==",
       "license": "ISC",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,7 @@
         "cors": "^2.8.3",
         "cross-env": "7.0.3",
         "css-loader": "6.8.1",
-        "data-relay": "^0.0.13",
+        "data-relay": "^0.0.15",
         "dompurify": "^3.2.4",
         "dotenv": "6.2.0",
         "express": "4.21.2",
@@ -75,7 +75,6 @@
         "moment": "2.29.4",
         "node-fetch": "2.6.7",
         "node-sass": "^9.0.0",
-        "pipedrive": "^20.3.0",
         "polyfill-react-native": "1.0.5",
         "postcss-loader": "4.3.0",
         "prettier": "^2.5.1",
@@ -7267,14 +7266,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7321,11 +7312,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/copy-webpack-plugin": {
       "version": "9.1.0",
@@ -7759,9 +7745,10 @@
       }
     },
     "node_modules/data-relay": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/data-relay/-/data-relay-0.0.13.tgz",
-      "integrity": "sha512-poKt8M8cNfv+JJQk6f+0AOYMJyY/f8jPraR5aknAsCcwB+sozMTcYMjISgDp/F042c66DGaIua0Eejvp8Yd2dg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/data-relay/-/data-relay-0.0.15.tgz",
+      "integrity": "sha512-Nkx406FVVyu9uR5KawFM8KlkUcbMShpadaaB/uHvQeACRduX2qMEcPHALg/wiA01XLsbM2eCg4sE6fB4LIUbaQ==",
+      "license": "ISC",
       "dependencies": {
         "node-fetch": "^3.3.2"
       }
@@ -7770,6 +7757,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -7787,6 +7775,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -8141,15 +8130,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/device-specs/-/device-specs-1.0.1.tgz",
       "integrity": "sha512-rxns/NDZfbdYumnn801z9uo8kWIz3Eld7Bk/F0V9zw4sZemSoD93+gxHEonLdxYulkws4iCMt7ZP8zuM8EzUSg=="
-    },
-    "node_modules/dezalgo": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
-      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -9646,11 +9626,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
-    },
     "node_modules/fast-uri": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
@@ -9705,6 +9680,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -10026,25 +10002,12 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -10650,14 +10613,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/highlight-es": {
@@ -14138,6 +14093,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
       "funding": [
         {
           "type": "github",
@@ -14148,6 +14104,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -15209,16 +15166,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pipedrive": {
-      "version": "20.5.2",
-      "resolved": "https://registry.npmjs.org/pipedrive/-/pipedrive-20.5.2.tgz",
-      "integrity": "sha512-46Sc6bEWv3fxr6cQVwbzGUY4GjIPhxuhZvHM4wMxea3fr6LdxljVPwjv4L8VHkbWirrAycyr7FBgmjsgmYvhoQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "lodash": "^4.17.21",
-        "superagent": "^7.1.3"
       }
     },
     "node_modules/pirates": {
@@ -17999,52 +17946,6 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
-    "node_modules/superagent": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.6.tgz",
-      "integrity": "sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==",
-      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.3",
-        "debug": "^4.3.4",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.0.1",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.10.3",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": ">=6.4.0 <13 || >=14"
-      }
-    },
-    "node_modules/superagent/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/superagent/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -20046,6 +19947,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,6 @@
     "moment": "2.29.4",
     "node-fetch": "2.6.7",
     "node-sass": "^9.0.0",
-    "pipedrive": "^20.3.0",
     "polyfill-react-native": "1.0.5",
     "postcss-loader": "4.3.0",
     "prettier": "^2.5.1",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Pipedrive was not in use anymore and surfaced a vulnerability alert (from `formidable`)
- removed pipedrive package and related code

## How did you test this code?
- Build the application
- `npm ls formidable`
```
npm ls formidable
flagsmith-frontend@2.68.0 /Users/xxx/flagsmith-projects/flagsmith/frontend
└── (empty)
```