### PR TITLE
fix(hubspot): restore logic for updating `orgid_unique` property

### DIFF
--- a/api/integrations/lead_tracking/hubspot/client.py
+++ b/api/integrations/lead_tracking/hubspot/client.py
@@ -222,12 +222,15 @@ class HubspotClient:
         hubspot_company_id: str,
         name: str | None = None,
         active_subscription: str | None = None,
+        flagsmith_organisation_id: int | None = None,
     ) -> dict[str, Any]:
         properties = {}
         if name is not None:
             properties["name"] = name
         if active_subscription is not None:
             properties["active_subscription"] = active_subscription
+        if flagsmith_organisation_id is not None:
+            properties["orgid_unique"] = str(flagsmith_organisation_id)
 
         simple_public_object_input = SimplePublicObjectInput(properties=properties)
 

--- a/api/integrations/lead_tracking/hubspot/lead_tracker.py
+++ b/api/integrations/lead_tracking/hubspot/lead_tracker.py
@@ -162,13 +162,13 @@ class HubspotLeadTracker(LeadTracker):
             return None
         org_hubspot_id: str = company["id"]
 
-        properties = company.get("properties", {})
-        existing_name = properties.get("name")
-        if existing_name != organisation.name:
-            self.client.update_company(
-                name=organisation.name,
-                hubspot_company_id=org_hubspot_id,
-            )
+        # Update the company in Hubspot with the name of the created
+        # organisation in Flagsmith, and its numeric ID.
+        self.client.update_company(
+            name=organisation.name,
+            hubspot_company_id=org_hubspot_id,
+            flagsmith_organisation_id=organisation.id,
+        )
 
         # Store the organisation data in the database since we are
         # unable to look them up via a unique identifier.

--- a/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
+++ b/api/tests/unit/integrations/lead_tracking/hubspot/test_unit_hubspot_client.py
@@ -286,13 +286,34 @@ def test_associate_contact_to_company_succeeds(hubspot_client: HubspotClient) ->
 @pytest.mark.parametrize(
     "kwargs, expected_properties",
     [
-        ({"name": "Test Organisation"}, {"name": "Test Organisation"}),
         (
-            {"name": "Test Organisation", "active_subscription": "scaleup"},
-            {"name": "Test Organisation", "active_subscription": "scaleup"},
+            {"name": "Test Organisation", "flagsmith_organisation_id": 1},
+            {"name": "Test Organisation", "orgid_unique": "1"},
         ),
-        ({"active_subscription": "scaleup"}, {"active_subscription": "scaleup"}),
-        ({"name": None, "active_subscription": None}, {}),
+        (
+            {
+                "name": "Test Organisation",
+                "active_subscription": "scaleup",
+                "flagsmith_organisation_id": 1,
+            },
+            {
+                "name": "Test Organisation",
+                "active_subscription": "scaleup",
+                "orgid_unique": "1",
+            },
+        ),
+        (
+            {"active_subscription": "scaleup", "flagsmith_organisation_id": 1},
+            {"active_subscription": "scaleup", "orgid_unique": "1"},
+        ),
+        (
+            {
+                "name": None,
+                "active_subscription": None,
+                "flagsmith_organisation_id": None,
+            },
+            {},
+        ),
     ],
 )
 def test_update_company_calls_hubspot_api(


### PR DESCRIPTION
## Changes

Since we stopped creating the company in Hubspot from the Flagsmith side (see [here](https://github.com/Flagsmith/flagsmith-private/issues/23) for more context) we no longer set the `orgid_unique` property, which is required for some analysis. 

This PR removes the previously conditional logic of updating the company in hubspot when a new company is created in Flagsmith and always updates it with the `orgid_unique` field. 

## How did you test this code?

Updated existing unit tests to cover the new field. 
