### PR TITLE
ci(temp): temporarily disable staging deploys during penetration testing

### DIFF
--- a/.github/workflows/api-deploy-staging-ecs.yml
+++ b/.github/workflows/api-deploy-staging-ecs.yml
@@ -1,13 +1,14 @@
 name: API Deploy to Staging ECS
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - api/**
-      - .github/**
-      - infrastructure/aws/staging/**
+#  Temporarily disabled while penetration testing is happening (w/c 29/09/2025).
+#  push:
+#    branches:
+#      - main
+#    paths:
+#      - api/**
+#      - .github/**
+#      - infrastructure/aws/staging/**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Changes

This PR temporarily disables automated staging deploys so we can keep a consistent environment for the penetration testing team. 

## How did you test this code?

N/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Comments out the push trigger for the staging ECS deploy workflow, leaving only manual (workflow_dispatch) runs.
> 
> - **CI/CD**:
>   - **Staging ECS Deploy Workflow** (`.github/workflows/api-deploy-staging-ecs.yml`):
>     - Disable automatic runs by commenting out the `push` trigger.
>     - Keep manual trigger via `workflow_dispatch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1851fd8cd085abcdc25136f9e35684f851baacf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->