### PR TITLE
fix: removed-gap-in-overflow-hook-invocation

### DIFF
--- a/frontend/web/components/modals/CreateFlag.js
+++ b/frontend/web/components/modals/CreateFlag.js
@@ -1874,7 +1874,7 @@ const CreateFlag = class extends Component {
                                         tabLabelString='Links'
                                         tabLabel={
                                           <Row className='justify-content-center'>
-                                            Links{' '}
+                                            Links
                                           </Row>
                                         }
                                       >

--- a/frontend/web/components/navigation/TabMenu/Tabs.tsx
+++ b/frontend/web/components/navigation/TabMenu/Tabs.tsx
@@ -94,7 +94,7 @@ const Tabs: React.FC<TabsProps> = ({
   const { isMeasuring, visibleCount } = useOverflowVisibleCount({
     extraWidth: overflowButtonWidth,
     force: false,
-    gap: 2,
+    gap: 0,
     itemCount: tabChildren.length,
     itemsContainerRef,
     outerContainerRef,


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
- Removed extra gap safety net when using overflow hook

## How did you test this code?
- Against not working set-up

<img width="1087" height="430" alt="image" src="https://github.com/user-attachments/assets/c78c4ad3-6a48-4348-90da-f2623db6d91a" />
