### PR TITLE
fix: Organisation usage charts are not correctly showing environment-document requests

### DIFF
--- a/api/app_analytics/mappers.py
+++ b/api/app_analytics/mappers.py
@@ -91,10 +91,12 @@ def map_flux_tables_to_usage_data(
                     day=date,
                     labels=labels,
                 )
-            if resource := values.get("resource"):
+            if (resource := Resource.get_from_name(values["resource"])) and (
+                resource_attr := resource.column_name
+            ):
                 setattr(
                     data_by_key[key],
-                    resource,
+                    resource_attr,
                     values["_value"],
                 )
     return list(data_by_key.values())


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Fixes #5886. The problem was in the mapper code.

## How did you test this code?

Added a unit test making sure the correct usage data is returned.