### PR TITLE
docs: remove beta caution for Datadog RUM SDK integration

### DIFF
--- a/docs/docs/clients/client-side/javascript.md
+++ b/docs/docs/clients/client-side/javascript.md
@@ -365,12 +365,6 @@ const font_size = flagsmith.getValue('font_size', { fallback: 12 });
 
 ## Datadog RUM JavaScript SDK Integration
 
-:::caution
-
-This feature is still in beta with Datadog. Contact your Datadog representative before enabling the integration below.
-
-:::
-
 The Flagsmith JavaScript SDK can be configured so that feature enabled state and remote config can be stored as
 [Datadog RUM feature flags](https://docs.datadoghq.com/real_user_monitoring/guide/setup-feature-flag-data-collection/?tab=npm#analyze-your-feature-flag-performance-in-rum)
 and user traits can be stored as


### PR DESCRIPTION
Removed caution note about beta status of Datadog integration.

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [ ] I have filled in the "How did you test this code" section below?
- [ ] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

Removing the beta caution, as it looks like this isn't in beta anymore on the Datadog side. 

## How did you test this code?

N/A