### PR TITLE
chore(evaluation-context): Freeform feature values

### DIFF
--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -49,7 +49,12 @@
                 "value": {
                     "description": "A default environment value for the feature. If the feature is multivariate, this will be the control value.",
                     "title": "Value",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "null"
+                    ]
                 },
                 "variants": {
                     "description": "An array of environment default values associated with the feature. Contains a single value for standard features, or multiple values for multivariate features.",
@@ -81,7 +86,12 @@
                 "value": {
                     "description": "The value of the feature.",
                     "title": "Value",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "null"
+                    ]
                 },
                 "weight": {
                     "description": "The weight of the feature value variant, as a percentage number (i.e. 100.0).",

--- a/sdk/evaluation-context.json
+++ b/sdk/evaluation-context.json
@@ -53,6 +53,8 @@
                         "string",
                         "number",
                         "boolean",
+                        "object",
+                        "array",
                         "null"
                     ]
                 },
@@ -90,6 +92,8 @@
                         "string",
                         "number",
                         "boolean",
+                        "object",
+                        "array",
                         "null"
                     ]
                 },

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -69,7 +69,7 @@
     "properties": {
         "context": {
             "existingJavaType": "com.flagsmith.flagengine.EvaluationContext",
-            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/chore/evaluation-context-object-values/sdk/evaluation-context.json"
+            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-context.json"
         },
         "flags": {
             "description": "List of feature flags evaluated for the context.",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -69,7 +69,7 @@
     "properties": {
         "context": {
             "existingJavaType": "com.flagsmith.flagengine.EvaluationContext",
-            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-context.json"
+            "$ref": "https://raw.githubusercontent.com/Flagsmith/flagsmith/chore/evaluation-context-object-values/sdk/evaluation-context.json"
         },
         "flags": {
             "description": "List of feature flags evaluated for the context.",

--- a/sdk/evaluation-result.json
+++ b/sdk/evaluation-result.json
@@ -20,13 +20,13 @@
                 "value": {
                     "description": "Feature flag value.",
                     "title": "Value",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
+                    "type": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "object",
+                        "array",
+                        "null"
                     ]
                 },
                 "reason": {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

In this PR, we extend `FeatureContext.value`, `FeatureValue.value` and `FlagResult.value` schemas to allow any values. This helps code generation for strictly typed languages like Java. In Python flagsmith-engine implementation, these fields are already overridden as `Any`.

## How did you test this code?

Made sure the engine tests pass in Java with the new engine interface.

