### PR TITLE
fix(usage-notifications): construct the variable outside of template

### DIFF
--- a/api/organisations/task_helpers.py
+++ b/api/organisations/task_helpers.py
@@ -31,6 +31,7 @@ def send_api_flags_blocked_notification(organisation: Organisation) -> None:
     context = {
         "organisation": organisation,
         "grace_period": not hasattr(organisation, "breached_grace_period"),
+        "usage_url": f"{url}/organisation/{organisation.id}/usage",
         "url": url,
     }
     message = "organisations/api_flags_blocked_notification.txt"
@@ -77,7 +78,6 @@ def _send_api_usage_notification(
         "organisation": organisation,
         "matched_threshold": matched_threshold,
         "grace_period": not hasattr(organisation, "breached_grace_period"),
-        "url": url,
         "usage_url": f"{url}/organisation/{organisation.id}/usage",
     }
 

--- a/api/organisations/templates/organisations/api_flags_blocked_notification.html
+++ b/api/organisations/templates/organisations/api_flags_blocked_notification.html
@@ -17,9 +17,7 @@
 
         <tr>
           <td>
-             {% with usage_url="{{ url }}/organisation/{{ organisation.id | urlencode }}/usage" %}
-                 You can view the details of your organisation's API usage at <a href="{{ usage_url }}">{{ usage_url }}</a>.
-             {% endwith %}
+             You can view the details of your organisation's API usage at <a href="{{ usage_url }}">{{ usage_url }}</a>.
           </td>
         </tr>
 

--- a/api/organisations/templates/organisations/api_flags_blocked_notification.txt
+++ b/api/organisations/templates/organisations/api_flags_blocked_notification.txt
@@ -2,9 +2,7 @@ Hi there,
 
 This is a system generated notification related to your Flagsmith API usage. As per previous warnings, we have had to block your organisation {{ organisation.name }} (ID: {{ organisation.id }}){% if grace_period %} after the 7 day grace period{% endif %}. Flags are not currently being served for your organisation, and it will continue to be blocked until your billing period resets or you upgrade your account. You can upgrade your account at {{ url }}.
 
-{% with usage_url="{{ url }}/organisation/{{ organisation.id | urlencode }}/usage" %}
-You can view the details of your organisation's API usage at <a href="{{ usage_url }}">{{ usage_url }}</a>.
-{% endwith %}
+You can view the details of your organisation's API usage at {{ usage_url }}.
 
 Thank you!
 

--- a/api/organisations/templates/organisations/api_usage_notification.txt
+++ b/api/organisations/templates/organisations/api_usage_notification.txt
@@ -11,9 +11,7 @@ Please note that once 100% use has been breached, the serving of feature flags a
 after a 7-day grace period{% endif %}. Please reach out to support@flagsmith.com in order to upgrade your account.
 {% endif %}
 
-{% with usage_url="{{ url }}/organisation/{{ organisation.id | urlencode }}/usage" %}
-You can view the details of your organisation's API usage at {{ url }}/organisation/{{ organisation.id }}/usage.
-{% endwith %}
+You can view the details of your organisation's API usage at {{ usage_url }}.
 
 Thank you!
 

--- a/api/organisations/templates/organisations/api_usage_notification_limit.html
+++ b/api/organisations/templates/organisations/api_usage_notification_limit.html
@@ -22,9 +22,7 @@
                  organisation's account (see pricing page).
                  {% endif %}
 
-                 {% with usage_url="{{ url }}/organisation/{{ organisation.id | urlencode }}/usage" %}
                  You can view the details of your organisation's API usage at <a href="{{ usage_url }}">{{ usage_url }}</a>.
-                 {% endwith %}
                </td>
 
 

--- a/api/tests/unit/organisations/test_unit_organisations_tasks.py
+++ b/api/tests/unit/organisations/test_unit_organisations_tasks.py
@@ -482,7 +482,6 @@ def test_handle_api_usage_notifications_below_100(
         context={
             "organisation": organisation,
             "matched_threshold": 90,
-            "url": get_current_site_url(),
             "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
@@ -496,7 +495,6 @@ def test_handle_api_usage_notifications_below_100(
         context={
             "organisation": organisation,
             "matched_threshold": 90,
-            "url": get_current_site_url(),
             "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
@@ -633,7 +631,6 @@ def test_handle_api_usage_notifications_above_100(
         context={
             "organisation": organisation,
             "matched_threshold": 100,
-            "url": get_current_site_url(),
             "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
@@ -641,13 +638,11 @@ def test_handle_api_usage_notifications_above_100(
     assert len(email.alternatives) == 1
     assert len(email.alternatives[0]) == 2
     assert email.alternatives[0][1] == "text/html"
-
     assert email.alternatives[0][0] == render_to_string(
         "organisations/api_usage_notification_limit.html",
         context={
             "organisation": organisation,
             "matched_threshold": 100,
-            "url": get_current_site_url(),
             "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
         },
     )
@@ -1803,13 +1798,21 @@ def test_restrict_use_due_to_api_limit_grace_period_over(
     assert email1.subject == "Flagsmith API use has been blocked due to overuse"
     assert email1.body == render_to_string(
         "organisations/api_flags_blocked_notification.txt",
-        context={"organisation": organisation, "url": get_current_site_url()},
+        context={
+            "organisation": organisation,
+            "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation.id}/usage",
+        },
     )
     email2 = mailoutbox[1]
     assert email2.subject == "Flagsmith API use has been blocked due to overuse"
     assert email2.body == render_to_string(
         "organisations/api_flags_blocked_notification.txt",
-        context={"organisation": organisation2, "url": get_current_site_url()},
+        context={
+            "organisation": organisation2,
+            "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation2.id}/usage",
+        },
     )
 
     assert len(email2.alternatives) == 1
@@ -1822,6 +1825,7 @@ def test_restrict_use_due_to_api_limit_grace_period_over(
             "organisation": organisation2,
             "grace_period": False,
             "url": get_current_site_url(),
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation2.id}/usage",
         },
     )
     assert email2.from_email == "noreply@flagsmith.com"
@@ -1838,6 +1842,7 @@ def test_restrict_use_due_to_api_limit_grace_period_over(
         context={
             "organisation": organisation6,
             "grace_period": False,
+            "usage_url": f"{get_current_site_url()}/organisation/{organisation6.id}/usage",
             "url": get_current_site_url(),
         },
     )


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
Pass `usage_url` directly to all templates to avoid (incorrectly) constructing it in the template

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Tested manually to make sure all the rendered templates don’t have any unrendered tags.

