### PR TITLE
chore: update CODEOWNERS to reflect new team structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 *                @flagsmith/flagsmith-engineering
 
 # Specific rules based on directory
-/api/            @flagsmith/back-end
-/frontend/       @flagsmith/front-end
-/infrastructure/ @flagsmith/infrastructure
+/api/            @flagsmith/flagsmith-back-end
+/frontend/       @flagsmith/flagsmith-front-end
+/infrastructure/ @flagsmith/flagsmith-infrastructure
 /docs/           @flagsmith/flagsmith-docs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # Global default rule
-*                @flagsmith/flagsmith-maintainers
+*                @flagsmith/flagsmith-engineering
 
 # Specific rules based on directory
-/api/            @flagsmith/flagsmith-back-end
+/api/            @flagsmith/back-end
+/frontend/       @flagsmith/front-end
+/infrastructure/ @flagsmith/infrastructure
 /docs/           @flagsmith/flagsmith-docs
-/frontend/       @flagsmith/flagsmith-front-end
-/infrastructure/ @flagsmith/flagsmith-infrastructure


### PR DESCRIPTION
## Changes

Update CODEOWNERS following teams restructure.

The teams in Github now look like this: 

```
Flagsmith
 - Flagsmith - Docs (all engineers + customer success)
 - Flagsmith - Engineering (empty)
   - Back End (all BE engineers)
   - Front End (all FE engineers)
   - Infrastructure (all infrastructure engineers)
 - Flagsmith - Other (agregoryfs, dabeeeenster)
```

This simplifies some of the maintenance here as we can just use the Flagsmith - Engineering team (which will assign PRs to all members of sub teams). Note, however, that I have excluded kyle-ssg from being assigned these PRs. 

Unfortunately there wasn't a simple way that I could find to avoid having users duplicated in the flagsmith - docs team. I tried creating a flagsmith - customer success team, and then we _could_ have done something like the following. This approach, however, would have resulted in a user from both teams being assigned to review, which I think is probably not what we want.  

```
...

/docs/ @Flagsmith/flagsmith-engineering, @Flagsmith/flagsmith-customer-success 
```

Keen to hear peoples thoughts on this nonetheless, so please feel free to make suggestions for alternative team structures if you think it can be improved. 

## How did you test this code?

N/a
