### PR TITLE
fix: Navigate to change request after creation

### DIFF
--- a/frontend/web/components/ExistingChangeRequestAlert.tsx
+++ b/frontend/web/components/ExistingChangeRequestAlert.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import InfoMessage from './InfoMessage'
 import Button from './base/forms/Button'
 import { ChangeRequestSummary } from 'common/types/responses'
-import { RouterChildContext } from 'react-router'
+import { RouterChildContext } from 'react-router-dom'
 
 type ExistingChangeRequestAlertType = {
   changeRequests: ChangeRequestSummary[]

--- a/frontend/web/components/ExistingChangeRequestAlert.tsx
+++ b/frontend/web/components/ExistingChangeRequestAlert.tsx
@@ -30,7 +30,6 @@ const ExistingChangeRequestAlert: FC<ExistingChangeRequestAlertType> = ({
     const latestChangeRequest = !editingChangeRequest?.id
       ? changes?.at(-1)?.id
       : editingChangeRequest?.id
-    console.log('history', history)
     closeModal()
     history.push(
       `/project/${projectId}/environment/${environmentId}/change-requests/${latestChangeRequest}`,

--- a/frontend/web/components/ExistingChangeRequestAlert.tsx
+++ b/frontend/web/components/ExistingChangeRequestAlert.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react'
 import InfoMessage from './InfoMessage'
-import { useHistory } from 'react-router-dom'
 import Button from './base/forms/Button'
 import { ChangeRequestSummary } from 'common/types/responses'
+import { RouterChildContext } from 'react-router'
 
 type ExistingChangeRequestAlertType = {
   changeRequests: ChangeRequestSummary[]
@@ -11,6 +11,7 @@ type ExistingChangeRequestAlertType = {
   projectId: number | string
   environmentId: string
   className?: string
+  history: RouterChildContext['router']['history']
 }
 
 const ExistingChangeRequestAlert: FC<ExistingChangeRequestAlertType> = ({
@@ -18,11 +19,10 @@ const ExistingChangeRequestAlert: FC<ExistingChangeRequestAlertType> = ({
   className,
   editingChangeRequest,
   environmentId,
+  history,
   projectId,
   scheduledChangeRequests,
 }) => {
-  const history = useHistory()
-
   const handleNavigate = () => {
     const changes = scheduledChangeRequests?.length
       ? scheduledChangeRequests
@@ -30,6 +30,7 @@ const ExistingChangeRequestAlert: FC<ExistingChangeRequestAlertType> = ({
     const latestChangeRequest = !editingChangeRequest?.id
       ? changes?.at(-1)?.id
       : editingChangeRequest?.id
+    console.log('history', history)
     closeModal()
     history.push(
       `/project/${projectId}/environment/${environmentId}/change-requests/${latestChangeRequest}`,

--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -837,6 +837,7 @@ const CreateFlag = class extends Component {
           {!!isEdit && !identity && (
             <ExistingChangeRequestAlert
               className='mb-4'
+              history={this.props.history}
               editingChangeRequest={this.props.changeRequest}
               projectId={this.props.projectId}
               environmentId={this.props.environmentId}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

<img width="719" alt="Screenshot 2025-06-25 at 15 57 50" src="https://github.com/user-attachments/assets/0de499c8-b340-419b-baa0-36917f0864f6" />


After updating react-router the navigation to recently created change requests from was broken due to missing history object.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

_Please describe._
