### PR TITLE
feat: Process `User-Agent` strings

### DIFF
--- a/api/app_analytics/constants.py
+++ b/api/app_analytics/constants.py
@@ -1,6 +1,6 @@
 from typing import get_args
 
-from app_analytics.types import Label, PeriodType
+from app_analytics.types import InputLabel, Label, PeriodType
 
 ANALYTICS_READ_BUCKET_SIZE = 15
 
@@ -15,9 +15,10 @@ NINETY_DAY_PERIOD: PeriodType
 ) = get_args(PeriodType)
 
 # Optional headers sent from client SDK mapped to their respective labels.
-TRACK_HEADERS: dict[str, Label] = {
+TRACK_HEADERS: dict[str, InputLabel] = {
     "Flagsmith-Application-Name": "client_application_name",
     "Flagsmith-Application-Version": "client_application_version",
+    "Flagsmith-SDK-User-Agent": "sdk_user_agent",
     "User-Agent": "user_agent",
 }
 LABELS: tuple[str, ...] = tuple(str(label) for label in get_args(Label))

--- a/api/app_analytics/mappers.py
+++ b/api/app_analytics/mappers.py
@@ -125,7 +125,7 @@ def map_input_labels_to_labels(input_labels: InputLabels) -> Labels:
             # represent server-side SDKs.
             parsed_ua_string: str = parse_ua(value)
             is_server_side_sdk = parsed_ua_string.startswith("Other - ")
-            
+
             # Skip browser SDKs that don't send the special header
             if not is_server_side_sdk:
                 continue

--- a/api/app_analytics/mappers.py
+++ b/api/app_analytics/mappers.py
@@ -121,10 +121,13 @@ def map_input_labels_to_labels(input_labels: InputLabels) -> Labels:
             labels["user_agent"] = value
             continue
         elif label == "user_agent":
+            # fastuaparser classifies unrecognized UAs as "Other" — assume these to
+            # represent server-side SDKs.
             parsed_ua_string: str = parse_ua(value)
-            # Assume UA strings categorised as "Other" to represent server-side SDKs.
-            # Skip browser SDKs that don't send the special header.
-            if parsed_ua_string.split(" - ")[0] != "Other":
+            is_server_side_sdk = parsed_ua_string.startswith("Other - ")
+            
+            # Skip browser SDKs that don't send the special header
+            if not is_server_side_sdk:
                 continue
         labels[label] = value
     return labels

--- a/api/app_analytics/mappers.py
+++ b/api/app_analytics/mappers.py
@@ -124,9 +124,8 @@ def map_input_labels_to_labels(input_labels: InputLabels) -> Labels:
             # fastuaparser classifies unrecognized UAs as "Other" — assume these to
             # represent server-side SDKs.
             parsed_ua_string: str = parse_ua(value)
-            is_server_side_sdk = parsed_ua_string.startswith("Other - ")
-
-            # Skip browser SDKs that don't send the special header
+            is_server_side_sdk = parsed_ua_string.startswith("Other")
+            # Skip browser SDKs that don't send the special header.
             if not is_server_side_sdk:
                 continue
         labels[label] = value

--- a/api/app_analytics/types.py
+++ b/api/app_analytics/types.py
@@ -54,4 +54,7 @@ Label = Literal[
     "user_agent",
 ]
 
+InputLabel = Label | Literal["sdk_user_agent"]
+
 Labels: TypeAlias = dict[Label, str]
+InputLabels: TypeAlias = dict[InputLabel, str]

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1887,6 +1887,23 @@ pyreadline = {version = "*", markers = "platform_system == \"Windows\""}
 pyrepl = ">=0.8.2"
 
 [[package]]
+name = "fastuaparser"
+version = "0.1.4"
+description = "A super-fast user agent string parser "
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "fastuaparser-0.1.4-py3-none-any.whl", hash = "sha256:9f84be99b435c73849d408b6cd161bdc752881054a7731a810d0deb8fd89842e"},
+    {file = "fastuaparser-0.1.4.tar.gz", hash = "sha256:c0b9113d17e40705dbf4582ca1303c703e2ea03ffdb2f0507afe267a317a3e79"},
+]
+
+[package.extras]
+dev = ["fastuaparser[docs,lint,tests]"]
+lint = ["ruff"]
+tests = ["pytest"]
+
+[[package]]
 name = "filelock"
 version = "3.16.1"
 description = "A platform independent file lock."
@@ -5419,4 +5436,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.11,<3.13"
-content-hash = "a2a6709fbd9d92160e6d9bbd9542ac9a1a2a0c944cb7d05f8ddd4cfba438bb63"
+content-hash = "f602f6bf08bc7bcdc50334600e27a5b260515a076b9e5b5ed775838621cc7fee"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -167,6 +167,7 @@ djangorestframework-simplejwt = "^5.3.1"
 structlog = "^24.4.0"
 prometheus-client = "^0.21.1"
 django_cockroachdb = "~4.2"
+fastuaparser = "^0.1.4"
 
 [tool.poetry.group.auth-controller]
 optional = true

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -565,6 +565,21 @@ def test_set_sdk_analytics_flags_with_identifier__influx__calls_expected(
                 "user_agent": "python-requests/2.31.0",
             },
         ),
+        (
+            {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0",
+            },
+            {},
+        ),
+        (
+            {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0",
+                "Flagsmith-SDK-User-Agent": "flagsmith-js-sdk/1.0.0",
+            },
+            {
+                "user_agent": "flagsmith-js-sdk/1.0.0",
+            },
+        ),
     ],
 )
 def test_sdk_analytics_flags_v1(


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Closes #5735.

This adds `User-Agent` processing ahead of labelling the usage and feature evaluation data. Browser UA strings are stripped, the rest are considered server-side SDKs, and a new `Flagsmith-SDK-User-Agent` header is expected to denote a browser SDK version.

# How did you test this code?

Updated existing view unit test to reflect the new behaviour.
