### PR TITLE
ci: Centralised Poetry install

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -44,17 +44,14 @@ jobs:
       - name: Cloning repo
         uses: actions/checkout@v4
 
-      - name: Install poetry
-        run: pipx install poetry
-
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
+          cache: poetry
 
       - name: Install Dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: make install-packages
+        run: make install
 
       - name: Create analytics database
         env:

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -50,7 +50,6 @@ jobs:
           cache: poetry
 
       - name: Install Dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: make install
 
       - name: Create analytics database

--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -44,13 +44,16 @@ jobs:
       - name: Cloning repo
         uses: actions/checkout@v4
 
+      - name: Install Poetry
+        run: make install-poetry
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
       - name: Install Dependencies
-        run: make install
+        run: make install-packages
 
       - name: Create analytics database
         env:

--- a/.github/workflows/api-run-makefile-target.yml
+++ b/.github/workflows/api-run-makefile-target.yml
@@ -27,7 +27,7 @@ defaults:
     working-directory: api
 
 jobs:
-  add-sdk-version:
+  run-makefile-target:
     runs-on: depot-ubuntu-latest
 
     steps:
@@ -36,10 +36,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
-          cache: "poetry"
+          cache: poetry
 
       - name: Install Dependencies
-        run: make install-packages
+        run: make install
 
       - name: Run `make ${{ inputs.target }} opts=${{ inputs.opts }}`
         env:

--- a/.github/workflows/api-run-makefile-target.yml
+++ b/.github/workflows/api-run-makefile-target.yml
@@ -33,13 +33,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Poetry
+        run: make install-poetry
+
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: poetry
 
       - name: Install Dependencies
-        run: make install
+        run: make install-packages
 
       - name: Run `make ${{ inputs.target }} opts=${{ inputs.opts }}`
         env:

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -30,12 +30,10 @@ jobs:
       - name: Cloning repo
         uses: actions/checkout@v4
 
-      - name: Install poetry
-        run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'poetry'
+          cache: poetry
 
       - name: Install SAML Dependencies
         run: sudo apt-get install -y xmlsec1
@@ -46,7 +44,7 @@ jobs:
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install-packages opts="--with saml,auth-controller,workflows"
+          make install opts="--with saml,auth-controller,workflows"
           make install-private-modules
           make integrate-private-tests
           rm -rf ${HOME}/.git-credentials

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -39,7 +39,6 @@ jobs:
         run: sudo apt-get install -y xmlsec1
 
       - name: Install packages and Tests
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Cloning repo
         uses: actions/checkout@v4
 
+      - name: Install Poetry
+        run: make install-poetry
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -43,7 +46,7 @@ jobs:
         run: |
           echo "https://${{ secrets.GH_PRIVATE_ACCESS_TOKEN }}:@github.com" > ${HOME}/.git-credentials
           git config --global credential.helper store
-          make install opts="--with saml,auth-controller,workflows"
+          make install-packages opts="--with saml,auth-controller,workflows"
           make install-private-modules
           make integrate-private-tests
           rm -rf ${HOME}/.git-credentials


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we: 
- Make sure the dev environment is available in the API Run Makefile Target workflow.
- Rely on `make install-poetry` target in CI.
- Correctly name the `run-makefile-target` job.
- Remove obsolete `if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'` directives. 

## How did you test this code?

This is a CI change that will be fully tested once it's merged. 