### PR TITLE
test: add new fixture to clear content type cache

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1301,6 +1301,6 @@ def enable_features(
 
 
 @pytest.fixture(autouse=True)
-def clear_content_type_cache(db: None) -> typing.Generator[None]:
+def clear_content_type_cache(db: None) -> typing.Generator[None, None, None]:
     yield
     ContentType.objects.clear_cache()

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1298,3 +1298,9 @@ def enable_features(
         )
 
     return _enable_features
+
+
+@pytest.fixture(autouse=True)
+def clear_content_type_cache(db: None) -> typing.Generator[None]:
+    yield
+    ContentType.objects.clear_cache()

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1301,6 +1301,6 @@ def enable_features(
 
 
 @pytest.fixture(autouse=True)
-def clear_content_type_cache(db: None) -> typing.Generator[None, None, None]:
+def clear_content_type_cache() -> typing.Generator[None, None, None]:
     yield
     ContentType.objects.clear_cache()

--- a/api/tests/unit/features/test_unit_features_views.py
+++ b/api/tests/unit/features/test_unit_features_views.py
@@ -2866,7 +2866,7 @@ def test_list_features_n_plus_1_without_rbac(
         with_project_permissions,
         django_assert_num_queries,
         environment,
-        num_queries=16,
+        num_queries=17,
     )
 
 
@@ -2889,7 +2889,7 @@ def test_list_features_n_plus_1_with_rbac(
         with_project_permissions,
         django_assert_num_queries,
         environment,
-        num_queries=17,
+        num_queries=18,
     )
 
 
@@ -3416,7 +3416,7 @@ def test_feature_list_last_modified_values_without_rbac(
         feature,
         with_project_permissions,
         django_assert_num_queries,
-        num_queries=18,
+        num_queries=19,
     )
 
 
@@ -3442,7 +3442,7 @@ def test_feature_list_last_modified_values_with_rbac(
         feature,
         with_project_permissions,
         django_assert_num_queries,
-        num_queries=19,
+        num_queries=20,
     )
 
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/Flagsmith/flagsmith/issues/4898

## How did you test this code?

Since this issue seemed to primarily affect the test `test_list_features_n_plus_1_without_rbac`, I've verified that (with these changes), this test now passes when run on its own and as part of the wider test suite. 
