### PR TITLE
fix(GitHub PoC): added-no-wrap-to-code-reference-item

### DIFF
--- a/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/CodeReferenceItem.tsx
+++ b/frontend/web/components/feature-page/FeatureNavTab/CodeReferences/components/CodeReferenceItem.tsx
@@ -9,7 +9,7 @@ const CodeReferenceItem: React.FC<CodeReferenceItemProps> = ({
   codeReference,
 }) => {
   return (
-    <Row className='flex items-center gap-1'>
+    <Row className='flex items-center gap-1' noWrap>
       <Icon
         name={'chevron-down'}
         className='w-4 h-4 transparent'


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- added no-wrap

## How did you test this code?
<img width="746" height="164" alt="image" src="https://github.com/user-attachments/assets/3ed465a2-ea09-483e-88a8-75dd090300af" />
