### PR TITLE
chore(evaluation-context): Support `string[]` as condition value for the `IN` operator

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -171,47 +171,74 @@
             "type": "object"
         },
         "SegmentCondition": {
-            "description": "Represents a condition within a segment rule for feature flag evaluation.",
-            "properties": {
-                "property": {
-                    "description": "A reference to the identity trait or value in the evaluation context.",
-                    "title": "Property",
-                    "type": "string"
+            "anyOf": [
+                {
+                    "description": "Represents a condition within a segment rule for feature flag evaluation.",
+                    "properties": {
+                        "property": {
+                            "description": "A reference to the identity trait or value in the evaluation context.",
+                            "title": "Property",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "description": "The operator to use for evaluating the condition.",
+                            "title": "Operator",
+                            "type": "string",
+                            "enum": [
+                                "EQUAL",
+                                "GREATER_THAN",
+                                "LESS_THAN",
+                                "LESS_THAN_INCLUSIVE",
+                                "CONTAINS",
+                                "GREATER_THAN_INCLUSIVE",
+                                "NOT_CONTAINS",
+                                "NOT_EQUAL",
+                                "REGEX",
+                                "PERCENTAGE_SPLIT",
+                                "MODULO",
+                                "IS_SET",
+                                "IS_NOT_SET",
+                                "IN"
+                            ]
+                        },
+                        "value": {
+                            "description": "The value to compare against the trait or context value.",
+                            "title": "Value",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "property",
+                        "operator",
+                        "value"
+                    ],
+                    "title": "SegmentCondition",
+                    "type": "object"
                 },
-                "operator": {
-                    "description": "The operator to use for evaluating the condition.",
-                    "title": "Operator",
-                    "type": "string",
-                    "enum": [
-                        "EQUAL",
-                        "GREATER_THAN",
-                        "LESS_THAN",
-                        "LESS_THAN_INCLUSIVE",
-                        "CONTAINS",
-                        "GREATER_THAN_INCLUSIVE",
-                        "NOT_CONTAINS",
-                        "NOT_EQUAL",
-                        "REGEX",
-                        "PERCENTAGE_SPLIT",
-                        "MODULO",
-                        "IS_SET",
-                        "IS_NOT_SET",
-                        "IN"
-                    ]
-                },
-                "value": {
-                    "description": "The value to compare against the trait or context value.",
-                    "title": "Value",
-                    "type": "string"
+                {
+                    "description": "Represents an IN condition within a segment rule for feature flag evaluation.",
+                    "properties": {
+                        "property": {
+                            "description": "A reference to the identity trait or value in the evaluation context.",
+                            "title": "Property",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "description": "The operator to use for evaluating the condition.",
+                            "title": "Operator",
+                            "const": "IN"
+                        },
+                        "value": {
+                            "description": "The values to compare against the trait or context value.",
+                            "title": "Value",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
-            },
-            "required": [
-                "property",
-                "operator",
-                "value"
-            ],
-            "title": "SegmentCondition",
-            "type": "object"
+            ]
         },
         "SegmentRule": {
             "description": "Represents a rule within a segment for feature flag evaluation.",

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -236,7 +236,14 @@
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "required": [
+                        "property",
+                        "operator",
+                        "value"
+                    ],
+                    "title": "InSegmentCondition",
+                    "type": "object"
                 }
             ]
         },


### PR DESCRIPTION
Closes #5935.

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This adds `string[]` support just for the `IN` operator to the engine evaluation context schema.

## How did you test this code?

Used jsonschema.dev to validate the following test data:

```json
{
  "environment": {
    "key": "",
    "name": ""
  },
  "segments": {
    "1": {
      "key": "",
      "name": "",
      "rules": [
        {
          "type": "ALL",
          "conditions": [
            {
              "property": "foo",
              "operator": "IN",
              "value": "my1,my2"
            },
             {
              "property": "foo",
              "operator": "IN",
              "value": ["my1", "my2"]
            }
          ]
        }
      ]
    }
  }
}
```