### PR TITLE
fix: optional-and-default-values-for-tasks-in-me-endpoint

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -189,7 +189,7 @@ class PatchOnboardingSerializer(serializers.Serializer[None]):
 
 
 class OnboardingResponseTypeSerializer(serializers.Serializer[None]):
-    tasks = OnboardingTaskSerializer(many=True)
+    tasks = OnboardingTaskSerializer(many=True, required=False, default=list)
     tools = OnboardingToolsSerializer(required=False)
 
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Integrations and getting started constitutes a 2-step onboarding flow, updating the onboarding_data through the same endpoint.
Onboarding_data is returned in `GET /me`. The second onboarding part (`tasks`) was required in the serializer while still undefined after completing the integrations part, leading to intermediate 500 on `GET /me`

- tasks as optional and default to `[]`

## How did you test this code?
- added tests