### PR TITLE
feat: added-hosted-preferences-to-onboarding-data

### DIFF
--- a/api/tests/unit/custom_auth/test_unit_custom_auth_views.py
+++ b/api/tests/unit/custom_auth/test_unit_custom_auth_views.py
@@ -54,6 +54,18 @@ def test_get_current_user(staff_user: FFAdminUser, staff_client: APIClient) -> N
                 "tools": {"completed": True, "integrations": ["integration-1"]},
             },
         ),
+        (
+            {
+                "tasks": [{"name": "task-1"}],
+                "tools": {"completed": True, "integrations": ["integration-1"]},
+                "hosting_preferences": ["hosting-preference-1, hosting-preference-2"],
+            },
+            {
+                "tasks": [{"name": "task-1", "completed_at": "2025-01-01T12:00:00Z"}],
+                "tools": {"completed": True, "integrations": ["integration-1"]},
+                "hosting_preferences": ["hosting-preference-1, hosting-preference-2"],
+            },
+        ),
     ],
 )
 @freeze_time("2025-01-01T12:00:00Z")
@@ -96,6 +108,14 @@ def test_get_me_should_return_onboarding_object(
             },
             {"tasks", "tools"},
         ),
+        (
+            {
+                "tasks": [{"name": "task-1", "completed_at": "2024-01-01T12:00:00Z"}],
+                "tools": {"completed": True, "integrations": ["integration-1"]},
+                "hosting_preferences": ["hosting-preference-1, hosting-preference-2"],
+            },
+            {"tasks", "tools", "hosting_preferences"},
+        ),
     ],
 )
 def test_patch_user_onboarding_updates_only_nested_objects_if_provided(
@@ -128,7 +148,7 @@ def test_patch_user_onboarding_updates_only_nested_objects_if_provided(
         ).get("integrations")
 
 
-def test_patch_user_onboarding_returns_error_if_tasks_and_tools_are_missing(
+def test_patch_user_onboarding_returns_error_if_preferences_tasks_and_tools_are_missing(
     staff_user: FFAdminUser,
     staff_client: APIClient,
 ) -> None:
@@ -141,7 +161,9 @@ def test_patch_user_onboarding_returns_error_if_tasks_and_tools_are_missing(
     # Then
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json() == {
-        "non_field_errors": ["At least one of 'tasks' or 'tools' must be provided."]
+        "non_field_errors": [
+            "At least one of 'tasks' or 'tools' or 'hosting_preferences' must be provided."
+        ]
     }
 
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -179,11 +179,18 @@ class OnboardingTaskSerializer(serializers.Serializer[None]):
 class PatchOnboardingSerializer(serializers.Serializer[None]):
     tasks = OnboardingTaskSerializer(many=True, required=False)
     tools = OnboardingToolsSerializer(required=False)
+    hosting_preferences = serializers.ListField(
+        child=serializers.CharField(), required=False, allow_empty=True
+    )
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
-        if "tasks" not in data and "tools" not in data:
+        if (
+            "tasks" not in data
+            and "tools" not in data
+            and "hosting_preferences" not in data
+        ):
             raise serializers.ValidationError(
-                "At least one of 'tasks' or 'tools' must be provided."
+                "At least one of 'tasks' or 'tools' or 'hosting_preferences' must be provided."
             )
         return data
 
@@ -191,6 +198,9 @@ class PatchOnboardingSerializer(serializers.Serializer[None]):
 class OnboardingResponseTypeSerializer(serializers.Serializer[None]):
     tasks = OnboardingTaskSerializer(many=True, required=False, default=list)
     tools = OnboardingToolsSerializer(required=False)
+    hosting_preferences = serializers.ListField(
+        child=serializers.CharField(), required=False, allow_empty=True
+    )
 
 
 class CustomCurrentUserSerializer(DjoserUserSerializer):  # type: ignore[misc]


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Related to #5806 
In order to save the hosting preferences in the onboarding object

## How did you test this code?
- Added tests
- Postman requests

Exemple request (each item is removable):

`PATCH http://localhost:8000/api/v1/auth/users/me/onboarding/`
```
// body

{
    "tasks": [
        {
            "name": "test-view-doc"
        },
        {
            "name": "create_project",
            "completed_at": "2025-05-27T14:00:00Z"
        }
    ],
    "tools": {
        "completed": true,
        "integrations": [
            "mine",
            "craft"
        ]
    },
    "hosting_preferences": [
        "hello",
        "yolo"
    ]
}
```