### PR TITLE
fix: `SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED` does not affect rules

### DIFF
--- a/api/integrations/launch_darkly/services.py
+++ b/api/integrations/launch_darkly/services.py
@@ -352,7 +352,7 @@ def _create_segment_rule_for_segment(
                 f" skipping for segment: {segment.name}",
             )
 
-    return parent_rule  # type: ignore[no-any-return]
+    return parent_rule
 
 
 def _create_feature_segment_from_clauses(

--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -41,7 +41,7 @@ class ConfiguredOrderManager(SoftDeleteExportableManager, models.Manager[ModelT]
     def get_queryset(
         self,
     ) -> models.QuerySet[ModelT]:
-        # Effectively `Condition.Meta.ordering = ("id",) if ... else ()`,
+        # Effectively `<ModelT>.Meta.ordering = ("id",) if ... else ()`,
         # but avoid the weirdness of a setting-dependant migration
         # and having to reload everything in tests
         qs: models.QuerySet[ModelT]

--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -179,13 +179,14 @@ class Segment(
         # Ensure top-level rules are cloned first (for dependencies)
         source_rules = source_rules.order_by(models.F("rule").asc(nulls_first=True))
 
-        rule_to_cloned_rule_map: dict[SegmentRule | None, SegmentRule] = {}
+        rule_to_cloned_rule_map: dict[SegmentRule, SegmentRule] = {}
         for rule in source_rules:
             cloned_rule = deepcopy(rule)
             cloned_rule.pk = None
             cloned_rule.uuid = uuid.uuid4()
             cloned_rule.segment = self if rule.segment else None
-            cloned_rule.rule = rule_to_cloned_rule_map.get(rule.rule)
+            if rule.rule in rule_to_cloned_rule_map:
+                cloned_rule.rule = rule_to_cloned_rule_map[rule.rule]
             cloned_rule.save()
             rule_to_cloned_rule_map[rule] = cloned_rule
 

--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -32,19 +32,19 @@ from projects.models import Project
 
 from .managers import LiveSegmentManager, SegmentManager
 
-T = typing.TypeVar("T", bound=models.Model)
+ModelT = typing.TypeVar("ModelT", bound=models.Model)
 
 logger = logging.getLogger(__name__)
 
 
-class ConfiguredOrderManager(SoftDeleteExportableManager, models.Manager[T]):
+class ConfiguredOrderManager(SoftDeleteExportableManager, models.Manager[ModelT]):
     def get_queryset(
         self,
-    ) -> models.QuerySet[T]:
+    ) -> models.QuerySet[ModelT]:
         # Effectively `Condition.Meta.ordering = ("id",) if ... else ()`,
         # but avoid the weirdness of a setting-dependant migration
         # and having to reload everything in tests
-        qs: models.QuerySet[T]
+        qs: models.QuerySet[ModelT]
         if settings.SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED:
             qs = SoftDeleteExportableManager.get_queryset(self).order_by("id")
         else:

--- a/api/segments/models.py
+++ b/api/segments/models.py
@@ -46,9 +46,9 @@ class ConfiguredOrderManager(SoftDeleteExportableManager, models.Manager[ModelT]
         # and having to reload everything in tests
         qs: models.QuerySet[ModelT]
         if settings.SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED:
-            qs = SoftDeleteExportableManager.get_queryset(self).order_by("id")
+            qs = super().get_queryset().order_by("id")
         else:
-            qs = SoftDeleteExportableManager.get_queryset(self)
+            qs = super().get_queryset()
         return qs
 
 

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -603,7 +603,9 @@ def test_identities_endpoint_returns_value_for_segment_if_rule_type_percentage_s
     )
     Condition.objects.create(
         operator=PERCENTAGE_SPLIT,
-        value=(identity_percentage_value + (1 - identity_percentage_value) / 2) * 100.0,
+        value=int(
+            (identity_percentage_value + (1 - identity_percentage_value) / 2) * 100.0
+        ),
         rule=segment_rule,
     )
     feature_segment = FeatureSegment.objects.create(
@@ -654,7 +656,7 @@ def test_identities_endpoint_returns_default_value_if_rule_type_percentage_split
     )
     Condition.objects.create(
         operator=PERCENTAGE_SPLIT,
-        value=identity_percentage_value / 2,
+        value=int(identity_percentage_value / 2),
         rule=segment_rule,
     )
     feature_segment = FeatureSegment.objects.create(

--- a/api/tests/unit/segments/test_unit_segments_views.py
+++ b/api/tests/unit/segments/test_unit_segments_views.py
@@ -707,8 +707,9 @@ def test_update_segment_add_new_condition(
     assert response.status_code == status.HTTP_200_OK
 
     assert nested_rule.conditions.count() == 2
-    assert nested_rule.conditions.last().property == new_condition_property
-    assert nested_rule.conditions.last().value == new_condition_value
+    assert (expected_new_condition := nested_rule.conditions.last())
+    assert expected_new_condition.property == new_condition_property
+    assert expected_new_condition.value == new_condition_value
 
 
 def test_update_segment_versioned_segment(

--- a/infrastructure/aws/staging/ecs-task-definition-web.json
+++ b/infrastructure/aws/staging/ecs-task-definition-web.json
@@ -218,6 +218,10 @@
                     "value": "True"
                 },
                 {
+                    "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
+                    "value": "True"
+                },
+                {
                     "name": "FLAGSMITH_ON_FLAGSMITH_SERVER_OFFLINE_MODE",
                     "value": "False"
                 },


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:
- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Makes `SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED` affect segment rules in addition to segment rule conditions.

## How did you test this code?

Will be tested extensively on staging.