### PR TITLE
fix: use-errors-from-api-on-login

### DIFF
--- a/frontend/web/project/api.ts
+++ b/frontend/web/project/api.ts
@@ -16,7 +16,10 @@ import Utils from 'common/utils/utils'
 const API = {
   ajaxHandler(
     store: { error?: any; goneABitWest: () => void },
-    res: string | Error | { data?: any; text?: () => Promise<string> },
+    res:
+      | string
+      | Error
+      | { data?: any; text?: () => Promise<string>; status?: number },
   ): void {
     if (typeof res === 'string') {
       store.error = new Error(res)
@@ -24,7 +27,6 @@ const API = {
       return
     }
     if (res instanceof Error) {
-      console.error(res)
       store.error = res
       store.goneABitWest()
       return
@@ -47,7 +49,16 @@ const API = {
         try {
           err = JSON.parse(errorText)
         } catch {}
-        store.error = err
+        if (res?.status === 500) {
+          store.error =
+            'An unknown error occurred while logging in. Please try again later or contact an administrator.'
+        } else if (err.detail) {
+          store.error = err.detail
+        } else if (err.non_field_errors) {
+          store.error = err.non_field_errors[0]
+        } else {
+          store.error = err
+        }
         store.goneABitWest()
       })
       .catch(() => {

--- a/frontend/web/project/api.ts
+++ b/frontend/web/project/api.ts
@@ -27,6 +27,7 @@ const API = {
       return
     }
     if (res instanceof Error) {
+      console.error(res)
       store.error = res
       store.goneABitWest()
       return


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

Closes #5371 
## Changes
- Forwards errors from backend on login

## How did you test this code?
**Restricted Auth methods**
To reproduce:
1. Install auth-controller
2. Go to django-admin > domain auth methods
3. Add restrictions
<img width="266" height="480" alt="image" src="https://github.com/user-attachments/assets/7a358a71-1a13-43c5-ad12-6a5ac3793dab" />

**Password-email restricted**
To reproduce:
1. Add `"PREVENT_EMAIL_PASSWORD": "true",` to backend env
<img width="559" height="547" alt="image" src="https://github.com/user-attachments/assets/b38d38f4-811e-4589-8d0f-69e4199f4fe9" />

**Incorrect credentials / password** (with valid email)
<img width="327" height="480" alt="image" src="https://github.com/user-attachments/assets/0a38b94f-18a0-4d8e-bb8d-f76f8ef2d365" />

**API Returns 500 for whatever reasons** (invalid email here, to be fixed
<img width="327" height="480" alt="image" src="https://github.com/user-attachments/assets/12d34432-e6d8-417b-83b1-77934873c5b4" />


