### PR TITLE
fix: prevent signup blocking invitation signups

### DIFF
--- a/api/custom_auth/permissions.py
+++ b/api/custom_auth/permissions.py
@@ -20,7 +20,7 @@ class CurrentUser(IsAuthenticated):
 
 
 class IsSignupAllowed(AllowAny):
-    message = "Signing-up without a valid invitation is disabled. Please contact your administrator."
+    message = "Signing up without an invitation is disabled. Please contact your administrator."
 
     def has_permission(self, request: Request, view: View) -> bool:
         if not settings.PREVENT_SIGNUP:
@@ -34,10 +34,11 @@ class IsSignupAllowed(AllowAny):
         if invite_hash:
             try:
                 invite_link = InviteLink.objects.get(hash=invite_hash)
-                if not invite_link.is_expired:
-                    return True
             except InviteLink.DoesNotExist:
                 pass
+
+        if not invite_link.is_expired:
+            return True
 
         raise PermissionDenied(self.message)
 

--- a/api/custom_auth/permissions.py
+++ b/api/custom_auth/permissions.py
@@ -1,9 +1,10 @@
 from django.conf import settings
 from django.views import View
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
-from organisations.invites.models import InviteLink, Invite
-from rest_framework.exceptions import PermissionDenied
+
+from organisations.invites.models import Invite, InviteLink
 
 
 class CurrentUser(IsAuthenticated):

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
@@ -51,7 +51,7 @@ def test_signup_blocked_when_prevent_signup_enabled_and_no_invitation(
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert (
         str(response.data["detail"])
-        == "Signing-up without a valid invitation is disabled. Please contact your administrator."
+        == "Signing up without an invitation is disabled. Please contact your administrator."
     )
 
 
@@ -84,7 +84,7 @@ def test_signup_allowed_with_email_invite(
         (
             lambda _: "invalid-hash",
             status.HTTP_403_FORBIDDEN,
-            "Signing-up without a valid invitation is disabled. Please contact your administrator.",
+            "Signing up without an invitation is disabled. Please contact your administrator.",
         ),
         (
             lambda organisation: InviteLink.objects.create(
@@ -92,7 +92,7 @@ def test_signup_allowed_with_email_invite(
                 expires_at=timezone.now() - timedelta(days=1),
             ),
             status.HTTP_403_FORBIDDEN,
-            "Signing-up without a valid invitation is disabled. Please contact your administrator.",
+            "Signing up without an invitation is disabled. Please contact your administrator.",
         ),
     ],
 )

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
@@ -1,0 +1,124 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, override_settings  # type: ignore[attr-defined]
+from datetime import timedelta
+from django.utils import timezone
+
+from organisations.invites.models import Invite, InviteLink
+from organisations.models import Organisation
+from users.models import FFAdminUser
+
+
+@pytest.fixture
+def signup_data():
+    return {
+        "email": "test@example.com",
+        "password": "testpass123",
+        "first_name": "Test",
+        "last_name": "User",
+    }
+
+
+def test_signup_allowed_when_prevent_signup_disabled(
+    api_client: APIClient, signup_data: dict, db: None
+) -> None:
+    # Given
+    url = reverse("api-v1:custom_auth:ffadminuser-list")
+
+    # When
+    response = api_client.post(url, data=signup_data)
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@override_settings(PREVENT_SIGNUP=True)
+def test_signup_blocked_when_prevent_signup_enabled_and_no_invitation(
+    api_client: APIClient, signup_data: dict, db: None
+) -> None:
+    # Given
+    url = reverse("api-v1:custom_auth:ffadminuser-list")
+
+    # When
+    response = api_client.post(url, data=signup_data)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        str(response.data["detail"])
+        == "Signing-up without a valid invitation is disabled. Please contact your administrator."
+    )
+
+
+@override_settings(PREVENT_SIGNUP=True)
+def test_signup_allowed_with_email_invite(
+    api_client: APIClient, signup_data: dict, db: None
+) -> None:
+    # Given
+    organisation = Organisation.objects.create(name="Test Org")
+    Invite.objects.create(email=signup_data["email"], organisation=organisation)
+    url = reverse("api-v1:custom_auth:ffadminuser-list")
+
+    # When
+    response = api_client.post(url, data=signup_data)
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@override_settings(PREVENT_SIGNUP=True)
+def test_signup_allowed_with_valid_invite_hash(
+    api_client: APIClient, signup_data: dict, invite_link: InviteLink, db: None
+) -> None:
+    # Given
+    signup_data_with_hash = {**signup_data, "invite_hash": invite_link.hash}
+    url = reverse("api-v1:custom_auth:ffadminuser-list")
+
+    # When
+    response = api_client.post(url, data=signup_data_with_hash)
+
+    # Then
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@override_settings(PREVENT_SIGNUP=True)
+def test_signup_blocked_with_invalid_invite_hash(
+    api_client: APIClient, signup_data: dict, db: None
+) -> None:
+    # Given
+    signup_data_with_hash = {**signup_data, "invite_hash": "invalid-hash"}
+    url = reverse("api-v1:custom_auth:ffadminuser-list")
+
+    # When
+    response = api_client.post(url, data=signup_data_with_hash)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        str(response.data["detail"])
+        == "Signing-up without a valid invitation is disabled. Please contact your administrator."
+    )
+
+
+@override_settings(PREVENT_SIGNUP=True)
+def test_signup_blocked_with_expired_invite_link(
+    api_client: APIClient, signup_data: dict, db: None
+) -> None:
+    # Given
+    organisation = Organisation.objects.create(name="Test Org")
+    expired_invite_link = InviteLink.objects.create(
+        organisation=organisation, expires_at=timezone.now() - timedelta(days=1)
+    )
+    signup_data_with_hash = {**signup_data, "invite_hash": expired_invite_link.hash}
+    url = reverse("api-v1:custom_auth:ffadminuser-list")
+
+    # When
+    response = api_client.post(url, data=signup_data_with_hash)
+
+    # Then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        str(response.data["detail"])
+        == "Signing-up without a valid invitation is disabled. Please contact your administrator."
+    )

--- a/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_permissions.py
@@ -1,10 +1,15 @@
+from datetime import timedelta
+from typing import Any, Callable
+
 import pytest
 from django.urls import reverse
-from rest_framework import status
-from rest_framework.test import APIClient, override_settings  # type: ignore[attr-defined]
-from datetime import timedelta
 from django.utils import timezone
-from typing import Any, Callable
+from rest_framework import status
+from rest_framework.test import (  # type: ignore[attr-defined]
+    APIClient,
+    override_settings,
+)
+
 from organisations.invites.models import Invite, InviteLink
 from organisations.models import Organisation
 

--- a/frontend/web/components/pages/HomePage.tsx
+++ b/frontend/web/components/pages/HomePage.tsx
@@ -267,7 +267,6 @@ const HomePage: React.FC<RouteComponentProps> = ({ history, location }) => {
       )
     }
   }
-
   return (
     <AccountProvider>
       {(
@@ -522,8 +521,9 @@ const HomePage: React.FC<RouteComponentProps> = ({ history, location }) => {
                                   >
                                     <ErrorMessage
                                       error={
-                                        typeof AccountStore.error === 'string'
-                                          ? AccountStore.error
+                                        typeof (AccountStore.error as any)
+                                          ?.detail === 'string'
+                                          ? (AccountStore.error as any).detail
                                           : 'Please check your details and try again'
                                       }
                                     />


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

closes #5506 

## Changes
- added email and link invitation checks in `IsSignupAllowed` permissions
- Use the request error in the frontend

## How did you test this code?
- Added tests

To test:
1. Run backend with `"PREVENT_SIGNUP": "1",`
2. Share invitation link / invite with email a user
3. Complete signup

https://www.loom.com/share/02c75a8dc28c4378b9856867c2ca7c85