### PR TITLE
fix: Add missing Swagger schema for GET feature by ID

### DIFF
--- a/api/features/views.py
+++ b/api/features/views.py
@@ -113,7 +113,6 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     def get_serializer_class(self):  # type: ignore[no-untyped-def]
         return {
             "list": ListFeatureSerializer,
-            "retrieve": ListFeatureSerializer,
             "create": ListFeatureSerializer,
             "update": UpdateFeatureSerializer,
             "partial_update": UpdateFeatureSerializer,

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -205,9 +205,10 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         instance.delete()
 
     def get_serializer_context(self):  # type: ignore[no-untyped-def]
-        if getattr(self, "swagger_fake_view", False):
-            return None
         context = super().get_serializer_context()
+        if getattr(self, "swagger_fake_view", False):
+            return context
+
         feature_states = getattr(self, "_feature_states", {})
         project = get_object_or_404(Project.objects.all(), pk=self.kwargs["project_pk"])
         context.update(
@@ -506,6 +507,8 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         """
         Override queryset to filter based on provided URL parameters.
         """
+        if getattr(self, "swagger_fake_view", False):
+            return FeatureState.objects.none()
 
         environment_api_key = self.kwargs["environment_api_key"]
 

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -102,6 +102,10 @@ def get_feature_by_uuid(request, uuid):  # type: ignore[no-untyped-def]
     name="list",
     decorator=swagger_auto_schema(query_serializer=FeatureQuerySerializer()),
 )
+@method_decorator(
+    name="retrieve",
+    decorator=swagger_auto_schema(responses={200: ProjectFeatureSerializer()}),
+)
 class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     permission_classes = [FeaturePermissions]
     pagination_class = CustomPagination

--- a/api/features/views.py
+++ b/api/features/views.py
@@ -102,10 +102,6 @@ def get_feature_by_uuid(request, uuid):  # type: ignore[no-untyped-def]
     name="list",
     decorator=swagger_auto_schema(query_serializer=FeatureQuerySerializer()),
 )
-@method_decorator(
-    name="retrieve",
-    decorator=swagger_auto_schema(responses={200: ProjectFeatureSerializer()}),
-)
 class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     permission_classes = [FeaturePermissions]
     pagination_class = CustomPagination
@@ -113,6 +109,7 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
     def get_serializer_class(self):  # type: ignore[no-untyped-def]
         return {
             "list": ListFeatureSerializer,
+            "retrieve": ListFeatureSerializer,
             "create": ListFeatureSerializer,
             "update": UpdateFeatureSerializer,
             "partial_update": UpdateFeatureSerializer,
@@ -208,6 +205,8 @@ class FeatureViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         instance.delete()
 
     def get_serializer_context(self):  # type: ignore[no-untyped-def]
+        if getattr(self, "swagger_fake_view", False):
+            return None
         context = super().get_serializer_context()
         feature_states = getattr(self, "_feature_states", {})
         project = get_object_or_404(Project.objects.all(), pk=self.kwargs["project_pk"])
@@ -507,8 +506,6 @@ class BaseFeatureStateViewSet(viewsets.ModelViewSet):  # type: ignore[type-arg]
         """
         Override queryset to filter based on provided URL parameters.
         """
-        if getattr(self, "swagger_fake_view", False):
-            return FeatureState.objects.none()
 
         environment_api_key = self.kwargs["environment_api_key"]
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] ~I have added information to `docs/` if required so people know about the feature!~
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Currently, there is no response schema for the "GET feature by ID" endpoint https://api.flagsmith.com/api/v1/docs/#/api/api_v1_projects_features_read

![image](https://github.com/user-attachments/assets/d1482bd2-2419-413f-9060-6b8475db10be)

This PR adds the correct response schema:

![image](https://github.com/user-attachments/assets/0b9ac347-ff7e-4fba-a88d-f57ef96d7e66)

## How did you test this code?

```
DEBUG=True python manage.py runserver
```

then browse to http://127.0.0.1:8000/api/v1/docs/#/api/api_v1_projects_features_read