### PR TITLE
chore: remove segment ordering var

### DIFF
--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -218,10 +218,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
-                    "value": "True"
-                },
-                {
                     "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_OFFLINE_MODE",
                     "value": "False"
                 },


### PR DESCRIPTION
## Changes

Remove segment ordering env var from staging to verify if it fixes the current E2E failures. 

## How did you test this code?

n/a 
