### PR TITLE
ci: skip-private-tests-and-comments-conditionally-for-oss-contributions

### DIFF
--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -37,11 +37,6 @@ on:
         description: Update visual regression baselines (use on main branch)
         required: false
         default: false
-      comment:
-        type: boolean
-        description: Whether to post test results as a PR comment
-        required: false
-        default: true
     secrets:
       GCR_TOKEN:
         description: A token to use for logging into Github Container Registry. If not provided, login does not occur.
@@ -194,7 +189,8 @@ jobs:
             **🔄 Run:** [#${{ github.run_number }} (attempt ${{ github.run_attempt }})](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Comment PR with test results
-        if: always() && inputs.comment && github.event_name == 'pull_request' && (steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary)
+        if: always() && github.event_name == 'pull_request' && (steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary)
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: playwright-e2e-results
@@ -237,7 +233,8 @@ jobs:
           fi
 
       - name: Comment PR with visual regression results
-        if: always() && inputs.comment && inputs.visual-regression && !inputs.visual-regression-update && github.event_name == 'pull_request' && steps.visual-regression-summary.outputs.message
+        if: always() && inputs.visual-regression && !inputs.visual-regression-update && github.event_name == 'pull_request' && steps.visual-regression-summary.outputs.message
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: visual-regression-results

--- a/.github/workflows/.reusable-docker-e2e-tests.yml
+++ b/.github/workflows/.reusable-docker-e2e-tests.yml
@@ -37,6 +37,11 @@ on:
         description: Update visual regression baselines (use on main branch)
         required: false
         default: false
+      comment:
+        type: boolean
+        description: Whether to post test results as a PR comment
+        required: false
+        default: true
     secrets:
       GCR_TOKEN:
         description: A token to use for logging into Github Container Registry. If not provided, login does not occur.
@@ -189,7 +194,7 @@ jobs:
             **🔄 Run:** [#${{ github.run_number }} (attempt ${{ github.run_attempt }})](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Comment PR with test results
-        if: always() && github.event_name == 'pull_request' && (steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary)
+        if: always() && inputs.comment && github.event_name == 'pull_request' && (steps.report-summary-success.outputs.summary || steps.report-summary-failure.outputs.summary)
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: playwright-e2e-results
@@ -232,7 +237,7 @@ jobs:
           fi
 
       - name: Comment PR with visual regression results
-        if: always() && inputs.visual-regression && !inputs.visual-regression-update && github.event_name == 'pull_request' && steps.visual-regression-summary.outputs.message
+        if: always() && inputs.comment && inputs.visual-regression && !inputs.visual-regression-update && github.event_name == 'pull_request' && steps.visual-regression-summary.outputs.message
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: visual-regression-results

--- a/.github/workflows/api-tests-with-private-packages.yml
+++ b/.github/workflows/api-tests-with-private-packages.yml
@@ -27,6 +27,7 @@ defaults:
 
 jobs:
   test:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork != true
     runs-on: depot-ubuntu-latest-16
     name: API Unit Tests
 

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -151,6 +151,7 @@ jobs:
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ needs.docker-build-api.outputs.image }}
       args: --grep @oss
+      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
       SLACK_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.SLACK_TOKEN || '' }}
@@ -169,6 +170,7 @@ jobs:
       api-image: ${{ needs.docker-build-private-cloud.outputs.image }}
       args: --grep "@oss|@enterprise"
       visual-regression: ${{ matrix.runs-on == 'depot-ubuntu-latest-16' }}
+      comment: true
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
       SLACK_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.SLACK_TOKEN || '' }}

--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -151,7 +151,6 @@ jobs:
       e2e-image: ${{ needs.docker-build-e2e.outputs.image }}
       api-image: ${{ needs.docker-build-api.outputs.image }}
       args: --grep @oss
-      comment: ${{ needs.permissions-check.outputs.can-write == 'true' }}
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
       SLACK_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.SLACK_TOKEN || '' }}
@@ -170,7 +169,6 @@ jobs:
       api-image: ${{ needs.docker-build-private-cloud.outputs.image }}
       args: --grep "@oss|@enterprise"
       visual-regression: ${{ matrix.runs-on == 'depot-ubuntu-latest-16' }}
-      comment: true
     secrets:
       GCR_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.GITHUB_TOKEN || '' }}
       SLACK_TOKEN: ${{ needs.permissions-check.outputs.can-write == 'true' && secrets.SLACK_TOKEN || '' }}


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have read the [Contributing Guide](/Flagsmith/flagsmith/blob/main/CONTRIBUTING.md).
- [ ] I have added information to `docs/` if required so people know about the feature.
- [x] I have filled in the "Changes" section below.
- [x] I have filled in the "How did you test this code" section below.

## Changes
Fork PRs receive a read-only GITHUB_TOKEN and have no access to repo secrets, causing private package tests to fail on checkout and E2E jobs to fail when posting PR comments despite tests passing.

- Skip private packages tests for fork PRs (secrets unavailable)
- `continue-on-error` sticky comments posting E2E results

## How did you test this code?
- not yet: CI