### PR TITLE
fix: deduplicate metrics live features states

### DIFF
--- a/api/environments/dynamodb/wrappers/identity_wrapper.py
+++ b/api/environments/dynamodb/wrappers/identity_wrapper.py
@@ -196,9 +196,31 @@ class DynamoIdentityWrapper(BaseDynamoWrapper):
 
     def get_identity_overrides_count(self, environment_api_key: str) -> int:
         return sum(
-            len(identity["identity_features"])
+            len({f["feature_id"] for f in identity["identity_features"]})
             for identity in self.iter_all_items_paginated(
                 environment_api_key=environment_api_key,
                 overrides_only=True,
             )
         )
+
+    def get_identity_override_feature_counts(
+        self, environment_api_key: str
+    ) -> dict[int, int]:
+        feature_to_identity_count: dict[int, int] = {}
+
+        for identity in self.iter_all_items_paginated(
+            environment_api_key=environment_api_key,
+            overrides_only=True,
+        ):
+            unique_feature_ids: set[int] = set()
+
+            for feature_override in identity.get("identity_features", []):
+                feature_id = feature_override.get("feature", {}).get("id", 0)
+                unique_feature_ids.add(feature_id)
+
+            for feature_id in unique_feature_ids:
+                feature_to_identity_count[feature_id] = (
+                    feature_to_identity_count.get(feature_id, 0) + 1
+                )
+
+        return feature_to_identity_count

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -383,9 +383,11 @@ class Environment(
         base_qs = FeatureState.objects.get_live_feature_states(
             environment=self,
             **(filter_kwargs or {}),
+        ).filter(
+            feature__is_archived=False,
         )
 
-        group_fields = ["feature_id"]
+        group_fields = ["feature_id", "environment_id"]
         if extra_group_by_fields is not None:
             group_fields.append(extra_group_by_fields)
 

--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -412,9 +412,15 @@ class Environment(
                 identity_id__isnull=True,
                 feature_segment_id__isnull=False,
             ),
-        ).values_list("id", flat=True)
+        ).filter(feature__is_archived=False)
 
-        return list(feature_states_qs)
+        return list(
+            feature_states_qs.values(
+                "feature_id", "feature_segment_id", "environment_id"
+            )
+            .annotate(id=Max("id"))
+            .values_list("id", flat=True)
+        )
 
     def get_segment_metrics_queryset(self) -> QuerySet[FeatureState]:
         ids = self._get_latest_segment_state_ids_subquery()

--- a/api/features/managers.py
+++ b/api/features/managers.py
@@ -41,6 +41,7 @@ class FeatureStateManager(UUIDNaturalKeyManagerMixin, SoftDeleteManager):  # typ
                     environment.id
                 )
             )
+
             latest_version_uuids = [efv.uuid for efv in latest_versions]
 
             # Note that since identity overrides aren't part of the versioning system,

--- a/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
+++ b/api/tests/unit/environments/dynamodb/wrappers/test_unit_dynamodb_identity_wrapper.py
@@ -604,19 +604,35 @@ def test_delete_all_identities__deletes_all_identities_documents_from_dynamodb(
 
 
 @pytest.mark.parametrize(
-    "identity_features",
+    "identity_features, expected_counts",
     [
-        [[1, 2, 3], [99], []],
-        [[1, 2, 3], [99], [1, 2, 3, 99]],
-        [[], [], []],
-        [[], [1, 2, 3], []],
-        [[4], [4, 25, 18, 19, 85, 100], [4]],
+        (
+            [[1, 2, 3], [99], []],
+            {1: 1, 2: 1, 3: 1, 99: 1},
+        ),
+        (
+            [[1, 2, 3], [99], [1, 2, 3, 99]],
+            {1: 2, 2: 2, 3: 2, 99: 2},
+        ),
+        (
+            [[], [], []],
+            {},
+        ),
+        (
+            [[], [1, 2, 3], []],
+            {1: 1, 2: 1, 3: 1},
+        ),
+        (
+            [[4], [4, 25, 18, 19, 85, 100], [4]],
+            {4: 3, 25: 1, 18: 1, 19: 1, 85: 1, 100: 1},
+        ),
     ],
 )
-def test_get_identity_overrides_count_dynamo_returns_correct_total(
+def test_get_identity_override_feature_counts_dynamo_returns_correct_total(
     flagsmith_identities_table: Table,
     dynamodb_identity_wrapper: DynamoIdentityWrapper,
     identity_features: list[list[int]],
+    expected_counts: dict[int, int],
 ) -> None:
     environment_api_key = "env_test"
 
@@ -624,29 +640,35 @@ def test_get_identity_overrides_count_dynamo_returns_correct_total(
         "composite_key": f"{environment_api_key}_identity1",
         "environment_api_key": environment_api_key,
         "identifier": "user1",
-        "identity_features": identity_features[0],
+        "identity_features": [
+            {"feature": {"id": feature_id}} for feature_id in identity_features[0]
+        ],
     }
 
     identity_two = {
         "composite_key": f"{environment_api_key}_identity2",
         "environment_api_key": environment_api_key,
         "identifier": "user2",
-        "identity_features": identity_features[1],
+        "identity_features": [
+            {"feature": {"id": feature_id}} for feature_id in identity_features[1]
+        ],
     }
 
     identity_three = {
         "composite_key": f"{environment_api_key}_identity3",
         "environment_api_key": environment_api_key,
         "identifier": "user3",
-        "identity_features": identity_features[2],
+        "identity_features": [
+            {"feature": {"id": feature_id}} for feature_id in identity_features[2]
+        ],
     }
 
     flagsmith_identities_table.put_item(Item=identity_one)
     flagsmith_identities_table.put_item(Item=identity_two)
     flagsmith_identities_table.put_item(Item=identity_three)
 
-    result = dynamodb_identity_wrapper.get_identity_overrides_count(environment_api_key)
-
-    assert result == len(identity_features[0]) + len(identity_features[1]) + len(
-        identity_features[2]
+    result = dynamodb_identity_wrapper.get_identity_override_feature_counts(
+        environment_api_key
     )
+
+    assert result == expected_counts

--- a/api/tests/unit/metrics/test_unit_metrics_service.py
+++ b/api/tests/unit/metrics/test_unit_metrics_service.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from environments.models import Environment
+from features.models import Feature
 from metrics.metrics_service import EnvironmentMetricsService
 from metrics.types import EnvMetricsName
 
@@ -82,6 +83,13 @@ def test_dynamo_identity_metric_used(
     monkeypatch.setattr(
         environment, "get_segment_metrics_queryset", lambda: MagicMock(count=lambda: 1)
     )
+    Feature.objects.create(
+        id=10,
+        project=environment.project,
+        name="feature-10",
+        is_archived=False,
+        deleted_at=None,
+    )
     identity_count_mock = MagicMock(return_value=1)
     monkeypatch.setattr(
         environment,
@@ -89,9 +97,9 @@ def test_dynamo_identity_metric_used(
         lambda: MagicMock(count=identity_count_mock),
     )
 
-    dynamo_mock = MagicMock(return_value=99)
+    dynamo_mock = MagicMock(return_value={10: 99})
     monkeypatch.setattr(
-        "edge_api.identities.models.EdgeIdentity.dynamo_wrapper.get_identity_overrides_count",
+        "edge_api.identities.models.EdgeIdentity.dynamo_wrapper.get_identity_override_feature_counts",
         dynamo_mock,
     )
     # When


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Reported metrics were incorrect on long-lived environment (with feature-versioning). This PR deduplicates the feature-states from the feature (Total features/Features enabled/Segment override) and adapted identity_overrides count with dynamoDB

## How did you test this code?
- Added tests
- Tested SQL queries against prod to eliminate duplication