### PR TITLE
chore: Use local storage over cookies for e2e

### DIFF
--- a/frontend/web/project/api.js
+++ b/frontend/web/project/api.js
@@ -370,15 +370,18 @@ global.API = {
   setCookie(key, v) {
     try {
       if (!v) {
-        require('js-cookie').remove(key, {
-          domain: Project.cookieDomain,
-          path: '/',
-        })
-        require('js-cookie').remove(key, { path: '/' })
+        if (E2E) {
+          localStorage.removeItem(key, v)
+        } else {
+          require('js-cookie').remove(key, {
+            domain: Project.cookieDomain,
+            path: '/',
+          })
+          require('js-cookie').remove(key, { path: '/' })
+        }
       } else {
         if (E2E) {
-          // Since E2E is not https, we can't set secure cookies
-          require('js-cookie').set(key, v, { expires: 30, path: '/' })
+          localStorage.setItem(key, v)
         } else {
           // We need samesite secure cookies to allow for IFrame embeds from 3rd parties
           require('js-cookie').set(key, v, {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Since we've found that Cookies have issues within E2E, it makes sense to just use localstorage.

## How did you test this code?

E2E Passes!