### PR TITLE
fix(GitHub PoC): Fix permalinks

### DIFF
--- a/api/projects/code_references/services.py
+++ b/api/projects/code_references/services.py
@@ -151,7 +151,8 @@ def _get_permalink(
     match provider:
         case VCSProvider.GITHUB:
             return urljoin(
-                repository_url, f"blob/{revision}/{file_path}#L{line_number}"
+                f"{repository_url}/",
+                f"blob/{revision}/{file_path}#L{line_number}",
             )
     raise NotImplementedError(  # pragma: no cover
         f"Permalink generation for {provider} is not implemented."

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_services.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_services.py
@@ -32,8 +32,8 @@ def test_get_permalink_generates_valid_public_github_url(
 @pytest.mark.parametrize(
     "repository_url",
     [
-        "https://github.flagsmith.com/backend",
-        "https://github.flagsmith.com/backend/",  # with trailing slash
+        "https://github.flagsmith.com/flagsmith/backend",
+        "https://github.flagsmith.com/flagsmith/backend/",  # with trailing slash
     ],
 )
 def test_get_permalink_generates_valid_private_github_url(
@@ -50,5 +50,5 @@ def test_get_permalink_generates_valid_private_github_url(
 
     # Then
     assert result == (
-        "https://github.flagsmith.com/backend/blob/revision-hash/path/to/file.py#L10"
+        "https://github.flagsmith.com/flagsmith/backend/blob/revision-hash/path/to/file.py#L10"
     )

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_services.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_services.py
@@ -1,0 +1,54 @@
+import pytest
+
+from projects.code_references.services import _get_permalink
+from projects.code_references.types import VCSProvider
+
+
+@pytest.mark.parametrize(
+    "repository_url",
+    [
+        "https://github.com/Flagsmith/flagsmith",
+        "https://github.com/Flagsmith/flagsmith/",  # with trailing slash
+    ],
+)
+def test_get_permalink_generates_valid_public_github_url(
+    repository_url: str,
+) -> None:
+    # When
+    result = _get_permalink(
+        provider=VCSProvider.GITHUB,
+        repository_url=repository_url,
+        revision="revision-hash",
+        file_path="path/to/file.py",
+        line_number=10,
+    )
+
+    # Then
+    assert result == (
+        "https://github.com/Flagsmith/flagsmith/blob/revision-hash/path/to/file.py#L10"
+    )
+
+
+@pytest.mark.parametrize(
+    "repository_url",
+    [
+        "https://github.flagsmith.com/backend",
+        "https://github.flagsmith.com/backend/",  # with trailing slash
+    ],
+)
+def test_get_permalink_generates_valid_private_github_url(
+    repository_url: str,
+) -> None:
+    # When
+    result = _get_permalink(
+        provider=VCSProvider.GITHUB,
+        repository_url=repository_url,
+        revision="revision-hash",
+        file_path="path/to/file.py",
+        line_number=10,
+    )
+
+    # Then
+    assert result == (
+        "https://github.flagsmith.com/backend/blob/revision-hash/path/to/file.py#L10"
+    )

--- a/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
+++ b/api/tests/unit/projects/code_references/test_unit_projects_code_references_views.py
@@ -185,7 +185,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_f
     with freezegun.freeze_time("2099-01-01T10:00:00-0300"):
         FeatureFlagCodeReferencesScan.objects.create(
             project=project,
-            repository_url="https://github.flagsmith.com/backend/",
+            repository_url="https://github.flagsmith.com/backend",
             revision="backend-1",
             code_references=[
                 {
@@ -197,7 +197,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_f
         )
         FeatureFlagCodeReferencesScan.objects.create(
             project=project,
-            repository_url="https://github.flagsmith.com/frontend/",
+            repository_url="https://github.flagsmith.com/frontend",
             revision="frontend-1",
             code_references=[
                 {
@@ -210,7 +210,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_f
     with freezegun.freeze_time("2099-01-02T11:00:00-0300"):
         FeatureFlagCodeReferencesScan.objects.create(
             project=project,
-            repository_url="https://github.flagsmith.com/frontend/",
+            repository_url="https://github.flagsmith.com/frontend",
             revision="frontend-2",
             code_references=[
                 {
@@ -235,7 +235,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_f
     assert response.status_code == 200
     assert response.json() == [
         {
-            "repository_url": "https://github.flagsmith.com/backend/",
+            "repository_url": "https://github.flagsmith.com/backend",
             "vcs_provider": "github",
             "revision": "backend-1",
             "last_successful_repository_scanned_at": "2099-01-01T13:00:00+00:00",
@@ -252,7 +252,7 @@ def test_FeatureCodeReferencesDetailAPIView__responds_200_with_code_references_f
             ],
         },
         {
-            "repository_url": "https://github.flagsmith.com/frontend/",
+            "repository_url": "https://github.flagsmith.com/frontend",
             "vcs_provider": "github",
             "revision": "frontend-2",
             "last_successful_repository_scanned_at": "2099-01-02T14:00:00+00:00",


### PR DESCRIPTION
Raised by @Zaimwa9.

> GitHub permalinks are incorrect, e.g.
> 
> ```
> https://github.com/Flagsmith/blob/eec9cfb9fda510ca267c594ac9b88bedebb9bf57/frontend/web/components/Announcement.tsx#L22
> ```

## Changes

Fix a bad `urljoin`.