### PR TITLE
fix: remove unnecessary database access in conditional logic for is_live

### DIFF
--- a/api/features/models.py
+++ b/api/features/models.py
@@ -547,15 +547,15 @@ class FeatureState(
         if self.type == other.type:
             if self.environment.use_v2_feature_versioning:  # type: ignore[union-attr]
                 if (
-                    self.environment_feature_version is None
-                    or other.environment_feature_version is None
+                    self.environment_feature_version_id is None
+                    or other.environment_feature_version_id is None
                 ):
                     raise ValueError(
                         "Cannot compare feature states as they are missing environment_feature_version."
                     )
 
                 return (  # type: ignore[no-any-return]
-                    self.environment_feature_version > other.environment_feature_version
+                    self.environment_feature_version > other.environment_feature_version  # type: ignore[operator]
                 )
             else:
                 # we use live_from here as a priority over the version since
@@ -618,8 +618,8 @@ class FeatureState(
     def is_live(self) -> bool:
         if self.environment.use_v2_feature_versioning:  # type: ignore[union-attr]
             return (
-                self.environment_feature_version is not None
-                and self.environment_feature_version.is_live
+                self.environment_feature_version_id is not None
+                and self.environment_feature_version.is_live  # type: ignore[union-attr]
             )
         else:
             return (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- ~[ ] I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Removes unnecessary database access from logic for determining if a featurestate is live or not. 

Note that I had to add some additional type ignores because the type checking is not smart enough to release that checking if the foreign key id exists implies that the related object itself is not none. 

## How did you test this code?

N/a - existing test coverage is sufficient, we are simply moving to use django best practices for foreign key existence checks. 
