### PR TITLE
fix: remove extra close modal call

### DIFF
--- a/frontend/bin/upload-file.js
+++ b/frontend/bin/upload-file.js
@@ -7,22 +7,25 @@ const SLACK_TOKEN = process.env.SLACK_TOKEN
 module.exports = function uploadFile(path) {
   if (!SLACK_TOKEN) {
     // eslint-disable-next-line
-        console.log('Slack token not specified, skipping upload');
+    console.log('Slack token not specified, skipping upload');
     return
   }
 
   const title = 'Test Run' // Optional
+  const epoch = new Date().valueOf()
+  const filename = `e2e-record-${epoch}.mp4`
   const channelId = 'C0102JZRG3G' // infra_tests channel ID
-
   // eslint-disable-next-line
-    console.log(`Uploading ${path}`);
+  console.log(`Uploading ${path}`);
 
-  const slackClient = new WebClient(process.env.SLACK_TOKEN)
+  const slackClient = new WebClient(SLACK_TOKEN)
 
   // Call the files.upload method using the WebClient
-  return slackClient.files.upload({
-    channels: channelId,
+  return slackClient.files.uploadV2({
+    channel_id: channelId,
     file: fs.createReadStream(path),
+    filename,
     initial_comment: `${title} ${process.env.GITHUB_ACTION_URL || ''}`,
   })
 }
+new Date().valueOf()

--- a/frontend/bin/upload-file.js
+++ b/frontend/bin/upload-file.js
@@ -25,7 +25,7 @@ module.exports = function uploadFile(path) {
     channel_id: channelId,
     file: fs.createReadStream(path),
     filename,
-    initial_comment: `${title} ${process.env.GITHUB_ACTION_URL || ''}`,
+    initial_comment: `✖ ${title} ${process.env.GITHUB_ACTION_URL || ''}`,
   })
 }
 new Date().valueOf()

--- a/frontend/e2e/tests/segment-test.ts
+++ b/frontend/e2e/tests/segment-test.ts
@@ -102,7 +102,6 @@ export const testSegment1 = async (flagsmith: any) => {
   await gotoSegments()
   const lastRule = segmentRules[segmentRules.length - 1]
   await createSegment(0, 'segment_to_update', [lastRule])
-  await closeModal()
   await click(byId('segment-0-name'))
   await setSegmentRule(0, 0, lastRule.name, lastRule.operator, lastRule.value + 1)
   await click(byId('update-segment'))


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Slack reporter showcased that after creating the segment, the test suite was on environments page (due to 2 close modal clicks)
- close modal click absolute on the left of the screen... it happened to be on the navbar
https://flagsmith.slack.com/archives/C0102JZRG3G/p1756106306162259

## How did you test this code?

