### PR TITLE
feat: adds multiple actions to release pipeline stage

### DIFF
--- a/frontend/common/services/useReleasePipelines.ts
+++ b/frontend/common/services/useReleasePipelines.ts
@@ -48,7 +48,9 @@ export const releasePipelinesService = service
         Res['releasePipeline'],
         Req['getReleasePipeline']
       >({
-        providesTags: [{ type: 'ReleasePipelines' }],
+        providesTags: (result, error, { pipelineId }) => [
+          { id: pipelineId, type: 'ReleasePipelines' },
+        ],
         query: (query: Req['getReleasePipeline']) => ({
           url: `projects/${query.projectId}/release-pipelines/${query.pipelineId}/`,
         }),
@@ -91,10 +93,12 @@ export const releasePipelinesService = service
         Res['releasePipeline'],
         Req['updateReleasePipeline']
       >({
-        invalidatesTags: (res) => [
-          { id: 'LIST', type: 'ReleasePipelines' },
-          { id: res?.id, type: 'ReleasePipelines' },
-        ],
+        invalidatesTags: (res) => {
+          return [
+            { id: res?.id, type: 'ReleasePipelines' },
+            { id: 'LIST', type: 'ReleasePipelines' },
+          ]
+        },
         query: (query: Req['updateReleasePipeline']) => ({
           body: {
             description: query.description,

--- a/frontend/common/types/requests.ts
+++ b/frontend/common/types/requests.ts
@@ -74,9 +74,10 @@ export type RegisterRequest = {
   utm_data?: UtmsType
 }
 
+export type StageActionBody = { enabled: boolean; segment_id?: number }
 export interface StageActionRequest {
-  action_type: StageActionType
-  action_body: { enabled: boolean; segment_id?: number }
+  action_type: StageActionType | ''
+  action_body: StageActionBody
 }
 
 export interface ReleasePipelineRequest {
@@ -90,7 +91,7 @@ export interface UpdateReleasePipelineRequest extends ReleasePipelineRequest {
   id: number
 }
 
-export type PipelineStageRequest = {
+export interface PipelineStageRequest {
   name: string
   environment: number
   order: number

--- a/frontend/web/components/release-pipelines/FlagActionDetail.tsx
+++ b/frontend/web/components/release-pipelines/FlagActionDetail.tsx
@@ -4,7 +4,7 @@ import { StageActionBody, StageActionType } from 'common/types/responses'
 type FlagActionDetailProps = {
   actionType: StageActionType
   actionBody: StageActionBody
-  projectId: string
+  projectId: number
 }
 
 const renderActionDetail = (
@@ -41,7 +41,7 @@ const FlagActionDetail = ({
   const { data: segmentData } = useGetSegmentQuery(
     {
       id: `${actionBody.segment_id}`,
-      projectId: projectId,
+      projectId: `${projectId}`,
     },
     {
       skip: !actionBody.segment_id || !isSegmentAction,

--- a/frontend/web/components/release-pipelines/PipelineStageActions.tsx
+++ b/frontend/web/components/release-pipelines/PipelineStageActions.tsx
@@ -3,17 +3,28 @@ import { StageActionRequest } from 'common/types/requests'
 
 import { useMemo } from 'react'
 import SinglePipelineStageAction from './SinglePipelineStageAction'
+import Button from 'components/base/forms/Button'
 
 interface PipelineStageActionsProps {
   actions: StageActionRequest[]
   projectId: number
-  onActionChange: (option: { value: string; label: string }) => void
-  onSegmentChange: (option: { value: number; label: string }) => void
+  onAddAction: () => void
+  onRemoveAction: (actionIndex: number) => void
+  onActionChange: (
+    option: { value: string; label: string },
+    stageIndex: number,
+  ) => void
+  onSegmentChange: (
+    option: { value: number; label: string },
+    stageIndex: number,
+  ) => void
 }
 
 const PipelineStageActions = ({
   actions,
   onActionChange,
+  onAddAction,
+  onRemoveAction,
   onSegmentChange,
   projectId,
 }: PipelineStageActionsProps) => {
@@ -33,29 +44,23 @@ const PipelineStageActions = ({
     }))
   }, [segments])
 
-  if (!actions?.length) {
-    return (
-      <SinglePipelineStageAction
-        onActionChange={onActionChange}
-        onSegmentChange={onSegmentChange}
-        isSegmentsLoading={isSegmentsLoading}
-        segmentOptions={segmentOptions}
-      />
-    )
-  }
-
   return (
     <>
-      {actions.map((action, index) => (
+      {actions?.map((action, index) => (
         <SinglePipelineStageAction
           key={index}
+          actionIndex={index}
           action={action}
           onActionChange={onActionChange}
           onSegmentChange={onSegmentChange}
           isSegmentsLoading={isSegmentsLoading}
           segmentOptions={segmentOptions}
+          onRemoveAction={index > 0 ? onRemoveAction : undefined}
         />
       ))}
+      <Button iconLeft='plus' className='w-100' onClick={onAddAction}>
+        Add Flag Action
+      </Button>
     </>
   )
 }

--- a/frontend/web/components/release-pipelines/SinglePipelineStageAction.tsx
+++ b/frontend/web/components/release-pipelines/SinglePipelineStageAction.tsx
@@ -2,6 +2,7 @@ import { StageActionRequest } from 'common/types/requests'
 import Utils from 'common/utils/utils'
 import InputGroup from 'components/base/forms/InputGroup'
 import { FLAG_ACTION_OPTIONS } from './constants'
+import Icon from 'components/Icon'
 
 const getActionType = (action: StageActionRequest | undefined) => {
   if (!action) {
@@ -24,17 +25,24 @@ const getSegment = (action: StageActionRequest | undefined) => {
 }
 
 interface SinglePipelineStageActionProps {
+  actionIndex?: number
   action?: StageActionRequest
-  onActionChange: (option: { value: string; label: string }) => void
-  onSegmentChange: (option: { value: number; label: string }) => void
+  onRemoveAction?: (id: number) => void
+  onActionChange: (option: { value: string; label: string }, id: number) => void
+  onSegmentChange: (
+    option: { value: number; label: string },
+    id: number,
+  ) => void
   isSegmentsLoading: boolean
   segmentOptions: { label: string; value: number }[] | undefined
 }
 
 const SinglePipelineStageAction = ({
   action,
+  actionIndex = 0,
   isSegmentsLoading,
   onActionChange,
+  onRemoveAction,
   onSegmentChange,
   segmentOptions,
 }: SinglePipelineStageActionProps) => {
@@ -42,24 +50,37 @@ const SinglePipelineStageAction = ({
     <>
       <Row>
         <div className='flex-1 and-divider__line' />
-        <div className='mx-2'>Then</div>
+        <div className='mx-2'>{actionIndex === 0 ? 'Then' : 'And'}</div>
         <div className='flex-1 and-divider__line' />
       </Row>
-      <FormGroup>
+      <FormGroup className='mt-2'>
         <InputGroup
           title='Flag Action'
           component={
-            <Select
-              menuPortalTarget={document.body}
-              maxMenuHeight={120}
-              value={Utils.toSelectedValue(
-                getActionType(action),
-                FLAG_ACTION_OPTIONS,
-                { label: 'Select an action', value: '' },
+            <div className='d-flex align-items-center'>
+              <div className='w-100'>
+                <Select
+                  maxMenuHeight={180}
+                  value={Utils.toSelectedValue(
+                    getActionType(action),
+                    FLAG_ACTION_OPTIONS,
+                    { label: 'Select an action', value: '' },
+                  )}
+                  options={FLAG_ACTION_OPTIONS}
+                  onChange={(option: { value: string; label: string }) =>
+                    onActionChange(option, actionIndex)
+                  }
+                />
+              </div>
+              {onRemoveAction && (
+                <div
+                  className='ml-2 clickable'
+                  onClick={() => onRemoveAction(actionIndex)}
+                >
+                  <Icon name='trash-2' width={20} fill='#8F98A3' />
+                </div>
               )}
-              options={FLAG_ACTION_OPTIONS}
-              onChange={onActionChange}
-            />
+            </div>
           }
         />
       </FormGroup>
@@ -69,8 +90,7 @@ const SinglePipelineStageAction = ({
             title='Segment'
             component={
               <Select
-                menuPortalTarget={document.body}
-                maxMenuHeight={120}
+                maxMenuHeight={180}
                 isDisabled={isSegmentsLoading}
                 isLoading={isSegmentsLoading}
                 value={Utils.toSelectedValue(
@@ -79,7 +99,9 @@ const SinglePipelineStageAction = ({
                   { label: 'Select a segment', value: '' },
                 )}
                 options={segmentOptions}
-                onChange={onSegmentChange}
+                onChange={(option: { value: number; label: string }) =>
+                  onSegmentChange(option, actionIndex)
+                }
               />
             }
           />

--- a/frontend/web/components/release-pipelines/StageInfo.tsx
+++ b/frontend/web/components/release-pipelines/StageInfo.tsx
@@ -47,14 +47,17 @@ const StageInfo = ({
                 stageData?.trigger?.trigger_type,
                 stageData?.trigger?.trigger_body,
               )}
-              {stageData?.actions?.map((action) => {
+              {stageData?.actions?.map((action, index) => {
                 return (
-                  <div key={action.id}>
+                  <div key={action.id} className='mt-1'>
                     <FlagActionDetail
                       actionBody={action.action_body}
                       actionType={action.action_type}
                       projectId={projectId}
                     />
+                    {index < stageData?.actions?.length - 1 && (
+                      <div className='mt-1'>And</div>
+                    )}
                   </div>
                 )
               })}

--- a/frontend/web/components/release-pipelines/constants.ts
+++ b/frontend/web/components/release-pipelines/constants.ts
@@ -1,3 +1,4 @@
+import { PipelineStageRequest, StageActionRequest } from 'common/types/requests'
 import { StageActionType, StageTriggerType } from 'common/types/responses'
 
 const TRIGGER_OPTIONS: { label: string; value: StageTriggerType }[] = [
@@ -36,4 +37,29 @@ const TIME_UNIT_OPTIONS = [
   { label: 'Minute(s)', value: TimeUnit.MINUTE },
 ]
 
-export { TRIGGER_OPTIONS, FLAG_ACTION_OPTIONS, TIME_UNIT_OPTIONS, TimeUnit }
+const NEW_PIPELINE_STAGE_ACTION_TYPE = ''
+const NEW_PIPELINE_STAGE_ACTION = {
+  action_body: { enabled: false },
+  action_type: NEW_PIPELINE_STAGE_ACTION_TYPE,
+} as StageActionRequest
+
+const NEW_PIPELINE_STAGE: PipelineStageRequest = {
+  actions: [NEW_PIPELINE_STAGE_ACTION],
+  environment: -1,
+  name: '',
+  order: 0,
+  trigger: {
+    trigger_body: null,
+    trigger_type: StageTriggerType.ON_ENTER,
+  },
+}
+
+export {
+  TRIGGER_OPTIONS,
+  FLAG_ACTION_OPTIONS,
+  TIME_UNIT_OPTIONS,
+  TimeUnit,
+  NEW_PIPELINE_STAGE,
+  NEW_PIPELINE_STAGE_ACTION,
+  NEW_PIPELINE_STAGE_ACTION_TYPE,
+}

--- a/frontend/web/styles/components/_release-pipelines.scss
+++ b/frontend/web/styles/components/_release-pipelines.scss
@@ -1,6 +1,8 @@
 @import '../variables';
 
-
+.release-pipeline-container {
+    padding-bottom: 100px;
+}
 
 .stage-line {
     width: 100px;


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

[#5271](https://github.com/Flagsmith/flagsmith/issues/5271)

- Allows users to create multiple actions per stage in a release pipeline.


### Create/Edit State
<img width="400" height="714" alt="Screenshot 2025-07-16 at 08 04 22" src="https://github.com/user-attachments/assets/b021ebfe-9043-4e31-9e09-012caa67ac32" />


### View State
<img width="1198" height="502" alt="Screenshot 2025-07-16 at 07 41 16" src="https://github.com/user-attachments/assets/1ca5d7e0-b246-4d56-9048-241df74c8fdd" />


## How did you test this code?

1. Go to release pipelines page -> Create a pipeline
2. Add at least 2 actions
3. Save
4. See new pipeline details
5. Edit item to validate if actions were rendered correctly

