### PR TITLE
fix: hide-billing-periods-if-subscription-has-no-periods

### DIFF
--- a/frontend/web/components/OrganisationUsage.tsx
+++ b/frontend/web/components/OrganisationUsage.tsx
@@ -77,7 +77,8 @@ const OrganisationUsage: FC<OrganisationUsageType> = ({ organisationId }) => {
   const currentPlan = Utils.getPlanName(AccountStore.getActiveOrgPlan())
   const orgSubscription = AccountStore.getOrganisation()?.subscription
   const isOnFreePlanPeriods =
-    planNames.free === currentPlan || !orgSubscription?.has_billing_periods
+    planNames.free === currentPlan ||
+    !orgSubscription?.has_active_billing_periods
   const [billingPeriod, setBillingPeriod] = useState<
     Req['getOrganisationUsage']['billing_period']
   >(isOnFreePlanPeriods ? '90_day_period' : 'current_billing_period')


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [X] I have filled in the "Changes" section below?
- [X] I have filled in the "How did you test this code" section below?
- [X] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Related #5472 and dependent on #5474 

- Uses `has_billing_periods` to hide `Current Billing Period` and `Previous Billing Period` in Usage page
- Fallback showing a message when no period sets (but shouldn't happen)
- Defaults to free plan views

## How did you test this code?
![image](https://github.com/user-attachments/assets/0cc0e46c-6e48-4e5c-a72d-da570d8d8a87)

![image](https://github.com/user-attachments/assets/8136d934-4cad-4a10-bfd1-b944bf7f0645)
