### PR TITLE
chore: Update and repurpose evaluation context schema for Context values

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -22,7 +22,7 @@
             "type": "object"
         },
         "IdentityContext": {
-            "description": "Represents an identity context for feature flag evaluation.",
+            "description": "Represents an identity context for feature flag evaluation.\n    ",
             "properties": {
                 "identifier": {
                     "description": "The unique identifier for the identity, used for segment and multivariate feature flag targeting.",
@@ -43,120 +43,9 @@
             ],
             "title": "IdentityContext",
             "type": "object"
-        },
-        "SegmentCondition": {
-            "description": "Represents a condition for segment evaluation.",
-            "properties": {
-                "property": {
-                    "title": "Property",
-                    "type": "string"
-                },
-                "operator": {
-                    "$ref": "#/$defs/SegmentConditionOperator"
-                },
-                "value": {
-                    "title": "Value",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "property",
-                "operator",
-                "value"
-            ],
-            "title": "SegmentCondition",
-            "type": "object"
-        },
-        "SegmentConditionOperator": {
-            "description": "Represents the operators used in segment conditions. Operators are used to compare segment properties against context values, like `$.identity.traits.user_role` or `$.environment.key`.",
-            "enum": [
-                "EQUAL",
-                "GREATER_THAN",
-                "LESS_THAN",
-                "LESS_THAN_INCLUSIVE",
-                "CONTAINS",
-                "GREATER_THAN_INCLUSIVE",
-                "NOT_CONTAINS",
-                "NOT_EQUAL",
-                "REGEX",
-                "PERCENTAGE_SPLIT",
-                "MODULO",
-                "IS_SET",
-                "IS_NOT_SET",
-                "IN"
-            ],
-            "title": "SegmentConditionOperator",
-            "type": "string"
-        },
-        "SegmentContext": {
-            "description": "Represents a segment context for feature flag evaluation.",
-            "properties": {
-                "key": {
-                    "description": "The unique identifier for the segment, used for percentage-based targeting.",
-                    "title": "Key",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "rules": {
-                    "items": {
-                        "$ref": "#/$defs/SegmentRule"
-                    },
-                    "title": "Rules",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "key",
-                "name",
-                "rules"
-            ],
-            "title": "SegmentContext",
-            "type": "object"
-        },
-        "SegmentRule": {
-            "description": "Represents a rule for segment evaluation. Rules can be nested. ",
-            "properties": {
-                "type": {
-                    "$ref": "#/$defs/SegmentRuleType"
-                },
-                "rules": {
-                    "items": {
-                        "$ref": "#/$defs/SegmentRule"
-                    },
-                    "title": "Rules",
-                    "type": "array"
-                },
-                "conditions": {
-                    "items": {
-                        "$ref": "#/$defs/SegmentCondition"
-                    },
-                    "title": "Conditions",
-                    "type": "array"
-                }
-            },
-            "required": [
-                "type",
-                "rules",
-                "conditions"
-            ],
-            "title": "SegmentRule",
-            "type": "object"
-        },
-        "SegmentRuleType": {
-            "description": "Enum representing the types of segment rules.",
-            "enum": [
-                "ANY",
-                "ALL",
-                "NONE"
-            ],
-            "title": "SegmentRuleType",
-            "type": "string"
         }
     },
-    "description": "Represents a context object containing the necessary information to evaluate Flagsmith feature flags for a given environment, (optionally) identity, feature, and segments.",
+    "description": "Represents a context object containing the necessary information\nto evaluate Flagsmith feature flags for a given environment,\n(optionally) identity, feature, and segments.",
     "properties": {
         "environment": {
             "$ref": "#/$defs/EnvironmentContext"
@@ -171,14 +60,6 @@
                 }
             ],
             "default": null
-        },
-        "segments": {
-            "description": "A list of segments to evaluate against the identity and environment context.",
-            "items": {
-                "$ref": "#/$defs/SegmentContext"
-            },
-            "title": "Segments",
-            "type": "array"
         }
     },
     "required": [

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -1,107 +1,170 @@
 {
     "$defs": {
-        "EnvironmentEvaluationContext": {
+        "EnvironmentContext": {
+            "description": "Represents an environment context for feature flag evaluation.",
             "properties": {
-                "api_key": {
-                    "title": "Api Key",
+                "key": {
+                    "description": "An environment's unique identifier.",
+                    "title": "Key",
                     "type": "string"
-                }
-            },
-            "required": [
-                "api_key"
-            ],
-            "title": "EnvironmentEvaluationContext",
-            "type": "object"
-        },
-        "FeatureEvaluationContext": {
-            "properties": {
+                },
                 "name": {
+                    "description": "An environment's human-readable name.",
                     "title": "Name",
                     "type": "string"
                 }
             },
             "required": [
+                "key",
                 "name"
             ],
-            "title": "FeatureEvaluationContext",
+            "title": "EnvironmentContext",
             "type": "object"
         },
-        "IdentityEvaluationContext": {
+        "IdentityContext": {
+            "description": "Represents an identity context for feature flag evaluation.",
             "properties": {
                 "identifier": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "title": "Identifier"
+                    "description": "The unique identifier for the identity, used for segment and multivariate feature flag targeting.",
+                    "title": "Identifier",
+                    "type": "string"
                 },
                 "traits": {
                     "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/$defs/TraitEvaluationContext"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+                        "type": "string"
                     },
+                    "description": "A map of traits associated with the identity, where the key is the trait name and the value is the trait value.",
                     "title": "Traits",
                     "type": "object"
-                },
-                "transient": {
-                    "anyOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Transient"
-                }
-            },
-            "required": [],
-            "title": "IdentityEvaluationContext",
-            "type": "object"
-        },
-        "TraitEvaluationContext": {
-            "properties": {
-                "value": {},
-                "transient": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "Transient"
                 }
             },
             "required": [
+                "identifier"
+            ],
+            "title": "IdentityContext",
+            "type": "object"
+        },
+        "SegmentCondition": {
+            "description": "Represents a condition for segment evaluation.",
+            "properties": {
+                "property": {
+                    "title": "Property",
+                    "type": "string"
+                },
+                "operator": {
+                    "$ref": "#/$defs/SegmentConditionOperator"
+                },
+                "value": {
+                    "title": "Value",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "property",
+                "operator",
                 "value"
             ],
-            "title": "TraitEvaluationContext",
+            "title": "SegmentCondition",
             "type": "object"
+        },
+        "SegmentConditionOperator": {
+            "description": "Represents the operators used in segment conditions. Operators are used to compare segment properties against context values, like `$.identity.traits.user_role` or `$.environment.key`.",
+            "enum": [
+                "EQUAL",
+                "GREATER_THAN",
+                "LESS_THAN",
+                "LESS_THAN_INCLUSIVE",
+                "CONTAINS",
+                "GREATER_THAN_INCLUSIVE",
+                "NOT_CONTAINS",
+                "NOT_EQUAL",
+                "REGEX",
+                "PERCENTAGE_SPLIT",
+                "MODULO",
+                "IS_SET",
+                "IS_NOT_SET",
+                "IN"
+            ],
+            "title": "SegmentConditionOperator",
+            "type": "string"
+        },
+        "SegmentContext": {
+            "description": "Represents a segment context for feature flag evaluation.",
+            "properties": {
+                "key": {
+                    "description": "The unique identifier for the segment, used for percentage-based targeting.",
+                    "title": "Key",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "rules": {
+                    "items": {
+                        "$ref": "#/$defs/SegmentRule"
+                    },
+                    "title": "Rules",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "key",
+                "name",
+                "rules"
+            ],
+            "title": "SegmentContext",
+            "type": "object"
+        },
+        "SegmentRule": {
+            "description": "Represents a rule for segment evaluation. Rules can be nested. ",
+            "properties": {
+                "type": {
+                    "$ref": "#/$defs/SegmentRuleType"
+                },
+                "rules": {
+                    "items": {
+                        "$ref": "#/$defs/SegmentRule"
+                    },
+                    "title": "Rules",
+                    "type": "array"
+                },
+                "conditions": {
+                    "items": {
+                        "$ref": "#/$defs/SegmentCondition"
+                    },
+                    "title": "Conditions",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "type",
+                "rules",
+                "conditions"
+            ],
+            "title": "SegmentRule",
+            "type": "object"
+        },
+        "SegmentRuleType": {
+            "description": "Enum representing the types of segment rules.",
+            "enum": [
+                "ANY",
+                "ALL",
+                "NONE"
+            ],
+            "title": "SegmentRuleType",
+            "type": "string"
         }
     },
+    "description": "Represents a context object containing the necessary information to evaluate Flagsmith feature flags for a given environment, (optionally) identity, feature, and segments.",
     "properties": {
         "environment": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/EnvironmentEvaluationContext"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null
+            "$ref": "#/$defs/EnvironmentContext"
         },
         "identity": {
             "anyOf": [
                 {
-                    "$ref": "#/$defs/IdentityEvaluationContext"
+                    "$ref": "#/$defs/IdentityContext"
                 },
                 {
                     "type": "null"
@@ -109,18 +172,18 @@
             ],
             "default": null
         },
-        "feature": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/FeatureEvaluationContext"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null
+        "segments": {
+            "description": "A list of segments to evaluate against the identity and environment context.",
+            "items": {
+                "$ref": "#/$defs/SegmentContext"
+            },
+            "title": "Segments",
+            "type": "array"
         }
     },
-    "title": "FlagsmithEvaluationContext",
+    "required": [
+        "environment"
+    ],
+    "title": "EvaluationContext",
     "type": "object"
 }

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -24,16 +24,16 @@
             "type": "object"
         },
         "IdentityContext": {
-            "description": "Represents an identity context for feature flag evaluation.\n    ",
+            "description": "Represents an identity context for feature flag evaluation.",
             "properties": {
                 "identifier": {
-                    "description": "The unique identifier for the identity, used for segment and multivariate feature flag targeting.",
+                    "description": "A unique identifier for an identity, used for segment and multivariate feature flag targeting, and displayed in the Flagsmith UI.",
                     "title": "Identifier",
                     "type": "string",
                     "x-flagsmith-engine-path": "$.identity.identifier"
                 },
                 "key": {
-                    "description": "Key used when selecting multivariate feature, or % split segmentation. Set to an internal identifier or a composite value based on the environment key and identifier, depends on Flagsmith implementation.",
+                    "description": "Key used when selecting a value for a multivariate feature, or for % split segmentation. Set to an internal identifier or a composite value based on the environment key and identifier, depending on Flagsmith implementation.",
                     "title": "Key",
                     "type": "string",
                     "x-flagsmith-engine-path": "$.identity.key"
@@ -55,7 +55,7 @@
             "type": "object"
         }
     },
-    "description": "Represents a context object containing the necessary information\nto evaluate Flagsmith feature flags for a given environment,\n(optionally) identity, feature, and segments.",
+    "description": "Represents a context object containing the necessary information to evaluate Flagsmith feature flags.",
     "properties": {
         "environment": {
             "$ref": "#/$defs/EnvironmentContext"

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -6,12 +6,14 @@
                 "key": {
                     "description": "An environment's unique identifier.",
                     "title": "Key",
-                    "type": "string"
+                    "type": "string",
+                    "x-flagsmith-engine-path": "$.environment.key"
                 },
                 "name": {
                     "description": "An environment's human-readable name.",
                     "title": "Name",
-                    "type": "string"
+                    "type": "string",
+                    "x-flagsmith-engine-path": "$.environment.name"
                 }
             },
             "required": [
@@ -27,12 +29,14 @@
                 "identifier": {
                     "description": "The unique identifier for the identity, used for segment and multivariate feature flag targeting.",
                     "title": "Identifier",
-                    "type": "string"
+                    "type": "string",
+                    "x-flagsmith-engine-path": "$.identity.identifier"
                 },
                 "key": {
                     "description": "Key used when selecting multivariate feature, or % split segmentation. Set to an internal identifier or a composite value based on the environment key and identifier, depends on Flagsmith implementation.",
                     "title": "Key",
-                    "type": "string"
+                    "type": "string",
+                    "x-flagsmith-engine-path": "$.identity.key"
                 },
                 "traits": {
                     "additionalProperties": {

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -29,6 +29,11 @@
                     "title": "Identifier",
                     "type": "string"
                 },
+                "key": {
+                    "description": "Key used when selecting multivariate feature, or % split segmentation. Set to an internal identifier or a composite value based on the environment key and identifier, depends on Flagsmith implementation.",
+                    "title": "Key",
+                    "type": "string"
+                },
                 "traits": {
                     "additionalProperties": {
                         "type": "string"
@@ -39,7 +44,8 @@
                 }
             },
             "required": [
-                "identifier"
+                "identifier",
+                "key"
             ],
             "title": "IdentityContext",
             "type": "object"


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This updates the evaluation context schema to reflect Flagsmith Engine dependencies.

The schema now represents an evaluation object used by the Flagsmith Engine when parsing Context values introduced by #5673.

## How did you test this code?

N/A