### PR TITLE
fix: incorrect-is-editing-property-check

### DIFF
--- a/frontend/web/components/segments/Rule/components/RuleConditionPropertySelect.tsx
+++ b/frontend/web/components/segments/Rule/components/RuleConditionPropertySelect.tsx
@@ -89,9 +89,9 @@ const RuleConditionPropertySelect = ({
   const displayedLabel =
     contextOptions.find((option) => option.value === propertyValue)?.label ||
     propertyValue
-
+  const isEditing = localCurrentValue !== propertyValue
   const traitAsGroupedOptions =
-    !isValueFromContext && localCurrentValue
+    localCurrentValue && (!isValueFromContext || isEditing)
       ? [
           {
             label: (


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Condition is incorrect and wouldn't show the trait options if currently selected option is from context value

## How did you test this code?
- manually