### PR TITLE
fix: Environments don't preserve feature versioning when cloned

### DIFF
--- a/api/environments/models.py
+++ b/api/environments/models.py
@@ -15,7 +15,7 @@ from django_lifecycle import (  # type: ignore[import-untyped]
     AFTER_DELETE,
     AFTER_SAVE,
     AFTER_UPDATE,
-    BEFORE_CREATE,
+    BEFORE_SAVE,
     LifecycleModel,
     hook,
 )
@@ -197,7 +197,9 @@ class Environment(
         ):
             environment_document_cache.delete(self.api_key)
 
-    @hook(BEFORE_CREATE)  # type: ignore[misc]
+    # Use the BEFORE_SAVE hook instead of BEFORE_CREATE to account for the logic in the
+    # Environment.clone() method
+    @hook(BEFORE_SAVE, when="pk", is_now=None)  # type: ignore[misc]
     def enable_v2_versioning(self) -> None:
         if self.use_v2_feature_versioning:
             # if the environment has already been created with versioning enabled,

--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -11,6 +11,7 @@ from environments.models import (
     environment_wrapper,
 )
 from features.versioning.models import EnvironmentFeatureVersion
+from features.versioning.tasks import enable_v2_versioning
 from sse import (  # type: ignore[attr-defined]
     send_environment_update_message_for_environment,
     send_environment_update_message_for_project,
@@ -91,6 +92,11 @@ def clone_environment_feature_states(
     else:
         for feature_state in queryset:
             feature_state.clone(clone, live_from=feature_state.live_from)
+
+        if clone.use_v2_feature_versioning:
+            # This logic exists to handle the rollout of v2 versioning, allowing us
+            # to create new versioned environments from non-versioned environments.
+            enable_v2_versioning(environment_id=clone.id)
 
     clone.is_creating = False
     clone.save()

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1259,6 +1259,6 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     new_environment = environment.clone(name="new-environment")
 
     # Then
-    assert not EnvironmentFeatureVersion.objects.filter(
+    assert EnvironmentFeatureVersion.objects.filter(
         environment=new_environment, feature=feature
     ).exists()

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1226,6 +1226,7 @@ def test_environment_create_with_use_v2_feature_versioning_true(
     assert EnvironmentFeatureVersion.objects.filter(
         environment=new_environment, feature=feature
     ).exists()
+    assert new_environment.use_v2_feature_versioning
 
 
 def test_environment_clone_from_versioned_environment_with_use_v2_feature_versioning_true(
@@ -1244,6 +1245,7 @@ def test_environment_clone_from_versioned_environment_with_use_v2_feature_versio
     assert EnvironmentFeatureVersion.objects.filter(
         environment=new_environment, feature=feature
     ).exists()
+    assert new_environment.use_v2_feature_versioning
 
 
 def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_versioning_true(
@@ -1262,3 +1264,4 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     assert EnvironmentFeatureVersion.objects.filter(
         environment=new_environment, feature=feature
     ).exists()
+    assert new_environment.use_v2_feature_versioning


### PR DESCRIPTION
## Changes

This PR resolves an issue found in manual testing (because one of my unit tests had a bug in it 🤦 ) where cloning an environment did not enable v2 versioning, even when the flag was enabled. 

## How did you test this code?

Updated the buggy unit test... 
