### PR TITLE
chore: Add segment event, unify identity override event

### DIFF
--- a/frontend/common/constants.ts
+++ b/frontend/common/constants.ts
@@ -339,11 +339,6 @@ const Constants = {
       'event': 'User feature removed',
     },
     'RESEND_INVITE': { 'category': 'Invite', 'event': 'Invite resent' },
-    'TOGGLE_FEATURE': { 'category': 'Features', 'event': 'Feature toggled' },
-    'TOGGLE_USER_FEATURE': {
-      'category': 'User Features',
-      'event': 'User feature toggled',
-    },
     'TRY_IT': { 'category': 'TryIt', 'event': 'Try it clicked' },
     'UPDATE_USER_ROLE': {
       'category': 'Organisation',

--- a/frontend/common/services/useSegment.ts
+++ b/frontend/common/services/useSegment.ts
@@ -3,6 +3,8 @@ import { Req } from 'common/types/requests'
 import { service } from 'common/service'
 import Utils from 'common/utils/utils'
 import transformCorePaging from 'common/transformCorePaging'
+import API from 'project/api'
+import Constants from 'common/constants'
 
 export const segmentService = service
   .enhanceEndpoints({ addTagTypes: ['Segment'] })
@@ -27,6 +29,10 @@ export const segmentService = service
           method: 'POST',
           url: `projects/${query.projectId}/segments/`,
         }),
+        transformResponse: (res) => {
+          API.trackEvent(Constants.events.CREATE_SEGMENT)
+          return res
+        },
       }),
       deleteSegment: builder.mutation<Res['segment'], Req['deleteSegment']>({
         invalidatesTags: (q, e, arg) => [

--- a/frontend/common/stores/identity-store.js
+++ b/frontend/common/stores/identity-store.js
@@ -14,7 +14,7 @@ const controller = {
     payload,
   }) {
     store.saving()
-    API.trackEvent(Constants.events.TOGGLE_USER_FEATURE)
+    API.trackEvent(Constants.events.EDIT_USER_FEATURE)
 
     const prom = data.put(
       `${
@@ -132,7 +132,7 @@ const controller = {
     projectFlag,
   }) {
     store.saving()
-    API.trackEvent(Constants.events.TOGGLE_USER_FEATURE)
+    API.trackEvent(Constants.events.EDIT_USER_FEATURE)
     const prom =
       identityFlag.identity || identityFlag.identity_uuid
         ? data.put(

--- a/frontend/web/components/modals/CreateSegment.tsx
+++ b/frontend/web/components/modals/CreateSegment.tsx
@@ -23,6 +23,7 @@ import { useGetIdentitiesQuery } from 'common/services/useIdentity'
 import {
   useCreateSegmentMutation,
   useGetSegmentQuery,
+  useGetSegmentsQuery,
   useUpdateSegmentMutation,
 } from 'common/services/useSegment'
 import Utils from 'common/utils/utils'
@@ -46,6 +47,7 @@ import ExistingProjectChangeRequestAlert from 'components/ExistingProjectChangeR
 import CreateSegmentRulesTabForm from './CreateSegmentRulesTabForm'
 import CreateSegmentUsersTabContent from './CreateSegmentUsersTabContent'
 import useDebouncedSearch from 'common/useDebouncedSearch'
+import API from 'project/api'
 
 type PageType = {
   number: number
@@ -135,6 +137,10 @@ const CreateSegment: FC<CreateSegmentType> = ({
       },
     ],
   }
+  const { data: segments } = useGetSegmentsQuery({
+    include_feature_specific: true,
+    projectId,
+  })
   const [segment, setSegment] = useState(_segment || defaultSegment)
   const [description, setDescription] = useState(segment.description)
   const [name, setName] = useState<Segment['name']>(segment.name)
@@ -247,10 +253,13 @@ const CreateSegment: FC<CreateSegmentType> = ({
             },
           }).unwrap()
         } else {
-          await createSegment({
+          const res = await createSegment({
             projectId,
             segment: segmentData,
           }).unwrap()
+          if (!segments?.results?.length) {
+            API.trackEvent(Constants.events.CREATE_FIRST_SEGMENT)
+          }
         }
       }
     } catch (error: any) {


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes

- Adds create segment / first segment event


Related - https://github.com/Flagsmith/flagsmith/issues/6076

## How did you test this code?

- Checked both events fire on first segment in project 
- Checked only created event fires on second