### PR TITLE
fix: Exclude identities when viewing change request

### DIFF
--- a/frontend/common/types/responses.ts
+++ b/frontend/common/types/responses.ts
@@ -439,25 +439,26 @@ export type IdentityFeatureState = {
 }
 
 export type FeatureState = {
-  id: number
-  feature_state_value: FlagsmithValue
-  multivariate_feature_state_values: MultivariateFeatureStateValue[]
-  uuid: string
-  enabled: boolean
+  change_request?: number
   created_at: string
-  updated_at: string
-  environment_feature_version: string
-  version?: number
-  live_from?: string
-  feature: number
+  enabled: boolean
   environment: number
+  environment_feature_version: string
+  feature: number
   feature_segment?: {
     id: number
     priority: number
     segment: number
     uuid: string
   }
-  change_request?: number
+  feature_state_value: FlagsmithValue
+  id: number
+  identity?: number
+  live_from?: string
+  multivariate_feature_state_values: MultivariateFeatureStateValue[]
+  updated_at: string
+  uuid: string
+  version?: number
   //Added by FE
   toRemove?: boolean
 }

--- a/frontend/web/components/diff/DiffChangeRequest.tsx
+++ b/frontend/web/components/diff/DiffChangeRequest.tsx
@@ -8,6 +8,7 @@ type DiffChangeRequestType = {
   changeRequest: ChangeRequest | null
   feature: number
   projectId: string
+  identity: number | null
   environmentId: string
   isVersioned: boolean
 }
@@ -15,6 +16,7 @@ const DiffChangeRequest: FC<DiffChangeRequestType> = ({
   changeRequest,
   environmentId,
   feature,
+  identity = null,
   isVersioned,
   projectId,
 }) => {
@@ -55,7 +57,7 @@ const DiffChangeRequest: FC<DiffChangeRequestType> = ({
       disableSegments={!isVersioned}
       projectId={projectId}
       newState={newState || []}
-      oldState={data?.results || []}
+      oldState={data?.results?.filter((v) => v.identity === identity) || []}
     />
   )
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Change requests were incorrectly including identity feature states when diffing the states. The following (live) is incorrect. The DiffChangeRequest component now takes an optional identity to diff against.

![image](https://github.com/user-attachments/assets/97476999-1a15-4895-90ad-464cf7c5c839)

vs

![image](https://github.com/user-attachments/assets/26537861-7c10-4c4a-aaf1-c9fa9d909e99)

## How did you test this code?

As above