### PR TITLE
fix: split-operator-to-remove-append

### DIFF
--- a/frontend/web/components/segments/Rule/Rule.tsx
+++ b/frontend/web/components/segments/Rule/Rule.tsx
@@ -69,7 +69,10 @@ const Rule: React.FC<RuleProps> = ({
     )
     const newOperator = operators.find((op) => op.value === operatorValue)
 
-    const updates: Partial<SegmentCondition> = { operator: operatorValue }
+    // Split the append part of the operator as not handled by backend
+    const updates: Partial<SegmentCondition> = {
+      operator: operatorValue?.split(':')[0],
+    }
 
     if (newOperator?.hideValue) {
       updates.value = null


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Some operators include an appended part `OPERATOR:{append}` that need to be cleaned-up when setting their values
E.G `GREATER_THAN:semver` breaking updates

Regression from [here](https://github.com/Flagsmith/flagsmith/pull/5766/files#diff-a0d1dabbeb420b8bb7d24b440d16ac8bbf4d988990cbf764a716a6a23b7c5ee4L228-L230)

## How did you test this code?
- Manually
<img width="1500" height="888" alt="image" src="https://github.com/user-attachments/assets/8622dc86-fb6c-41d0-bd60-7f611e1c596a" />

Fixed and correct condition payload example
```
{
    "id": 268,
    "operator": "GREATER_THAN_INCLUSIVE",
    "property": "$.environment.name",
    "value": "18.21.2:semver",
    "description": null,
    "version_of": null
}
```