### PR TITLE
ci: Ensure one active flagsmith-charts PR

### DIFF
--- a/.github/workflows/platform-docker-build-test-publish.yml
+++ b/.github/workflows/platform-docker-build-test-publish.yml
@@ -200,6 +200,33 @@ jobs:
     needs: [docker-publish-api, docker-publish-frontend, docker-publish-unified]
     runs-on: depot-ubuntu-latest
     steps:
+      - name: Close prior open PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.FLAGSMITH_CHARTS_GITHUB_TOKEN }}
+          script: |
+            const owner = "flagsmith";
+            const repo = "flagsmith-charts";
+
+            const prs = await github.paginate(
+              github.rest.pulls.list,
+              {
+                owner, repo,
+                state: "open",
+              }
+            );
+      
+            for (const pr of prs) {
+              const labels = pr.labels.map(label => label.name);
+              if (labels.includes("yaml-updates")) {
+                await github.rest.pulls.update({
+                  owner, repo,
+                  pull_number: pr.number,
+                  state: "closed",
+                });
+              }
+            }
+
       - name: Checkout Target Charts Repository to update yaml
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This prevents bloat in the flagsmith-charts repo by closing all stale PRs before creating a new one on release.

## How did you test this code?

This is a CI change that will have to be merged and tested on the next release.