### PR TITLE
fix: Disable e2e tests in draft PRs

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -144,7 +144,7 @@ jobs:
         github_private_cloud_token=${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}
 
   run-e2e-tests:
-    if: '!cancelled()'
+    if: github.event.pull_request.draft == false && !cancelled()
     needs: [permissions-check, docker-build-api, docker-build-e2e]
     uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
     with:
@@ -161,7 +161,7 @@ jobs:
         runs-on: [depot-ubuntu-latest-16, depot-ubuntu-latest-arm-16]
 
   run-e2e-tests-private-cloud:
-    if: needs.permissions-check.outputs.can-write == 'true' && !cancelled()
+    if: github.event.pull_request.draft == false && !cancelled() && needs.permissions-check.outputs.can-write == 'true'
     needs: [permissions-check, docker-build-private-cloud, docker-build-e2e]
     uses: ./.github/workflows/.reusable-docker-e2e-tests.yml
     with:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Something is unexpected in GHA: it runs e2e jobs even if their build dependency is skipped when in draft PRs. The missing fresh build could be related to why it fails, but we're also not interested in running e2e tests unless the PR is ready for review.


## How did you test this code?

Observing CI in this PR while in draft mode, and when ready for review.

Draft:
<img width="919" alt="image" src="https://github.com/user-attachments/assets/a30647b8-53ad-4dd9-a51c-ba24fe9f05a2" />

Ready for review: check out below.