### PR TITLE
refactor(tests): combine `staff_user` and `test_user` fixtures

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -9,10 +9,11 @@ import pytest
 from common.environments.permissions import (
     MANAGE_IDENTITIES,
     MANAGE_SEGMENT_OVERRIDES,
+    UPDATE_FEATURE_STATE,
     VIEW_ENVIRONMENT,
     VIEW_IDENTITIES,
 )
-from common.projects.permissions import VIEW_PROJECT
+from common.projects.permissions import CREATE_ENVIRONMENT, DELETE_FEATURE, VIEW_PROJECT
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import caches
 from django.db.backends.base.creation import TEST_DATABASE_PREFIX
@@ -27,7 +28,6 @@ from pytest import FixtureRequest
 from pytest_django.fixtures import SettingsWrapper
 from pytest_django.plugin import blocking_manager_key
 from pytest_mock import MockerFixture
-from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 from task_processor.task_run_method import TaskRunMethod
 from urllib3 import BaseHTTPResponse
@@ -218,16 +218,6 @@ trait_value = "value1"
 
 
 @pytest.fixture()
-def test_user(django_user_model):  # type: ignore[no-untyped-def]
-    return django_user_model.objects.create(email="user@example.com")
-
-
-@pytest.fixture()
-def auth_token(test_user):  # type: ignore[no-untyped-def]
-    return Token.objects.create(user=test_user)
-
-
-@pytest.fixture()
 def admin_client_original(admin_user):  # type: ignore[no-untyped-def]
     client = APIClient()
     client.force_authenticate(user=admin_user)
@@ -252,12 +242,6 @@ def admin_client(admin_client_original):  # type: ignore[no-untyped-def]
     fixture will ultimately be updated to the new approach.
     """
     yield admin_client_original
-
-
-@pytest.fixture()
-def test_user_client(api_client, test_user):  # type: ignore[no-untyped-def]
-    api_client.force_authenticate(test_user)
-    return api_client
 
 
 @pytest.fixture()
@@ -805,27 +789,50 @@ def create_project_permission(db):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture()
+def create_environment_permission(db: None) -> PermissionModel:
+    return PermissionModel.objects.get(key=CREATE_ENVIRONMENT)
+
+
+@pytest.fixture()
 def manage_segment_overrides_permission(db: None) -> PermissionModel:
     return PermissionModel.objects.get(key=MANAGE_SEGMENT_OVERRIDES)
 
 
 @pytest.fixture()
-def user_environment_permission(test_user, environment):  # type: ignore[no-untyped-def]
+def delete_feature_permission(db: None) -> PermissionModel:
+    return PermissionModel.objects.get(key=DELETE_FEATURE)
+
+
+@pytest.fixture()
+def update_feature_state_permission(db: None) -> PermissionModel:
+    return PermissionModel.objects.get(key=UPDATE_FEATURE_STATE)
+
+
+@pytest.fixture()
+def user_environment_permission(
+    staff_user: FFAdminUser,
+    environment: Environment,
+) -> UserEnvironmentPermission:
     return UserEnvironmentPermission.objects.create(
-        user=test_user, environment=environment
+        user=staff_user, environment=environment
     )
 
 
 @pytest.fixture()
-def user_environment_permission_group(test_user, user_permission_group, environment):  # type: ignore[no-untyped-def]
+def user_environment_permission_group(
+    user_permission_group: UserPermissionGroup,
+    environment: Environment,
+) -> UserPermissionGroupEnvironmentPermission:
     return UserPermissionGroupEnvironmentPermission.objects.create(
         group=user_permission_group, environment=environment
     )
 
 
 @pytest.fixture()
-def user_project_permission(test_user, project):  # type: ignore[no-untyped-def]
-    return UserProjectPermission.objects.create(user=test_user, project=project)
+def user_project_permission(
+    staff_user: FFAdminUser, project: Project
+) -> UserProjectPermission:
+    return UserProjectPermission.objects.create(user=staff_user, project=project)
 
 
 @pytest.fixture()

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -575,6 +575,7 @@ def test_get_user_is_not_throttled(  # type: ignore[no-untyped-def]
         assert response.status_code == status.HTTP_200_OK
 
 
+@pytest.mark.django_db
 def test_delete_token(api_client: APIClient, db: None) -> None:
     # Given
     register_url = reverse("api-v1:custom_auth:ffadminuser-list")

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -1,5 +1,6 @@
 import json
 import re
+import uuid
 from collections import ChainMap
 
 import pyotp
@@ -9,7 +10,6 @@ from django.core import mail
 from django.urls import reverse
 from pytest_mock import MockerFixture
 from rest_framework import status
-from rest_framework.authtoken.models import Token
 from rest_framework.test import (  # type: ignore[attr-defined]
     APIClient,
     override_settings,
@@ -575,24 +575,34 @@ def test_get_user_is_not_throttled(  # type: ignore[no-untyped-def]
         assert response.status_code == status.HTTP_200_OK
 
 
-def test_delete_token(staff_user: FFAdminUser, api_client: APIClient) -> None:
+def test_delete_token(api_client: APIClient, db: None) -> None:
     # Given
-    url = reverse("api-v1:custom_auth:delete-token")
+    register_url = reverse("api-v1:custom_auth:ffadminuser-list")
+    password = FFAdminUser.objects.make_random_password()
+    register_data = {
+        "first_name": "test",
+        "last_name": "user",
+        "email": f"user{uuid.uuid4()}@example.com",
+        "password": password,
+        "re_password": password,
+    }
+    response = api_client.post(
+        register_url, data=json.dumps(register_data), content_type="application/json"
+    )
+    auth_token = response.json()["key"]
 
-    token, _ = Token.objects.get_or_create(user=staff_user)
-    api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    delete_token_url = reverse("api-v1:custom_auth:delete-token")
+    client = APIClient(HTTP_AUTHORIZATION=f"Token {auth_token}")
 
     # When
-    response = api_client.delete(url)
+    response = client.delete(delete_token_url)
 
     # Then
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    # and - if we try to access an authenticated endpoint
-    # it will fail
-    me_url = reverse("api-v1:custom_auth:ffadminuser-me")
-    response = api_client.get(me_url)
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    # and - if we try to delete the token again (i.e: access anything that uses
+    # is_authenticated) we will get 401
+    assert client.delete(delete_token_url).status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_register_with_sign_up_type(client, db, settings):  # type: ignore[no-untyped-def]

--- a/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
+++ b/api/tests/integration/custom_auth/end_to_end/test_custom_auth_integration.py
@@ -9,6 +9,7 @@ from django.core import mail
 from django.urls import reverse
 from pytest_mock import MockerFixture
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from rest_framework.test import (  # type: ignore[attr-defined]
     APIClient,
     override_settings,
@@ -574,20 +575,24 @@ def test_get_user_is_not_throttled(  # type: ignore[no-untyped-def]
         assert response.status_code == status.HTTP_200_OK
 
 
-def test_delete_token(test_user, auth_token):  # type: ignore[no-untyped-def]
+def test_delete_token(staff_user: FFAdminUser, api_client: APIClient) -> None:
     # Given
     url = reverse("api-v1:custom_auth:delete-token")
-    client = APIClient(HTTP_AUTHORIZATION=f"Token {auth_token.key}")
+
+    token, _ = Token.objects.get_or_create(user=staff_user)
+    api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
 
     # When
-    response = client.delete(url)
+    response = api_client.delete(url)
 
     # Then
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    # and - if we try to delete the token again(i.e: access anything that uses is_authenticated)
-    # we should will get 401
-    assert client.delete(url).status_code == status.HTTP_401_UNAUTHORIZED
+    # and - if we try to access an authenticated endpoint
+    # it will fail
+    me_url = reverse("api-v1:custom_auth:ffadminuser-me")
+    response = api_client.get(me_url)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_register_with_sign_up_type(client, db, settings):  # type: ignore[no-untyped-def]

--- a/api/tests/integration/features/feature_health/test_views.py
+++ b/api/tests/integration/features/feature_health/test_views.py
@@ -89,7 +89,7 @@ def test_feature_health_providers__delete__expected_response(
 def test_feature_health_events__dismiss__unauthorized__expected_response(
     project: int,
     unhealthy_feature_health_event: int,
-    test_user_client: APIClient,
+    staff_client: APIClient,
 ) -> None:
     # Given
     feature_health_events_dismiss_url = reverse(
@@ -98,7 +98,7 @@ def test_feature_health_events__dismiss__unauthorized__expected_response(
     )
 
     # When
-    response = test_user_client.post(feature_health_events_dismiss_url)
+    response = staff_client.post(feature_health_events_dismiss_url)
 
     # Then
     assert response.status_code == 403

--- a/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
+++ b/api/tests/unit/app_analytics/test_unit_app_analytics_views.py
@@ -359,14 +359,15 @@ def test_get_usage_data__labels_filter__returns_expected(
     )
 
 
-def test_get_usage_data_for_non_admin_user_returns_403(  # type: ignore[no-untyped-def]
-    mocker, test_user_client, organisation
-):
+def test_get_usage_data_for_non_admin_user_returns_403(
+    staff_client: APIClient,
+    organisation: Organisation,
+) -> None:
     # Given
     url = reverse("api-v1:organisations:usage-data", args=[organisation.id])
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -393,16 +394,17 @@ def test_get_total_usage_count(mocker, admin_client, organisation):  # type: ign
     mocked_get_total_events_count.assert_called_once_with(organisation)
 
 
-def test_get_total_usage_count_for_non_admin_user_returns_403(  # type: ignore[no-untyped-def]
-    mocker, test_user_client, organisation
-):
+def test_get_total_usage_count_for_non_admin_user_returns_403(
+    staff_client: APIClient,
+    organisation: Organisation,
+) -> None:
     # Given
     url = reverse(
         "api-v1:organisations:usage-data-total-count",
         args=[organisation.id],
     )
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/api/tests/unit/edge_api/identities/test_edge_identity_featurestate_view.py
+++ b/api/tests/unit/edge_api/identities/test_edge_identity_featurestate_view.py
@@ -1,16 +1,25 @@
+from typing import Any
+from unittest.mock import MagicMock
+
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APIClient
+
+from environments.models import Environment
+from environments.permissions.models import UserEnvironmentPermission
+from features.models import Feature
+from permissions.models import PermissionModel
 
 
-def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_identity(  # type: ignore[no-untyped-def]  # noqa: E501
-    test_user_client,
-    environment,
-    feature,
-    view_environment_permission,
-    user_environment_permission,
-    identity_document_without_fs,
-    edge_identity_dynamo_wrapper_mock,
-):
+def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_edge_identity(
+    staff_client: APIClient,
+    environment: Environment,
+    feature: Feature,
+    view_environment_permission: PermissionModel,
+    user_environment_permission: UserEnvironmentPermission,
+    identity_document_without_fs: dict[str, Any],
+    edge_identity_dynamo_wrapper_mock: MagicMock,
+) -> None:
     # Given
     edge_identity_dynamo_wrapper_mock.get_item_from_uuid_or_404.return_value = (
         identity_document_without_fs
@@ -22,7 +31,7 @@ def test_user_with_view_environment_permission_can_retrieve_all_feature_states_f
     )
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_feature_states_views.py
@@ -8,15 +8,18 @@ from common.environments.permissions import (
 from django.test import Client
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from core.constants import STRING
 from environments.identities.models import Identity
 from environments.models import Environment
+from environments.permissions.models import UserEnvironmentPermission
 from features.models import Feature, FeatureState, FeatureStateValue
 from features.multivariate.models import (
     MultivariateFeatureOption,
     MultivariateFeatureStateValue,
 )
+from permissions.models import PermissionModel
 from projects.models import Project
 from tests.unit.environments.helpers import get_environment_user_client
 
@@ -96,13 +99,13 @@ def test_user_with_update_feature_state_permission_can_update_identity_feature_s
     assert response.status_code == status.HTTP_201_CREATED
 
 
-def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_identity(  # type: ignore[no-untyped-def]  # noqa: E501
-    environment,
-    identity,
-    test_user_client,
-    view_environment_permission,
-    user_environment_permission,
-):
+def test_user_with_view_environment_permission_can_retrieve_all_feature_states_for_identity(
+    environment: Environment,
+    identity: Identity,
+    staff_client: APIClient,
+    view_environment_permission: PermissionModel,
+    user_environment_permission: UserEnvironmentPermission,
+) -> None:
     # Given
     user_environment_permission.permissions.add(view_environment_permission)
 
@@ -112,7 +115,7 @@ def test_user_with_view_environment_permission_can_retrieve_all_feature_states_f
     )
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/environments/identities/test_unit_identities_views.py
+++ b/api/tests/unit/environments/identities/test_unit_identities_views.py
@@ -29,11 +29,13 @@ from environments.identities.models import Identity
 from environments.identities.traits.models import Trait
 from environments.identities.views import IdentityViewSet
 from environments.models import Environment, EnvironmentAPIKey
+from environments.permissions.models import UserEnvironmentPermission
 from environments.permissions.permissions import NestedEnvironmentPermissions
 from features.models import Feature, FeatureSegment, FeatureState
 from integrations.amplitude.models import AmplitudeConfiguration
 from organisations.models import Organisation
-from projects.models import Project
+from permissions.models import PermissionModel
+from projects.models import Project, UserProjectPermission
 from segments.models import Condition, Segment, SegmentRule
 
 
@@ -1331,16 +1333,16 @@ def test_post_identities__transient_traits__no_persistence(
     assert not Trait.objects.filter(trait_key=transient_trait_key).exists()
 
 
-def test_user_with_view_identities_permission_can_retrieve_identity(  # type: ignore[no-untyped-def]
-    environment,
-    identity,
-    test_user_client,
-    view_environment_permission,
-    view_identities_permission,
-    view_project_permission,
-    user_environment_permission,
-    user_project_permission,
-):
+def test_user_with_view_identities_permission_can_retrieve_identity(
+    environment: Environment,
+    identity: Identity,
+    staff_client: APIClient,
+    view_environment_permission: PermissionModel,
+    view_identities_permission: PermissionModel,
+    view_project_permission: PermissionModel,
+    user_environment_permission: UserEnvironmentPermission,
+    user_project_permission: UserProjectPermission,
+) -> None:
     # Given
 
     user_environment_permission.permissions.add(
@@ -1354,22 +1356,22 @@ def test_user_with_view_identities_permission_can_retrieve_identity(  # type: ig
     )
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_user_with_view_environment_permission_can_not_list_identities(  # type: ignore[no-untyped-def]
-    environment,
-    identity,
-    test_user_client,
-    view_environment_permission,
-    manage_identities_permission,
-    view_project_permission,
-    user_environment_permission,
-    user_project_permission,
-):
+def test_user_with_view_environment_permission_can_not_list_identities(
+    environment: Environment,
+    identity: Identity,
+    staff_client: APIClient,
+    view_environment_permission: PermissionModel,
+    manage_identities_permission: PermissionModel,
+    view_project_permission: PermissionModel,
+    user_environment_permission: UserEnvironmentPermission,
+    user_project_permission: UserProjectPermission,
+) -> None:
     # Given
 
     user_environment_permission.permissions.add(view_environment_permission)
@@ -1381,7 +1383,7 @@ def test_user_with_view_environment_permission_can_not_list_identities(  # type:
     )
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -5,9 +5,6 @@ from common.environments.permissions import (
     TAG_SUPPORTED_PERMISSIONS,
     VIEW_ENVIRONMENT,
 )
-from common.projects.permissions import (
-    CREATE_ENVIRONMENT,
-)
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -29,7 +26,8 @@ from features.models import Feature, FeatureState
 from features.versioning.models import EnvironmentFeatureVersion
 from metadata.models import Metadata, MetadataModelField
 from organisations.models import Organisation
-from projects.models import Project
+from permissions.models import PermissionModel
+from projects.models import Project, UserProjectPermission
 from segments.models import Condition, Segment, SegmentRule
 from tests.types import WithEnvironmentPermissionsCallable
 from users.models import FFAdminUser
@@ -131,20 +129,20 @@ def test_user_with_view_environment_permission_can_retrieve_environment(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_can_clone_environment_with_create_environment_permission(  # type: ignore[no-untyped-def]
-    test_user,
-    test_user_client,
-    environment,
-    user_project_permission,
+def test_can_clone_environment_with_create_environment_permission(
+    staff_client: APIClient,
+    environment: Environment,
+    user_project_permission: UserProjectPermission,
+    create_environment_permission: PermissionModel,
 ) -> None:
     # Given
     env_name = "Cloned env"
-    user_project_permission.permissions.add(CREATE_ENVIRONMENT)
+    user_project_permission.permissions.add(create_environment_permission)
 
     url = reverse("api-v1:environments:environment-clone", args=[environment.api_key])
 
     # When
-    response = test_user_client.post(url, {"name": env_name})
+    response = staff_client.post(url, {"name": env_name})
 
     # Then
     assert response.status_code == status.HTTP_200_OK

--- a/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
+++ b/api/tests/unit/features/feature_segments/test_unit_feature_segments_views.py
@@ -197,9 +197,12 @@ def test_create_feature_segment(segment, feature, environment, client):  # type:
     assert response_json["id"]
 
 
-def test_create_feature_segment_without_permission_returns_403(  # type: ignore[no-untyped-def]
-    segment, feature, environment, test_user_client
-):
+def test_create_feature_segment_without_permission_returns_403(
+    segment: Segment,
+    feature: Feature,
+    environment: Environment,
+    staff_client: APIClient,
+) -> None:
     # Given
     data = {
         "feature": feature.id,
@@ -209,7 +212,7 @@ def test_create_feature_segment_without_permission_returns_403(  # type: ignore[
     url = reverse("api-v1:features:feature-segment-list")
 
     # When
-    response = test_user_client.post(
+    response = staff_client.post(
         url, data=json.dumps(data), content_type="application/json"
     )
 
@@ -357,11 +360,11 @@ def test_update_priority_for_staff(
 
 
 def test_update_priority_returns_403_if_user_does_not_have_permission(  # type: ignore[no-untyped-def]
-    feature_segment,
-    project,
-    environment,
-    feature,
-    test_user_client,
+    feature_segment: FeatureSegment,
+    project: Project,
+    environment: Environment,
+    feature: Feature,
+    staff_client: APIClient,
 ):
     # Given
     url = reverse("api-v1:features:feature-segment-update-priorities")
@@ -371,7 +374,7 @@ def test_update_priority_returns_403_if_user_does_not_have_permission(  # type: 
     ]
 
     # When
-    response = test_user_client.post(
+    response = staff_client.post(
         url, data=json.dumps(data), content_type="application/json"
     )
 
@@ -444,16 +447,20 @@ def test_get_feature_segment_by_uuid_for_staff(
     assert json_response["uuid"] == str(feature_segment.uuid)
 
 
-def test_get_feature_segment_by_uuid_returns_404_if_user_does_not_have_access(  # type: ignore[no-untyped-def]
-    feature_segment, project, test_user_client, environment, feature
-):
+def test_get_feature_segment_by_uuid_returns_404_if_user_does_not_have_access(
+    feature_segment: FeatureSegment,
+    project: Project,
+    staff_client: APIClient,
+    environment: Environment,
+    feature: Feature,
+) -> None:
     # Given
     url = reverse(
         "api-v1:features:feature-segment-get-by-uuid", args=[feature_segment.uuid]
     )
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
+++ b/api/tests/unit/features/import_export/test_unit_features_import_export_views.py
@@ -111,7 +111,7 @@ def test_list_feature_export_with_filtered_environments(
 
 
 def test_list_feature_exports_unauthorized(
-    test_user_client: APIClient,
+    staff_client: APIClient,
     project: Project,
     environment: Environment,
 ) -> None:
@@ -127,7 +127,7 @@ def test_list_feature_exports_unauthorized(
     )
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == 403

--- a/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
+++ b/api/tests/unit/integrations/datadog/test_unit_datadog_views.py
@@ -156,7 +156,7 @@ def test_create_datadog_configuration_in_project_with_deleted_configuration(  # 
 
 
 def test_datadog_project_view__no_permissions__return_expected(
-    test_user_client: APIClient,
+    staff_client: APIClient,
     project: Project,
 ) -> None:
     # Given
@@ -168,7 +168,7 @@ def test_datadog_project_view__no_permissions__return_expected(
     url = reverse("api-v1:projects:integrations-datadog-list", args=[project.id])
 
     # When
-    response = test_user_client.post(
+    response = staff_client.post(
         url,
         data=json.dumps(data),
         content_type="application/json",

--- a/api/tests/unit/integrations/dynatrace/test_unit_dynatrace_views.py
+++ b/api/tests/unit/integrations/dynatrace/test_unit_dynatrace_views.py
@@ -147,7 +147,7 @@ def test_should_remove_configuration_when_delete(
 
 
 def test_dynatrace_environment_view__no_permissions__return_expected(
-    test_user_client: APIClient,
+    staff_client: APIClient,
     environment: Environment,
 ) -> None:
     # Given
@@ -162,7 +162,7 @@ def test_dynatrace_environment_view__no_permissions__return_expected(
     )
 
     # When
-    response = test_user_client.post(
+    response = staff_client.post(
         url,
         data=json.dumps(data),
         content_type="application/json",

--- a/api/tests/unit/integrations/grafana/test_views.py
+++ b/api/tests/unit/integrations/grafana/test_views.py
@@ -134,7 +134,7 @@ def test_grafana_organisation_view__delete_configuration__return_expected(
 
 
 def test_grafana_organisation_view__create_configuration__non_admin__return_expected(
-    test_user_client: APIClient,
+    staff_client: APIClient,
     organisation: Organisation,
     grafana_organisation_configuration: GrafanaOrganisationConfiguration,
 ) -> None:
@@ -148,7 +148,7 @@ def test_grafana_organisation_view__create_configuration__non_admin__return_expe
     )
 
     # When
-    response = test_user_client.post(
+    response = staff_client.post(
         url,
         data=json.dumps(data),
         content_type="application/json",
@@ -159,7 +159,7 @@ def test_grafana_organisation_view__create_configuration__non_admin__return_expe
 
 
 def test_grafana_organisation_view__get_configuration__non_admin__return_expected(
-    test_user_client: APIClient,
+    staff_client: APIClient,
     organisation: Organisation,
     grafana_organisation_configuration: GrafanaOrganisationConfiguration,
 ) -> None:
@@ -170,14 +170,14 @@ def test_grafana_organisation_view__get_configuration__non_admin__return_expecte
     )
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_grafana_organisation_view__delete_configuration__non_admin__return_expected(
-    test_user_client: APIClient,
+    staff_client: APIClient,
     organisation: Organisation,
     grafana_organisation_configuration: GrafanaOrganisationConfiguration,
 ) -> None:
@@ -188,7 +188,7 @@ def test_grafana_organisation_view__delete_configuration__non_admin__return_expe
     )
 
     # When
-    response = test_user_client.delete(url)
+    response = staff_client.delete(url)
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/api/tests/unit/integrations/launch_darkly/conftest.py
+++ b/api/tests/unit/integrations/launch_darkly/conftest.py
@@ -59,13 +59,13 @@ def ld_client_class_mock(
 def import_request(
     ld_client_class_mock: MagicMock,
     project: Project,
-    test_user: FFAdminUser,
+    staff_user: FFAdminUser,
     ld_project_key: str,
     ld_token: str,
 ) -> LaunchDarklyImportRequest:
     return create_import_request(
         project=project,
-        user=test_user,
+        user=staff_user,
         ld_project_key=ld_project_key,
         ld_token=ld_token,
     )

--- a/api/tests/unit/integrations/launch_darkly/test_services.py
+++ b/api/tests/unit/integrations/launch_darkly/test_services.py
@@ -30,18 +30,18 @@ def test_create_import_request__return_expected(
     ld_client_mock: MagicMock,
     ld_client_class_mock: MagicMock,
     project: Project,
-    test_user: FFAdminUser,
+    staff_user: FFAdminUser,
 ) -> None:
     # Given
     ld_project_key = "test-project-key"
     ld_token = "test-token"
 
-    expected_salt = f"ld_import_{test_user.id}"
+    expected_salt = f"ld_import_{staff_user.id}"
 
     # When
     result = create_import_request(
         project=project,
-        user=test_user,
+        user=staff_user,
         ld_project_key=ld_project_key,
         ld_token=ld_token,
     )
@@ -58,7 +58,7 @@ def test_create_import_request__return_expected(
     }
     assert signing.loads(result.ld_token, salt=expected_salt) == ld_token
     assert result.ld_project_key == ld_project_key
-    assert result.created_by == test_user
+    assert result.created_by == staff_user
     assert result.project == project
 
 

--- a/api/tests/unit/integrations/launch_darkly/test_views.py
+++ b/api/tests/unit/integrations/launch_darkly/test_views.py
@@ -45,7 +45,7 @@ def test_launch_darkly_import_request_view__list__return_expected(
         {
             "completed_at": None,
             "created_at": mocker.ANY,
-            "created_by": "user@example.com",
+            "created_by": "staff@example.com",
             "id": import_request.id,
             "project": project.id,
             "status": {

--- a/api/tests/unit/metadata/test_views.py
+++ b/api/tests/unit/metadata/test_views.py
@@ -113,7 +113,8 @@ def test_retrieve_metadata_fields(admin_client, a_metadata_field):  # type: igno
 
 
 def test_create_metadata_field_returns_403_for_non_org_admin(  # type: ignore[no-untyped-def]
-    test_user_client, organisation
+    staff_client: APIClient,
+    organisation: Organisation,
 ):
     url = reverse("api-v1:metadata:metadata-fields-list")
     field_name = "some_id"
@@ -122,7 +123,7 @@ def test_create_metadata_field_returns_403_for_non_org_admin(  # type: ignore[no
     data = {"name": field_name, "type": field_type, "organisation": organisation.id}
 
     # When
-    response = test_user_client.post(
+    response = staff_client.post(
         url, data=json.dumps(data), content_type="application/json"
     )
 

--- a/api/tests/unit/onboarding/test_views.py
+++ b/api/tests/unit/onboarding/test_views.py
@@ -12,13 +12,13 @@ from users.models import FFAdminUser
 
 
 def test_send_onboarding_request_to_saas_flagsmith_view_for_non_admin_user(
-    test_user_client: APIClient, is_oss: MagicMock
+    staff_client: APIClient, is_oss: MagicMock
 ) -> None:
     # Given
     url = reverse("api-v1:onboarding:send-onboarding-request")
 
     # When
-    response = test_user_client.get(url)
+    response = staff_client.get(url)
 
     # Then
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/api/tests/unit/organisations/invites/conftest.py
+++ b/api/tests/unit/organisations/invites/conftest.py
@@ -1,15 +1,23 @@
 import pytest
 
 from organisations.invites.models import Invite, InviteLink
+from organisations.models import Organisation
+from users.models import FFAdminUser
 
 
 @pytest.fixture()
-def invite_link(organisation):  # type: ignore[no-untyped-def]
-    return InviteLink.objects.create(organisation=organisation)
+def invite_link(organisation: Organisation) -> InviteLink:
+    _invite_link: InviteLink = InviteLink.objects.create(organisation=organisation)
+    return _invite_link
 
 
 @pytest.fixture()
-def invite(organisation, admin_user, test_user):  # type: ignore[no-untyped-def]
-    return Invite.objects.create(
-        organisation=organisation, email=test_user.email, invited_by=admin_user
+def invite(
+    organisation: Organisation,
+    admin_user: FFAdminUser,
+    staff_user: FFAdminUser,
+) -> Invite:
+    _invite: Invite = Invite.objects.create(
+        organisation=organisation, email=staff_user.email, invited_by=admin_user
     )
+    return _invite

--- a/api/tests/unit/organisations/invites/test_unit_invites_views.py
+++ b/api/tests/unit/organisations/invites/test_unit_invites_views.py
@@ -381,7 +381,7 @@ def test_join_organisation_from_link_returns_403_if_invite_links_disabled(
     settings.DISABLE_INVITE_LINKS = True
     url = reverse("api-v1:users:user-join-organisation-link", args=[invite_link.hash])
 
-    new_user = django_user_model.objects.create(email=f"user{uuid.uuid4()}@example.com")
+    new_user = FFAdminUser.objects.create(email=f"user{uuid.uuid4()}@example.com")
     api_client.force_authenticate(user=new_user)
 
     # When

--- a/api/tests/unit/permissions/permission_service/conftest.py
+++ b/api/tests/unit/permissions/permission_service/conftest.py
@@ -1,5 +1,12 @@
 import pytest
 
+from environments.permissions.models import (
+    UserEnvironmentPermission,
+    UserPermissionGroupEnvironmentPermission,
+)
+from projects.models import UserPermissionGroupProjectPermission
+from users.models import FFAdminUser, UserPermissionGroup
+
 
 @pytest.fixture
 def project_permission_using_user_permission(user_project_permission):  # type: ignore[no-untyped-def]
@@ -15,10 +22,12 @@ def project_admin_via_user_permission(project_permission_using_user_permission):
 
 
 @pytest.fixture
-def project_permission_using_user_permission_group(  # type: ignore[no-untyped-def]
-    user_project_permission_group, user_permission_group, test_user
-):
-    user_permission_group.users.add(test_user)
+def project_permission_using_user_permission_group(
+    user_project_permission_group: UserPermissionGroupProjectPermission,
+    user_permission_group: UserPermissionGroup,
+    staff_user: FFAdminUser,
+) -> UserPermissionGroupProjectPermission:
+    user_permission_group.users.add(staff_user)
     return user_project_permission_group
 
 
@@ -33,7 +42,9 @@ def project_admin_via_user_permission_group(  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture
-def environment_admin_via_user_permission(test_user, user_environment_permission):  # type: ignore[no-untyped-def]
+def environment_admin_via_user_permission(
+    staff_user: FFAdminUser, user_environment_permission: UserEnvironmentPermission
+) -> UserEnvironmentPermission:
     user_environment_permission.admin = True
     user_environment_permission.save()
 
@@ -46,10 +57,12 @@ def environment_permission_using_user_permission(user_environment_permission):  
 
 
 @pytest.fixture
-def environment_admin_via_user_permission_group(  # type: ignore[no-untyped-def]
-    user_environment_permission_group, test_user, user_permission_group
-):
-    user_permission_group.users.add(test_user)
+def environment_admin_via_user_permission_group(
+    user_environment_permission_group: UserPermissionGroupEnvironmentPermission,
+    staff_user: FFAdminUser,
+    user_permission_group: UserPermissionGroup,
+) -> UserPermissionGroupEnvironmentPermission:
+    user_permission_group.users.add(staff_user)
 
     user_environment_permission_group.admin = True
     user_environment_permission_group.save()
@@ -58,8 +71,10 @@ def environment_admin_via_user_permission_group(  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture
-def environment_permission_using_user_permission_group(  # type: ignore[no-untyped-def]
-    user_environment_permission_group, user_permission_group, test_user
-):
-    user_permission_group.users.add(test_user)
+def environment_permission_using_user_permission_group(
+    user_environment_permission_group: UserPermissionGroupEnvironmentPermission,
+    user_permission_group: UserPermissionGroup,
+    staff_user: FFAdminUser,
+) -> UserPermissionGroupEnvironmentPermission:
+    user_permission_group.users.add(staff_user)
     return user_environment_permission_group

--- a/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
+++ b/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
@@ -110,10 +110,7 @@ def test_get_permitted_environments_for_user_returns_correct_environment(
     # Next, let's give user some permissions using `user_permission`
     permissions_as_user = [VIEW_ENVIRONMENT, UPDATE_FEATURE_STATE]
     environment_permission_using_user_permission.permissions.add(
-        *[
-            PermissionModel.objects.get(key=permission)
-            for permission in permissions_as_user
-        ]
+        *PermissionModel.objects.filter(key__in=permissions_as_user)
     )
 
     # Next, let's assert that the environment is returned only for those permissions (and not for others).
@@ -134,10 +131,7 @@ def test_get_permitted_environments_for_user_returns_correct_environment(
         MANAGE_IDENTITIES,
     ]
     environment_permission_using_user_permission_group.permissions.add(
-        *[
-            PermissionModel.objects.get(key=permission)
-            for permission in permissions_as_group
-        ]
+        *PermissionModel.objects.filter(key__in=permissions_as_group)
     )
 
     # And assert again

--- a/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
+++ b/api/tests/unit/permissions/permission_service/test_get_permitted_environments_for_user.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 from common.environments.permissions import (
     MANAGE_IDENTITIES,
@@ -6,8 +8,19 @@ from common.environments.permissions import (
 )
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
-from environments.permissions.models import EnvironmentPermissionModel
+from environments.models import Environment
+from environments.permissions.models import (
+    EnvironmentPermissionModel,
+    UserEnvironmentPermission,
+)
+from permissions.models import PermissionModel
 from permissions.permission_service import get_permitted_environments_for_user
+from projects.models import (
+    Project,
+    UserPermissionGroupProjectPermission,
+    UserProjectPermission,
+)
+from users.models import FFAdminUser
 
 
 def test_get_permitted_environments_for_user_returns_all_environments_for_org_admin(  # type: ignore[no-untyped-def]
@@ -30,15 +43,21 @@ def test_get_permitted_environments_for_user_returns_all_environments_for_org_ad
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_get_permitted_environments_for_user_returns_all_the_environments_for_project_admin(  # type: ignore[no-untyped-def]  # noqa: E501
-    test_user, environment, project, project_admin, project_two_environment
-):
+def test_get_permitted_environments_for_user_returns_all_the_environments_for_project_admin(  # noqa: E501
+    staff_user: FFAdminUser,
+    environment: Environment,
+    project: Project,
+    project_admin: typing.Union[
+        UserProjectPermission, UserPermissionGroupProjectPermission
+    ],
+    project_two_environment: Environment,
+) -> None:
     for permission in EnvironmentPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
         # Then
         assert (
-            get_permitted_environments_for_user(test_user, project, permission).count()
+            get_permitted_environments_for_user(staff_user, project, permission).count()
             == 1
         )
 
@@ -50,53 +69,75 @@ def test_get_permitted_environments_for_user_returns_all_the_environments_for_pr
         (lazy_fixture("environment_admin_via_user_permission_group")),
     ],
 )
-def test_get_permitted_environments_for_user_returns_the_environment_for_environment_admin(  # type: ignore[no-untyped-def]  # noqa: E501
-    test_user, environment, project, environment_admin, project_two_environment
-):
+def test_get_permitted_environments_for_user_returns_the_environment_for_environment_admin(  # noqa: E501
+    staff_user: FFAdminUser,
+    environment: Environment,
+    project: Project,
+    environment_admin: typing.Union[
+        UserEnvironmentPermission, UserPermissionGroupProjectPermission
+    ],
+    project_two_environment: Environment,
+) -> None:
     for permission in EnvironmentPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
         # Then
         assert (
-            get_permitted_environments_for_user(test_user, project, permission).count()
+            get_permitted_environments_for_user(staff_user, project, permission).count()
             == 1
         )
 
 
-def test_get_permitted_environments_for_user_returns_correct_environment(  # type: ignore[no-untyped-def]
-    test_user,
-    environment,
-    project_two_environment,
-    project,
-    environment_permission_using_user_permission,
-    environment_permission_using_user_permission_group,
-):
+def test_get_permitted_environments_for_user_returns_correct_environment(
+    staff_user: FFAdminUser,
+    environment: Environment,
+    project_two_environment: Environment,
+    project: Project,
+    view_environment_permission: PermissionModel,
+    update_feature_state_permission: PermissionModel,
+    manage_identities_permission: PermissionModel,
+    environment_permission_using_user_permission: UserEnvironmentPermission,
+    environment_permission_using_user_permission_group: UserPermissionGroupProjectPermission,
+) -> None:
     # First, let's assert that the user does not have access to any environment
     for permission in EnvironmentPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
         assert (
-            get_permitted_environments_for_user(test_user, project, permission).count()
+            get_permitted_environments_for_user(staff_user, project, permission).count()
             == 0
         )
     # Next, let's give user some permissions using `user_permission`
     permissions_as_user = [VIEW_ENVIRONMENT, UPDATE_FEATURE_STATE]
-    environment_permission_using_user_permission.permissions.add(*permissions_as_user)
+    environment_permission_using_user_permission.permissions.add(
+        *[
+            PermissionModel.objects.get(key=permission)
+            for permission in permissions_as_user
+        ]
+    )
 
     # Next, let's assert that the environment is returned only for those permissions (and not for others).
     for permission in EnvironmentPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
         environment_count = get_permitted_environments_for_user(
-            test_user, project, permission
+            staff_user, project, permission
         ).count()
 
-        assert environment_count == 0 if permission not in permissions_as_user else 1
+        assert environment_count == 0 if permission not in permissions_as_user else 1, (
+            f"Failed for permission {permission}"
+        )
 
     # Next, let's give some more permissions using `user_permission_group`
-    permissions_as_group = [UPDATE_FEATURE_STATE, MANAGE_IDENTITIES]
+    permissions_as_group = [
+        UPDATE_FEATURE_STATE,
+        MANAGE_IDENTITIES,
+    ]
     environment_permission_using_user_permission_group.permissions.add(
-        *permissions_as_group
+        *[
+            PermissionModel.objects.get(key=permission)
+            for permission in permissions_as_group
+        ]
     )
 
     # And assert again
@@ -104,7 +145,7 @@ def test_get_permitted_environments_for_user_returns_correct_environment(  # typ
         "key", flat=True
     ):
         environment_count = get_permitted_environments_for_user(
-            test_user, project, permission
+            staff_user, project, permission
         ).count()
 
         assert (

--- a/api/tests/unit/permissions/permission_service/test_get_permitted_projects_for_user.py
+++ b/api/tests/unit/permissions/permission_service/test_get_permitted_projects_for_user.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 from common.projects.permissions import (
     CREATE_ENVIRONMENT,
@@ -6,8 +8,15 @@ from common.projects.permissions import (
 )
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
+from permissions.models import PermissionModel
 from permissions.permission_service import get_permitted_projects_for_user
-from projects.models import ProjectPermissionModel
+from projects.models import (
+    Project,
+    ProjectPermissionModel,
+    UserPermissionGroupProjectPermission,
+    UserProjectPermission,
+)
+from users.models import FFAdminUser
 
 
 def test_get_permitted_projects_for_user_returns_all_projects_for_org_admin(  # type: ignore[no-untyped-def]
@@ -27,37 +36,47 @@ def test_get_permitted_projects_for_user_returns_all_projects_for_org_admin(  # 
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_get_permitted_projects_for_user_returns_the_project_for_project_admin(  # type: ignore[no-untyped-def]
-    test_user, project, project_admin, project_two
-):
+def test_get_permitted_projects_for_user_returns_the_project_for_project_admin(
+    staff_user: FFAdminUser,
+    project: Project,
+    project_admin: typing.Union[
+        UserProjectPermission, UserPermissionGroupProjectPermission
+    ],
+    project_two: Project,
+) -> None:
     for permission in ProjectPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
         # Then
-        assert get_permitted_projects_for_user(test_user, permission).count() == 1
+        assert get_permitted_projects_for_user(staff_user, permission).count() == 1
 
 
-def test_get_permitted_projects_for_user_returns_correct_project(  # type: ignore[no-untyped-def]
-    test_user,
-    project,
-    project_permission_using_user_permission,
-    project_permission_using_user_permission_group,
-):
+def test_get_permitted_projects_for_user_returns_correct_project(
+    staff_user: FFAdminUser,
+    project: Project,
+    view_project_permission: PermissionModel,
+    create_environment_permission: PermissionModel,
+    delete_feature_permission: PermissionModel,
+    project_permission_using_user_permission: UserProjectPermission,
+    project_permission_using_user_permission_group: UserPermissionGroupProjectPermission,
+) -> None:
     # First, let's assert that the user does not have access to any project
     for permission in ProjectPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
-        assert get_permitted_projects_for_user(test_user, permission).count() == 0
+        assert get_permitted_projects_for_user(staff_user, permission).count() == 0
 
     # Next, let's give user some permissions using `user_permission`
-    project_permission_using_user_permission.permissions.add(VIEW_PROJECT)
-    project_permission_using_user_permission.permissions.add(CREATE_ENVIRONMENT)
+    project_permission_using_user_permission.permissions.add(view_project_permission)
+    project_permission_using_user_permission.permissions.add(
+        create_environment_permission
+    )
 
     # Next, let's assert that the project is returned only for those permissions (and not for others).
     for permission in ProjectPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
-        project_count = get_permitted_projects_for_user(test_user, permission).count()
+        project_count = get_permitted_projects_for_user(staff_user, permission).count()
 
         assert (
             project_count == 0
@@ -66,14 +85,18 @@ def test_get_permitted_projects_for_user_returns_correct_project(  # type: ignor
         )
 
     # Next, let's give some more permissions using `user_permission_group`
-    project_permission_using_user_permission_group.permissions.add(CREATE_ENVIRONMENT)
-    project_permission_using_user_permission_group.permissions.add(DELETE_FEATURE)
+    project_permission_using_user_permission_group.permissions.add(
+        create_environment_permission
+    )
+    project_permission_using_user_permission_group.permissions.add(
+        delete_feature_permission
+    )
 
     # And assert again
     for permission in ProjectPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
-        project_count = get_permitted_projects_for_user(test_user, permission).count()
+        project_count = get_permitted_projects_for_user(staff_user, permission).count()
 
         assert (
             project_count == 0

--- a/api/tests/unit/permissions/permission_service/test_is_user_environment_admin.py
+++ b/api/tests/unit/permissions/permission_service/test_is_user_environment_admin.py
@@ -1,7 +1,16 @@
+import typing
+
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
+from environments.models import Environment
+from environments.permissions.models import (
+    UserEnvironmentPermission,
+    UserPermissionGroupEnvironmentPermission,
+)
 from permissions.permission_service import is_user_environment_admin
+from projects.models import UserPermissionGroupProjectPermission, UserProjectPermission
+from users.models import FFAdminUser
 
 
 def test_is_user_environment_admin_returns_true_for_org_admin(admin_user, environment):  # type: ignore[no-untyped-def]  # noqa: E501
@@ -15,11 +24,15 @@ def test_is_user_environment_admin_returns_true_for_org_admin(admin_user, enviro
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_is_user_environment_admin_returns_true_for_project_admin(  # type: ignore[no-untyped-def]
-    test_user, environment, project_admin
-):
+def test_is_user_environment_admin_returns_true_for_project_admin(
+    staff_user: FFAdminUser,
+    environment: Environment,
+    project_admin: typing.Union[
+        UserProjectPermission, UserPermissionGroupProjectPermission
+    ],
+) -> None:
     # Then
-    assert is_user_environment_admin(test_user, environment) is True
+    assert is_user_environment_admin(staff_user, environment) is True
 
 
 @pytest.mark.parametrize(
@@ -30,17 +43,21 @@ def test_is_user_environment_admin_returns_true_for_project_admin(  # type: igno
     ],
 )
 def test_is_user_environment_admin_returns_true_for_environment_admin(  # type: ignore[no-untyped-def]
-    test_user, environment, environment_admin
+    staff_user: FFAdminUser,
+    environment: Environment,
+    environment_admin: typing.Union[
+        UserEnvironmentPermission, UserPermissionGroupEnvironmentPermission
+    ],
 ):
     # Then
-    assert is_user_environment_admin(test_user, environment) is True
+    assert is_user_environment_admin(staff_user, environment) is True
 
 
-def test_is_user_environment_admin_returns_false_for_user_with_no_permission(  # type: ignore[no-untyped-def]
-    test_user,
-    environment,
-):
-    assert is_user_environment_admin(test_user, environment) is False
+def test_is_user_environment_admin_returns_false_for_user_with_no_permission(
+    staff_user: FFAdminUser,
+    environment: Environment,
+) -> None:
+    assert is_user_environment_admin(staff_user, environment) is False
 
 
 def test_is_user_environment_admin_returns_false_for_user_with_admin_permission_of_other_org(  # type: ignore[no-untyped-def]  # noqa: E501

--- a/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
+++ b/api/tests/unit/permissions/permission_service/test_is_user_project_admin.py
@@ -1,7 +1,15 @@
+import typing
+
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from permissions.permission_service import is_user_project_admin
+from projects.models import (
+    Project,
+    UserPermissionGroupProjectPermission,
+    UserProjectPermission,
+)
+from users.models import FFAdminUser
 
 
 def test_is_user_project_admin_returns_true_for_org_admin(admin_user, project):  # type: ignore[no-untyped-def]
@@ -15,20 +23,22 @@ def test_is_user_project_admin_returns_true_for_org_admin(admin_user, project): 
         (lazy_fixture("project_admin_via_user_permission_group")),
     ],
 )
-def test_is_user_project_admin_returns_true_for_project_admin(  # type: ignore[no-untyped-def]
-    test_user,
-    project,
-    project_admin,
-):
+def test_is_user_project_admin_returns_true_for_project_admin(
+    staff_user: FFAdminUser,
+    project: Project,
+    project_admin: typing.Union[
+        UserProjectPermission, UserPermissionGroupProjectPermission
+    ],
+) -> None:
     # Then
-    assert is_user_project_admin(test_user, project) is True
+    assert is_user_project_admin(staff_user, project) is True
 
 
-def test_is_user_project_admin_returns_false_for_user_with_no_permission(  # type: ignore[no-untyped-def]
-    test_user,
-    project,
-):
-    assert is_user_project_admin(test_user, project) is False
+def test_is_user_project_admin_returns_false_for_user_with_no_permission(
+    staff_user: FFAdminUser,
+    project: Project,
+) -> None:
+    assert is_user_project_admin(staff_user, project) is False
 
 
 def test_is_user_project_admin_returns_false_for_user_with_admin_permission_of_other_org(  # type: ignore[no-untyped-def]  # noqa: E501

--- a/api/tests/unit/permissions/permission_service/test_user_has_organisation_permissions.py
+++ b/api/tests/unit/permissions/permission_service/test_user_has_organisation_permissions.py
@@ -1,3 +1,4 @@
+from organisations.models import Organisation
 from organisations.permissions.models import (
     OrganisationPermissionModel,
     UserOrganisationPermission,
@@ -8,16 +9,18 @@ from organisations.permissions.permissions import (
     MANAGE_USER_GROUPS,
 )
 from permissions.permission_service import user_has_organisation_permission
+from users.models import FFAdminUser, UserPermissionGroup
 
 
-def test_user_has_organisation_permission_returns_false_if_user_does_not_have_permission(  # type: ignore[no-untyped-def]  # noqa: E501
-    test_user, organisation
-):
+def test_user_has_organisation_permission_returns_false_if_user_does_not_have_permission(
+    staff_user: FFAdminUser,
+    organisation: Organisation,
+) -> None:
     for permission in OrganisationPermissionModel.objects.all().values_list(
         "key", flat=True
     ):
         assert (
-            user_has_organisation_permission(test_user, organisation, permission)
+            user_has_organisation_permission(staff_user, organisation, permission)
             is False
         )
 
@@ -34,32 +37,34 @@ def test_user_has_organisation_permission_returns_true_if_user_is_admin(  # type
         )
 
 
-def test_user_has_organisation_permission_returns_true_if_user_has_permission_directly(  # type: ignore[no-untyped-def]  # noqa: E501
-    test_user, organisation
-):
+def test_user_has_organisation_permission_returns_true_if_user_has_permission_directly(
+    staff_user: FFAdminUser, organisation: Organisation
+) -> None:
     # Given
     user_org_permission = UserOrganisationPermission.objects.create(
-        user=test_user, organisation=organisation
+        user=staff_user, organisation=organisation
     )
     user_org_permission.permissions.add(CREATE_PROJECT)  # type: ignore[arg-type]
     user_org_permission.permissions.add(MANAGE_USER_GROUPS)  # type: ignore[arg-type]
 
     # Then
     assert (
-        user_has_organisation_permission(test_user, organisation, CREATE_PROJECT)
+        user_has_organisation_permission(staff_user, organisation, CREATE_PROJECT)
         is True
     )
     assert (
-        user_has_organisation_permission(test_user, organisation, MANAGE_USER_GROUPS)
+        user_has_organisation_permission(staff_user, organisation, MANAGE_USER_GROUPS)
         is True
     )
 
 
-def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group(  # type: ignore[no-untyped-def]  # noqa: E501
-    test_user, organisation, user_permission_group
-):
+def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group(
+    staff_user: FFAdminUser,
+    organisation: Organisation,
+    user_permission_group: UserPermissionGroup,
+) -> None:
     # Given
-    user_permission_group.users.add(test_user)
+    user_permission_group.users.add(staff_user)
     user_perm_org_group = UserPermissionGroupOrganisationPermission.objects.create(
         group=user_permission_group, organisation=organisation
     )
@@ -67,37 +72,39 @@ def test_user_has_organisation_permission_returns_true_if_user_has_permission_vi
 
     # Then
     assert (
-        user_has_organisation_permission(test_user, organisation, CREATE_PROJECT)
+        user_has_organisation_permission(staff_user, organisation, CREATE_PROJECT)
         is True
     )
 
     assert (
-        user_has_organisation_permission(test_user, organisation, MANAGE_USER_GROUPS)
+        user_has_organisation_permission(staff_user, organisation, MANAGE_USER_GROUPS)
         is False
     )
 
 
-def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group_and_directly(  # type: ignore[no-untyped-def]  # noqa: E501
-    test_user, organisation, user_permission_group
-):
+def test_user_has_organisation_permission_returns_true_if_user_has_permission_via_group_and_directly(
+    staff_user: FFAdminUser,
+    organisation: Organisation,
+    user_permission_group: UserPermissionGroup,
+) -> None:
     # Given
-    user_permission_group.users.add(test_user)
+    user_permission_group.users.add(staff_user)
     user_perm_org_group = UserPermissionGroupOrganisationPermission.objects.create(
         group=user_permission_group, organisation=organisation
     )
     user_perm_org_group.permissions.add(CREATE_PROJECT)  # type: ignore[arg-type]
 
     user_org_permission = UserOrganisationPermission.objects.create(
-        user=test_user, organisation=organisation
+        user=staff_user, organisation=organisation
     )
     user_org_permission.permissions.add(MANAGE_USER_GROUPS)  # type: ignore[arg-type]
 
     # Then
     assert (
-        user_has_organisation_permission(test_user, organisation, CREATE_PROJECT)
+        user_has_organisation_permission(staff_user, organisation, CREATE_PROJECT)
         is True
     )
     assert (
-        user_has_organisation_permission(test_user, organisation, MANAGE_USER_GROUPS)
+        user_has_organisation_permission(staff_user, organisation, MANAGE_USER_GROUPS)
         is True
     )

--- a/api/tests/unit/users/test_unit_users_models.py
+++ b/api/tests/unit/users/test_unit_users_models.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from common.projects.permissions import VIEW_PROJECT
 from django.db.utils import IntegrityError
@@ -7,7 +9,7 @@ from organisations.permissions.models import UserOrganisationPermission
 from organisations.permissions.permissions import ORGANISATION_PERMISSIONS
 from projects.models import Project
 from tests.types import WithProjectPermissionsCallable
-from users.models import FFAdminUser
+from users.models import FFAdminUser, UserPermissionGroup
 
 
 def test_user_belongs_to_success(
@@ -154,15 +156,20 @@ def test_has_organisation_permission_is_false_when_user_does_not_have_permission
     )
 
 
-def test_user_add_organisation_adds_user_to_the_default_user_permission_group(  # type: ignore[no-untyped-def]
-    test_user, organisation, default_user_permission_group, user_permission_group
-):
+def test_user_add_organisation_adds_user_to_the_default_user_permission_group(
+    organisation: Organisation,
+    default_user_permission_group: UserPermissionGroup,
+    user_permission_group: UserPermissionGroup,
+) -> None:
+    # Given
+    user = FFAdminUser.objects.create(email=f"test{uuid.uuid4()}@example.com")
+
     # When
-    test_user.add_organisation(organisation, OrganisationRole.USER)
+    user.add_organisation(organisation, OrganisationRole.USER)
 
     # Then
-    assert default_user_permission_group in test_user.permission_groups.all()
-    assert user_permission_group not in test_user.permission_groups.all()
+    assert default_user_permission_group in user.permission_groups.all()
+    assert user_permission_group not in user.permission_groups.all()
 
 
 def test_user_remove_organisation_removes_user_from_the_user_permission_group(  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Changes

Refactor to combine staff_user and test_user fixtures which serve the same purpose as identified in #5865 . 

This PR only changes test code, no actual business logic is changing. The test code should behave in exactly the same way, I have just migrated from one fixture (which was removed in this PR) to another. Where I have modified tests, I have also added typing. 

## How did you test this code?

Existing unit tests. 
