### PR TITLE
infra: disable offline-mode in Flagsmith for API ECS instances

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -188,6 +188,10 @@
                 {
                     "name": "GITHUB_APP_ID",
                     "value": "811209"
+                },
+                {
+                    "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_OFFLINE_MODE",
+                    "value": "False"
                 }
             ],
             "secrets": [

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -220,6 +220,10 @@
                 {
                     "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
+                },
+                {
+                    "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_OFFLINE_MODE",
+                    "value": "False"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

In order to make dynamic changes to flags for logic handled in the API instances in SaaS (production and staging), this disables offline mode (which is the default). Note that this setting is already configured in the task processor instances. 

## How did you test this code?

Needs deployment
