### PR TITLE
fix(env-update): make is_creating read only

### DIFF
--- a/api/environments/serializers.py
+++ b/api/environments/serializers.py
@@ -58,7 +58,10 @@ class EnvironmentSerializerLight(serializers.ModelSerializer):  # type: ignore[t
             "use_identity_overrides_in_local_eval",
             "is_creating",
         )
-        read_only_fields = ("use_v2_feature_versioning",)
+        read_only_fields = (
+            "use_v2_feature_versioning",
+            "is_creating",
+        )
 
     def get_use_mv_v2_evaluation(self, instance: Environment) -> bool:
         """
@@ -104,7 +107,6 @@ class EnvironmentRetrieveSerializerWithMetadata(EnvironmentSerializerWithMetadat
         fields = EnvironmentSerializerWithMetadata.Meta.fields + (  # type: ignore[has-type]
             "total_segment_overrides",
         )
-        read_only_fields = ("total_segment_overrides",)
 
 
 class CreateUpdateEnvironmentSerializer(

--- a/api/tests/unit/environments/test_unit_environments_views.py
+++ b/api/tests/unit/environments/test_unit_environments_views.py
@@ -965,6 +965,30 @@ def test_audit_log_entry_created_when_environment_updated(
     )
 
 
+def test_environment_update_cannot_change_is_creating(
+    environment: Environment, project: Project, admin_client_new: APIClient
+) -> None:
+    # Given
+    environment = Environment.objects.create(name="Test environment", project=project)
+    assert environment.is_creating is False
+    url = reverse("api-v1:environments:environment-detail", args=[environment.api_key])
+
+    data = {
+        "project": project.id,
+        "name": "New name",
+        "is_creating": True,
+    }
+
+    # When
+    response = admin_client_new.put(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    # Then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["is_creating"] is False
+
+
 def test_get_document(
     environment: Environment,
     project: Project,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Make `is_creating` a read-only field because a user should not be allowed to update it.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Add unit test
