### PR TITLE
refactor: only clone latest feature states

### DIFF
--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -84,10 +84,10 @@ def clone_environment_feature_states(
         additional_filters=Q(identity__isnull=True),
     )
 
-    # Since we only want to create a single version for each environment / feature
-    # combination in the new environment to create a 'snapshot' of the source
-    # environment, we keep a local cache of environment feature version objects
-    # to avoid having to use get_or_create and hit the db unnecessarily.
+    # Since, in versioned environments, we only want to create a single version for
+    # each feature to create a 'snapshot' of the source environment, we keep a local
+    # cache of EnvironmentFeatureVersion objects to avoid having to use get_or_create
+    # and hit the db unnecessarily.
     version_map: dict[int, EnvironmentFeatureVersion] = {}
 
     for feature_state in source_feature_states:

--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -88,17 +88,17 @@ def clone_environment_feature_states(
     # each feature to create a 'snapshot' of the source environment, we keep a local
     # cache of EnvironmentFeatureVersion objects to avoid having to use get_or_create
     # and hit the db unnecessarily.
-    version_map: dict[int, EnvironmentFeatureVersion] = {}
+    efv_by_feature_id: dict[int, EnvironmentFeatureVersion] = {}
 
     for feature_state in source_feature_states:
         kwargs = {"env": clone}
 
         if clone.use_v2_feature_versioning:
-            if not (efv := version_map.get(feature_state.feature_id)):
+            if not (efv := efv_by_feature_id.get(feature_state.feature_id)):
                 efv = EnvironmentFeatureVersion.create_initial_version(
                     environment=clone, feature=feature_state.feature
                 )
-                version_map[feature_state.feature_id] = efv
+                efv_by_feature_id[feature_state.feature_id] = efv
 
             kwargs.update(environment_feature_version=efv)
         else:

--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.db.models import Prefetch, Q
 from django.utils import timezone
 from task_processor.decorators import (
@@ -64,7 +62,7 @@ def delete_environment(environment_id: int) -> None:
     Environment.objects.get(id=environment_id).delete()
 
 
-@register_task_handler(timeout=timedelta(hours=1))
+@register_task_handler()
 def clone_environment_feature_states(
     source_environment_id: int, clone_environment_id: int
 ) -> None:

--- a/api/environments/tasks.py
+++ b/api/environments/tasks.py
@@ -86,7 +86,12 @@ def clone_environment_feature_states(
         additional_filters=Q(identity__isnull=True),
     )
 
+    # Since we only want to create a single version for each environment / feature
+    # combination in the new environment to create a 'snapshot' of the source
+    # environment, we keep a local cache of environment feature version objects
+    # to avoid having to use get_or_create and hit the db unnecessarily.
     version_map: dict[int, EnvironmentFeatureVersion] = {}
+
     for feature_state in source_feature_states:
         kwargs = {"env": clone}
 

--- a/api/features/versioning/models.py
+++ b/api/features/versioning/models.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import typing
 import uuid
-from copy import deepcopy
 
 from django.conf import settings
 from django.db import models
@@ -174,17 +173,6 @@ class EnvironmentFeatureVersion(  # type: ignore[django-manager-missing]
         if persist:
             self.save()
             environment_feature_version_published.send(self.__class__, instance=self)
-
-    def clone_to_environment(
-        self, environment: "Environment"
-    ) -> "EnvironmentFeatureVersion":
-        _clone = deepcopy(self)
-
-        _clone.uuid = None  # type: ignore[assignment]
-        _clone.environment = environment
-
-        _clone.save()
-        return _clone
 
 
 class VersionChangeSet(LifecycleModelMixin, SoftDeleteObject):  # type: ignore[misc]

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1255,13 +1255,17 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     enable_v2_versioning_for_new_environments: typing.Callable[[], None],
 ) -> None:
     # Given
+    assert not environment.use_v2_feature_versioning
     enable_v2_versioning_for_new_environments()
 
     # When
     new_environment = environment.clone(name="new-environment")
 
     # Then
-    assert EnvironmentFeatureVersion.objects.filter(
-        environment=new_environment, feature=feature
-    ).exists()
     assert new_environment.use_v2_feature_versioning
+
+    latest_feature_states = get_environment_flags_queryset(new_environment)
+    assert latest_feature_states.count() == 1
+
+    latest_feature_state = latest_feature_states.get()
+    assert latest_feature_state.environment_feature_version is not None

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1256,6 +1256,8 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     enable_v2_versioning_for_new_environments: typing.Callable[[], None],
 ) -> None:
     # Given
+    # Ensure that v2 versioning is not enabled for this test as we explicitly
+    # want to test that we can clone from v1 -> v2 successsfully.
     environment.use_v2_feature_versioning = False
     environment.save()
 

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1256,7 +1256,9 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
     enable_v2_versioning_for_new_environments: typing.Callable[[], None],
 ) -> None:
     # Given
-    assert not environment.use_v2_feature_versioning
+    environment.use_v2_feature_versioning = False
+    environment.save()
+
     enable_v2_versioning_for_new_environments()
 
     # When

--- a/api/tests/unit/environments/test_unit_environments_models.py
+++ b/api/tests/unit/environments/test_unit_environments_models.py
@@ -1267,9 +1267,9 @@ def test_environment_clone_from_non_versioned_environment_with_use_v2_feature_ve
 
     # we only expect a single environment feature version as we are essentially
     # taking a snapshot and creating a new environment.
-    efv = EnvironmentFeatureVersion.objects.filter(
+    efv = EnvironmentFeatureVersion.objects.get(
         environment=new_environment, feature=feature
-    ).get()
+    )
 
     # But we expect 2 feature states, each with the same version
     latest_feature_states = get_environment_flags_queryset(new_environment)


### PR DESCRIPTION
## Changes

This PR changes the behaviour when cloning an environment. Previously, the logic would create a clone of _all_ feature states, including old versions, feature states associated with uncommitted change requests, etc. This PR updates the logic to only clone the latest feature states, and mark them as live from the moment the environment is created. 

This does change the user experience, but only really for those using v2 versioning (which is currently very few customers), in that they will no longer see a history of changes in the new environment. In my opinion, it was odd behaviour to show the history from another environment in the new environment anyway, so I think this is an improvement. 

Refactor environment clone functionality to only clone the latest feature states. This will optimise the logic to speed it up reduce the impact of cloning environments on the database. I've also included some additional DB optimisations using select and prefetch related where necessary. 

Note that this also fixes a bug in the logic for enabling versioning on new environments which existed because we were previously using the `enable_v2_versioning` task to create the versions, but this expected the input environment to not have versioning enabled. 

## How did you test this code?

Existing tests should cover the refactor. Updated an existing test with better assertions to verify the bug fix, and new logic. 
