### PR TITLE
chore(evaluation-context): Work around the lack of `anyOf` support in Java

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -292,7 +292,15 @@
             "description": "Environment context required for evaluation."
         },
         "identity": {
-            "$ref": "#/$defs/IdentityContext",
+            "existingJavaType": "com.flagsmith.flagengine.IdentityContext",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/IdentityContext"
+                },
+                {
+                    "type": "null"
+                }
+            ],
             "default": null,
             "description": "Identity context used for identity-based evaluation."
         },

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -292,14 +292,7 @@
             "description": "Environment context required for evaluation."
         },
         "identity": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/IdentityContext"
-                },
-                {
-                    "type": "null"
-                }
-            ],
+            "$ref": "#/$defs/IdentityContext",
             "default": null,
             "description": "Identity context used for identity-based evaluation."
         },

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -171,6 +171,7 @@
             "type": "object"
         },
         "SegmentCondition": {
+            "existingJavaType": "com.flagsmith.flagengine.SegmentCondition",
             "anyOf": [
                 {
                     "description": "Represents a condition within a segment rule for feature flag evaluation.",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -69,7 +69,7 @@
     "properties": {
         "context": {
             "existingJavaType": "com.flagsmith.flagengine.EvaluationContext",
-            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/chore/evaluation-context-java-support/sdk/evaluation-context.json"
+            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-context.json"
         },
         "flags": {
             "description": "List of feature flags evaluated for the context.",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -68,6 +68,7 @@
     "description": "Evaluation result object containing the used context, flag evaluation results, and segments used in the evaluation.",
     "properties": {
         "context": {
+            "existingJavaType": "com.flagsmith.flagengine.EvaluationContext",
             "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/chore/evaluation-context-java-support/sdk/evaluation-context.json"
         },
         "flags": {

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -68,7 +68,7 @@
     "description": "Evaluation result object containing the used context, flag evaluation results, and segments used in the evaluation.",
     "properties": {
         "context": {
-            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-context.json"
+            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/chore/evaluation-context-java-support/sdk/evaluation-context.json"
         },
         "flags": {
             "description": "List of feature flags evaluated for the context.",


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we enable `jsonschema2pojo` usage for the Java SDK with our current engine evaluation context and evaluation result schemas. The `anyOf` fields are annotated with `existingJavaType` properties, directing codegen to use available manually included classes.

## How did you test this code?

`mvn generate-sources` against the upcoming Java SDK PR.