### PR TITLE
Enable explicit rules and conditions ordering in production

### DIFF
--- a/infrastructure/aws/production/ecs-task-definition-web.json
+++ b/infrastructure/aws/production/ecs-task-definition-web.json
@@ -198,7 +198,7 @@
                     "value": "https://edge.api.flagsmith.com/api/v1/"
                 },
                 {
-                    "name": "SEGMENT_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
+                    "name": "SEGMENT_RULES_CONDITIONS_EXPLICIT_ORDERING_ENABLED",
                     "value": "True"
                 }
             ],


### PR DESCRIPTION
## Changes

As per agreement, and customer notification, this PR enables explicit ordering for segment rules and conditions, resolving issues with segment rules being reordered after save. 

## How did you test this code?

Previously enabled this value in production for a short window and verified that the ordering was consistent. 
