### PR TITLE
chore: revert cookie darkmode

### DIFF
--- a/frontend/common/stores/config-store.js
+++ b/frontend/common/stores/config-store.js
@@ -1,5 +1,4 @@
 import Project from 'common/project'
-import { setDarkMode } from 'project/darkMode'
 
 const Dispatcher = require('../dispatcher/dispatcher')
 const BaseStore = require('./base/_store')
@@ -10,9 +9,9 @@ const controller = {
     store.loading()
   },
   loaded(oldFlags) {
-    //todo: Remove this after a few weeks have passed
-    if (API.getCookie('dark_mode') === undefined) {
-      setDarkMode(flagsmith.hasFeature('dark_mode'))
+    // Occurs whenever flags are changed
+    if (flagsmith.hasFeature('dark_mode')) {
+      document.body.classList.add('dark')
     }
     if (!oldFlags || !Object.keys(oldFlags).length) {
       store.loaded()

--- a/frontend/web/components/App.js
+++ b/frontend/web/components/App.js
@@ -23,7 +23,7 @@ import Announcement from './Announcement'
 import { getBuildVersion } from 'common/services/useBuildVersion'
 import AccountProvider from 'common/providers/AccountProvider'
 import Nav from './navigation/Nav'
-import 'project/darkMode'
+
 const App = class extends Component {
   static propTypes = {
     children: propTypes.element.isRequired,
@@ -200,6 +200,10 @@ const App = class extends Component {
         })
       }
     }
+
+    if (Utils.getFlagsmithHasFeature('dark_mode')) {
+      document.body.classList.add('dark')
+    }
   }
 
   handleScroll = () => {
@@ -227,6 +231,12 @@ const App = class extends Component {
   }
 
   render() {
+    if (
+      Utils.getFlagsmithHasFeature('dark_mode') &&
+      !document.body.classList.contains('dark')
+    ) {
+      document.body.classList.add('dark')
+    }
     const { location } = this.props
     const pathname = location.pathname
 

--- a/frontend/web/components/CompareEnvironments.js
+++ b/frontend/web/components/CompareEnvironments.js
@@ -13,7 +13,6 @@ import Constants from 'common/constants'
 import Button from './base/forms/Button'
 import Tooltip from './Tooltip'
 import { withRouter } from 'react-router-dom'
-import { getDarkMode } from 'project/darkMode'
 
 const featureNameWidth = 300
 
@@ -175,7 +174,9 @@ class CompareEnvironments extends Component {
               <Icon
                 name='arrow-right'
                 width={20}
-                fill={getDarkMode() ? '#fff' : '#1A2634'}
+                fill={
+                  Utils.getFlagsmithHasFeature('dark_mode') ? '#fff' : '#1A2634'
+                }
               />
             </div>
 

--- a/frontend/web/components/CompareIdentities.tsx
+++ b/frontend/web/components/CompareIdentities.tsx
@@ -22,7 +22,6 @@ import SegmentOverridesIcon from './SegmentOverridesIcon'
 import IdentityOverridesIcon from './IdentityOverridesIcon'
 import Tooltip from './Tooltip'
 import PageTitle from './PageTitle'
-import { getDarkMode } from 'project/darkMode'
 
 type CompareIdentitiesType = {
   projectId: string
@@ -207,7 +206,9 @@ const CompareIdentities: FC<CompareIdentitiesType> = ({
             <Icon
               name='arrow-right'
               width={20}
-              fill={getDarkMode() ? '#fff' : '#1A2634'}
+              fill={
+                Utils.getFlagsmithHasFeature('dark_mode') ? '#fff' : '#1A2634'
+              }
             />
           </div>
           <div style={{ width: selectWidth }}>

--- a/frontend/web/components/DarkModeSwitch.tsx
+++ b/frontend/web/components/DarkModeSwitch.tsx
@@ -1,23 +1,27 @@
-import React, { FC, useState } from 'react'
+import React, { FC } from 'react'
+import Utils from 'common/utils/utils'
 import ConfigProvider from 'common/providers/ConfigProvider'
+import flagsmith from 'flagsmith'
+import Tooltip from './Tooltip'
 import Setting from './Setting'
-import { getDarkMode, setDarkMode as persistDarkMode } from 'project/darkMode'
 
 type DarkModeSwitchType = {}
 
 const DarkModeSwitch: FC<DarkModeSwitchType> = ({}) => {
-  const [darkModeLocal, setDarkModeLocal] = useState(getDarkMode())
-
   const toggleDarkMode = () => {
-    const newDarkMode = !getDarkMode()
-    setDarkModeLocal(newDarkMode)
-    persistDarkMode(newDarkMode)
+    const newValue = !Utils.getFlagsmithHasFeature('dark_mode')
+    flagsmith.setTrait('dark_mode', newValue)
+    if (newValue) {
+      document.body.classList.add('dark')
+    } else {
+      document.body.classList.remove('dark')
+    }
   }
   return (
     <Setting
       title='Dark Mode'
       description='Adjust the theme you see when using Flagsmith.'
-      checked={darkModeLocal}
+      checked={Utils.getFlagsmithHasFeature('dark_mode')}
       onChange={toggleDarkMode}
     />
   )

--- a/frontend/web/components/modals/RuleInputValue.tsx
+++ b/frontend/web/components/modals/RuleInputValue.tsx
@@ -5,7 +5,6 @@ import InputGroup from 'components/base/forms/InputGroup'
 import Button from 'components/base/forms/Button'
 import Utils from 'common/utils/utils'
 import ModalHR from './ModalHR'
-import { getDarkMode } from 'project/darkMode'
 
 type RuleInputValueProps = {
   'data-test'?: string
@@ -120,7 +119,7 @@ const RuleInputValue = (props: RuleInputValueProps) => {
   }
 
   const showIcon = hasWarning || isLongText
-  const isDarkMode = getDarkMode()
+  const isDarkMode = Utils.getFlagsmithHasFeature('dark_mode')
 
   return (
     <div className='relative'>

--- a/frontend/web/components/tags/Tag.tsx
+++ b/frontend/web/components/tags/Tag.tsx
@@ -6,7 +6,6 @@ import ToggleChip from 'components/ToggleChip'
 import Utils from 'common/utils/utils'
 import TagContent from './TagContent'
 import Constants from 'common/constants'
-import { getDarkMode } from 'project/darkMode'
 
 type TagType = {
   className?: string
@@ -18,7 +17,7 @@ type TagType = {
 }
 
 export const getTagColor = (tag: Partial<TTag>, selected?: boolean) => {
-  if (getDarkMode() && tag.color === '#344562') {
+  if (Utils.getFlagsmithHasFeature('dark_mode') && tag.color === '#344562') {
     return '#9DA4AE'
   }
   if (tag.type === 'UNHEALTHY') {

--- a/frontend/web/project/setDarkMode.ts
+++ b/frontend/web/project/setDarkMode.ts
@@ -1,20 +1,9 @@
-import API from './api'
-
-export const getDarkMode = () => {
-  return API.getCookie('dark_mode') === 'true'
-}
 export const setDarkMode = (enabled: boolean) => {
   if (enabled) {
-    API.setCookie('dark_mode', true)
     document.body.classList.add('dark')
     document.documentElement.setAttribute('data-bs-theme', 'dark')
   } else {
-    API.setCookie('dark_mode', 'false')
     document.body.classList.remove('dark')
     document.documentElement.removeAttribute('data-bs-theme')
   }
-}
-
-if (API.getCookie('dark_mode')) {
-  setDarkMode(getDarkMode())
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

For some reason https://github.com/Flagsmith/flagsmith/pull/5680 caused a regression in E2E, it looks like setting the 'dark_mode' cookie is somehow interfering with clearing 't' on logout even though document.cookie reports it as being correctly removed until the next session. At the moment I haven't diagnosed it fully but it seems that either

- TestCafe is proxying cookies via a HTTP only cookie
- TestCafe is setting cookies on different domains
