### PR TITLE
fix: body overflow

### DIFF
--- a/frontend/web/styles/styles.scss
+++ b/frontend/web/styles/styles.scss
@@ -233,7 +233,7 @@ input:disabled {
 }
 
 
-html,body {
+body {
   max-width: 100vw;
   overflow-x: hidden;
 }


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes 

Before - any overflow was causing a double scrollbar : 

<img width="1387" height="526" alt="image" src="https://github.com/user-attachments/assets/79a94782-e4da-4235-8e8a-b27ff165bf78" />

After:

<img width="1328" height="701" alt="image" src="https://github.com/user-attachments/assets/c9e65091-4f77-4be8-904c-e8a941ab4758" />


## How did you test this code?

As above