### PR TITLE
fix: hide-dropdown-caret-if-no-text-content

### DIFF
--- a/frontend/web/components/modals/FeatureHealthTabContent.tsx
+++ b/frontend/web/components/modals/FeatureHealthTabContent.tsx
@@ -54,14 +54,18 @@ const EventTextBlocks = ({
           {textBlock.title && (
             <div className='mb-2 text-body'>
               <strong style={{ color }}>{textBlock.title ?? 'Event'}</strong>
-              <IonIcon
-                style={{ color, marginBottom: -2 }}
-                className='ms-1'
-                icon={
-                  collapsibleItems?.[index]?.collapsed ? chevronDown : chevronUp
-                }
-                onClick={() => handleCollapse(index)}
-              />
+              {!!textBlock.text && (
+                <IonIcon
+                  style={{ color, marginBottom: -2 }}
+                  className='ms-1'
+                  icon={
+                    collapsibleItems?.[index]?.collapsed
+                      ? chevronDown
+                      : chevronUp
+                  }
+                  onClick={() => handleCollapse(index)}
+                />
+              )}
             </div>
           )}
           <Collapse key={index} in={!collapsibleItems?.[index]?.collapsed}>


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

Closes #5516 

## Changes
Low hanging fruit
- Show dropdown caret only if collapsible text

## How did you test this code?
- Reproduced with dummy data
![image](https://github.com/user-attachments/assets/16d14b34-cd85-43a4-8aeb-69a247c1b010)
