### PR TITLE
chore(evaluation-context): Fix `EvaluationContext` reference in `EvaluationResult` schema

### DIFF
--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -68,7 +68,7 @@
     "description": "Evaluation result object containing the used context, flag evaluation results, and segments used in the evaluation.",
     "properties": {
         "context": {
-            "$ref": "https://github.com/Flagsmith/flagsmith/blob/chore/features-contexts-in-eval-context-schema/sdk/evaluation-context.json"
+            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-context.json"
         },
         "flags": {
             "description": "List of feature flags evaluated for the context.",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

This fixes code generation errors when using `https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-result.json` directly.

## How did you test this code?

Used `jsonschema2pojo` with `https://raw.githubusercontent.com/Flagsmith/flagsmith/chore/evaluation-result-schema-fix-ref/sdk/evaluation-result.json` and verified the code generation works.